### PR TITLE
Hai 67 rajapintakuvaus backendiin

### DIFF
--- a/services/hanke-service/README.md
+++ b/services/hanke-service/README.md
@@ -33,6 +33,10 @@ After the application has started, the services should be available at URLs:
 > http://localhost:8080/ \
 > http://localhost:8080/api/hello/
 
+Swagger UI (see https://springdoc.org/) and OpenAPI v3 description (JSON):
+> http://localhost:8080/swagger-ui.html \
+> http://localhost:8080/v3/api-docs
+
 At least Firefox seems to be able to show the REST JSON results in a nice way directly.
 
 ## History

--- a/services/hanke-service/build.gradle.kts
+++ b/services/hanke-service/build.gradle.kts
@@ -12,6 +12,7 @@ plugins {
 group = "fi.hel.haitaton"
 version = "0.0.1-SNAPSHOT"
 java.sourceCompatibility = JavaVersion.VERSION_11
+val springDocVersion = "1.4.8"
 
 repositories {
 	mavenCentral()
@@ -44,6 +45,7 @@ dependencies {
 	implementation("org.jetbrains.kotlin:kotlin-reflect")
 	implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
 	runtimeOnly("org.postgresql:postgresql")
+	runtimeOnly("org.springdoc:springdoc-openapi-ui:$springDocVersion")
 	testImplementation("org.springframework.boot:spring-boot-starter-test") {
 		exclude(group = "org.junit.vintage", module = "junit-vintage-engine")
 	}


### PR DESCRIPTION
Swagger UI and OpenAPI v3 description with SpringDoc (https://springdoc.org/)