### PR TITLE
Hai 90 readiness and liveness probes

### DIFF
--- a/services/hanke-service/Dockerfile
+++ b/services/hanke-service/Dockerfile
@@ -1,5 +1,5 @@
 FROM registry.redhat.io/openjdk/openjdk-11-rhel7
-EXPOSE 8080
+EXPOSE 8080 8081
 VOLUME /tmp
 ADD "hanke-service-*.jar" hanke-service.jar
 CMD [ "sh", "-c", "java $JAVA_OPTS -Djava.security.egd=file:/dev/urandom -jar hanke-service.jar" ]

--- a/services/hanke-service/README.md
+++ b/services/hanke-service/README.md
@@ -51,6 +51,11 @@ To run the postgres in localhost
 You can change the port and data folder to your liking in configure-database
 .sh and build-postgres-docker.sh. Note that you will also need to change
  settings in application.properties accordingly.
+
+## Probes
+There are following Spring Boot Actuator probes (https://docs.spring.io/spring-boot/docs/2.3.4.RELEASE/reference/html/production-ready-features.html#production-ready-kubernetes-probes) for Kubernetes (these must be configured in Kuberneters/OpenShift):
+> http://localhost:8081/actuator/health/readiness \
+> http://localhost:8081/actuator/health/liveness
  
 ## Setting up build process
 

--- a/services/hanke-service/README.md
+++ b/services/hanke-service/README.md
@@ -52,6 +52,24 @@ You can change the port and data folder to your liking in configure-database
 .sh and build-postgres-docker.sh. Note that you will also need to change
  settings in application.properties accordingly.
 
+## Info
+There is a Spring Boot Actuator endpoint for general info:
+> http://localhost:8081/actuator/info
+```
+{
+    "java-name": "Java Platform API Specification",
+    "java-version": "11",
+    "java-vendor": "Oracle Corporation",
+    "build": {
+        "artifact": "hanke-service",
+        "name": "hanke-service",
+        "time": "2020-11-02T07:00:31.071Z",
+        "version": "0.0.1-SNAPSHOT",
+        "group": "fi.hel.haitaton"
+    }
+}
+```
+
 ## Probes
 There are following Spring Boot Actuator probes (https://docs.spring.io/spring-boot/docs/2.3.4.RELEASE/reference/html/production-ready-features.html#production-ready-kubernetes-probes) for Kubernetes (these must be configured in Kuberneters/OpenShift):
 > http://localhost:8081/actuator/health/readiness \

--- a/services/hanke-service/build.gradle.kts
+++ b/services/hanke-service/build.gradle.kts
@@ -50,6 +50,8 @@ dependencies {
 	testImplementation("org.springframework.boot:spring-boot-starter-test") {
 		exclude(group = "org.junit.vintage", module = "junit-vintage-engine")
 	}
+	// Spring Boot Management
+	implementation("org.springframework.boot:spring-boot-starter-actuator")
 }
 
 //tasks.withType<Test> {

--- a/services/hanke-service/build.gradle.kts
+++ b/services/hanke-service/build.gradle.kts
@@ -39,6 +39,10 @@ idea {
 	}
 }
 
+springBoot {
+	buildInfo()
+}
+
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-web")
 	implementation("com.fasterxml.jackson.module:jackson-module-kotlin")

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hello/ActuatorEndpointITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hello/ActuatorEndpointITests.kt
@@ -1,0 +1,49 @@
+package fi.hel.haitaton.hello
+
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+
+
+/**
+ * For testing Spring Boot Actuator endpoints
+ */
+@SpringBootTest(properties = ["management.server.port="])
+@AutoConfigureMockMvc
+@EnableAutoConfiguration
+class ActuatorEndpointITests(@Autowired val mockMvc: MockMvc) {
+
+    @Test
+    fun readiness() {
+        mockMvc
+                .perform(get("/actuator/health/readiness"))
+                .andExpect(status().isOk)
+                .andExpect(content().contentType("application/vnd.spring-boot.actuator.v3+json"))
+                .andExpect(jsonPath("$.status").value("UP"))
+    }
+
+    @Test
+    fun liveness() {
+        mockMvc
+                .perform(get("/actuator/health/liveness"))
+                .andExpect(status().isOk)
+                .andExpect(content().contentType("application/vnd.spring-boot.actuator.v3+json"))
+                .andExpect(jsonPath("$.status").value("UP"))
+    }
+
+    @Test
+    fun info() {
+        mockMvc
+                .perform(get("/actuator/info"))
+                .andExpect(status().isOk)
+                .andExpect(content().contentType("application/vnd.spring-boot.actuator.v3+json"))
+                .andExpect(jsonPath("$.build.artifact").value("hanke-service"))
+    }
+}

--- a/services/hanke-service/src/main/resources/application.properties
+++ b/services/hanke-service/src/main/resources/application.properties
@@ -3,7 +3,10 @@ app.datasource.username=haitaton_user
 app.datasource.password=haitaton
 spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
 
-# Spring Boot Management for Kubernetes (see https://docs.spring.io/spring-boot/docs/2.3.4.RELEASE/reference/html/production-ready-features.html#production-ready-kubernetes-probes)
+# Spring Boot Actuator Management for Kubernetes (see https://docs.spring.io/spring-boot/docs/2.3.4.RELEASE/reference/html/production-ready-features.html#production-ready-kubernetes-probes)
 # Use separate HTTP port for probes
 management.server.port=8081
 management.endpoint.health.probes.enabled=liveness,readiness
+# Spring Boot Actuator Info properties
+info.java-version = ${java.specification.version}
+info.java-vendor = ${java.specification.vendor}

--- a/services/hanke-service/src/main/resources/application.properties
+++ b/services/hanke-service/src/main/resources/application.properties
@@ -2,3 +2,8 @@ app.datasource.url=jdbc:postgresql://${HAITATON_HOST:localhost}:${HAITATON_PORT:
 app.datasource.username=haitaton_user
 app.datasource.password=haitaton
 spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
+
+# Spring Boot Management for Kubernetes (see https://docs.spring.io/spring-boot/docs/2.3.4.RELEASE/reference/html/production-ready-features.html#production-ready-kubernetes-probes)
+# Use separate HTTP port for probes
+management.server.port=8081
+management.endpoint.health.probes.enabled=liveness,readiness


### PR DESCRIPTION
# Description

Added Spring Boot Actuator liveness and readiness probes for Kubernetes and general info endpoint

### Jira Issue:  HAI-90

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
Gradle integration tests:
`$ ./gradlew :services:hanke-service:clean integrationTest`

Build and run for manual testing:
`$ ./gradlew :services:hanke-service:bootRun`
Readiness probe:
> http://localhost:8081/actuator/health/readiness

Liveness probe:
> http://localhost:8081/actuator/health/liveness

Info:
> http://localhost:8081/actuator/info

With Docker:
```
$ ./gradlew build
$ cd services/hanke-service
$ cp build/libs/hanke-service-0.0.1-SNAPSHOT.jar .
$ docker build . -t hanke-service:0.0.1-SNAPSHOT
$ docker run -p 8080:8080 -p 8081:8081 hanke-service:0.0.1-SNAPSHOT
```
Urls for testing are the same as above.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: not yet - will have to add info about the probe urls on IBM Jira for ARO people when this version image has been built on "dev".
