### PR TITLE
HAI-221 added postgis extension to docker

### DIFF
--- a/scripts/docker-postgres/configure-database.sh
+++ b/scripts/docker-postgres/configure-database.sh
@@ -11,6 +11,7 @@ set -euo pipefail
 #POSTGRES_PASSWORD=postgres
 
 echo "Creating database \"$DB_APP_DB\", creating role \"$DB_APP_USER\" with database owner privileges…"
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname template1 -c 'create extension postgis;'
 
 psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-END
 create role "${DB_APP_USER}" with password '${DB_APP_PASSWORD}' login;

--- a/scripts/docker-postgres/configure-database.sh
+++ b/scripts/docker-postgres/configure-database.sh
@@ -11,10 +11,12 @@ set -euo pipefail
 #POSTGRES_PASSWORD=postgres
 
 echo "Creating database \"$DB_APP_DB\", creating role \"$DB_APP_USER\" with database owner privileges…"
-psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname template1 -c 'create extension postgis;'
 
 psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-END
+create extension postgis;
 create role "${DB_APP_USER}" with password '${DB_APP_PASSWORD}' login;
+alter user "${DB_APP_USER}" with superuser;
+alter user "${DB_APP_USER}" with superuser;
 create database "${DB_APP_DB}" encoding 'UTF-8';
 create database "${DB_APP_DB_TEST}" encoding 'UTF-8';
 grant all privileges on database "${DB_APP_DB}" to "${DB_APP_USER}";


### PR DESCRIPTION
Created postgis extension for test db. 
Instructions for testing:
1. Delete containers
2. Rebuild container db with

`docker-compose docker-compose --env-file .env.local up db
`
3. Login to psql and validate that extension exists:
```
 psql -U postgres -d haitaton -h 127.0.0.1 -p 5432
select * from pg_extension;
```