### PR TITLE
HAI-256added haitaton db to env variables

### DIFF
--- a/scripts/docker-postgres/configure-database.sh
+++ b/scripts/docker-postgres/configure-database.sh
@@ -13,7 +13,7 @@ set -euo pipefail
 echo "Creating database \"$DB_APP_DB\", creating role \"$DB_APP_USER\" with database owner privileges…"
 
 psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-END
-create extension postgis;
+create extension if not exists postgis;
 create role "${DB_APP_USER}" with password '${DB_APP_PASSWORD}' login;
 alter user "${DB_APP_USER}" with superuser;
 alter user "${DB_APP_USER}" with superuser;

--- a/services/hanke-service/src/main/resources/application.properties
+++ b/services/hanke-service/src/main/resources/application.properties
@@ -5,7 +5,7 @@
 #app.datasource.password=${HAITATON_PASSWORD:haitaton}
 #spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
 
-spring.datasource.url=jdbc:postgresql://${HAITATON_HOST:localhost}:${HAITATON_PORT:5432}/haitaton
+spring.datasource.url=jdbc:postgresql://${HAITATON_HOST:localhost}:${HAITATON_PORT:5432}/${HAITATON_DATABASE:haitaton}
 spring.datasource.username=${HAITATON_USER:haitaton_user}
 spring.datasource.password=${HAITATON_PASSWORD:haitaton}
 


### PR DESCRIPTION
As per request from ibm to azure, also added the db name to env variables. In addition added if exists to postgis extension creation since noticed it was lacking (and docker-compose up fails if you try to add it to already existing db). 