### PR TITLE
HAI-269 fixed postgis/postgres version to fix issue with unsupported …

### DIFF
--- a/scripts/docker-postgres/Dockerfile
+++ b/scripts/docker-postgres/Dockerfile
@@ -1,6 +1,6 @@
 # Based on <https://registry.hub.docker.com/r/postgis/postgis>
 
-FROM postgis/postgis:11-3.0
+FROM postgis/postgis:13-master
 RUN localedef -i fi_FI -c -f UTF-8 -A /usr/share/locale/locale.alias fi_FI.UTF-8
 ENV LANG fi_FI.utf8
 


### PR DESCRIPTION
Updated postgis/postgres version. Note: you will need to delete (or change) your data-folder since it is not compatible with the old one. Remember to update your folder to .env.local!