### PR TITLE
HAI-61 and HAI-202 liquibase base and hanke basic info db operations

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/ActuatorEndpointITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/ActuatorEndpointITests.kt
@@ -5,6 +5,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
@@ -20,6 +21,10 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
 @AutoConfigureMockMvc
 @EnableAutoConfiguration
 class ActuatorEndpointITests(@Autowired val mockMvc: MockMvc) {
+
+    // Just to prevent the context trying to init that service, and fail doing it.
+    @MockBean
+    lateinit var hankeService: HankeService
 
     @Test
     fun readiness() {

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeControllerITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeControllerITests.kt
@@ -76,7 +76,7 @@ class HankeControllerITests(@Autowired val mockMvc: MockMvc) {
         var hankeToBeAdded = Hanke(hankeId = "", name = hankeName, isYKTHanke = false, startDate = null, endDate = null, owner = "Tiina", phase = 0)
 
         //faking the service call
-        Mockito.`when`(hankeService.save(hankeToBeAdded))
+        Mockito.`when`(hankeService.createHanke(hankeToBeAdded))
                 .thenReturn(hankeToBeAdded)
 
         val objectMapper = ObjectMapper()
@@ -101,7 +101,7 @@ class HankeControllerITests(@Autowired val mockMvc: MockMvc) {
         val hankeJSON = objectMapper.writeValueAsString(hankeToBeAdded)
 
         //faking the service call
-        Mockito.`when`(hankeService.save(hankeToBeAdded))
+        Mockito.`when`(hankeService.updateHanke(hankeToBeAdded))
                 .thenReturn(hankeToBeAdded)
 
         mockMvc.perform(put("/hankkeet/hankeId=idHankkeelle123")
@@ -130,5 +130,3 @@ class HankeControllerITests(@Autowired val mockMvc: MockMvc) {
     }
 
 }
-
-

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeControllerITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeControllerITests.kt
@@ -68,7 +68,7 @@ class HankeControllerITests(@Autowired val mockMvc: MockMvc) {
         val hankeName = "Mannerheimintien remontti remonttinen"
         var hankeToBeAdded = Hanke(id = null, hankeTunnus = "", nimi = hankeName, kuvaus = "lorem ipsum dolor sit amet...",
                 onYKTHanke = false, alkuPvm = null, loppuPvm = null, vaihe = "OHJELMOINTI",
-                version = null, creatorUserId = "Tiina", createdAt = null, modifierUserId = null, modifiedAt = null, saveType = SaveType.DRAFT)
+                version = null, createdBy = "Tiina", createdAt = null, modifiedBy = null, modifiedAt = null, saveType = SaveType.DRAFT)
 
         // faking the service call
         Mockito.`when`(hankeService.createHanke(hankeToBeAdded))
@@ -91,7 +91,7 @@ class HankeControllerITests(@Autowired val mockMvc: MockMvc) {
         // initializing only part of the data for Hanke
         val hankeToBeAdded = Hanke(id = null, hankeTunnus = null, nimi = name, kuvaus = null,
                 onYKTHanke = false, alkuPvm = null, loppuPvm = null, vaihe = "OHJELMOINTI",
-                version = null, creatorUserId = "Tiina", createdAt = null, modifierUserId = null, modifiedAt = null, saveType = SaveType.DRAFT)
+                version = null, createdBy = "Tiina", createdAt = null, modifiedBy = null, modifiedAt = null, saveType = SaveType.DRAFT)
 
         val objectMapper = ObjectMapper()
         val hankeJSON = objectMapper.writeValueAsString(hankeToBeAdded)
@@ -112,7 +112,7 @@ class HankeControllerITests(@Autowired val mockMvc: MockMvc) {
     fun `test that the validation gives error and Bad Request is returned when creatorUserId is empty`() {
         var hankeToBeAdded = Hanke(id = null, hankeTunnus = "idHankkeelle123", nimi = "", kuvaus = null,
                 onYKTHanke = false, alkuPvm = null, loppuPvm = null, vaihe = "RAKENTAMINEN",
-                version = null, creatorUserId = "", createdAt = null, modifierUserId = null, modifiedAt = null, saveType = SaveType.DRAFT)
+                version = null, createdBy = "", createdAt = null, modifiedBy = null, modifiedAt = null, saveType = SaveType.DRAFT)
         // mock HankeService response
         Mockito.`when`(hankeService.createHanke(hankeToBeAdded)).thenReturn(hankeToBeAdded)
 

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeGeometriaControllerITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeGeometriaControllerITests.kt
@@ -5,8 +5,8 @@ import io.mockk.every
 import io.mockk.verify
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
-import org.springframework.context.annotation.Import
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
@@ -17,8 +17,8 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import java.nio.file.Files
 import java.nio.file.Paths
 
-@WebMvcTest
-@Import(Configuration::class)
+@SpringBootTest(properties = ["spring.liquibase.enabled=false"])  // Without this, the JPA repository service won't be found as a bean
+@AutoConfigureMockMvc
 internal class HankeGeometriaControllerITests(@Autowired val mockMvc: MockMvc) {
 
     @MockkBean

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeRepositoryITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeRepositoryITests.kt
@@ -7,7 +7,7 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager
 
 @DataJpaTest(properties = ["spring.liquibase.enabled=false"])
-class HankeRepositoryTests @Autowired constructor(
+class HankeRepositoryITests @Autowired constructor(
         val entityManager: TestEntityManager,
         val hankeRepository: HankeRepository) {
 

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeRepositoryITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeRepositoryITests.kt
@@ -14,8 +14,9 @@ class HankeRepositoryITests @Autowired constructor(
     @Test
     fun `findByHankeTunnus returns existing hanke`() {
         // First insert one hanke to the repository:
-        val hankeEntity = HankeEntity(SaveType.AUTO, "ABC-123", null, null, null, "Onni Omistaja", null,
-            false, null, null)
+        val hankeEntity = HankeEntity(SaveType.AUTO, "ABC-123", null, null,
+                null, null, null, false,
+                1, null, null, null, null)
         entityManager.persist(hankeEntity)
         entityManager.flush()
 

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeRepositoryTests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeRepositoryTests.kt
@@ -14,7 +14,7 @@ class HankeRepositoryTests @Autowired constructor(
     @Test
     fun `findByHankeTunnus returns existing hanke`() {
         // First insert one hanke to the repository:
-        val hankeEntity = HankeEntity(SaveType.AUTO, "ABC-123", null, null, "Onni Omistaja", null,
+        val hankeEntity = HankeEntity(SaveType.AUTO, "ABC-123", null, null, null, "Onni Omistaja", null,
             false, null, null)
         entityManager.persist(hankeEntity)
         entityManager.flush()
@@ -23,5 +23,7 @@ class HankeRepositoryTests @Autowired constructor(
         val testResultEntity = hankeRepository.findByHankeTunnus("ABC-123")
         assertThat(testResultEntity).isEqualTo(hankeEntity)
     }
+
+    // TODO: more tests
 
 }

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hello/HelloApiControllerITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hello/HelloApiControllerITests.kt
@@ -1,9 +1,11 @@
 package fi.hel.haitaton.hanke.hello
 
+import fi.hel.haitaton.hanke.HankeService
 import org.hamcrest.Matchers.stringContainsInOrder
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.context.annotation.Import
 import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.MockMvc
@@ -18,6 +20,10 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
 @WebMvcTest
 @Import(fi.hel.haitaton.hanke.Configuration::class)
 class HelloApiControllerITests(@Autowired val mockMvc: MockMvc) {
+
+    // Just to prevent the context trying to init that service, and fail doing it.
+    @MockBean
+    lateinit var hankeService: HankeService
 
     @Test
     fun `Hello response at web layer`() {

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Configuration.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Configuration.kt
@@ -11,10 +11,11 @@ class Configuration {
         return HankeDaoImpl()
     }
 
-    @Bean
-    fun hankeService(dao: HankeDao): HankeService {
-        return HankeServiceImpl(dao)
-    }
+//    @Bean
+//    fun hankeService(dao: HankeDao): HankeService {
+//        return HankeServiceImpl(dao)
+//    }
+
 
     @Bean
     fun hankeGeometriaService(dao: HankeDao): HankeGeometriaService {

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Domain.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Domain.kt
@@ -27,9 +27,9 @@ data class Hanke(
         var vaihe: String?,
 
         var version: Int?,
-        val creatorUserId: String,
+        val createdBy: String,
         val createdAt: ZonedDateTime?,
-        var modifierUserId: String?,
+        var modifiedBy: String?,
         var modifiedAt: ZonedDateTime?,
 
         var saveType: SaveType? = SaveType.SUBMIT // Default for machine API's. UI should always give the save type.

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Domain.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Domain.kt
@@ -11,16 +11,29 @@ Domain classes
 
 
 /**
- * When creating Hanke, only owner is mandatory.
+ * When creating Hanke, only creatorUserId is mandatory.
+ * TODO: may be changing to a bit more of mandatory fields for at least draft saving.
  */
 data class Hanke(
-        var hankeId: String?,
-        var isYKTHanke: Boolean?,
-        var name: String?,
-        var startDate: ZonedDateTime?,
-        var endDate: ZonedDateTime?,
-        val owner: String,
-        var phase: Int?)
+        var id: Int?, // Can be used for e.g. autosaving before hankeTunnus has been given (optional future stuff)
+
+        var hankeTunnus: String?,
+        var onYKTHanke: Boolean?,
+        var nimi: String?,
+        var kuvaus: String?,
+        var alkuPvm: ZonedDateTime?,
+        var loppuPvm: ZonedDateTime?,
+        // TODO: change to enum?
+        var vaihe: String?,
+
+        var version: Int?,
+        val creatorUserId: String,
+        val createdAt: ZonedDateTime?,
+        var modifierUserId: String?,
+        var modifiedAt: ZonedDateTime?,
+
+        var saveType: SaveType? = SaveType.SUBMIT // Default for machine API's. UI should always give the save type.
+)
 
 data class HankeGeometriat(
         var hankeId: String? = null,

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeController.kt
@@ -18,18 +18,18 @@ private val logger = KotlinLogging.logger { }
 class HankeController(@Autowired private val hankeService: HankeService) {
 
     /**
-     * Get one hanke with hankeId.
+     * Get one hanke with hankeTunnus.
      *  TODO: token and user from front?
      *  TODO: validation for input parameter
      *
      */
     @GetMapping
-    fun getHankeById(@RequestParam(name = "hankeId") hankeId: String?): ResponseEntity<Any> {
-        if (hankeId == null) {
+    fun getHankeByTunnus(@RequestParam(name = "hankeId") hankeTunnus: String?): ResponseEntity<Any> {
+        if (hankeTunnus == null) {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(HankeError.HAI1002)
         }
         return try {
-            val hanke = hankeService.loadHanke(hankeId)
+            val hanke = hankeService.loadHanke(hankeTunnus)
             ResponseEntity.status(HttpStatus.OK).body(hanke)
 
         } catch (e: HankeNotFoundException) {
@@ -52,7 +52,6 @@ class HankeController(@Autowired private val hankeService: HankeService) {
      */
     @PostMapping
     fun createHanke(@ValidHanke @RequestBody hanke: Hanke?): ResponseEntity<Any> {
-
         logger.info { "Entering createHanke ${hanke?.toJsonString()}" }
 
         if (hanke == null) {
@@ -64,9 +63,9 @@ class HankeController(@Autowired private val hankeService: HankeService) {
             ResponseEntity.status(HttpStatus.OK).body(createdHanke)
         } catch (e: Exception) {
             logger.error(e) {
-                HankeError.HAI1016.toString()
-            } // TODO: change codes ^ v
-            ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(HankeError.HAI1016)
+                HankeError.HAI1003.toString()
+            }
+            ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(HankeError.HAI1003)
         }
     }
 
@@ -74,11 +73,10 @@ class HankeController(@Autowired private val hankeService: HankeService) {
      * Update one hanke.
      *  TODO: user from front?
      */
-    @PutMapping("/{hankeId}")
-    fun updateHanke(@ValidHanke @RequestBody hanke: Hanke?, @PathVariable hankeId: String?): ResponseEntity<Any> {
-
-        logger.info { "Entering update Hanke $hankeId : ${hanke?.toJsonString()}" }
-        if (hanke == null || hankeId == null) {
+    @PutMapping("/{hankeTunnus}")
+    fun updateHanke(@ValidHanke @RequestBody hanke: Hanke?, @PathVariable hankeTunnus: String?): ResponseEntity<Any> {
+        logger.info { "Entering update Hanke $hankeTunnus : ${hanke?.toJsonString()}" }
+        if (hanke == null || hankeTunnus == null) {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(HankeError.HAI1002)
         }
         return try {

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeController.kt
@@ -25,13 +25,11 @@ class HankeController(@Autowired private val hankeService: HankeService) {
      */
     @GetMapping
     fun getHankeById(@RequestParam(name = "hankeId") hankeId: String?): ResponseEntity<Any> {
-
         if (hankeId == null) {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(HankeError.HAI1002)
         }
         return try {
             val hanke = hankeService.loadHanke(hankeId)
-
             ResponseEntity.status(HttpStatus.OK).body(hanke)
 
         } catch (e: HankeNotFoundException) {
@@ -61,7 +59,15 @@ class HankeController(@Autowired private val hankeService: HankeService) {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(HankeError.HAI1002)
         }
 
-        return saveHanke(hanke)
+        return try {
+            val createdHanke = hankeService.createHanke(hanke)
+            ResponseEntity.status(HttpStatus.OK).body(createdHanke)
+        } catch (e: Exception) {
+            logger.error(e) {
+                HankeError.HAI1016.toString()
+            } // TODO: change codes ^ v
+            ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(HankeError.HAI1016)
+        }
     }
 
     /**
@@ -75,15 +81,8 @@ class HankeController(@Autowired private val hankeService: HankeService) {
         if (hanke == null || hankeId == null) {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(HankeError.HAI1002)
         }
-        return saveHanke(hanke)
-    }
-
-    /**
-     * Helper method for saving and handling errors
-     */
-    private fun saveHanke(hanke: Hanke): ResponseEntity<Any> {
         return try {
-            val createdHanke = hankeService.save(hanke)
+            val createdHanke = hankeService.updateHanke(hanke)
             ResponseEntity.status(HttpStatus.OK).body(createdHanke)
         } catch (e: Exception) {
             logger.error(e) {

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeService.kt
@@ -7,11 +7,8 @@ interface HankeService {
      */
     fun loadHanke(hankeId: String): Hanke?
 
-    /**
-     * Save hanke.
-     *
-     * If hankeId missing that is resolved here and returned back within hanke
-     */
-    fun save(hanke: Hanke): Hanke?
+    fun createHanke(hanke: Hanke): Hanke
+
+    fun updateHanke(hanke: Hanke): Hanke
 
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeServiceImpl.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeServiceImpl.kt
@@ -1,37 +1,80 @@
 package fi.hel.haitaton.hanke
 
 import mu.KotlinLogging
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Service
 import java.time.ZonedDateTime
 
 private val logger = KotlinLogging.logger { }
 
-class HankeServiceImpl(private val dao: HankeDao) : HankeService {
-
-    var index: Int = 12 //TODO: real hankeId generation
+@Service
+class HankeServiceImpl (@Autowired val hankeRepository: HankeRepository) : HankeService {
 
     override fun loadHanke(hankeId: String): Hanke? {
-        // TODO
-        return Hanke("", true, "Hämeentien perusparannus ja katuvalot", ZonedDateTime.now(), ZonedDateTime.now(), "", 1)
+        // TODO: Remove this special case after other stuff works; for testing purposes
+        if (hankeId.equals("SMTGEN_12"))
+            return Hanke("", true, "Hämeentien perusparannus ja katuvalot", ZonedDateTime.now(), ZonedDateTime.now(), "", 1)
+
+        val entity = hankeRepository.findByHankeTunnus(hankeId) ?: throw HankeNotFoundException(hankeId)
+        val hanke = createHankeDomainObjectFromEntity(entity)
+        return hanke
     }
 
-    override fun save(hanke: Hanke): Hanke? {
+    override fun createHanke(hanke: Hanke): Hanke {
+        // TODO: Once we have a proper service for creating hanke-tunnus,
+        // only one save call is needed here. I.e. get a new tunnus, put it into
+        // both the domain object and the entity, save the entity, return
 
-        if (hanke.hankeId.isNullOrEmpty()) {
-            //generate hankeID //TODO: real implementation for hankeid
-            hanke.hankeId = "SMTGEN_" + index++;
-        } else {
-            dao.findHankeByHankeId(hanke.hankeId!!) ?: throw HankeNotFoundException(hanke.hankeId)
-        }
-        logger.info {
-            "Saving  Hanke ${hanke.hankeId}: ${hanke.toJsonString()}"
-        }
-        val hankeEntity = dao.saveHanke(hanke)
-        logger.info {
-            "Saved Hanke ${hanke.hankeId}"
-        }
+        // Create the entity object and save it (first time) to get db-id
+        val entity = HankeEntity()
+        copyNonNullHankeFieldsToEntity(hanke, entity)
+        hankeRepository.save(entity)
+        // TEMPORARY: Get the db-id and create hankeTunnus with it, put it in both objects, save again
+        val id = entity.id
+        val tunnus = "SMTGEN2_$id"
+        entity.hankeTunnus = tunnus
+        hanke.hankeId = tunnus
+        hankeRepository.save(entity) // ... Just to save that hankeTunnus
 
-        //TODO: return mapped Entity data!!
-        return Hanke(hanke.hankeId, true, "Hämeentien perusparannus ja katuvalot tietokannasta", ZonedDateTime.now(), ZonedDateTime.now(), "", 1)
+        return hanke
+    }
+
+    override fun updateHanke(hanke: Hanke): Hanke {
+        if (hanke.hankeId == null)
+            error("Somehow got here with hanke without hanke-tunnus")
+        val entity = hankeRepository.findByHankeTunnus(hanke.hankeId!!) ?: throw HankeNotFoundException(hanke.hankeId)
+        copyNonNullHankeFieldsToEntity(hanke, entity)
+        entity.modifiedAt = ZonedDateTime.now(TZ_UTC).toLocalDateTime() // TODO: check that it is UTC
+        // TODO: modifiedAt to domain once/if domain gets that field
+        hankeRepository.save(entity)
+
+        // TODO: could also just copy all fields from the entity to the existing domain object,
+        // but would need to create that helper method first.
+        return createHankeDomainObjectFromEntity(entity)
+    }
+
+    fun createHankeDomainObjectFromEntity(hankeEntity: HankeEntity): Hanke {
+        // TODO: check if the SQL date things could be converted newer types in the database/mapping,
+        // to avoid these conversions. (Note though that we do not really need the time part.)
+        val h = Hanke(
+                hankeEntity.hankeTunnus,
+                hankeEntity.isYKTHanke,
+                hankeEntity.name,
+                hankeEntity.startDate?.atStartOfDay(TZ_UTC),
+                hankeEntity.endDate?.atStartOfDay(TZ_UTC),
+                hankeEntity.owner ?: "",
+                hankeEntity.phase?.toIntOrNull()
+        )
+        return h
+    }
+
+    fun copyNonNullHankeFieldsToEntity(hanke: Hanke, entity: HankeEntity) {
+        hanke.isYKTHanke?.let { entity.isYKTHanke = hanke.isYKTHanke }
+        hanke.name?.let { entity.name = hanke.name }
+        hanke.startDate?.let { entity.startDate = hanke.startDate?.toLocalDate() }
+        hanke.endDate?.let { entity.endDate = hanke.endDate?.toLocalDate() }
+        entity.owner = hanke.owner
+        hanke.phase?.let { entity.phase = hanke.phase.toString() }
     }
 
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeServiceImpl.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeServiceImpl.kt
@@ -10,71 +10,150 @@ private val logger = KotlinLogging.logger { }
 @Service
 class HankeServiceImpl (@Autowired val hankeRepository: HankeRepository) : HankeService {
 
-    override fun loadHanke(hankeId: String): Hanke? {
-        // TODO: Remove this special case after other stuff works; for testing purposes
-        if (hankeId.equals("SMTGEN_12"))
-            return Hanke("", true, "Hämeentien perusparannus ja katuvalot", ZonedDateTime.now(), ZonedDateTime.now(), "", 1)
+    // TODO:
+    /*
+       - a structure to return a list of references to Hanke and their savetypes (i.e. can contain up to 3 saves for the same hanke)
+       -- there could be all 3 simultaneously, and any combination ...
+       -- UI should show about autosave if (autosave exists and is newer than draft/submit and is different from draft/submit);
+           it should show either a draft or submit, whichever is newest (if there is a draft, it should be newer than submit, since submit deletes drafts and autosaves)
+       - a method to query all hankkeet for a given user..
+            findAllHankeForUser(userId: String): SpecialListOf ...
+       - a method to query the current savestates for given hanke
+           getHankeSaves(hankeId: Long): SpecialListOf ...
+            getHankeSaves(hankeTunnus: String): SpecialListOf ...
 
-        val entity = hankeRepository.findByHankeTunnus(hankeId) ?: throw HankeNotFoundException(hankeId)
-        val hanke = createHankeDomainObjectFromEntity(entity)
-        return hanke
+       - change loadHanke(tunnus) to return latest non-autosave (either draft or submit)
+       - loadHanke(tunnus, savetype)
+       - loadHanke(id, savetype)
+     */
+
+    override fun loadHanke(hankeTunnus: String): Hanke? {
+        // TODO: Remove this special case after other stuff works; for testing purposes
+        if (hankeTunnus.equals("SMTGEN_12"))
+            return Hanke(0, "", true, "Hämeentien perusparannus ja katuvalot", "Lorem ipsum dolor sit amet...",
+                    getCurrentTimeUTC(), getCurrentTimeUTC(), "OHJELMOINTI",
+                    1, "0", getCurrentTimeUTC(), "0", getCurrentTimeUTC(), SaveType.DRAFT)
+
+        // TODO: Find out all savetype matches and return the more recent draft vs. submit.
+        val entity = hankeRepository.findByHankeTunnus(hankeTunnus) ?: throw HankeNotFoundException(hankeTunnus)
+        return createHankeDomainObjectFromEntity(entity)
     }
 
     override fun createHanke(hanke: Hanke): Hanke {
         // TODO: Once we have a proper service for creating hanke-tunnus,
-        // only one save call is needed here. I.e. get a new tunnus, put it into
-        // both the domain object and the entity, save the entity, return
+        //   only one save call is needed here. I.e. get a new tunnus, put it into
+        //   both the domain object and the entity, save the entity, return
+        // TODO: Only create that hanke-tunnus if a specific set of fields are non-empty/set.
+        //   For now, hanke-tunnus is created as soon as this function is called, even for fully empty data.
 
         // Create the entity object and save it (first time) to get db-id
         val entity = HankeEntity()
         copyNonNullHankeFieldsToEntity(hanke, entity)
+        // Special fields; handled "manually".. TODO: see if some framework could handle (some of) these for us automatically
+        entity.version = 0
+        // TODO: will need proper stuff derived from the logged in user.
+        entity.creatorUserId =  1
+        entity.createdAt = getCurrentTimeUTCAsLocalTime()
+        entity.modifierUserId = null
+        entity.modifiedAt = null
+
+        logger.info {
+            // TODO: once the hanke-tunnus gets its own service, this logging line gets more useful
+            //"Saving  Hanke ${hanke.hankeId}: ${hanke.toJsonString()}"
+            "Saving Hanke step 1 for: ${hanke.toJsonString()}"
+        }
         hankeRepository.save(entity)
-        // TEMPORARY: Get the db-id and create hankeTunnus with it, put it in both objects, save again
+        // TODO: For now, get the db-id and create hankeTunnus with it, put it in both objects, save again
         val id = entity.id
         val tunnus = "SMTGEN2_$id"
         entity.hankeTunnus = tunnus
-        hanke.hankeId = tunnus
-        hankeRepository.save(entity) // ... Just to save that hankeTunnus
+        hanke.hankeTunnus = tunnus
+        // TODO: once the hanke-tunnus gets its own service, this logging and the second save becomes obsolete.
+        logger.info {
+            "Saving  Hanke step 2 for: ${hanke.hankeTunnus}"
+        }
+        hankeRepository.save(entity) // ... Just to save that newly created hankeTunnus
+        logger.info {
+            "Saved Hanke ${hanke.hankeTunnus}"
+        }
 
         return hanke
     }
 
     override fun updateHanke(hanke: Hanke): Hanke {
-        if (hanke.hankeId == null)
+        if (hanke.hankeTunnus == null)
             error("Somehow got here with hanke without hanke-tunnus")
-        val entity = hankeRepository.findByHankeTunnus(hanke.hankeId!!) ?: throw HankeNotFoundException(hanke.hankeId)
+
+        val entity = hankeRepository.findByHankeTunnus(hanke.hankeTunnus!!) ?: throw HankeNotFoundException(hanke.hankeTunnus)
         copyNonNullHankeFieldsToEntity(hanke, entity)
-        entity.modifiedAt = ZonedDateTime.now(TZ_UTC).toLocalDateTime() // TODO: check that it is UTC
-        // TODO: modifiedAt to domain once/if domain gets that field
+        // Special fields; handled "manually".. TODO: see if some framework could handle (some of) these for us automatically
+        entity.version = entity.version?.inc() ?: 1
+        // (Not changing creator/time fields.)
+        // TODO: will need proper stuff derived from the logged in user.
+        entity.modifierUserId = 1
+        entity.modifiedAt = getCurrentTimeUTCAsLocalTime()
+
+        logger.info {
+            "Saving  Hanke ${hanke.hankeTunnus}: ${hanke.toJsonString()}"
+        }
         hankeRepository.save(entity)
+        logger.info {
+            "Saved  Hanke ${hanke.hankeTunnus}"
+        }
 
         // TODO: could also just copy all fields from the entity to the existing domain object,
         // but would need to create that helper method first.
         return createHankeDomainObjectFromEntity(entity)
     }
 
+
     fun createHankeDomainObjectFromEntity(hankeEntity: HankeEntity): Hanke {
-        // TODO: check if the SQL date things could be converted newer types in the database/mapping,
+        // TODO: check if the SQL date things could be converted to newer types in the database/mapping,
         // to avoid these conversions. (Note though that we do not really need the time part.)
         val h = Hanke(
+                hankeEntity.id,
+
                 hankeEntity.hankeTunnus,
-                hankeEntity.isYKTHanke,
-                hankeEntity.name,
-                hankeEntity.startDate?.atStartOfDay(TZ_UTC),
-                hankeEntity.endDate?.atStartOfDay(TZ_UTC),
-                hankeEntity.owner ?: "",
-                hankeEntity.phase?.toIntOrNull()
+                hankeEntity.onYKTHanke,
+                hankeEntity.nimi,
+                hankeEntity.kuvaus,
+                hankeEntity.alkuPvm?.atStartOfDay(TZ_UTC),
+                hankeEntity.loppuPvm?.atStartOfDay(TZ_UTC),
+                hankeEntity.vaihe,
+
+                hankeEntity.version,
+                // TODO: will need in future to actually fetch the username from another service.. (or whatever we choose to pass out here)
+                //   Do it below, outside this construction call.
+                hankeEntity.creatorUserId?.toString() ?: "",
+                // From UTC without timezone info to UTC with timezone info
+                if (hankeEntity.createdAt != null) ZonedDateTime.of(hankeEntity.createdAt, TZ_UTC) else null,
+                hankeEntity.modifierUserId?.toString(),
+                if (hankeEntity.modifiedAt != null) ZonedDateTime.of(hankeEntity.modifiedAt, TZ_UTC) else null,
+
+                hankeEntity.saveType
         )
         return h
     }
 
+    /**
+     * Does NOT copy the id and hankeTunnus fields because one is supposed to find
+     * the HankeEntity instance from the database with those values, and after that,
+     * the values are filled by the database and should not be changed.
+     * Also, version, creatorUserId, createdAt, modifierUserId, modifiedAt, version are not
+     * set here, as they are to be set internally, and depends on which operation
+     * is being done.
+     */
     fun copyNonNullHankeFieldsToEntity(hanke: Hanke, entity: HankeEntity) {
-        hanke.isYKTHanke?.let { entity.isYKTHanke = hanke.isYKTHanke }
-        hanke.name?.let { entity.name = hanke.name }
-        hanke.startDate?.let { entity.startDate = hanke.startDate?.toLocalDate() }
-        hanke.endDate?.let { entity.endDate = hanke.endDate?.toLocalDate() }
-        entity.owner = hanke.owner
-        hanke.phase?.let { entity.phase = hanke.phase.toString() }
+        hanke.onYKTHanke?.let { entity.onYKTHanke = hanke.onYKTHanke }
+        hanke.nimi?.let { entity.nimi = hanke.nimi }
+        hanke.kuvaus?.let { entity.kuvaus = hanke.kuvaus }
+        // Assuming the incoming date, while being zoned date and time, is in UTC and time value can be simply dropped here.
+        // Note, .toLocalDate() does not do any time zone conversion.
+        hanke.alkuPvm?.let { entity.alkuPvm = hanke.alkuPvm?.toLocalDate() }
+        hanke.loppuPvm?.let { entity.loppuPvm = hanke.loppuPvm?.toLocalDate() }
+        hanke.vaihe?.let { entity.vaihe = hanke.vaihe }
+
+        hanke.saveType?.let { entity.saveType = hanke.saveType }
     }
 
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Persistence.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Persistence.kt
@@ -1,8 +1,7 @@
 package fi.hel.haitaton.hanke
 
 import org.springframework.data.jpa.repository.JpaRepository
-import java.sql.Date
-import java.sql.Timestamp
+import java.time.LocalDate
 import java.time.LocalDateTime
 import javax.persistence.*
 
@@ -22,18 +21,19 @@ enum class SaveType {
 
 // Build-time plugins will open the class and add no-arg constructor for @Entity classes.
 
-@Entity @Table(name = "Hanke")
+@Entity @Table(name = "hanke")
 class HankeEntity (
     @Enumerated(EnumType.STRING)
     var saveType: SaveType? = null,
     var hankeTunnus: String? = null,
-    var startDate: Date? = null, // TODO: possibly ZonedDateTime, but we don't need the time or timezone...
-    var endDate: Date? = null, // TODO: possibly ZonedDateTime, but we don't need the time or timezone...
+    var name: String? = null,
+    var startDate: LocalDate? = null, // NOTE: stored and handled in UTC, not "local"
+    var endDate: LocalDate? = null, // NOTE: stored and handled in UTC, not "local"
     var owner: String? = null,
-    var phase: String? = null, // TODO: convert to enum, once known, and @Enumerated(EnumType.STRING)
+    var phase: String? = null,
     var isYKTHanke: Boolean? = false,
-    var createdAt: Timestamp? = Timestamp.valueOf(LocalDateTime.now()),
-    var modifiedAt: Timestamp? = Timestamp.valueOf(LocalDateTime.now()),
+    var createdAt: LocalDateTime? = LocalDateTime.now(),
+    var modifiedAt: LocalDateTime? = LocalDateTime.now(),
     // NOTE: using IDENTITY (i.e. db does auto-increments, Hibernate reads the result back)
     // can be a performance problem if there is a need to do bulk inserts.
     // Using SEQUENCE would allow getting multiple ids more efficiently.

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Persistence.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Persistence.kt
@@ -23,28 +23,28 @@ enum class SaveType {
 
 @Entity @Table(name = "hanke")
 class HankeEntity (
-    @Enumerated(EnumType.STRING)
-    var saveType: SaveType? = null,
-    var hankeTunnus: String? = null,
-    var nimi: String? = null,
-    var kuvaus: String? = null,
-    var alkuPvm: LocalDate? = null, // NOTE: stored and handled in UTC, not in "local" time
-    var loppuPvm: LocalDate? = null, // NOTE: stored and handled in UTC, not in "local" time
-    // TODO: change to enum?
-    var vaihe: String? = null,
-    var onYKTHanke: Boolean? = false,
-    var version: Int? = 0,
-    // NOTE: creatorUserId must be non-null for valid data, but to allow creating instances with
-    // no-arg constructor and programming convenience, this class allows it to be null (temporarily).
-    var creatorUserId: Int? = null,
-    var createdAt: LocalDateTime? = null,
-    var modifierUserId: Int? = null,
-    var modifiedAt: LocalDateTime? = null,
-    // NOTE: using IDENTITY (i.e. db does auto-increments, Hibernate reads the result back)
-    // can be a performance problem if there is a need to do bulk inserts.
-    // Using SEQUENCE would allow getting multiple ids more efficiently.
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-    var id: Int? = null
+        @Enumerated(EnumType.STRING)
+        var saveType: SaveType? = null,
+        var hankeTunnus: String? = null,
+        var nimi: String? = null,
+        var kuvaus: String? = null,
+        var alkuPvm: LocalDate? = null, // NOTE: stored and handled in UTC, not in "local" time
+        var loppuPvm: LocalDate? = null, // NOTE: stored and handled in UTC, not in "local" time
+        // TODO: change to enum?
+        var vaihe: String? = null,
+        var onYKTHanke: Boolean? = false,
+        var version: Int? = 0,
+        // NOTE: creatorUserId must be non-null for valid data, but to allow creating instances with
+        // no-arg constructor and programming convenience, this class allows it to be null (temporarily).
+        var createdByUserId: Int? = null,
+        var createdAt: LocalDateTime? = null,
+        var modifiedByUserId: Int? = null,
+        var modifiedAt: LocalDateTime? = null,
+        // NOTE: using IDENTITY (i.e. db does auto-increments, Hibernate reads the result back)
+        // can be a performance problem if there is a need to do bulk inserts.
+        // Using SEQUENCE would allow getting multiple ids more efficiently.
+        @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+        var id: Int? = null
 )
 
 interface HankeRepository : JpaRepository<HankeEntity, Long> {

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Persistence.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Persistence.kt
@@ -26,19 +26,25 @@ class HankeEntity (
     @Enumerated(EnumType.STRING)
     var saveType: SaveType? = null,
     var hankeTunnus: String? = null,
-    var name: String? = null,
-    var startDate: LocalDate? = null, // NOTE: stored and handled in UTC, not "local"
-    var endDate: LocalDate? = null, // NOTE: stored and handled in UTC, not "local"
-    var owner: String? = null,
-    var phase: String? = null,
-    var isYKTHanke: Boolean? = false,
-    var createdAt: LocalDateTime? = LocalDateTime.now(),
-    var modifiedAt: LocalDateTime? = LocalDateTime.now(),
+    var nimi: String? = null,
+    var kuvaus: String? = null,
+    var alkuPvm: LocalDate? = null, // NOTE: stored and handled in UTC, not in "local" time
+    var loppuPvm: LocalDate? = null, // NOTE: stored and handled in UTC, not in "local" time
+    // TODO: change to enum?
+    var vaihe: String? = null,
+    var onYKTHanke: Boolean? = false,
+    var version: Int? = 0,
+    // NOTE: creatorUserId must be non-null for valid data, but to allow creating instances with
+    // no-arg constructor and programming convenience, this class allows it to be null (temporarily).
+    var creatorUserId: Int? = null,
+    var createdAt: LocalDateTime? = null,
+    var modifierUserId: Int? = null,
+    var modifiedAt: LocalDateTime? = null,
     // NOTE: using IDENTITY (i.e. db does auto-increments, Hibernate reads the result back)
     // can be a performance problem if there is a need to do bulk inserts.
     // Using SEQUENCE would allow getting multiple ids more efficiently.
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-    var id: Long? = null
+    var id: Int? = null
 )
 
 interface HankeRepository : JpaRepository<HankeEntity, Long> {

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Utils.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Utils.kt
@@ -1,0 +1,18 @@
+package fi.hel.haitaton.hanke
+
+import java.time.LocalDateTime
+import java.time.ZonedDateTime
+
+/**
+ * Returns the current time in UTC, with time zone info.
+ */
+fun getCurrentTimeUTC(): ZonedDateTime {
+    return ZonedDateTime.now(TZ_UTC)
+}
+
+/**
+ * Returns the current time in UTC, without time zone info (i.e. LocalTime instance).
+ */
+fun getCurrentTimeUTCAsLocalTime(): LocalDateTime {
+    return ZonedDateTime.now(TZ_UTC).toLocalDateTime()
+}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/validation/HankeValidator.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/validation/HankeValidator.kt
@@ -2,7 +2,6 @@ package fi.hel.haitaton.hanke.validation
 
 import fi.hel.haitaton.hanke.Hanke
 import fi.hel.haitaton.hanke.HankeError
-import java.time.ZonedDateTime
 import javax.validation.ConstraintValidator
 import javax.validation.ConstraintValidatorContext
 
@@ -17,13 +16,13 @@ class HankeValidator : ConstraintValidator<ValidHanke, Hanke> {
         }
 
         var ok = true
-        if (hanke.owner.isNullOrBlank()) {
-            context.buildConstraintViolationWithTemplate(HankeError.HAI1002.toString()).addPropertyNode("owner").addConstraintViolation()
+        if (hanke.creatorUserId.isNullOrBlank()) {
+            context.buildConstraintViolationWithTemplate(HankeError.HAI1002.toString()).addPropertyNode("creatorUserId").addConstraintViolation()
             ok = false
         }
         when {
-            hanke.name.isNullOrBlank() -> {
-                context.buildConstraintViolationWithTemplate(HankeError.HAI1002.toString()).addPropertyNode("name").addConstraintViolation()
+            hanke.nimi.isNullOrBlank() -> {
+                context.buildConstraintViolationWithTemplate(HankeError.HAI1002.toString()).addPropertyNode("nimi").addConstraintViolation()
                 ok = false
             }
 /*          hanke.startDate == null -> {  //TODO: these to be added when we are ready to add the mandatory datas to tests
@@ -35,10 +34,12 @@ class HankeValidator : ConstraintValidator<ValidHanke, Hanke> {
                 ok = false
             }
 */
-            hanke.phase!! > 7 -> { //TODO: real phase validation checks when we know what we are passing through
-                context.buildConstraintViolationWithTemplate(HankeError.HAI1002.toString()).addPropertyNode("phase").addConstraintViolation()
-                ok = false
-            }
+            // TODO: real phase validation checks when we know what we are passing through
+            // TODO: no longer a number, but either a string or enum
+//            hanke.vaihe!! > 7 -> {
+//                context.buildConstraintViolationWithTemplate(HankeError.HAI1002.toString()).addPropertyNode("vaihe").addConstraintViolation()
+//                ok = false
+//            }
         }
         return ok
     }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/validation/HankeValidator.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/validation/HankeValidator.kt
@@ -16,7 +16,7 @@ class HankeValidator : ConstraintValidator<ValidHanke, Hanke> {
         }
 
         var ok = true
-        if (hanke.creatorUserId.isNullOrBlank()) {
+        if (hanke.createdBy.isNullOrBlank()) {
             context.buildConstraintViolationWithTemplate(HankeError.HAI1002.toString()).addPropertyNode("creatorUserId").addConstraintViolation()
             ok = false
         }
@@ -25,12 +25,12 @@ class HankeValidator : ConstraintValidator<ValidHanke, Hanke> {
                 context.buildConstraintViolationWithTemplate(HankeError.HAI1002.toString()).addPropertyNode("nimi").addConstraintViolation()
                 ok = false
             }
-/*          hanke.startDate == null -> {  //TODO: these to be added when we are ready to add the mandatory datas to tests
-                context.buildConstraintViolationWithTemplate(HankeError.HAI1002.toString()).addPropertyNode("startDate").addConstraintViolation()
+/*          hanke.alkuPvm == null -> {  //TODO: these to be added when we are ready to add the mandatory datas to tests
+                context.buildConstraintViolationWithTemplate(HankeError.HAI1002.toString()).addPropertyNode("alkuPvm").addConstraintViolation()
                 ok = false
             }
-            hanke.endDate == null -> {
-                context.buildConstraintViolationWithTemplate(HankeError.HAI1002.toString()).addPropertyNode("endDate").addConstraintViolation()
+            hanke.loppuPvm == null -> {
+                context.buildConstraintViolationWithTemplate(HankeError.HAI1002.toString()).addPropertyNode("loppuPvm").addConstraintViolation()
                 ok = false
             }
 */

--- a/services/hanke-service/src/main/resources/application.properties
+++ b/services/hanke-service/src/main/resources/application.properties
@@ -11,6 +11,7 @@ spring.datasource.password=${HAITATON_PASSWORD:haitaton}
 
 # JPA
 # This makes the database field names to match the entity member names
+spring.jpa.database-platform=org.hibernate.dialect.PostgreSQL94Dialect
 spring.jpa.hibernate.naming.physical-strategy=org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
 
 # Spring Boot Actuator Management for Kubernetes (see https://docs.spring.io/spring-boot/docs/2.3.4.RELEASE/reference/html/production-ready-features.html#production-ready-kubernetes-probes)

--- a/services/hanke-service/src/main/resources/application.properties
+++ b/services/hanke-service/src/main/resources/application.properties
@@ -10,8 +10,8 @@ spring.datasource.username=${HAITATON_USER:haitaton_user}
 spring.datasource.password=${HAITATON_PASSWORD:haitaton}
 
 # JPA
-# This makes the database field names to match the entity member names
 spring.jpa.database-platform=org.hibernate.dialect.PostgreSQL94Dialect
+# This makes the database field names to match the entity member names
 spring.jpa.hibernate.naming.physical-strategy=org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
 
 # Spring Boot Actuator Management for Kubernetes (see https://docs.spring.io/spring-boot/docs/2.3.4.RELEASE/reference/html/production-ready-features.html#production-ready-kubernetes-probes)

--- a/services/hanke-service/src/main/resources/db/changelog/changesets/create-initial-tables.yml
+++ b/services/hanke-service/src/main/resources/db/changelog/changesets/create-initial-tables.yml
@@ -5,25 +5,26 @@ databaseChangeLog:
       author: Markku Hassinen
       changes:
         - createTable:
-            tableName: Hanke
+            tableName: hanke
             columns:
               - column: { name: id, type: int, autoIncrement: true, constraints: { primaryKey: true, nullable: false }}
-              - column: { name: saveType, type: varchar(10) }
+              - column: { name: savetype, type: varchar(10) }
               # This column is split on multiple lines just to show the different formatting styles.
               # "hankeTunnus" (and not "hankeID") in order to reserve the hankeID for referencing back
               # to this table's "ID" field.
               - column:
-                  name: hankeTunnus
+                  name: hanketunnus
                   type: varchar(15)
                   constraints:
                     unique: true
-              - column: { name: startDate, type: date }
-              - column: { name: endDate, type: date }
+              - column: { name: name, type: varchar(100) }
+              - column: { name: startdate, type: date }
+              - column: { name: enddate, type: date }
               - column: { name: owner, type: varchar(100) }
               - column: { name: phase, type: varchar(30) }
-              - column: { name: isYKTHanke, type: boolean }
-              - column: { name: createdAt, type: timestamp }
-              - column: { name: modifiedAt, type: timestamp }
+              - column: { name: isykthanke, type: boolean }
+              - column: { name: createdat, type: timestamp }
+              - column: { name: modifiedat, type: timestamp }
               # Things to consider:
               # * the saving of draft states (SaveType can show the draft-state, but not e.g. the user, in case edit locking is not in effect/use)
               # * saving the user who created and user who modified. However, latter is bad design,

--- a/services/hanke-service/src/main/resources/db/changelog/changesets/create-initial-tables.yml
+++ b/services/hanke-service/src/main/resources/db/changelog/changesets/create-initial-tables.yml
@@ -10,23 +10,19 @@ databaseChangeLog:
               - column: { name: id, type: int, autoIncrement: true, constraints: { primaryKey: true, nullable: false }}
               - column: { name: savetype, type: varchar(10) }
               # This column is split on multiple lines just to show the different formatting styles.
-              # "hankeTunnus" (and not "hankeID") in order to reserve the hankeID for referencing back
-              # to this table's "ID" field.
               - column:
                   name: hanketunnus
                   type: varchar(15)
                   constraints:
                     unique: true
-              - column: { name: name, type: varchar(100) }
-              - column: { name: startdate, type: date }
-              - column: { name: enddate, type: date }
-              - column: { name: owner, type: varchar(100) }
-              - column: { name: phase, type: varchar(30) }
-              - column: { name: isykthanke, type: boolean }
+              - column: { name: nimi, type: varchar(100) }
+              - column: { name: kuvaus, type: clob }
+              - column: { name: alkupaiva, type: date }
+              - column: { name: loppupaiva, type: date }
+              - column: { name: vaihe, type: varchar(30) }
+              - column: { name: onykthanke, type: boolean }
+              - column: { name: version, type: int }
+              - column: { name: creatoruserid, type: int } # Is pseudonymized personal info if access to rest of the data is restricted
               - column: { name: createdat, type: timestamp }
+              - column: { name: modifieruserid, type: int } # Is pseudonymized personal info if access to rest of the data is restricted
               - column: { name: modifiedat, type: timestamp }
-              # Things to consider:
-              # * the saving of draft states (SaveType can show the draft-state, but not e.g. the user, in case edit locking is not in effect/use)
-              # * saving the user who created and user who modified. However, latter is bad design,
-              #   as a single change will override previous user info; proper audit logging might be
-              #   better solution, and thus having the modification info with that..

--- a/services/hanke-service/src/main/resources/db/changelog/changesets/create-initial-tables.yml
+++ b/services/hanke-service/src/main/resources/db/changelog/changesets/create-initial-tables.yml
@@ -17,12 +17,12 @@ databaseChangeLog:
                     unique: true
               - column: { name: nimi, type: varchar(100) }
               - column: { name: kuvaus, type: clob }
-              - column: { name: alkupaiva, type: date }
-              - column: { name: loppupaiva, type: date }
+              - column: { name: alkupvm, type: date }
+              - column: { name: loppupvm, type: date }
               - column: { name: vaihe, type: varchar(30) }
               - column: { name: onykthanke, type: boolean }
               - column: { name: version, type: int }
-              - column: { name: creatoruserid, type: int } # Is pseudonymized personal info if access to rest of the data is restricted
+              - column: { name: createdbyuserid, type: int } # Is pseudonymized personal info if access to rest of the data is restricted
               - column: { name: createdat, type: timestamp }
-              - column: { name: modifieruserid, type: int } # Is pseudonymized personal info if access to rest of the data is restricted
+              - column: { name: modifiedbyuserid, type: int } # Is pseudonymized personal info if access to rest of the data is restricted
               - column: { name: modifiedat, type: timestamp }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/HankeControllerTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/HankeControllerTest.kt
@@ -58,7 +58,7 @@ class HankeControllerTest {
 
         var partialHanke = Hanke(hankeId = "id123", name = "hankkeen nimi", isYKTHanke = false, startDate = null, endDate = null, owner = "Tiina", phase = 0)
         //mock HankeService response
-        Mockito.`when`(hankeService.save(partialHanke)).thenReturn(partialHanke)
+        Mockito.`when`(hankeService.updateHanke(partialHanke)).thenReturn(partialHanke)
 
         //Actual call
         val response: ResponseEntity<Any> = hankeController.updateHanke(partialHanke, "id123")

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/HankeControllerTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/HankeControllerTest.kt
@@ -60,7 +60,7 @@ class HankeControllerTest {
         var partialHanke = Hanke(id = 123, hankeTunnus = "id123",
                 nimi = "hankkeen nimi", kuvaus = "lorem ipsum dolor sit amet...", onYKTHanke = false,
                 alkuPvm = null, loppuPvm = null, vaihe = "OHJELMOINTI",
-                version = 1, creatorUserId = "Tiina", createdAt = getCurrentTimeUTC(), modifierUserId = null, modifiedAt = null, saveType = SaveType.DRAFT)
+                version = 1, createdBy = "Tiina", createdAt = getCurrentTimeUTC(), modifiedBy = null, modifiedAt = null, saveType = SaveType.DRAFT)
         // mock HankeService response
         Mockito.`when`(hankeService.updateHanke(partialHanke)).thenReturn(partialHanke)
 
@@ -79,7 +79,7 @@ class HankeControllerTest {
     fun `test that the updateHanke will give validation errors from invalid hanke data for creatorUserId and name`() {
         var partialHanke = Hanke(id = 0, hankeTunnus = "id123", nimi = "", kuvaus = "", onYKTHanke = false,
                 alkuPvm = null, loppuPvm = null, vaihe = "",
-                version = 1, creatorUserId = "", createdAt = null, modifierUserId = null, modifiedAt = null, saveType = SaveType.DRAFT)
+                version = 1, createdBy = "", createdAt = null, modifiedBy = null, modifiedAt = null, saveType = SaveType.DRAFT)
         // mock HankeService response
         Mockito.`when`(hankeService.updateHanke(partialHanke)).thenReturn(partialHanke)
 

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/HankeControllerTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/HankeControllerTest.kt
@@ -1,7 +1,6 @@
 package fi.hel.haitaton.hanke
 
 import org.assertj.core.api.Assertions
-import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mockito
@@ -33,7 +32,7 @@ class HankeControllerTest {
         fun hankeController(hankeService: HankeService): HankeController = HankeController(hankeService)
     }
 
-    private val mockedHankeId = "AFC1234"
+    private val mockedHankeTunnus = "AFC1234"
 
     @Autowired
     private lateinit var hankeService: HankeService
@@ -42,46 +41,52 @@ class HankeControllerTest {
     private lateinit var hankeController: HankeController
 
     @Test
-    fun `test that the getHankebyId returns ok`() {
-        Mockito.`when`(hankeService.loadHanke(mockedHankeId))
-                .thenReturn(fi.hel.haitaton.hanke.Hanke(mockedHankeId, true, "Mannerheimintien remontti remonttinen", java.time.ZonedDateTime.now(), java.time.ZonedDateTime.now(), "Risto", 1))
+    fun `test that the getHankebyTunnus returns ok`() {
+        Mockito.`when`(hankeService.loadHanke(mockedHankeTunnus))
+                .thenReturn(Hanke(1234, mockedHankeTunnus, true,
+                        "Mannerheimintien remontti remonttinen", "Lorem ipsum dolor sit amet...",
+                        getCurrentTimeUTC(), getCurrentTimeUTC(), "OHJELMOINTI",
+                        1,"Risto", getCurrentTimeUTC(), null, null, SaveType.DRAFT))
 
-        val response: ResponseEntity<Any> = hankeController.getHankeById(mockedHankeId)
+        val response: ResponseEntity<Any> = hankeController.getHankeByTunnus(mockedHankeTunnus)
 
         Assertions.assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
         Assertions.assertThat(response.body).isNotNull
-        Assertions.assertThat((response.body as Hanke).name).isNotEmpty()
+        Assertions.assertThat((response.body as Hanke).nimi).isNotEmpty()
     }
 
     @Test
     fun `test that the updateHanke can be called with partial hanke data`() {
-
-        var partialHanke = Hanke(hankeId = "id123", name = "hankkeen nimi", isYKTHanke = false, startDate = null, endDate = null, owner = "Tiina", phase = 0)
-        //mock HankeService response
+        var partialHanke = Hanke(id = 123, hankeTunnus = "id123",
+                nimi = "hankkeen nimi", kuvaus = "lorem ipsum dolor sit amet...", onYKTHanke = false,
+                alkuPvm = null, loppuPvm = null, vaihe = "OHJELMOINTI",
+                version = 1, creatorUserId = "Tiina", createdAt = getCurrentTimeUTC(), modifierUserId = null, modifiedAt = null, saveType = SaveType.DRAFT)
+        // mock HankeService response
         Mockito.`when`(hankeService.updateHanke(partialHanke)).thenReturn(partialHanke)
 
-        //Actual call
+        // Actual call
         val response: ResponseEntity<Any> = hankeController.updateHanke(partialHanke, "id123")
 
         Assertions.assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
         Assertions.assertThat(response.body).isNotNull
         var responseHanke = response as ResponseEntity<Hanke>
         Assertions.assertThat(responseHanke.body).isNotNull
-        Assertions.assertThat(responseHanke.body?.name).isEqualTo("hankkeen nimi")
+        Assertions.assertThat(responseHanke.body?.nimi).isEqualTo("hankkeen nimi")
     }
 
 
     @Test
-    fun `test that the updateHanke will give validation errors from invalid hanke data for owner and name`() {
+    fun `test that the updateHanke will give validation errors from invalid hanke data for creatorUserId and name`() {
+        var partialHanke = Hanke(id = 0, hankeTunnus = "id123", nimi = "", kuvaus = "", onYKTHanke = false,
+                alkuPvm = null, loppuPvm = null, vaihe = "",
+                version = 1, creatorUserId = "", createdAt = null, modifierUserId = null, modifiedAt = null, saveType = SaveType.DRAFT)
+        // mock HankeService response
+        Mockito.`when`(hankeService.updateHanke(partialHanke)).thenReturn(partialHanke)
 
-        var partialHanke = Hanke(hankeId = "id123", name = "", isYKTHanke = false, startDate = null, endDate = null, owner = "", phase = 0)
-        //mock HankeService response
-        Mockito.`when`(hankeService.save(partialHanke)).thenReturn(partialHanke)
-
-        //Actual call
+        // Actual call
         Assertions.assertThatExceptionOfType(ConstraintViolationException::class.java).isThrownBy {
             hankeController.updateHanke(partialHanke, "id123")
-        }.withMessageContaining("updateHanke.hanke.name: "+HankeError.HAI1002.toString()).withMessageContaining("updateHanke.hanke.owner: "+HankeError.HAI1002.toString())
+        }.withMessageContaining("updateHanke.hanke.nimi: "+HankeError.HAI1002.toString()).withMessageContaining("updateHanke.hanke.creatorUserId: "+HankeError.HAI1002.toString())
 
     }
 


### PR DESCRIPTION
# Description

Adding Liquibase master file, first changeset, JPA/Hibernate based entity and mappings to database fields, proper HankeService implementation, and changes to controllers and tests to accommodate these changes. Covers the first page data, and some meta-data for Hanke.

## Jira Issue:
HAI-61
HAI-202

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Other

# Instructions for testing

See README.md how to build with unit and integration tests.
The swagger UI can be used to test and investigate the API (if the service and database is running).

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
    or other location:
https://helsinkisolutionoffice.atlassian.net/wiki/spaces/HAI/pages/981696609/Hanke+API+UI+lle
https://helsinkisolutionoffice.atlassian.net/wiki/spaces/HAI/pages/939262392/Hanke

# Other relevant info

API change: Most field/parameter names were changed (to Finnish), and many new fields have been added. The requests for saving/submitting Hanke data must now always contain also the "saveType"-field, with value "DRAFT" or "SUBMIT". (If not given, the default is submit..)

The xxxUserId-fields' values are ignored/ignorable for now.

When saving the data, fields id, version, creatorUserId, createdAt, modifierUserId, modifiedAt are (or will be) all ignored, because their values are (or will be) set internally. HankeTunnus is also created internally, and can not be changed.

Example response:
```
{
  "id": 1,
  "hankeTunnus": "SMTGEN2_1",
  "onYKTHanke": true,
  "nimi": "Ai hurja ai hurja - tosi hurja",
  "kuvaus": "Hurjaa testausta 100m kuopassa",
  "alkuPaiva": "2020-11-19T00:00:00Z",
  "loppuPaiva": "2020-11-25T00:00:00Z",
  "vaihe": "OHJELMOINTI",
  "version": 1,
  "creatorUserId": "1",
  "createdAt": "2020-11-19T13:50:21.480629Z",
  "modifierUserId": "1",
  "modifiedAt": "2020-11-19T14:06:01.9577229Z",
  "saveType": "DRAFT"
}
```