### PR TITLE
HAI-161 added suunnitteluVaihe, renamed changeset and ...

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeControllerITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeControllerITests.kt
@@ -43,9 +43,9 @@ class HankeControllerITests(@Autowired val mockMvc: MockMvc) {
     @Test
     fun `When hankeTunnus is given then return Hanke with it (GET)`() {
 
-        //faking the service call
+        // faking the service call
         every { hankeService.loadHanke(any()) }.returns(Hanke(123, mockedHankeTunnus, true, "Hämeentien perusparannus ja katuvalot", "lorem ipsum dolor sit amet...",
-                getCurrentTimeUTC(), getCurrentTimeUTC(), Vaihe.OHJELMOINTI,
+                getCurrentTimeUTC(), getCurrentTimeUTC(), Vaihe.OHJELMOINTI, null,
                 1, "Risto", getCurrentTimeUTC(), null, null, SaveType.DRAFT))
 
         mockMvc.perform(get("/hankkeet/" + mockedHankeTunnus).accept(MediaType.APPLICATION_JSON))
@@ -63,10 +63,10 @@ class HankeControllerITests(@Autowired val mockMvc: MockMvc) {
         val hankeName = "Mannerheimintien remontti remonttinen"
 
         var hankeToBeMocked = Hanke(id = null, hankeTunnus = null, nimi = hankeName, kuvaus = "lorem ipsum dolor sit amet...",
-                onYKTHanke = false, alkuPvm = getCurrentTimeUTC(), loppuPvm = getCurrentTimeUTC(), vaihe = Vaihe.OHJELMOINTI,
+                onYKTHanke = false, alkuPvm = getCurrentTimeUTC(), loppuPvm = getCurrentTimeUTC(), vaihe = Vaihe.OHJELMOINTI, suunnitteluVaihe = null,
                 version = null, createdBy = "Tiina", createdAt = null, modifiedBy = null, modifiedAt = null, saveType = SaveType.DRAFT)
 
-        //faking the service call
+        // faking the service call
         every { hankeService.createHanke(any()) }.returns(hankeToBeMocked)
 
         val content = hankeToBeMocked.toJsonString()
@@ -82,7 +82,7 @@ class HankeControllerITests(@Autowired val mockMvc: MockMvc) {
                 .andExpect(jsonPath("$.hankeTunnus").value(mockedHankeTunnus))
         verify { hankeService.createHanke(any()) }
 
-        //TODO: Should we make sure that the hankeId is returned?
+        // TODO: Should we make sure that the hankeId is returned?
     }
 
     @Test
@@ -92,10 +92,10 @@ class HankeControllerITests(@Autowired val mockMvc: MockMvc) {
 
         // initializing only part of the data for Hanke
         val hankeToBeUpdated = Hanke(id = 23, hankeTunnus = "idHankkeelle123", nimi = hankeName, kuvaus = "kuvaus",
-                onYKTHanke = false, alkuPvm = getCurrentTimeUTC(), loppuPvm = getCurrentTimeUTC(), vaihe = Vaihe.OHJELMOINTI,
+                onYKTHanke = false, alkuPvm = getCurrentTimeUTC(), loppuPvm = getCurrentTimeUTC(), vaihe = Vaihe.OHJELMOINTI, suunnitteluVaihe = null,
                 version = null, createdBy = "Tiina", createdAt = null, modifiedBy = null, modifiedAt = null, saveType = SaveType.DRAFT)
 
-        //faking the service call
+        // faking the service call
         every { hankeService.updateHanke(any()) }.returns(hankeToBeUpdated)
 
         val content = hankeToBeUpdated.toJsonString()
@@ -113,7 +113,7 @@ class HankeControllerITests(@Autowired val mockMvc: MockMvc) {
     @Test
     fun `test that the validation gives error and Bad Request is returned when creatorUserId is empty`() {
         var hankeToBeAdded = Hanke(id = null, hankeTunnus = "idHankkeelle123", nimi = "", kuvaus = null,
-                onYKTHanke = false, alkuPvm = null, loppuPvm = null, vaihe = Vaihe.RAKENTAMINEN,
+                onYKTHanke = false, alkuPvm = null, loppuPvm = null, vaihe = Vaihe.RAKENTAMINEN, suunnitteluVaihe = null,
                 version = null, createdBy = "", createdAt = null, modifiedBy = null, modifiedAt = null, saveType = SaveType.DRAFT)
 
         every { hankeService.createHanke(any()) }.returns(hankeToBeAdded)

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeRepositoryITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeRepositoryITests.kt
@@ -15,7 +15,7 @@ class HankeRepositoryITests @Autowired constructor(
     fun `findByHankeTunnus returns existing hanke`() {
         // First insert one hanke to the repository:
         val hankeEntity = HankeEntity(SaveType.AUTO, "ABC-123", null, null,
-                null, null, null, false,
+                null, null, null, null, false,
                 1, null, null, null, null)
         entityManager.persist(hankeEntity)
         entityManager.flush()

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeServiceImpl.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeServiceImpl.kt
@@ -35,7 +35,7 @@ class HankeServiceImpl (@Autowired val hankeRepository: HankeRepository) : Hanke
         // TODO: Remove this special case after other stuff works; for testing purposes
         if (hankeTunnus.equals("SMTGEN_12"))
             return Hanke(0, "", true, "Hämeentien perusparannus ja katuvalot", "Lorem ipsum dolor sit amet...",
-                    getCurrentTimeUTC(), getCurrentTimeUTC(), Vaihe.OHJELMOINTI,
+                    getCurrentTimeUTC(), getCurrentTimeUTC(), Vaihe.OHJELMOINTI, null,
                     1, "0", getCurrentTimeUTC(), "0", getCurrentTimeUTC(), SaveType.DRAFT)
 
         // TODO: Find out all savetype matches and return the more recent draft vs. submit.
@@ -128,6 +128,7 @@ class HankeServiceImpl (@Autowired val hankeRepository: HankeRepository) : Hanke
                     hankeEntity.alkuPvm?.atStartOfDay(TZ_UTC),
                     hankeEntity.loppuPvm?.atStartOfDay(TZ_UTC),
                     hankeEntity.vaihe,
+                    hankeEntity.suunnitteluVaihe,
 
                     hankeEntity.version,
                     // TODO: will need in future to actually fetch the username from another service.. (or whatever we choose to pass out here)
@@ -160,6 +161,7 @@ class HankeServiceImpl (@Autowired val hankeRepository: HankeRepository) : Hanke
             hanke.alkuPvm?.let { entity.alkuPvm = hanke.alkuPvm?.toLocalDate() }
             hanke.loppuPvm?.let { entity.loppuPvm = hanke.loppuPvm?.toLocalDate() }
             hanke.vaihe?.let { entity.vaihe = hanke.vaihe }
+            hanke.suunnitteluVaihe?.let { entity.suunnitteluVaihe = hanke.suunnitteluVaihe }
 
             hanke.saveType?.let { entity.saveType = hanke.saveType }
         }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Persistence.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Persistence.kt
@@ -25,6 +25,13 @@ enum class Vaihe {
     RAKENTAMINEN
 }
 
+enum class SuunnitteluVaihe {
+    YLEIS_TAI_HANKE,
+    KATUSUUNNITTELU_TAI_ALUEVARAUS,
+    RAKENNUS_TAI_TOTEUTUS,
+    TYOMAAN_TAI_HANKKEEN_AIKAINEN
+}
+
 // Build-time plugins will open the class and add no-arg constructor for @Entity classes.
 
 @Entity @Table(name = "hanke")
@@ -38,6 +45,7 @@ class HankeEntity (
         var loppuPvm: LocalDate? = null, // NOTE: stored and handled in UTC, not in "local" time
         @Enumerated(EnumType.STRING)
         var vaihe: Vaihe? = null,
+        var suunnitteluVaihe: SuunnitteluVaihe? = null,
         var onYKTHanke: Boolean? = false,
         var version: Int? = 0,
         // NOTE: creatorUserId must be non-null for valid data, but to allow creating instances with

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/Hanke.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/Hanke.kt
@@ -1,6 +1,7 @@
 package fi.hel.haitaton.hanke.domain
 
 import fi.hel.haitaton.hanke.SaveType
+import fi.hel.haitaton.hanke.SuunnitteluVaihe
 import fi.hel.haitaton.hanke.Vaihe
 import java.time.ZonedDateTime
 
@@ -19,6 +20,7 @@ data class Hanke(
         var alkuPvm: ZonedDateTime?,
         var loppuPvm: ZonedDateTime?,
         var vaihe: Vaihe?,
+        var suunnitteluVaihe: SuunnitteluVaihe?,
 
         var version: Int?,
         val createdBy: String,

--- a/services/hanke-service/src/main/resources/application.properties
+++ b/services/hanke-service/src/main/resources/application.properties
@@ -1,6 +1,6 @@
 # To be removed once everything tested to run smooth without these. (Note, these were used
 # in DbConfigProperties.kt)
-#app.datasource.url=jdbc:postgresql://${HAITATON_HOST:localhost}:${HAITATON_PORT:5432}/haitaton
+#app.datasource.url=jdbc:postgresql://${HAITATON_HOST:localhost}:${HAITATON_PORT:5432}/${HAITATON_DATABASE:haitaton}
 #app.datasource.username=${HAITATON_USER:haitaton_user}
 #app.datasource.password=${HAITATON_PASSWORD:haitaton}
 #spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
@@ -28,7 +28,7 @@ server.forward-headers-strategy=FRAMEWORK
 # be able to use the (primary) data source of Spring Boot directly.
 # TODO: If testing will at some point need database "haitaton_test", that will need to handled
 # with e.g. Spring profiles
-spring.liquibase.url=jdbc:postgresql://${HAITATON_HOST:localhost}:${HAITATON_PORT:5432}/haitaton
-spring.liquibase.user=haitaton_user
-spring.liquibase.password=haitaton
+spring.liquibase.url=jdbc:postgresql://${HAITATON_HOST:localhost}:${HAITATON_PORT:5432}/${HAITATON_DATABASE:haitaton}
+spring.liquibase.user=${HAITATON_USER:haitaton_user}
+spring.liquibase.password=${HAITATON_PASSWORD:haitaton}
 logging.level.liquibase = INFO

--- a/services/hanke-service/src/main/resources/db/changelog/changesets/create-initial-hanke-table.yml
+++ b/services/hanke-service/src/main/resources/db/changelog/changesets/create-initial-hanke-table.yml
@@ -1,28 +1,34 @@
 databaseChangeLog:
   - changeSet:
-      id: create-initial-tables
-      comment: Create initial tables
+      id: create-initial-hanke-table
+      comment: Create hanke table with initial fields
       author: Markku Hassinen
       changes:
         - createTable:
             tableName: hanke
             columns:
-              - column: { name: id, type: int, autoIncrement: true, constraints: { primaryKey: true, nullable: false }}
-              - column: { name: savetype, type: varchar(10) }
               # This column is split on multiple lines just to show the different formatting styles.
               - column:
-                  name: hanketunnus
-                  type: varchar(15)
+                  name: id
+                  type: int
+                  autoIncrement: true
                   constraints:
-                    unique: true
+                    primaryKey: true
+                    nullable: false
+              - column: { name: savetype, type: varchar(10) }
+              - column: { name: hanketunnus, type: varchar(15) }
               - column: { name: nimi, type: varchar(100) }
               - column: { name: kuvaus, type: clob }
               - column: { name: alkupvm, type: date }
               - column: { name: loppupvm, type: date }
               - column: { name: vaihe, type: varchar(30) }
+              - column: { name: suunnitteluvaihe, type: varchar(40) }
               - column: { name: onykthanke, type: boolean }
               - column: { name: version, type: int }
               - column: { name: createdbyuserid, type: int } # Is pseudonymized personal info if access to rest of the data is restricted
               - column: { name: createdat, type: timestamp }
               - column: { name: modifiedbyuserid, type: int } # Is pseudonymized personal info if access to rest of the data is restricted
               - column: { name: modifiedat, type: timestamp }
+        - addUniqueConstraint:
+            tableName: hanke
+            columnNames: savetype, hanketunnus

--- a/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,3 +1,3 @@
 databaseChangeLog:
   - include:
-      file: db/changelog/changesets/create-initial-tables.yml
+      file: db/changelog/changesets/create-initial-hanke-table.yml

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/HankeControllerTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/HankeControllerTest.kt
@@ -14,7 +14,6 @@ import org.springframework.http.ResponseEntity
 import org.springframework.test.context.junit.jupiter.SpringExtension
 import org.springframework.validation.beanvalidation.MethodValidationPostProcessor
 import org.springframework.context.annotation.Configuration
-import java.time.ZonedDateTime
 import javax.validation.ConstraintViolationException
 
 @ExtendWith(SpringExtension::class)
@@ -48,7 +47,7 @@ class HankeControllerTest {
         Mockito.`when`(hankeService.loadHanke(mockedHankeTunnus))
                 .thenReturn(Hanke(1234, mockedHankeTunnus, true,
                         "Mannerheimintien remontti remonttinen", "Lorem ipsum dolor sit amet...",
-                        getCurrentTimeUTC(), getCurrentTimeUTC(), Vaihe.OHJELMOINTI,
+                        getCurrentTimeUTC(), getCurrentTimeUTC(), Vaihe.OHJELMOINTI, null,
                         1, "Risto", getCurrentTimeUTC(), null, null, SaveType.DRAFT))
 
         val response: ResponseEntity<Any> = hankeController.getHankeByTunnus(mockedHankeTunnus)
@@ -62,7 +61,7 @@ class HankeControllerTest {
     fun `test that the updateHanke can be called with hanke data and response will be 200`() {
         var partialHanke = Hanke(id = 123, hankeTunnus = "id123",
                 nimi = "hankkeen nimi", kuvaus = "lorem ipsum dolor sit amet...", onYKTHanke = false,
-                alkuPvm = getCurrentTimeUTC(), loppuPvm = getCurrentTimeUTC(), vaihe = Vaihe.OHJELMOINTI,
+                alkuPvm = getCurrentTimeUTC(), loppuPvm = getCurrentTimeUTC(), vaihe = Vaihe.OHJELMOINTI, suunnitteluVaihe = null,
                 version = 1, createdBy = "Tiina", createdAt = getCurrentTimeUTC(), modifiedBy = null, modifiedAt = null, saveType = SaveType.DRAFT)
 
         // mock HankeService response
@@ -82,7 +81,7 @@ class HankeControllerTest {
     @Test
     fun `test that the updateHanke will give validation errors from invalid hanke data for createdBy and name`() {
         var partialHanke = Hanke(id = 0, hankeTunnus = "id123", nimi = "", kuvaus = "", onYKTHanke = false,
-                alkuPvm = null, loppuPvm = null, vaihe = Vaihe.OHJELMOINTI,
+                alkuPvm = null, loppuPvm = null, vaihe = Vaihe.OHJELMOINTI, suunnitteluVaihe = null,
                 version = 1, createdBy = "", createdAt = null, modifiedBy = null, modifiedAt = null, saveType = SaveType.DRAFT)
         // mock HankeService response
         Mockito.`when`(hankeService.updateHanke(partialHanke)).thenReturn(partialHanke)
@@ -95,14 +94,14 @@ class HankeControllerTest {
 
     }
 
-    //sending of sub types
+    // sending of sub types
 /* in the construction
 
     @Test
     fun `test that update with listOfOmistaja can be sent to controller and is responded with 200`() {
         var partialHanke = Hanke(id = 123, hankeTunnus = "id123",
                 nimi = "hankkeen nimi", kuvaus = "lorem ipsum dolor sit amet...", onYKTHanke = false,
-                alkuPvm = getCurrentTimeUTC(), loppuPvm = getCurrentTimeUTC(), vaihe = Vaihe.OHJELMOINTI,
+                alkuPvm = getCurrentTimeUTC(), loppuPvm = getCurrentTimeUTC(), vaihe = Vaihe.OHJELMOINTI, suunnitteluVaihe = null,
                 version = 1, createdBy = "Tiina", createdAt = getCurrentTimeUTC(), modifiedBy = null, modifiedAt = null, saveType = SaveType.DRAFT)
 
         // mock HankeService response


### PR DESCRIPTION
… changed unique constraint from just hanketunnus to the pair of hanketunnus and savetype.

The change of the unique constraint to pair allows storing multiple different save states simultaneously.

Has been tested (including integrationTest, a liquibase run, and with swagger POST and GET).
Documentation updated.

TODO: the suunnitteluVaihe-field is not validated (it must be given if vaihe is "SUUNNITTELU").