### PR TITLE
HAI-247 added fields tyomaaKatuosoite, tyomaaTyyppi and tyomaaKoko

### DIFF
--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeService.kt
@@ -5,9 +5,9 @@ import fi.hel.haitaton.hanke.domain.Hanke
 interface HankeService {
 
     /**
-     * Fetch hanke with hankeId
+     * Fetch hanke with hankeTunnus
      */
-    fun loadHanke(hankeId: String): Hanke?
+    fun loadHanke(hankeTunnus: String): Hanke?
 
     fun createHanke(hanke: Hanke): Hanke
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeServiceImpl.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeServiceImpl.kt
@@ -141,6 +141,11 @@ class HankeServiceImpl (@Autowired val hankeRepository: HankeRepository) : Hanke
 
                     hankeEntity.saveType
             )
+
+            h.tyomaaKatuosoite = hankeEntity.tyomaaKatuosoite
+            h.tyomaaTyyppi = hankeEntity.tyomaaTyyppi ?: mutableSetOf()
+            h.tyomaaKoko = hankeEntity.tyomaaKoko
+
             return h
         }
 
@@ -164,6 +169,10 @@ class HankeServiceImpl (@Autowired val hankeRepository: HankeRepository) : Hanke
             hanke.suunnitteluVaihe?.let { entity.suunnitteluVaihe = hanke.suunnitteluVaihe }
 
             hanke.saveType?.let { entity.saveType = hanke.saveType }
+
+            hanke.tyomaaKatuosoite?.let { entity.tyomaaKatuosoite = hanke.tyomaaKatuosoite }
+            hanke.tyomaaTyyppi?.let { entity.tyomaaTyyppi = hanke.tyomaaTyyppi }
+            hanke.tyomaaKoko?.let { entity.tyomaaKoko = hanke.tyomaaKoko }
         }
     }
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Persistence.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Persistence.kt
@@ -32,6 +32,48 @@ enum class SuunnitteluVaihe {
     TYOMAAN_TAI_HANKKEEN_AIKAINEN
 }
 
+enum class TyomaaTyyppi {
+    VESI,
+    VIEMARI,
+    SADEVESI,
+    SAHKO,
+    TIETOLIIKENNE,
+    LIIKENNEVALO,
+    YKT,
+    ULKOVALAISTUS,
+    KAAPPITYO,
+    KAUKOLAMPO,
+    KAUKOKYLMA,
+    KAASUJOHTO,
+    KISKOTYO,
+    MUU,
+    KADUNRAKENNUS,
+    KADUN_KUNNOSSAPITO,
+    KIINTEISTOLIITTYMA,
+    SULKU_TAI_KAIVO,
+    UUDISRAKENNUS,
+    SANEERAUS,
+    AKILLINEN_VIKAKORJAUS,
+    VIHERTYO,
+    RUNKOLINJA,
+    NOSTOTYO,
+    MUUTTO,
+    PYSAKKITYO,
+    KIINTEISTOREMONTTI,
+    ULKOMAINOS,
+    KUVAUKSET,
+    LUMENPUDOTUS,
+    YLEISOTILAISUUS,
+    VAIHTOLAVA
+}
+
+enum class TyomaaKoko {
+    SUPPEA_TAI_PISTE,
+    YLI_10M_TAI_KORTTELI,
+    LAAJA_TAI_USEA_KORTTELI
+}
+
+
 // Build-time plugins will open the class and add no-arg constructor for @Entity classes.
 
 @Entity @Table(name = "hanke")
@@ -59,7 +101,16 @@ class HankeEntity (
         // Using SEQUENCE would allow getting multiple ids more efficiently.
         @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
         var id: Int? = null
-)
+) {
+        // --------------- Hankkeen lisätiedot / Työmaan tiedot -------------------
+        var tyomaaKatuosoite: String? = null
+        @ElementCollection(fetch = FetchType.EAGER)
+        @CollectionTable(name = "hanketyomaatyyppi", joinColumns = arrayOf(JoinColumn(name = "hankeid")))
+        @Enumerated(EnumType.STRING)
+        var tyomaaTyyppi: MutableSet<TyomaaTyyppi> = mutableSetOf()
+        var tyomaaKoko: TyomaaKoko? = null
+}
+
 
 interface HankeRepository : JpaRepository<HankeEntity, Int> {
     fun findByHankeTunnus(hankeTunnus: String): HankeEntity?

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/Hanke.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/Hanke.kt
@@ -2,6 +2,8 @@ package fi.hel.haitaton.hanke.domain
 
 import fi.hel.haitaton.hanke.SaveType
 import fi.hel.haitaton.hanke.SuunnitteluVaihe
+import fi.hel.haitaton.hanke.TyomaaKoko
+import fi.hel.haitaton.hanke.TyomaaTyyppi
 import fi.hel.haitaton.hanke.Vaihe
 import java.time.ZonedDateTime
 
@@ -34,4 +36,8 @@ data class Hanke(
     var listOfOmistaja: List<HankeYhteystiedot> = arrayListOf()
     var listOfArvioija: List<HankeYhteystiedot> = arrayListOf()
     var listOfToteuttaja: List<HankeYhteystiedot> = arrayListOf()
+
+    var tyomaaKatuosoite: String? = null
+    var tyomaaTyyppi: MutableSet<TyomaaTyyppi> = mutableSetOf()
+    var tyomaaKoko: TyomaaKoko? = null
 }

--- a/services/hanke-service/src/main/resources/db/changelog/changesets/add-hanke-tyomaatiedot-fields.yml
+++ b/services/hanke-service/src/main/resources/db/changelog/changesets/add-hanke-tyomaatiedot-fields.yml
@@ -1,0 +1,21 @@
+databaseChangeLog:
+  - changeSet:
+      id: add-hanke-tyomaatiedot-fields
+      comment: Add new fields for 'hanke lisätiedot' -page
+      author: Markku Hassinen
+      changes:
+        - addColumn:
+            tableName: hanke
+            columns:
+              - column: { name: tyomaakatuosoite, type: clob }
+              - column: { name: tyomaakoko, type: varchar(25) } # enum
+        # Hanke can have multiple tyomaatyyppi -values, so a separate table for them
+        - createTable:
+            tableName: hanketyomaatyyppi
+            columns:
+              - column: { name: id, type: int, autoIncrement: true, constraints: { primaryKey: true, nullable: false }}
+              - column: { name: hankeid, type: int, constraints: { foreignKeyName: fk_hanke_hanketyomaatyyppi, references: hanke(id), nullable: false } }
+              - column: { name: tyomaatyyppi, type: varchar(30) } # enum
+        - addUniqueConstraint:
+            tableName: hanketyomaatyyppi
+            columnNames: hankeid, tyomaatyyppi

--- a/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,3 +1,5 @@
 databaseChangeLog:
   - include:
       file: db/changelog/changesets/create-initial-hanke-table.yml
+  - include:
+      file: db/changelog/changesets/add-hanke-tyomaatiedot-fields.yml


### PR DESCRIPTION
Adds new fields to hanke-table, and a new table for one field that can contain multiple enum values, using a new changeset.

Tested with swagger and integrationTests run.

Documentation update in confluence (API page) being done.

TODO: validations and unit tests.