### PR TITLE
HAI-249 added fields for 'haitat'-page

### DIFF
--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Domain.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Domain.kt
@@ -25,6 +25,7 @@ enum class HankeError(
     HAI1001("Hanke not found"),
     HAI1002("Invalid Hanke data"),
     HAI1003("Internal error while saving Hanke"),
+    HAI1004("Internal error while loading Hanke"),
     HAI1011("Invalid Hanke geometry"),
     HAI1012("Internal error while saving Hanke geometry"),
     HAI1013("Invalid coordinate system"),

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeController.kt
@@ -40,9 +40,9 @@ class HankeController(@Autowired private val hankeService: HankeService) {
 
         } catch (e: Exception) {
             logger.error(e) {
-                HankeError.HAI1003.toString()
+                HankeError.HAI1004.toString()
             }
-            ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(HankeError.HAI1003)
+            ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(HankeError.HAI1004)
         }
     }
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeServiceImpl.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeServiceImpl.kt
@@ -146,6 +146,14 @@ class HankeServiceImpl (@Autowired val hankeRepository: HankeRepository) : Hanke
             h.tyomaaTyyppi = hankeEntity.tyomaaTyyppi ?: mutableSetOf()
             h.tyomaaKoko = hankeEntity.tyomaaKoko
 
+            h.haittaAlkuPvm = hankeEntity.haittaAlkuPvm?.atStartOfDay(TZ_UTC)
+            h.haittaLoppuPvm = hankeEntity.haittaLoppuPvm?.atStartOfDay(TZ_UTC)
+            h.kaistaHaitta = hankeEntity.kaistaHaitta
+            h.kaistaPituusHaitta = hankeEntity.kaistaPituusHaitta
+            h.meluHaitta = hankeEntity.meluHaitta
+            h.polyHaitta = hankeEntity.polyHaitta
+            h.tarinaHaitta = hankeEntity.tarinaHaitta
+
             return h
         }
 
@@ -173,6 +181,16 @@ class HankeServiceImpl (@Autowired val hankeRepository: HankeRepository) : Hanke
             hanke.tyomaaKatuosoite?.let { entity.tyomaaKatuosoite = hanke.tyomaaKatuosoite }
             hanke.tyomaaTyyppi?.let { entity.tyomaaTyyppi = hanke.tyomaaTyyppi }
             hanke.tyomaaKoko?.let { entity.tyomaaKoko = hanke.tyomaaKoko }
+
+            // Assuming the incoming date, while being zoned date and time, is in UTC and time value can be simply dropped here.
+            // Note, .toLocalDate() does not do any time zone conversion.
+            hanke.haittaAlkuPvm?.let { entity.haittaAlkuPvm = hanke.haittaAlkuPvm?.toLocalDate() }
+            hanke.haittaLoppuPvm?.let { entity.haittaLoppuPvm = hanke.haittaLoppuPvm?.toLocalDate() }
+            hanke.kaistaHaitta?.let { entity.kaistaHaitta = hanke.kaistaHaitta }
+            hanke.kaistaPituusHaitta?.let { entity.kaistaPituusHaitta = hanke.kaistaPituusHaitta }
+            hanke.meluHaitta?.let { entity.meluHaitta = hanke.meluHaitta }
+            hanke.polyHaitta?.let { entity.polyHaitta = hanke.polyHaitta }
+            hanke.tarinaHaitta?.let { entity.tarinaHaitta = hanke.tarinaHaitta }
         }
     }
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Persistence.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Persistence.kt
@@ -73,6 +73,20 @@ enum class TyomaaKoko {
     LAAJA_TAI_USEA_KORTTELI
 }
 
+enum class Haitta04 {
+    EI_VAIKUTA,
+    YKSI,
+    KAKSI,
+    KOLME,
+    NELJA
+}
+
+enum class Haitta13 {
+    YKSI,
+    KAKSI,
+    KOLME
+}
+
 
 // Build-time plugins will open the class and add no-arg constructor for @Entity classes.
 
@@ -108,7 +122,18 @@ class HankeEntity (
         @CollectionTable(name = "hanketyomaatyyppi", joinColumns = arrayOf(JoinColumn(name = "hankeid")))
         @Enumerated(EnumType.STRING)
         var tyomaaTyyppi: MutableSet<TyomaaTyyppi> = mutableSetOf()
+        @Enumerated(EnumType.STRING)
         var tyomaaKoko: TyomaaKoko? = null
+
+        // --------------- Hankkeen haitat -------------------
+        var haittaAlkuPvm: LocalDate? = null // NOTE: stored and handled in UTC, not in "local" time
+        var haittaLoppuPvm: LocalDate? = null // NOTE: stored and handled in UTC, not in "local" time
+        // These five fields have generic string values, so can just as well store them with the ordinal number.
+        var kaistaHaitta: Haitta04? = null
+        var kaistaPituusHaitta: Haitta04? = null
+        var meluHaitta: Haitta13? = null
+        var polyHaitta: Haitta13? = null
+        var tarinaHaitta: Haitta13? = null
 }
 
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/Hanke.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/Hanke.kt
@@ -1,5 +1,7 @@
 package fi.hel.haitaton.hanke.domain
 
+import fi.hel.haitaton.hanke.Haitta04
+import fi.hel.haitaton.hanke.Haitta13
 import fi.hel.haitaton.hanke.SaveType
 import fi.hel.haitaton.hanke.SuunnitteluVaihe
 import fi.hel.haitaton.hanke.TyomaaKoko
@@ -40,4 +42,13 @@ data class Hanke(
     var tyomaaKatuosoite: String? = null
     var tyomaaTyyppi: MutableSet<TyomaaTyyppi> = mutableSetOf()
     var tyomaaKoko: TyomaaKoko? = null
+
+    var haittaAlkuPvm: ZonedDateTime? = null
+    var haittaLoppuPvm: ZonedDateTime? = null
+    var kaistaHaitta: Haitta04? = null
+    var kaistaPituusHaitta: Haitta04? = null
+    var meluHaitta: Haitta13? = null
+    var polyHaitta: Haitta13? = null
+    var tarinaHaitta: Haitta13? = null
+
 }

--- a/services/hanke-service/src/main/resources/db/changelog/changesets/add-hanke-haitat-fields.yml
+++ b/services/hanke-service/src/main/resources/db/changelog/changesets/add-hanke-haitat-fields.yml
@@ -1,0 +1,16 @@
+databaseChangeLog:
+  - changeSet:
+      id: add-hanke-haitat-fields
+      comment: Add new fields for 'hanke haitat' -page
+      author: Markku Hassinen
+      changes:
+        - addColumn:
+            tableName: hanke
+            columns:
+              - column: { name: haittaalkupvm, type: date }
+              - column: { name: haittaloppupvm, type: date }
+              - column: { name: kaistahaitta, type: tinyint } # enum
+              - column: { name: kaistapituushaitta, type: tinyint } # enum
+              - column: { name: meluhaitta, type: tinyint } # enum
+              - column: { name: polyhaitta, type: tinyint } # enum
+              - column: { name: tarinahaitta, type: tinyint } # enum

--- a/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -3,3 +3,5 @@ databaseChangeLog:
       file: db/changelog/changesets/create-initial-hanke-table.yml
   - include:
       file: db/changelog/changesets/add-hanke-tyomaatiedot-fields.yml
+  - include:
+      file: db/changelog/changesets/add-hanke-haitat-fields.yml


### PR DESCRIPTION
**Note: also includes a fix for tyomaakoko-enum entity-mapping, which changes the field mapping to convert enum to/from string value/names (instead of string-format ordinal number). If there are existing values in the database, they need to be null'ed or converted to corresponding values/names .**

Documentation updated.
IntegrationTests run.
Tested with swagger.

TODO: validation and tests.