### PR TITLE
HAI-247 and HAI-249 validations

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeControllerITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeControllerITests.kt
@@ -110,26 +110,6 @@ class HankeControllerITests(@Autowired val mockMvc: MockMvc) {
     }
 
     @Test
-    fun `test that the validation gives error and Bad Request is returned when creatorUserId is empty`() {
-
-        val hankeToBeAdded = Hanke(id = null, hankeTunnus = "idHankkeelle123", nimi = "", kuvaus = null,
-                onYKTHanke = false, alkuPvm = null, loppuPvm = null, vaihe = Vaihe.RAKENTAMINEN, suunnitteluVaihe = null,
-                version = null, createdBy = "", createdAt = null, modifiedBy = null, modifiedAt = null, saveType = SaveType.DRAFT)
-
-        every { hankeService.createHanke(any()) }.returns(hankeToBeAdded)
-
-        val objectMapper = ObjectMapper()
-        val hankeJSON = objectMapper.writeValueAsString(hankeToBeAdded)
-
-        mockMvc.perform(put("/hankkeet/idHankkeelle123")
-                .contentType(MediaType.APPLICATION_JSON).content(hankeJSON)
-                .accept(MediaType.APPLICATION_JSON))
-                .andExpect(status().isBadRequest())
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-
-    }
-
-    @Test
     fun `Add Hanke and HankeYhteystiedot and return it with newly created hankeTunnus (POST)`() {
         val hankeName = "Mannerheimintien remontti remonttinen"
 

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeRepositoryITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeRepositoryITests.kt
@@ -6,6 +6,9 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager
 
+/**
+ * Testing the HankeRepository with a database.
+ */
 @DataJpaTest(properties = ["spring.liquibase.enabled=false"])
 class HankeRepositoryITests @Autowired constructor(
         val entityManager: TestEntityManager,
@@ -13,18 +16,32 @@ class HankeRepositoryITests @Autowired constructor(
 
     @Test
     fun `findByHankeTunnus returns existing hanke`() {
-        // First insert one hanke to the repository:
+        // First insert one hanke to the repository (using entityManager directly):
         val hankeEntity = HankeEntity(SaveType.AUTO, "ABC-123", null, null,
                 null, null, null, null, false,
                 1, null, null, null, null)
         entityManager.persist(hankeEntity)
         entityManager.flush()
 
-        // Try to find that
+        // Try to find that (using our Repository implementation):
         val testResultEntity = hankeRepository.findByHankeTunnus("ABC-123")
         assertThat(testResultEntity).isEqualTo(hankeEntity)
     }
 
-    // TODO: more tests
+    @Test
+    fun `findByHankeTunnus does not return anything for non-existing hanke`() {
+        // First insert one hanke to the repository (using entityManager directly):
+        val hankeEntity = HankeEntity(SaveType.AUTO, "ABC-123", null, null,
+                null, null, null, null, false,
+                1, null, null, null, null)
+        entityManager.persist(hankeEntity)
+        entityManager.flush()
+
+        // Check that non-existing hanke returns nothing:
+        val testResultEntity = hankeRepository.findByHankeTunnus("NOT-000")
+        assertThat(testResultEntity).isNull()
+    }
+
+    // TODO: more tests (when more functions appear)
 
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Constants.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Constants.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import java.time.ZoneId
+import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 
 const val SRID = 3879
@@ -18,3 +19,7 @@ val OBJECT_MAPPER = jacksonObjectMapper().apply {
 val TZ_UTC: ZoneId = ZoneId.of("UTC")
 
 val DATABASE_TIMESTAMP_FORMAT: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS")
+
+// Note: database definition has no limit, so this is sort of important; must be quite long, but not excessive (considering database size etc.)
+const val MAXIMUM_TYOMAAKATUOSOITE_LENGTH = 2000
+val MAXIMUM_DATE = ZonedDateTime.of(2099, 12, 31, 23, 59, 59, 999999999, TZ_UTC)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeController.kt
@@ -22,11 +22,9 @@ class HankeController(@Autowired private val hankeService: HankeService) {
      * Get one hanke with hankeTunnus.
      *  TODO: token  from front?
      *  TODO: validation for input parameter
-     *
      */
     @GetMapping("/{hankeTunnus}")
     fun getHankeByTunnus(@PathVariable(name = "hankeTunnus") hankeTunnus: String?): ResponseEntity<Any> {
-
         if (hankeTunnus == null) {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(HankeError.HAI1002)
         }
@@ -48,7 +46,6 @@ class HankeController(@Autowired private val hankeService: HankeService) {
 
     /**
      * Add one hanke.
-     *  TODO: validation for input
      * This method will be called when we do not have id for hanke yet
      */
     @PostMapping
@@ -58,7 +55,6 @@ class HankeController(@Autowired private val hankeService: HankeService) {
         if (hanke == null) {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(HankeError.HAI1002)
         }
-
 
         return try {
             val createdHanke = hankeService.createHanke(hanke)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeServiceImpl.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeServiceImpl.kt
@@ -239,7 +239,7 @@ class HankeServiceImpl(private val hankeRepository: HankeRepository,
      * Does NOT copy the id and hankeTunnus fields because one is supposed to find
      * the HankeEntity instance from the database with those values, and after that,
      * the values are filled by the database and should not be changed.
-     * Also, version, creatorUserId, createdAt, modifierUserId, modifiedAt, version are not
+     * Also, version, createdByUserId, createdAt, modifiedByUserId, modifiedAt, version are not
      * set here, as they are to be set internally, and depends on which operation
      * is being done.
      */
@@ -256,8 +256,8 @@ class HankeServiceImpl(private val hankeRepository: HankeRepository,
 
         hanke.saveType?.let { entity.saveType = hanke.saveType }
         hanke.tyomaaKatuosoite?.let { entity.tyomaaKatuosoite = hanke.tyomaaKatuosoite }
-        hanke.tyomaaTyyppi?.let { entity.tyomaaTyyppi = hanke.tyomaaTyyppi }
-        hanke.tyomaaKoko.let { entity.tyomaaKoko = hanke.tyomaaKoko }
+        entity.tyomaaTyyppi = hanke.tyomaaTyyppi
+        hanke.tyomaaKoko?.let { entity.tyomaaKoko = hanke.tyomaaKoko }
 
         // Assuming the incoming date, while being zoned date and time, is in UTC and time value can be simply dropped here.
         // Note, .toLocalDate() does not do any time zone conversion.
@@ -284,8 +284,8 @@ class HankeServiceImpl(private val hankeRepository: HankeRepository,
     internal fun addHankeYhteystietoEntitysToList(listOfHankeYhteystiedot: List<HankeYhteystieto>, hankeEntity: HankeEntity, contactType: ContactType) {
 
         listOfHankeYhteystiedot.forEach { hankeYht ->
-            if (hankeYht.sukunimi?.isNotBlank() && hankeYht.etunimi?.isNotBlank() && hankeYht.email?.isNotBlank() &&
-                    hankeYht.puhelinnumero?.isNotBlank()) {
+            if (hankeYht.sukunimi.isNotBlank() && hankeYht.etunimi.isNotBlank() && hankeYht.email.isNotBlank()
+                    && hankeYht.puhelinnumero.isNotBlank()) {
                 val hankeYhtEntity = HankeYhteystietoEntity(
                         contactType,
                         hankeYht.sukunimi,

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/Hanke.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/Hanke.kt
@@ -12,7 +12,6 @@ import java.time.ZonedDateTime
 
 /**
  * When creating Hanke, only creatorUserId is mandatory.
- * TODO: may be changing to a bit more of mandatory fields for at least draft saving.
  */
 data class Hanke(
 
@@ -29,7 +28,7 @@ data class Hanke(
         var suunnitteluVaihe: SuunnitteluVaihe?,
 
         var version: Int?,
-        val createdBy: String,
+        val createdBy: String?,
         val createdAt: ZonedDateTime?,
         var modifiedBy: String?,
         var modifiedAt: ZonedDateTime?,

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/validation/HankeValidator.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/validation/HankeValidator.kt
@@ -6,8 +6,8 @@ import fi.hel.haitaton.hanke.MAXIMUM_TYOMAAKATUOSOITE_LENGTH
 import fi.hel.haitaton.hanke.Vaihe
 import fi.hel.haitaton.hanke.domain.Hanke
 import fi.hel.haitaton.hanke.domain.HankeYhteystieto
-import fi.hel.haitaton.hanke.getCurrentTimeUTC
-import java.time.temporal.ChronoUnit
+//import fi.hel.haitaton.hanke.getCurrentTimeUTC
+//import java.time.temporal.ChronoUnit
 import javax.validation.ConstraintValidator
 import javax.validation.ConstraintValidatorContext
 
@@ -30,12 +30,16 @@ class HankeValidator : ConstraintValidator<ValidHanke, Hanke> {
         }
 
         // Must be from the begin of today or later, and earlier than some relevant maximum date
-        if (hanke.alkuPvm == null || hanke.alkuPvm!!.isBefore(getCurrentTimeUTC().truncatedTo(ChronoUnit.DAYS)) || hanke.alkuPvm!!.isAfter(MAXIMUM_DATE)) {
+        // TODO: past date should only be prevented during creation of new hanke, not when updating one.
+        if (hanke.alkuPvm == null /* || hanke.alkuPvm!!.isBefore(getCurrentTimeUTC().truncatedTo(ChronoUnit.DAYS)) */
+                || hanke.alkuPvm!!.isAfter(MAXIMUM_DATE)) {
             context.buildConstraintViolationWithTemplate(HankeError.HAI1002.toString()).addPropertyNode("alkuPvm").addConstraintViolation()
             ok = false
         }
         // Must be from the begin of today or later, and earlier than some relevant maximum date, and same or later than alkuPvm
-        if (hanke.loppuPvm == null || hanke.loppuPvm!!.isBefore(getCurrentTimeUTC().truncatedTo(ChronoUnit.DAYS)) || hanke.loppuPvm!!.isAfter(MAXIMUM_DATE)) {
+        // TODO: past date should only be prevented during creation of new hanke, not when updating one.
+        if (hanke.loppuPvm == null /* || hanke.loppuPvm!!.isBefore(getCurrentTimeUTC().truncatedTo(ChronoUnit.DAYS)) */
+                || hanke.loppuPvm!!.isAfter(MAXIMUM_DATE)) {
             context.buildConstraintViolationWithTemplate(HankeError.HAI1002.toString()).addPropertyNode("loppuPvm").addConstraintViolation()
             ok = false
         }
@@ -79,11 +83,11 @@ class HankeValidator : ConstraintValidator<ValidHanke, Hanke> {
 
     private fun checkMandatoryYhteystietoData(yhteystieto: HankeYhteystieto, context: ConstraintValidatorContext, ok: Boolean): Boolean {
         var ok1 = ok
-        if (!yhteystieto.sukunimi.isNullOrBlank() || !yhteystieto.etunimi.isNullOrBlank()
-                || !yhteystieto.email.isNullOrBlank() || !yhteystieto.puhelinnumero.isNullOrBlank()) {
+        if (!yhteystieto.sukunimi.isBlank() || !yhteystieto.etunimi.isBlank()
+                || !yhteystieto.email.isBlank() || !yhteystieto.puhelinnumero.isBlank()) {
             // if any of the attributes contains something then all must exist
-            if (yhteystieto.sukunimi.isNullOrBlank() || yhteystieto.etunimi.isNullOrBlank()
-                    || yhteystieto.email.isNullOrBlank() || yhteystieto.puhelinnumero.isNullOrBlank()) {
+            if (yhteystieto.sukunimi.isBlank() || yhteystieto.etunimi.isBlank()
+                    || yhteystieto.email.isBlank() || yhteystieto.puhelinnumero.isBlank()) {
                 // TODO: is that property node correct?
                 // TODO: Does not currently matter, though, as the node information does not get through to error response.
                 context.buildConstraintViolationWithTemplate(HankeError.HAI1002.toString()).addPropertyNode("YhteysTiedot").addConstraintViolation()

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/validation/HankeValidator.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/validation/HankeValidator.kt
@@ -1,11 +1,13 @@
 package fi.hel.haitaton.hanke.validation
 
 import fi.hel.haitaton.hanke.HankeError
-import fi.hel.haitaton.hanke.SaveType
-import fi.hel.haitaton.hanke.SuunnitteluVaihe
+import fi.hel.haitaton.hanke.MAXIMUM_DATE
+import fi.hel.haitaton.hanke.MAXIMUM_TYOMAAKATUOSOITE_LENGTH
 import fi.hel.haitaton.hanke.Vaihe
 import fi.hel.haitaton.hanke.domain.Hanke
 import fi.hel.haitaton.hanke.domain.HankeYhteystieto
+import fi.hel.haitaton.hanke.getCurrentTimeUTC
+import java.time.temporal.ChronoUnit
 import javax.validation.ConstraintValidator
 import javax.validation.ConstraintValidatorContext
 
@@ -15,78 +17,108 @@ class HankeValidator : ConstraintValidator<ValidHanke, Hanke> {
      *  isValid collects all the validation errors and returns them
      */
     override fun isValid(hanke: Hanke?, context: ConstraintValidatorContext): Boolean {
-
         if (hanke == null) {
             context.buildConstraintViolationWithTemplate(HankeError.HAI1002.toString()).addConstraintViolation()
             return false
         }
 
         var ok = true
-        if (hanke.createdBy.isNullOrBlank()) {
-            context.buildConstraintViolationWithTemplate(HankeError.HAI1002.toString()).addPropertyNode("createdBy").addConstraintViolation()
-            ok = false
-        }
         if (hanke.nimi.isNullOrBlank()) {
+            context.disableDefaultConstraintViolation()
             context.buildConstraintViolationWithTemplate(HankeError.HAI1002.toString()).addPropertyNode("nimi").addConstraintViolation()
             ok = false
         }
-        if (hanke.alkuPvm == null) {
+
+        // Must be from the begin of today or later, and earlier than some relevant maximum date
+        if (hanke.alkuPvm == null || hanke.alkuPvm!!.isBefore(getCurrentTimeUTC().truncatedTo(ChronoUnit.DAYS)) || hanke.alkuPvm!!.isAfter(MAXIMUM_DATE)) {
             context.buildConstraintViolationWithTemplate(HankeError.HAI1002.toString()).addPropertyNode("alkuPvm").addConstraintViolation()
             ok = false
         }
-        if (hanke.loppuPvm == null) {
+        // Must be from the begin of today or later, and earlier than some relevant maximum date, and same or later than alkuPvm
+        if (hanke.loppuPvm == null || hanke.loppuPvm!!.isBefore(getCurrentTimeUTC().truncatedTo(ChronoUnit.DAYS)) || hanke.loppuPvm!!.isAfter(MAXIMUM_DATE)) {
             context.buildConstraintViolationWithTemplate(HankeError.HAI1002.toString()).addPropertyNode("loppuPvm").addConstraintViolation()
             ok = false
         }
-        if (hanke.vaihe == null || !Vaihe.values().contains(hanke.vaihe)) {
-            context.buildConstraintViolationWithTemplate(HankeError.HAI1002.toString()).addPropertyNode("vaihe").addConstraintViolation()
-            ok = false
-        }
-        // if vaihe = SUUNNITTELU then suunniteluVaihe must have value
-        // notice: suunnitteluVaihe can be null but if it is not, then enum values needs to match
-        if ((hanke.vaihe!!.equals(Vaihe.SUUNNITTELU) && hanke.suunnitteluVaihe == null) ||
-                (hanke.suunnitteluVaihe != null && !SuunnitteluVaihe.values().contains(hanke.suunnitteluVaihe))) {
-            context.buildConstraintViolationWithTemplate(HankeError.HAI1002.toString()).addPropertyNode("suunnitteluVaihe").addConstraintViolation()
-            ok = false
-        }
-        if (hanke.saveType == null || !SaveType.values().contains(hanke.saveType)) {
-            context.buildConstraintViolationWithTemplate(HankeError.HAI1002.toString()).addPropertyNode("tallennus").addConstraintViolation()
+        if (hanke.alkuPvm != null && hanke.loppuPvm != null && hanke.loppuPvm!!.isBefore(hanke.alkuPvm)) {
+            context.buildConstraintViolationWithTemplate(HankeError.HAI1002.toString()).addPropertyNode("loppuPvm").addConstraintViolation()
             ok = false
         }
 
-        ok = isValidHankeYhteystietos(hanke, context, ok)
+        // if vaihe = SUUNNITTELU then suunniteluVaihe must have value
+        if ((hanke.vaihe!!.equals(Vaihe.SUUNNITTELU) && hanke.suunnitteluVaihe == null)) {
+            context.buildConstraintViolationWithTemplate(HankeError.HAI1002.toString()).addPropertyNode("suunnitteluVaihe").addConstraintViolation()
+            ok = false
+        }
+
+        ok = ok && isValidHankeYhteystietos(hanke, context)
+        ok = ok && checkTyomaaTiedot(hanke, context)
+        ok = ok && checkHaitat(hanke, context)
 
         return ok
     }
 
-    private fun isValidHankeYhteystietos(hanke: Hanke, context: ConstraintValidatorContext, ok: Boolean): Boolean {
-        var ok1 = ok
+    /**
+     * Checks that each given Yhteystieto has valid data, or not given at all.
+     */
+    private fun isValidHankeYhteystietos(hanke: Hanke, context: ConstraintValidatorContext): Boolean {
+        var ok = true
         hanke.omistajat.forEach { yhteystieto ->
-            //mandatory
-            ok1 = checkMandatoryYhteystietoData(yhteystieto, context, ok1)
+            // mandatory
+            ok = checkMandatoryYhteystietoData(yhteystieto, context, ok)
         }
         hanke.toteuttajat.forEach { yhteystieto ->
-            //mandatory
-            ok1 = checkMandatoryYhteystietoData(yhteystieto, context, ok1)
+            // mandatory
+            ok = checkMandatoryYhteystietoData(yhteystieto, context, ok)
         }
         hanke.arvioijat.forEach { yhteystieto ->
-            //mandatory
-            ok1 = checkMandatoryYhteystietoData(yhteystieto, context, ok1)
+            // mandatory
+            ok = checkMandatoryYhteystietoData(yhteystieto, context, ok)
         }
-        return ok1
+        return ok
     }
 
     private fun checkMandatoryYhteystietoData(yhteystieto: HankeYhteystieto, context: ConstraintValidatorContext, ok: Boolean): Boolean {
         var ok1 = ok
         if (!yhteystieto.sukunimi.isNullOrBlank() || !yhteystieto.etunimi.isNullOrBlank()
                 || !yhteystieto.email.isNullOrBlank() || !yhteystieto.puhelinnumero.isNullOrBlank()) {
-            //if any of the attributes contains something then all must exist
-            if(yhteystieto.sukunimi.isNullOrBlank() || yhteystieto.etunimi.isNullOrBlank()
+            // if any of the attributes contains something then all must exist
+            if (yhteystieto.sukunimi.isNullOrBlank() || yhteystieto.etunimi.isNullOrBlank()
                     || yhteystieto.email.isNullOrBlank() || yhteystieto.puhelinnumero.isNullOrBlank()) {
+                // TODO: is that property node correct?
+                // TODO: Does not currently matter, though, as the node information does not get through to error response.
                 context.buildConstraintViolationWithTemplate(HankeError.HAI1002.toString()).addPropertyNode("YhteysTiedot").addConstraintViolation()
                 ok1 = false
             }
         }
         return ok1
     }
+
+    private fun checkTyomaaTiedot(hanke: Hanke, context: ConstraintValidatorContext): Boolean {
+        var ok = true
+        // tyomaaKatuosoite - either null or length <= maximum
+        if (hanke.tyomaaKatuosoite != null && hanke.tyomaaKatuosoite!!.length > MAXIMUM_TYOMAAKATUOSOITE_LENGTH) {
+            context.buildConstraintViolationWithTemplate(HankeError.HAI1002.toString()).addPropertyNode("tyomaaKatuosoite").addConstraintViolation()
+            ok = false
+        }
+
+        return ok
+    }
+
+    private fun checkHaitat(hanke: Hanke, context: ConstraintValidatorContext): Boolean {
+        var ok = true
+        // TODO: can haitta start/end after the hanke ends? E.g. if agreed that another hanke will continue with the same hole soon after?
+        // haittaAlkuPvm - either null or after alkuPvm and before maximum end date
+        if (hanke.haittaAlkuPvm != null && (hanke.haittaAlkuPvm!!.isBefore(hanke.alkuPvm) || hanke.haittaAlkuPvm!!.isAfter(MAXIMUM_DATE))) {
+            context.buildConstraintViolationWithTemplate(HankeError.HAI1002.toString()).addPropertyNode("haittaAlkuPvm").addConstraintViolation()
+            ok = false
+        }
+        // haittaLoppuPvm - either null or after haittaAlkuPvm and before maximum end date
+        if (hanke.haittaLoppuPvm != null && (hanke.haittaLoppuPvm!!.isBefore(hanke.haittaAlkuPvm) || hanke.haittaLoppuPvm!!.isAfter(MAXIMUM_DATE))) {
+            context.buildConstraintViolationWithTemplate(HankeError.HAI1002.toString()).addPropertyNode("haittaLoppuPvm").addConstraintViolation()
+            ok = false
+        }
+
+        return ok
+    }
+
 }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/HankeControllerTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/HankeControllerTest.kt
@@ -22,8 +22,7 @@ class HankeControllerTest {
 
     @Configuration
     class TestConfiguration {
-
-        //makes validation happen here in unit test as well
+        // makes validation happen here in unit test as well
         @Bean
         fun bean(): MethodValidationPostProcessor = MethodValidationPostProcessor()
 
@@ -59,7 +58,7 @@ class HankeControllerTest {
 
     @Test
     fun `test that the updateHanke can be called with hanke data and response will be 200`() {
-        var partialHanke = Hanke(id = 123, hankeTunnus = "id123",
+        val partialHanke = Hanke(id = 123, hankeTunnus = "id123",
                 nimi = "hankkeen nimi", kuvaus = "lorem ipsum dolor sit amet...", onYKTHanke = false,
                 alkuPvm = getCurrentTimeUTC(), loppuPvm = getCurrentTimeUTC(), vaihe = Vaihe.SUUNNITTELU, suunnitteluVaihe = SuunnitteluVaihe.KATUSUUNNITTELU_TAI_ALUEVARAUS,
                 version = 1, createdBy = "Tiina", createdAt = getCurrentTimeUTC(), modifiedBy = null, modifiedAt = null, saveType = SaveType.DRAFT)
@@ -72,15 +71,17 @@ class HankeControllerTest {
 
         Assertions.assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
         Assertions.assertThat(response.body).isNotNull
-        var responseHanke = response as ResponseEntity<Hanke>
+        // If the status is ok, we expect ResponseEntity<Hanke>
+        @Suppress("UNCHECKED_CAST")
+        val responseHanke = response as ResponseEntity<Hanke>
         Assertions.assertThat(responseHanke.body).isNotNull
         Assertions.assertThat(responseHanke.body?.nimi).isEqualTo("hankkeen nimi")
     }
 
 
     @Test
-    fun `test that the updateHanke will give validation errors from invalid hanke data for createdBy and name`() {
-        var partialHanke = Hanke(id = 0, hankeTunnus = "id123", nimi = "", kuvaus = "", onYKTHanke = false,
+    fun `test that the updateHanke will give validation errors from invalid hanke data for name`() {
+        val partialHanke = Hanke(id = 0, hankeTunnus = "id123", nimi = "", kuvaus = "", onYKTHanke = false,
                 alkuPvm = null, loppuPvm = null, vaihe = Vaihe.OHJELMOINTI, suunnitteluVaihe = null,
                 version = 1, createdBy = "", createdAt = null, modifiedBy = null, modifiedAt = null, saveType = SaveType.DRAFT)
         // mock HankeService response
@@ -90,14 +91,12 @@ class HankeControllerTest {
         Assertions.assertThatExceptionOfType(ConstraintViolationException::class.java).isThrownBy {
             hankeController.updateHanke(partialHanke, "id123")
         }.withMessageContaining("updateHanke.hanke.nimi: " + HankeError.HAI1002.toString())
-                .withMessageContaining("updateHanke.hanke.createdBy: " + HankeError.HAI1002.toString())
-
     }
 
-    //sending of sub types
+    // sending of sub types
     @Test
     fun `test that create with listOfOmistaja can be sent to controller and is responded with 200`() {
-        var hanke = Hanke(id = null, hankeTunnus = null,
+        val hanke = Hanke(id = null, hankeTunnus = null,
                 nimi = "hankkeen nimi", kuvaus = "lorem ipsum dolor sit amet...", onYKTHanke = false,
                 alkuPvm = getCurrentTimeUTC(), loppuPvm = getCurrentTimeUTC(), vaihe = Vaihe.OHJELMOINTI, suunnitteluVaihe = null,
                 version = 1, createdBy = "Tiina", createdAt = getCurrentTimeUTC(), modifiedBy = null, modifiedAt = null, saveType = SaveType.DRAFT)
@@ -109,11 +108,11 @@ class HankeControllerTest {
                         "Kaivuri ja mies", null, null, null,
                         null, null))
 
-        var mockedHanke = hanke.copy()
+        val mockedHanke = hanke.copy()
         mockedHanke.omistajat = mutableListOf(hanke.omistajat.get(0))
         mockedHanke.id = 12
         mockedHanke.hankeTunnus= "JOKU12"
-        mockedHanke.omistajat.get(0).id =1
+        mockedHanke.omistajat.get(0).id = 1
 
         // mock HankeService response
         Mockito.`when`(hankeService.createHanke(hanke)).thenReturn(hanke)
@@ -123,7 +122,9 @@ class HankeControllerTest {
 
         Assertions.assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
         Assertions.assertThat(response.body).isNotNull
-        var responseHanke = response as ResponseEntity<Hanke>
+        // If the status is ok, we expect ResponseEntity<Hanke>
+        @Suppress("UNCHECKED_CAST")
+        val responseHanke = response as ResponseEntity<Hanke>
         Assertions.assertThat(responseHanke.body).isNotNull
         Assertions.assertThat(responseHanke.body?.nimi).isEqualTo("hankkeen nimi")
     }


### PR DESCRIPTION
and some minor fixes, cleanups and an additional test

Integrationtests run, confluence docs updated.

UI no longer needs to send the unnecessary createdBy-field. On the other hand, e.g. date values have now some checks.