### PR TITLE
HAI-247 and HAI-249 tests and changed yhteystieto persistence

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeRepositoryITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeRepositoryITests.kt
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager
+import java.time.temporal.ChronoUnit
 
 /**
  * Testing the HankeRepository with a database.
@@ -42,6 +43,152 @@ class HankeRepositoryITests @Autowired constructor(
         assertThat(testResultEntity).isNull()
     }
 
+    // Purpose of these field tests is to ensure that entity mappings and liquibase columns work correctly.
+    // Note that due to using DataJpaTest, liquibase may map the field types slightly differently here than
+    // in production mode, but these are quite usual field types, so shouldn't be an issue.
+    @Test
+    fun `basic fields, tyomaa and haitat fields can be round-trip saved and loaded`() {
+        val date = getCurrentTimeUTCAsLocalTime().toLocalDate()
+        // Setup test fields
+        val baseHankeEntity = HankeEntity(SaveType.DRAFT, "ABC-123", "nimi", "kuvaus",
+                date, date, Vaihe.SUUNNITTELU, SuunnitteluVaihe.RAKENNUS_TAI_TOTEUTUS, true,
+                1, null, null, null, null)
+        baseHankeEntity.tyomaaKatuosoite = "katu 1"
+        baseHankeEntity.tyomaaTyyppi.add(TyomaaTyyppi.VESI)
+        baseHankeEntity.tyomaaTyyppi.add(TyomaaTyyppi.MUU)
+        baseHankeEntity.tyomaaKoko = TyomaaKoko.LAAJA_TAI_USEA_KORTTELI
+        baseHankeEntity.haittaAlkuPvm = date
+        baseHankeEntity.haittaLoppuPvm = date
+        baseHankeEntity.kaistaHaitta = Haitta04.KAKSI
+        baseHankeEntity.kaistaPituusHaitta = Haitta04.KOLME
+        baseHankeEntity.meluHaitta = Haitta13.YKSI
+        baseHankeEntity.polyHaitta = Haitta13.KAKSI
+        baseHankeEntity.tarinaHaitta = Haitta13.KOLME
+
+        // Save it
+        hankeRepository.save(baseHankeEntity)
+        entityManager.flush() // Make sure the stuff is run to database (though not necessarily committed)
+        entityManager.clear() // Ensure the original entity is no longer in Hibernate's 1st level cache
+
+        // Load it back to different entity and check the fields
+        val loadedHanke = hankeRepository.findByHankeTunnus("ABC-123")
+        assertThat(loadedHanke).isNotNull
+
+        assertThat(loadedHanke!!.saveType).isEqualTo(SaveType.DRAFT)
+        assertThat(loadedHanke.nimi).isEqualTo("nimi")
+        assertThat(loadedHanke.kuvaus).isEqualTo("kuvaus")
+        assertThat(loadedHanke.alkuPvm).isEqualTo(date)
+        assertThat(loadedHanke.loppuPvm).isEqualTo(date)
+        assertThat(loadedHanke.vaihe).isEqualTo(Vaihe.SUUNNITTELU)
+        assertThat(loadedHanke.suunnitteluVaihe).isEqualTo(SuunnitteluVaihe.RAKENNUS_TAI_TOTEUTUS)
+
+        assertThat(loadedHanke.tyomaaKatuosoite).isEqualTo("katu 1")
+        assertThat(loadedHanke.tyomaaTyyppi).contains(TyomaaTyyppi.VESI, TyomaaTyyppi.MUU)
+        assertThat(loadedHanke.tyomaaKoko).isEqualTo(TyomaaKoko.LAAJA_TAI_USEA_KORTTELI)
+        assertThat(loadedHanke.haittaAlkuPvm).isEqualTo(date)
+        assertThat(loadedHanke.haittaLoppuPvm).isEqualTo(date)
+        assertThat(loadedHanke.kaistaHaitta).isEqualTo(Haitta04.KAKSI)
+        assertThat(loadedHanke.kaistaPituusHaitta).isEqualTo(Haitta04.KOLME)
+        assertThat(loadedHanke.meluHaitta).isEqualTo(Haitta13.YKSI)
+        assertThat(loadedHanke.polyHaitta).isEqualTo(Haitta13.KAKSI)
+        assertThat(loadedHanke.tarinaHaitta).isEqualTo(Haitta13.KOLME)
+    }
+
+    @Test
+    fun `yhteystieto fields can be round-trip saved and loaded`() {
+        val datetime = getCurrentTimeUTCAsLocalTime().truncatedTo(ChronoUnit.MILLIS)
+        val date = datetime.toLocalDate()
+        // Setup test fields
+        val baseHankeEntity = HankeEntity(SaveType.DRAFT, "ABC-124", "nimi", "kuvaus",
+                date, date, Vaihe.SUUNNITTELU, SuunnitteluVaihe.RAKENNUS_TAI_TOTEUTUS, true,
+                1, null, null, null, null)
+
+        // Note, leaving id and hanke fields unset on purpose (Hibernate should set them as needed)
+        val hankeYhteystietoEntity1 = HankeYhteystietoEntity(
+                ContactType.OMISTAJA, "Suku1", "Etu1", "email1", "0101111111",
+                1, "org1", "osasto1",
+                1, datetime, 11, datetime, null, baseHankeEntity)
+        val hankeYhteystietoEntity2 = HankeYhteystietoEntity(
+                ContactType.ARVIOIJA, "Suku2", "Etu2", "email2", "0102222222",
+                2, "org2", "osasto2",
+                2, datetime, 22, datetime, null, baseHankeEntity)
+        val hankeYhteystietoEntity3 = HankeYhteystietoEntity(
+                ContactType.TOTEUTTAJA, "Suku3", "Etu3", "email3", "0103333333",
+                3, "org3", "osasto3",
+                3, datetime, 33, datetime, null, baseHankeEntity)
+
+        baseHankeEntity.listOfHankeYhteystieto.add(hankeYhteystietoEntity1)
+        baseHankeEntity.listOfHankeYhteystieto.add(hankeYhteystietoEntity2)
+        baseHankeEntity.listOfHankeYhteystieto.add(hankeYhteystietoEntity3)
+
+        // Save it:
+        hankeRepository.save(baseHankeEntity)
+        entityManager.flush() // Make sure the stuff is run to database (though not necessarily committed)
+        entityManager.clear() // Ensure the original entity is no longer in Hibernate's 1st level cache
+
+        // Load it back to different entity and check the fields
+        val loadedHanke = hankeRepository.findByHankeTunnus("ABC-124")
+        assertThat(loadedHanke).isNotNull
+        assertThat(loadedHanke!!.listOfHankeYhteystieto).isNotNull
+        assertThat(loadedHanke.listOfHankeYhteystieto).hasSize(3)
+
+        val loadedHankeYhteystietoEntity1 = loadedHanke.listOfHankeYhteystieto[0]
+        val loadedHankeYhteystietoEntity2 = loadedHanke.listOfHankeYhteystieto[1]
+        val loadedHankeYhteystietoEntity3 = loadedHanke.listOfHankeYhteystieto[2]
+
+        // Check every field from one yhteystieto:
+        assertThat(loadedHankeYhteystietoEntity1).isNotNull
+        assertThat(loadedHankeYhteystietoEntity1.sukunimi).isEqualTo("Suku1")
+        assertThat(loadedHankeYhteystietoEntity1.etunimi).isEqualTo("Etu1")
+        assertThat(loadedHankeYhteystietoEntity1.email).isEqualTo("email1")
+        assertThat(loadedHankeYhteystietoEntity1.puhelinnumero).isEqualTo("0101111111")
+        assertThat(loadedHankeYhteystietoEntity1.organisaatioId).isEqualTo(1)
+        assertThat(loadedHankeYhteystietoEntity1.organisaatioNimi).isEqualTo("org1")
+        assertThat(loadedHankeYhteystietoEntity1.osasto).isEqualTo("osasto1")
+        assertThat(loadedHankeYhteystietoEntity1.createdByUserId).isEqualTo(1)
+        assertThat(loadedHankeYhteystietoEntity1.createdAt).isEqualTo(datetime)
+        assertThat(loadedHankeYhteystietoEntity1.modifiedByUserId).isEqualTo(11)
+        assertThat(loadedHankeYhteystietoEntity1.modifiedAt).isEqualTo(datetime)
+        // Check the back reference to parent Hanke:
+        assertThat(loadedHankeYhteystietoEntity1.hanke).isSameAs(loadedHanke)
+        // Check other yhteystietos:
+        assertThat(loadedHankeYhteystietoEntity2).isNotNull
+        assertThat(loadedHankeYhteystietoEntity2.sukunimi).isEqualTo("Suku2")
+        assertThat(loadedHankeYhteystietoEntity2.etunimi).isEqualTo("Etu2")
+        assertThat(loadedHankeYhteystietoEntity2.email).isEqualTo("email2")
+        assertThat(loadedHankeYhteystietoEntity2.puhelinnumero).isEqualTo("0102222222")
+        assertThat(loadedHankeYhteystietoEntity2.organisaatioId).isEqualTo(2)
+        assertThat(loadedHankeYhteystietoEntity2.organisaatioNimi).isEqualTo("org2")
+        assertThat(loadedHankeYhteystietoEntity2.osasto).isEqualTo("osasto2")
+        assertThat(loadedHankeYhteystietoEntity2.createdByUserId).isEqualTo(2)
+        assertThat(loadedHankeYhteystietoEntity2.createdAt).isEqualTo(datetime)
+        assertThat(loadedHankeYhteystietoEntity2.modifiedByUserId).isEqualTo(22)
+        assertThat(loadedHankeYhteystietoEntity2.modifiedAt).isEqualTo(datetime)
+
+        assertThat(loadedHankeYhteystietoEntity3).isNotNull
+        assertThat(loadedHankeYhteystietoEntity3.sukunimi).isEqualTo("Suku3")
+        assertThat(loadedHankeYhteystietoEntity3.etunimi).isEqualTo("Etu3")
+        assertThat(loadedHankeYhteystietoEntity3.email).isEqualTo("email3")
+        assertThat(loadedHankeYhteystietoEntity3.puhelinnumero).isEqualTo("0103333333")
+        assertThat(loadedHankeYhteystietoEntity3.organisaatioId).isEqualTo(3)
+        assertThat(loadedHankeYhteystietoEntity3.organisaatioNimi).isEqualTo("org3")
+        assertThat(loadedHankeYhteystietoEntity3.osasto).isEqualTo("osasto3")
+        assertThat(loadedHankeYhteystietoEntity3.createdByUserId).isEqualTo(3)
+        assertThat(loadedHankeYhteystietoEntity3.createdAt).isEqualTo(datetime)
+        assertThat(loadedHankeYhteystietoEntity3.modifiedByUserId).isEqualTo(33)
+        assertThat(loadedHankeYhteystietoEntity3.modifiedAt).isEqualTo(datetime)
+    }
+
+
+
+
     // TODO: more tests (when more functions appear)
+
+
+
+
+
+
+
 
 }

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
@@ -1,0 +1,61 @@
+package fi.hel.haitaton.hanke
+
+import fi.hel.haitaton.hanke.domain.Hanke
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+
+
+// TODO: works with the springboottest, but not with the datajpatest... WHY ?
+
+@ActiveProfiles("default")
+@SpringBootTest
+//@DataJpaTest(properties = ["spring.liquibase.enabled=false"])
+class HankeServiceITests {
+
+    @Autowired
+    private lateinit var hankeService: HankeService
+
+    @Test
+    fun `create Hanke with full data set succeeds and returns new domain object`() {
+        val hanke: Hanke = getATestHanke("yksi", 1)
+
+        val returnedHanke = hankeService.createHanke(hanke)
+
+        assertThat(returnedHanke).isNotNull
+
+        assertThat(returnedHanke.nimi).isEqualTo("testihanke yksi")
+        // TODO: more checks
+
+    }
+
+    // TODO: more tests (mostly about correct handling of data that goes to other tables)
+
+    /**
+     * Just fills a new Hanke domain object with some crap and returns it.
+     * The audit and id/tunnus fields are left at null.
+     */
+    private fun getATestHanke(stringValue: String, intValue: Int): Hanke {
+        val date = getCurrentTimeUTC()
+        val hanke = Hanke(id = null, hankeTunnus = null, nimi = "testihanke $stringValue", kuvaus = "lorem ipsum dolor sit amet...",
+                onYKTHanke = false, alkuPvm = date, loppuPvm = date, vaihe = Vaihe.SUUNNITTELU, suunnitteluVaihe = SuunnitteluVaihe.RAKENNUS_TAI_TOTEUTUS,
+                version = null, createdBy = null, createdAt = null, modifiedBy = null, modifiedAt = null, saveType = SaveType.DRAFT)
+
+        hanke.tyomaaKatuosoite = "Testikatu $intValue"
+        hanke.tyomaaTyyppi.add(TyomaaTyyppi.VESI)
+        hanke.tyomaaTyyppi.add(TyomaaTyyppi.MUU)
+        hanke.tyomaaKoko = TyomaaKoko.LAAJA_TAI_USEA_KORTTELI
+        hanke.haittaAlkuPvm = date
+        hanke.haittaLoppuPvm = date
+        hanke.kaistaHaitta = Haitta04.KAKSI
+        hanke.kaistaPituusHaitta = Haitta04.NELJA
+        hanke.meluHaitta = Haitta13.YKSI
+        hanke.polyHaitta = Haitta13.KAKSI
+        hanke.tarinaHaitta = Haitta13.KOLME
+
+        return hanke
+    }
+
+}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Configuration.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Configuration.kt
@@ -17,7 +17,7 @@ import org.springframework.jdbc.core.JdbcOperations
 class Configuration {
 
     @Bean
-    fun hankeService(hankeRepository: HankeRepository, hankeYhteystietoRepository: HankeYhteystietoRepository): HankeService = HankeServiceImpl(hankeRepository, hankeYhteystietoRepository)
+    fun hankeService(hankeRepository: HankeRepository): HankeService = HankeServiceImpl(hankeRepository)
 
     @Bean
     fun organisaatioService(organisaatioRepository: OrganisaatioRepository): OrganisaatioService = OrganisaatioServiceImpl(organisaatioRepository)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Domain.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Domain.kt
@@ -19,8 +19,8 @@ enum class HankeError(
     HAI1012("Internal error while saving Hanke geometry"),
     HAI1013("Invalid coordinate system"),
     HAI1014("Internal error while loading Hanke geometry"),
-    HAI1015("Hanke geometry not found");
-
+    HAI1015("Hanke geometry not found"),
+    HAI1020("HankeYhteystieto not found");
 
 
     val errorCode: String
@@ -40,5 +40,7 @@ enum class HankeError(
 }
 
 class HankeNotFoundException(val hankeTunnus: String? = null) : RuntimeException(HankeError.HAI1001.errorMessage)
+
+class HankeYhteystietoNotFoundException(val hankeid: Int? = null, val ytId: Int? = null) : RuntimeException(HankeError.HAI1020.errorMessage)
 
 class DatabaseStateException(val context: String? = null) : RuntimeException(HankeError.HAI1005.errorMessage)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Domain.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Domain.kt
@@ -39,6 +39,6 @@ enum class HankeError(
     }
 }
 
-class HankeNotFoundException(val hankeId: String? = null) : RuntimeException(HankeError.HAI1001.errorMessage)
+class HankeNotFoundException(val hankeTunnus: String? = null) : RuntimeException(HankeError.HAI1001.errorMessage)
 
-class DatabaseStateException(val hankeId: String? = null) : RuntimeException(HankeError.HAI1005.errorMessage)
+class DatabaseStateException(val context: String? = null) : RuntimeException(HankeError.HAI1005.errorMessage)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeService.kt
@@ -7,6 +7,7 @@ interface HankeService {
     /**
      * Fetch hanke with hankeTunnus.
      * Either returns the hanke instance, or throws exception.
+     * TODO: return type to "Hanke?", and return null if not found, move the exception to controller.
      */
     fun loadHanke(hankeTunnus: String): Hanke
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeService.kt
@@ -5,9 +5,10 @@ import fi.hel.haitaton.hanke.domain.Hanke
 interface HankeService {
 
     /**
-     * Fetch hanke with hankeTunnus
+     * Fetch hanke with hankeTunnus.
+     * Either returns the hanke instance, or throws exception.
      */
-    fun loadHanke(hankeTunnus: String): Hanke?
+    fun loadHanke(hankeTunnus: String): Hanke
 
     fun createHanke(hanke: Hanke): Hanke
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeServiceImpl.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeServiceImpl.kt
@@ -255,7 +255,8 @@ class HankeServiceImpl(private val hankeRepository: HankeRepository) : HankeServ
         // preserve createdBy and createdAt field values without having to rely on the client-side to hold
         // the values for us (bad design), which would also require checks on those (to prevent tampering).
 
-        // Create temporary id-to-existingyhteystieto -map, used to find quickly whether an incoming YT is new or exists already.
+        // Create temporary id-to-existingyhteystieto -map, used to find quickly whether an incoming Yhteystieto is new or exists already.
+        // YT = Yhteystieto
         val existingYTs: MutableMap<Int, HankeYhteystietoEntity> = mutableMapOf()
         for (existingYT in entity.listOfHankeYhteystieto) {
             if (existingYT.id == null) {
@@ -281,7 +282,7 @@ class HankeServiceImpl(private val hankeRepository: HankeRepository) : HankeServ
         // If there is anything left in the existingYTs map, they have been removed in the incoming data,
         // so remove them from the entity's list and make the back-reference null (and thus delete from the database).
         // TODO: it should not be a list, but a "bag", or ensure it is e.g. linkedlist instead of arraylist (or similars).
-        //    The order of YTs does not matter(?), and removing things from e.g. array list
+        //    The order of Yhteystietos does not matter(?), and removing things from e.g. array list
         //    gets inefficient. Since there are so few entries, this crude solution works, for now.
         entity.listOfHankeYhteystieto.removeAll(existingYTs.values)
         for (hankeYht in existingYTs.values) {
@@ -294,41 +295,52 @@ class HankeServiceImpl(private val hankeRepository: HankeRepository) : HankeServ
             listOfHankeYhteystiedot: List<HankeYhteystieto>, hankeEntity: HankeEntity, contactType: ContactType,
             userid: Int, existingYTs: MutableMap<Int, HankeYhteystietoEntity>) {
         for (hankeYht in listOfHankeYhteystiedot) {
-            var someFieldsSet = false
-            var validYT = false
-            // The UI has currently bigger problems implementing it so that YT entries that haven't even been touched
+            val someFieldsSet = isSomeFieldsSet(hankeYht)
+            var validYhteystieto = false
+            // The UI has currently bigger problems implementing it so that Yhteystieto entries that haven't even been touched
             //   would not be sent to backend as a group of ""-fields, so the condition here is to make
             //   such fully-empty entry considered as non-existent (i.e. skip it).
             //   Also, for now, if anything is given, it is checked that all 4 mandatory fields are given, or we log an error and skip it.
             // Note, validator should have enforced that at least the four main fields are all set (or all of them are empty).
             // TODO: Currently validator does allow through an entry with four mandatory fields empty, but organisation field(s) non-empty!
-            // If anything field is given (not empty and not only whitespace)...
-            if (hankeYht.sukunimi.isNotBlank() || hankeYht.etunimi.isNotBlank()
-                    || hankeYht.email.isNotBlank() || hankeYht.puhelinnumero.isNotBlank()
-                    || !hankeYht.organisaatioNimi.isNullOrBlank() || !hankeYht.osasto.isNullOrBlank()) {
-                someFieldsSet = true
-                // ... and if at least the 4 mandatory fields are given ...
-                if (hankeYht.sukunimi.isNotBlank() && hankeYht.etunimi.isNotBlank()
-                        && hankeYht.email.isNotBlank() && hankeYht.puhelinnumero.isNotBlank()) {
-                    validYT = true
-                }
+            // If any field is given (not empty and not only whitespace)...
+            if (someFieldsSet) {
+                // Check if at least the 4 mandatory fields are given
+                validYhteystieto = isValidYhteystieto(hankeYht)
             }
 
-            // Is the incoming YT new (does not have id, create new) or old (has id, update existing)?
+            // Is the incoming Yhteystieto new (does not have id, create new) or old (has id, update existing)?
             if (hankeYht.id == null) {
-                // New YT
-                processCreateYT(hankeYht, validYT, contactType, userid, hankeEntity)
+                // New Yhteystieto
+                processCreateYhteystieto(hankeYht, validYhteystieto, contactType, userid, hankeEntity)
             } else {
-                // Should be an existing YT
-                processUpdateYT(hankeYht, existingYTs, someFieldsSet, validYT, userid, hankeEntity)
+                // Should be an existing Yhteystieto
+                processUpdateYhteystieto(hankeYht, existingYTs, someFieldsSet, validYhteystieto, userid, hankeEntity)
             }
         }
     }
 
-    private fun processCreateYT(hankeYht: HankeYhteystieto, validYT: Boolean, contactType: ContactType, userid: Int,
-            hankeEntity: HankeEntity ) {
-        if (validYT) {
-            // ... it is valid, so create a new YT
+    /**
+     * Returns true if at least one Yhteystieto-field is non-null, non-empty and non-whitespace-only.
+     */
+    private fun isSomeFieldsSet(hankeYht: HankeYhteystieto) : Boolean {
+        return hankeYht.sukunimi.isNotBlank() || hankeYht.etunimi.isNotBlank()
+                || hankeYht.email.isNotBlank() || hankeYht.puhelinnumero.isNotBlank()
+                || !hankeYht.organisaatioNimi.isNullOrBlank() || !hankeYht.osasto.isNullOrBlank()
+    }
+
+    /**
+     * Returns true if all the four mandatory fields are non-null, non-empty and non-whitespace-only.
+     */
+    private fun isValidYhteystieto(hankeYht: HankeYhteystieto) : Boolean {
+        return hankeYht.sukunimi.isNotBlank() && hankeYht.etunimi.isNotBlank()
+                && hankeYht.email.isNotBlank() && hankeYht.puhelinnumero.isNotBlank()
+    }
+
+    private fun processCreateYhteystieto(hankeYht: HankeYhteystieto, validYhteystieto: Boolean, contactType: ContactType,
+            userid: Int, hankeEntity: HankeEntity ) {
+        if (validYhteystieto) {
+            // ... it is valid, so create a new Yhteystieto
             val hankeYhtEntity = HankeYhteystietoEntity(
                     contactType,
                     hankeYht.sukunimi,
@@ -354,19 +366,19 @@ class HankeServiceImpl(private val hankeRepository: HankeRepository) : HankeServ
         }
     }
 
-    private fun processUpdateYT(hankeYht: HankeYhteystieto, existingYTs: MutableMap<Int, HankeYhteystietoEntity>,
-            someFieldsSet: Boolean, validYT: Boolean, userid: Int, hankeEntity: HankeEntity) {
-        // If incoming YT has id set, it _should_ be among the existing YTs, or some kind of error has happened.
+    private fun processUpdateYhteystieto(hankeYht: HankeYhteystieto, existingYTs: MutableMap<Int, HankeYhteystietoEntity>,
+            someFieldsSet: Boolean, validYhteystieto: Boolean, userid: Int, hankeEntity: HankeEntity) {
+        // If incoming Yhteystieto has id set, it _should_ be among the existing Yhteystietos, or some kind of error has happened.
         val incomingId: Int = hankeYht.id!!
         val existingYT: HankeYhteystietoEntity? = existingYTs[incomingId]
         if (existingYT == null) {
             // Some sort of error situation;
-            // - simultaneous edits to the same hanke by someone else (the YT could have been removed in the database)
+            // - simultaneous edits to the same hanke by someone else (the Yhteystieto could have been removed in the database)
             // - the incoming ids are for different hanke (i.e. incorrect data in the incoming request)
             throw HankeYhteystietoNotFoundException(hankeEntity.id, incomingId)
         }
 
-        if (validYT) {
+        if (validYhteystieto) {
             // All required fields found, so update existing entity fields:
             existingYT.sukunimi = hankeYht.sukunimi
             existingYT.etunimi = hankeYht.etunimi
@@ -381,16 +393,16 @@ class HankeServiceImpl(private val hankeRepository: HankeRepository) : HankeServ
             existingYT.modifiedAt = getCurrentTimeUTCAsLocalTime()
             // (Not touching the id or hanke fields)
 
-            // No need to add the existing YT entity to the hanke's list; it is already in it.
+            // No need to add the existing Yhteystieto entity to the hanke's list; it is already in it.
             // Remove the corresponding entry from the map. (Afterwards, the entries remaining in the map
             // were not in the incoming data, so should be removed from the database.)
             existingYTs.remove(incomingId)
         } else {
-            // Trying to update an YT with one or more empty mandatory data fields.
+            // Trying to update an Yhteystieto with one or more empty mandatory data fields.
             // If we do not change anything, the response will send back to previous stored values.
             // TODO: Check if the above operation is ok?
             // However, checking one special case; all fields being empty. This corresponds to initial state,
-            // where the corresponding YT is not set. Therefore, for now, considering it as "please delete".
+            // where the corresponding Yhteystieto is not set. Therefore, for now, considering it as "please delete".
             // (Handling it by reversed logic using the existingYTs map, see above.)
             if (someFieldsSet) {
                 logger.error {

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeYhteystietoEntity.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeYhteystietoEntity.kt
@@ -6,7 +6,7 @@ import javax.persistence.*
 enum class ContactType {
     OMISTAJA, //owner
     ARVIOIJA, //planner or person to do the planning of hanke
-    TOTEUTTAJA // implementator or builder
+    TOTEUTTAJA // implementor or builder
 }
 
 
@@ -16,17 +16,17 @@ class HankeYhteystietoEntity (
         @Enumerated(EnumType.STRING)
         var contactType: ContactType,
 
-        //must have contact information
+        // must have contact information
         var sukunimi: String,
         var etunimi: String,
         var email: String,
         var puhelinnumero: String,
 
-        var organisaatioid: Int? = 0,
-        var organisaationimi: String? = null,
+        var organisaatioId: Int? = 0,
+        var organisaatioNimi: String? = null,
         var osasto: String? = null,
 
-        // NOTE: creatorUserId must be non-null for valid data, but to allow creating instances with
+        // NOTE: createdByUserId must be non-null for valid data, but to allow creating instances with
         // no-arg constructor and programming convenience, this class allows it to be null (temporarily).
         var createdByUserId: Int? = null,
         var createdAt: LocalDateTime? = null,
@@ -39,7 +39,6 @@ class HankeYhteystietoEntity (
         var id: Int? = null,
 
         @ManyToOne(fetch = FetchType.EAGER)
-        @JoinColumn(name="hankeid") var hanke: HankeEntity? = null
+        @JoinColumn(name="hankeid")
+        var hanke: HankeEntity? = null
 )
-
-

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Persistence.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Persistence.kt
@@ -9,10 +9,6 @@ import javax.persistence.*
 Hibernate/JPA Entity classes
  */
 
-// TODO: remove once everything has been converted to use the new, real entity class
-data class OldHankeEntity(val id: String) {}
-
-
 enum class SaveType {
     AUTO, // When the information has been saved by a periodic auto-save feature
     DRAFT, // When the user presses "saves as draft"
@@ -118,7 +114,8 @@ class HankeEntity(
         var id: Int? = null,
 
         // related
-        @OneToMany(fetch = FetchType.LAZY, mappedBy = "hanke", cascade = [CascadeType.ALL])
+        // orphanRemoval is needed for even explicit child-object removal. JPA weirdness...
+        @OneToMany(fetch = FetchType.LAZY, mappedBy = "hanke", cascade = [CascadeType.ALL], orphanRemoval = true)
         var listOfHankeYhteystieto: MutableList<HankeYhteystietoEntity> = mutableListOf()
 
 ) {

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Persistence.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Persistence.kt
@@ -118,15 +118,15 @@ class HankeEntity(
         var id: Int? = null,
 
         // related
-        @OneToMany(fetch = FetchType.EAGER, mappedBy = "id")
-        var listOfHankeYhteystieto: MutableList<HankeYhteystietoEntity>? = null //mutableListOf()
+        @OneToMany(fetch = FetchType.LAZY, mappedBy = "hanke", cascade = [CascadeType.ALL])
+        var listOfHankeYhteystieto: MutableList<HankeYhteystietoEntity> = mutableListOf()
 
 ) {
     // --------------- Hankkeen lisätiedot / Työmaan tiedot -------------------
     var tyomaaKatuosoite: String? = null
 
     @ElementCollection(fetch = FetchType.EAGER)
-    @CollectionTable(name = "hanketyomaatyyppi", joinColumns = arrayOf(JoinColumn(name = "hankeid")))
+    @CollectionTable(name = "hanketyomaatyyppi", joinColumns = [JoinColumn(name = "hankeid")])
     @Enumerated(EnumType.STRING)
     var tyomaaTyyppi: MutableSet<TyomaaTyyppi> = mutableSetOf()
 
@@ -167,9 +167,4 @@ class HankeEntity(
 interface HankeRepository : JpaRepository<HankeEntity, Int> {
     fun findByHankeTunnus(hankeTunnus: String): HankeEntity?
     // TODO: add any special 'find' etc. functions here, like searching by date range.
-}
-
-
-interface HankeYhteystietoRepository : JpaRepository<HankeYhteystietoEntity, Int> {
-    fun findByHankeId(hankeId: Int): List<HankeYhteystietoEntity>
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/validation/HankeValidator.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/validation/HankeValidator.kt
@@ -31,6 +31,9 @@ class HankeValidator : ConstraintValidator<ValidHanke, Hanke> {
 
         // Must be from the begin of today or later, and earlier than some relevant maximum date
         // TODO: past date should only be prevented during creation of new hanke, not when updating one.
+        //  (However, this is currently a situation which can not be validated correctly, as the update-method here
+        //  does not differentiate between updates during using wizard vs. updates being done weeks afterward,
+        //  where the date isn't even being changed (just that old date being doing a round-trip in the UI).
         if (hanke.alkuPvm == null /* || hanke.alkuPvm!!.isBefore(getCurrentTimeUTC().truncatedTo(ChronoUnit.DAYS)) */
                 || hanke.alkuPvm!!.isAfter(MAXIMUM_DATE)) {
             context.buildConstraintViolationWithTemplate(HankeError.HAI1002.toString()).addPropertyNode("alkuPvm").addConstraintViolation()
@@ -38,6 +41,9 @@ class HankeValidator : ConstraintValidator<ValidHanke, Hanke> {
         }
         // Must be from the begin of today or later, and earlier than some relevant maximum date, and same or later than alkuPvm
         // TODO: past date should only be prevented during creation of new hanke, not when updating one.
+        //  (However, this is currently a situation which can not be validated correctly, as the update-method here
+        //  does not differentiate between updates during using wizard vs. updates being done weeks afterward,
+        //  where the date isn't even being changed (just that old date being doing a round-trip in the UI).
         if (hanke.loppuPvm == null /* || hanke.loppuPvm!!.isBefore(getCurrentTimeUTC().truncatedTo(ChronoUnit.DAYS)) */
                 || hanke.loppuPvm!!.isAfter(MAXIMUM_DATE)) {
             context.buildConstraintViolationWithTemplate(HankeError.HAI1002.toString()).addPropertyNode("loppuPvm").addConstraintViolation()
@@ -110,7 +116,7 @@ class HankeValidator : ConstraintValidator<ValidHanke, Hanke> {
 
     private fun checkHaitat(hanke: Hanke, context: ConstraintValidatorContext): Boolean {
         var ok = true
-        // TODO: can haitta start/end after the hanke ends? E.g. if agreed that another hanke will continue with the same hole soon after?
+        // TODO: can haitta alku/loppu pvm be after the hanke ends? E.g. if agreed that another hanke will continue with the same hole soon after?
         // haittaAlkuPvm - either null or after alkuPvm and before maximum end date
         if (hanke.haittaAlkuPvm != null && (hanke.haittaAlkuPvm!!.isBefore(hanke.alkuPvm) || hanke.haittaAlkuPvm!!.isAfter(MAXIMUM_DATE))) {
             context.buildConstraintViolationWithTemplate(HankeError.HAI1002.toString()).addPropertyNode("haittaAlkuPvm").addConstraintViolation()

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/validation/HankeValidator.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/validation/HankeValidator.kt
@@ -24,7 +24,6 @@ class HankeValidator : ConstraintValidator<ValidHanke, Hanke> {
 
         var ok = true
         if (hanke.nimi.isNullOrBlank()) {
-            context.disableDefaultConstraintViolation()
             context.buildConstraintViolationWithTemplate(HankeError.HAI1002.toString()).addPropertyNode("nimi").addConstraintViolation()
             ok = false
         }
@@ -89,9 +88,12 @@ class HankeValidator : ConstraintValidator<ValidHanke, Hanke> {
 
     private fun checkMandatoryYhteystietoData(yhteystieto: HankeYhteystieto, context: ConstraintValidatorContext, ok: Boolean): Boolean {
         var ok1 = ok
+        // TODO: NOTE: having all four mandatory fields empty, but giving organisation is still valid for this... needs to be fixed.
+        // Short version: Either all four mandatory fields must be have proper value, or all of them must be empty/whitespace-only.
+        // If any of the four mandatory fields have any non-whitespace in them...
         if (!yhteystieto.sukunimi.isBlank() || !yhteystieto.etunimi.isBlank()
                 || !yhteystieto.email.isBlank() || !yhteystieto.puhelinnumero.isBlank()) {
-            // if any of the attributes contains something then all must exist
+            // ... but if any other of them is empty/whitespace-only, it is not valid
             if (yhteystieto.sukunimi.isBlank() || yhteystieto.etunimi.isBlank()
                     || yhteystieto.email.isBlank() || yhteystieto.puhelinnumero.isBlank()) {
                 // TODO: is that property node correct?

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/HankeControllerTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/HankeControllerTest.kt
@@ -129,4 +129,9 @@ class HankeControllerTest {
         Assertions.assertThat(responseHanke.body?.nimi).isEqualTo("hankkeen nimi")
     }
 
+    // TODO: test that checks that tyomaa- and haitat-fields can be sent to controller and come back in the response
+
+
+
+
 }


### PR DESCRIPTION
yhteystieto persistence changed to use Cascade.ALL and not using own Repository.
Fixed outgoing yhteystieto createdAt-field getting value from saved modifiedAt field.
Changed yhteystieto audit-fields to use internal info only, and along with cascade-all usage, updates to fields are copied to existing entity objects, instead of creating new ones.

Effects are contained mostly internally into the HankeServiceImpl-class.
Tested manually in swagger that the persistency and yhteystietohandling code changes should not affect REST API.
Did not cause changes to database.

Integration tests run.

TODO: some more tests to service and controller -levels.