### PR TITLE
HAI-467 CORS

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,6 +78,7 @@ services:
       HAITATON_PORT: 5432
       HAITATON_USER: haitaton_user
       HAITATON_PASSWORD: haitaton
+      HAITATON_CORS_ALLOWED_ORIGINS: http://localhost:8000
     depends_on:
       - db
       - auth-service

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Application.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Application.kt
@@ -5,6 +5,12 @@ import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 import org.springframework.context.annotation.Bean
 import org.springframework.web.filter.ForwardedHeaderFilter
+import org.springframework.web.servlet.config.annotation.CorsRegistry
+
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+
+
 
 @SpringBootApplication
 class Application {
@@ -12,6 +18,16 @@ class Application {
     @Bean
     fun forwardedHeaderFilter(): ForwardedHeaderFilter? {
         return ForwardedHeaderFilter()
+    }
+
+    @Bean
+    fun corsConfigurer(): WebMvcConfigurer? {
+        return object : WebMvcConfigurer {
+            override fun addCorsMappings(registry: CorsRegistry) {
+                registry.addMapping("/hankkeet").allowedOrigins("http://localhost", "http://localhost:8000", "http://localhost:3001", "https://haitaton-ui-dev.agw.arodevtest.hel.fi")
+                registry.addMapping("/organisaatiot").allowedOrigins("http://localhost", "http://localhost:8000", "http://localhost:3001", "https://haitaton-ui-dev.agw.arodevtest.hel.fi")
+            }
+        }
     }
 }
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Application.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Application.kt
@@ -1,6 +1,7 @@
 package fi.hel.haitaton.hanke
 
 import mu.KotlinLogging
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 import org.springframework.context.annotation.Bean
@@ -15,6 +16,9 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
 @SpringBootApplication
 class Application {
 
+    @Value("\${haitaton.cors.allowedOrigins}")
+    lateinit var allowedOrigins: String
+
     @Bean
     fun forwardedHeaderFilter(): ForwardedHeaderFilter? {
         return ForwardedHeaderFilter()
@@ -24,8 +28,9 @@ class Application {
     fun corsConfigurer(): WebMvcConfigurer? {
         return object : WebMvcConfigurer {
             override fun addCorsMappings(registry: CorsRegistry) {
-                registry.addMapping("/hankkeet").allowedOrigins("http://localhost", "http://localhost:8000", "http://localhost:3001", "https://haitaton-ui-dev.agw.arodevtest.hel.fi")
-                registry.addMapping("/organisaatiot").allowedOrigins("http://localhost", "http://localhost:8000", "http://localhost:3001", "https://haitaton-ui-dev.agw.arodevtest.hel.fi")
+                registry.addMapping("/hankkeet").allowedMethods("POST", "GET").allowedOrigins(allowedOrigins)
+                registry.addMapping("/hankkeet/**").allowedMethods("POST", "GET", "PUT").allowedOrigins(allowedOrigins)
+                registry.addMapping("/organisaatiot").allowedMethods("GET").allowedOrigins(allowedOrigins)
             }
         }
     }

--- a/services/hanke-service/src/main/resources/application.properties
+++ b/services/hanke-service/src/main/resources/application.properties
@@ -1,3 +1,5 @@
+haitaton.cors.allowedOrigins=${HAITATON_CORS_ALLOWED_ORIGINS:http://localhost:3001}
+
 # To be removed once everything tested to run smooth without these. (Note, these were used
 # in DbConfigProperties.kt)
 #app.datasource.url=jdbc:postgresql://${HAITATON_HOST:localhost}:${HAITATON_PORT:5432}/${HAITATON_DATABASE:haitaton}


### PR DESCRIPTION
* docker-compose.yml:ssä HAITATON_CORS_ALLOWED_ORIGINS: http://localhost:8000, jotta voisi Dockerilla ajaa kantoja ja bäkkäriä ja fronttia IDE:ssä tms erikseen
* application.properties:ssa oletuksena http://localhost:3001, jotta voisi ajaa Dockerilla kantaa ja UI:a ja bäkkäriä IDE:ssä erikseen

Jotta voi testata (siten, että hanke-service on localhost:8080), niin haitaton-ui:ssa pitää tehdä muutos src/common/utils/api.ts:
```
const api: AxiosInstance = axios.create({
  baseURL: 'http://localhost:8080',
});

```