### PR TITLE
HAI-583 added default value and notnull constraint to flag fields

### DIFF
--- a/services/hanke-service/src/main/resources/db/changelog/changesets/set-defaults-to-hanke-flag-fields.yml
+++ b/services/hanke-service/src/main/resources/db/changelog/changesets/set-defaults-to-hanke-flag-fields.yml
@@ -1,0 +1,12 @@
+databaseChangeLog:
+  - changeSet:
+      id: set-defaults-to-hanke-flag-fields
+      comment: Set the default values to false and notnull constraint for all flag fields
+      author: Markku Hassinen
+      changes:
+        - addDefaultValue: { tableName: hanke, columnName: tilaongeometrioita, defaultValueBoolean: false }
+        - addDefaultValue: { tableName: hanke, columnName: tilaonviereisiahankkeita, defaultValueBoolean: false }
+        - addDefaultValue: { tableName: hanke, columnName: tilaonasiakasryhmia, defaultValueBoolean: false }
+        - addNotNullConstraint: { tableName: hanke, columnName: tilaongeometrioita, defaultNullValue: false }
+        - addNotNullConstraint: { tableName: hanke, columnName: tilaonviereisiahankkeita, defaultNullValue: false }
+        - addNotNullConstraint: { tableName: hanke, columnName: tilaonasiakasryhmia, defaultNullValue: false }

--- a/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -19,3 +19,5 @@ databaseChangeLog:
       file: db/changelog/changesets/modify-userids-to-strings.yml
   - include:
       file: db/changelog/changesets/add-hanke-flag-fields.yml
+  - include:
+      file: db/changelog/changesets/set-defaults-to-hanke-flag-fields.yml


### PR DESCRIPTION
Would have been cleaner in the original changeset, but since that has already been run in to dev database, this does the relevant changes as additional step.

Tested locally, observing database results directly. Not yet tested in full environment, but since dev isn't working now, this certainly does not make it worse. Might even fix the problem.