### PR TITLE
HAI-628 authentication & authorization tests for controllers

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/ActuatorEndpointITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/ActuatorEndpointITests.kt
@@ -5,6 +5,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.Import
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
@@ -23,6 +24,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 )
 @AutoConfigureMockMvc
 @EnableAutoConfiguration
+@Import(IntegrationTestConfiguration::class)
 @ActiveProfiles("itest")
 class ActuatorEndpointITests(@Autowired val mockMvc: MockMvc) {
 

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/IntegrationTestConfiguration.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/IntegrationTestConfiguration.kt
@@ -4,12 +4,12 @@ import fi.hel.haitaton.hanke.geometria.HankeGeometriatDao
 import fi.hel.haitaton.hanke.geometria.HankeGeometriatService
 import fi.hel.haitaton.hanke.organisaatio.OrganisaatioService
 import io.mockk.mockk
+import org.springframework.boot.test.context.TestConfiguration
 import org.springframework.context.annotation.Bean
-import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Profile
 import org.springframework.jdbc.core.JdbcOperations
 
-@Configuration
+@TestConfiguration
 @Profile("itest")
 class IntegrationTestConfiguration {
 

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/IntegrationTestResourceServerConfig.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/IntegrationTestResourceServerConfig.kt
@@ -2,6 +2,7 @@ package fi.hel.haitaton.hanke
 
 import fi.hel.haitaton.hanke.security.AccessRules
 import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Profile
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.oauth2.config.annotation.web.configuration.EnableResourceServer
@@ -9,6 +10,7 @@ import org.springframework.security.oauth2.config.annotation.web.configuration.R
 import org.springframework.security.oauth2.config.annotation.web.configurers.ResourceServerSecurityConfigurer
 
 @TestConfiguration
+@Profile("itest")
 @EnableResourceServer
 @EnableGlobalMethodSecurity(prePostEnabled = true)
 class IntegrationTestResourceServerConfig : ResourceServerConfigurerAdapter() {

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/IntegrationTestResourceServerConfig.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/IntegrationTestResourceServerConfig.kt
@@ -1,0 +1,24 @@
+package fi.hel.haitaton.hanke
+
+import fi.hel.haitaton.hanke.security.AccessRules
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.oauth2.config.annotation.web.configuration.EnableResourceServer
+import org.springframework.security.oauth2.config.annotation.web.configuration.ResourceServerConfigurerAdapter
+import org.springframework.security.oauth2.config.annotation.web.configurers.ResourceServerSecurityConfigurer
+
+@TestConfiguration
+@EnableResourceServer
+@EnableGlobalMethodSecurity(prePostEnabled = true)
+class IntegrationTestResourceServerConfig : ResourceServerConfigurerAdapter() {
+
+    override fun configure(http: HttpSecurity) {
+        AccessRules.configureHttpAccessRules(http)
+    }
+
+    // See a comment in https://github.com/spring-projects/spring-security-oauth/issues/385
+    override fun configure(resources: ResourceServerSecurityConfigurer) {
+        resources.stateless(false)
+    }
+}

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/security/HankeControllerSecurityTests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/security/HankeControllerSecurityTests.kt
@@ -1,0 +1,179 @@
+package fi.hel.haitaton.hanke.security
+
+import fi.hel.haitaton.hanke.HankeController
+import fi.hel.haitaton.hanke.HankeService
+import fi.hel.haitaton.hanke.IntegrationTestConfiguration
+import fi.hel.haitaton.hanke.IntegrationTestResourceServerConfig
+import fi.hel.haitaton.hanke.SaveType
+import fi.hel.haitaton.hanke.TZ_UTC
+import fi.hel.haitaton.hanke.Vaihe
+import fi.hel.haitaton.hanke.domain.Hanke
+import fi.hel.haitaton.hanke.domain.HankeSearch
+import fi.hel.haitaton.hanke.getCurrentTimeUTC
+import fi.hel.haitaton.hanke.toJsonString
+import io.mockk.every
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.context.annotation.Import
+import org.springframework.http.MediaType
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors
+import org.springframework.security.test.web.servlet.response.SecurityMockMvcResultMatchers.unauthenticated
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.ResultActions
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.time.ZonedDateTime
+import java.time.temporal.ChronoUnit
+
+
+/**
+ * Tests to ensure HankeController endpoints have correct authentication and
+ * authorization restrictions and handling.
+ *
+ * The actual activities in each test are not important, as long as they cause
+ * the relevant method to be called.
+ * "Perform" function implementations have been adapted from HankeControllerITests.
+ * As long as the mocked operation goes through and returns something "ok" (when
+ * authenticated correctly), it will be usable as an authentication test's operation.
+ *
+ * TODO
+ * Note, HankeService's method-based security is to be tested separately, (in own test class),
+ * once it gets any activated. For now, testing the Controller is enough as the service's
+ * finer things are not implemented.
+ */
+@WebMvcTest(HankeController::class)
+@Import(IntegrationTestConfiguration::class, IntegrationTestResourceServerConfig::class)
+@ActiveProfiles("itest")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class HankeControllerSecurityTests(@Autowired val mockMvc: MockMvc) {
+
+    @Autowired
+    private lateinit var hankeService: HankeService
+
+    private val testHankeTunnus = "HAI21-TEST-1"
+
+
+    @Test
+    @WithMockUser(username = "test7358", roles = ["haitaton-user"])
+    fun `status ok with authenticated user with correct role`() {
+        performGetHankkeet().andExpect(status().isOk)
+        performPostHankkeet().andExpect(status().isOk)
+        performPutHankkeetTunnus().andExpect(status().isOk)
+        performGetHankkeetTunnus().andExpect(status().isOk)
+    }
+
+    @Test
+    // Without mock user, i.e. anonymous
+    fun `status unauthorized (401) without authenticated user`() {
+        performGetHankkeet()
+                .andExpect(unauthenticated())
+                .andExpect(status().isUnauthorized)
+        performPostHankkeet()
+                .andExpect(unauthenticated())
+                .andExpect(status().isUnauthorized)
+        performPutHankkeetTunnus()
+                .andExpect(unauthenticated())
+                .andExpect(status().isUnauthorized)
+        performGetHankkeetTunnus()
+                .andExpect(unauthenticated())
+                .andExpect(status().isUnauthorized)
+    }
+
+    @Test
+    @WithMockUser(username = "test7358", roles = ["bad role"])
+    fun `status forbidden (403) with authenticated user with bad role`() {
+        performGetHankkeet().andExpect(status().isForbidden)
+        performPostHankkeet().andExpect(status().isForbidden)
+        performPutHankkeetTunnus().andExpect(status().isForbidden)
+        performGetHankkeetTunnus().andExpect(status().isForbidden)
+    }
+
+    @Test
+    @WithMockUser(username = "test7358", roles = [])
+    fun `status forbidden (403) with authenticated user without roles`() {
+        performGetHankkeet().andExpect(status().isForbidden)
+        performPostHankkeet().andExpect(status().isForbidden)
+        performPutHankkeetTunnus().andExpect(status().isForbidden)
+        performGetHankkeetTunnus().andExpect(status().isForbidden)
+    }
+
+    // --------- GET /hankkeet/ --------------
+
+    private fun performGetHankkeet(): ResultActions {
+        val criteria = HankeSearch()
+        every { hankeService.loadAllHanke(criteria) }.returns(
+                listOf(Hanke(123, testHankeTunnus),
+                        Hanke(444, "HAI-TEST-2")))
+
+        return mockMvc.perform(get("/hankkeet")
+                .accept(MediaType.APPLICATION_JSON))
+    }
+
+    // --------- POST /hankkeet/ --------------
+
+    private fun performPostHankkeet(): ResultActions {
+        val hanke = getTestHanke(null, null)
+        val content = hanke.toJsonString()
+
+        every { hankeService.createHanke(any()) }.returns(hanke)
+
+        return mockMvc.perform(post("/hankkeet")
+                .contentType(MediaType.APPLICATION_JSON).characterEncoding("UTF-8").content(content)
+                .with(SecurityMockMvcRequestPostProcessors.csrf())
+                .accept(MediaType.APPLICATION_JSON))
+    }
+
+    // --------- PUT /hankkeet/{hankeTunnus} --------------
+
+    private fun performPutHankkeetTunnus(): ResultActions {
+        val hanke = getTestHanke(123, testHankeTunnus)
+        val content = hanke.toJsonString()
+
+        every { hankeService.updateHanke(any()) }.returns(hanke)
+
+        return mockMvc.perform(put("/hankkeet/$testHankeTunnus")
+                .contentType(MediaType.APPLICATION_JSON).characterEncoding("UTF-8").content(content)
+                .with(SecurityMockMvcRequestPostProcessors.csrf())
+                .accept(MediaType.APPLICATION_JSON))
+    }
+
+    // --------- GET /hankkeet/{hankeTunnus} --------------
+
+    private fun performGetHankkeetTunnus(): ResultActions {
+        every { hankeService.loadHanke(any()) }
+                .returns(Hanke(123, "HAI-TEST-1"))
+
+        return mockMvc.perform(get("/hankkeet/$testHankeTunnus")
+                .accept(MediaType.APPLICATION_JSON))
+    }
+
+
+    // ===================== HELPERS ========================
+
+    private fun getDatetimeAlku(): ZonedDateTime {
+        val year = getCurrentTimeUTC().year + 1
+        return ZonedDateTime.of(year, 2, 20, 23, 45, 56, 0, TZ_UTC)
+                .truncatedTo(ChronoUnit.MILLIS)
+    }
+
+    private fun getDatetimeLoppu(): ZonedDateTime {
+        val year = getCurrentTimeUTC().year + 1
+        return ZonedDateTime.of(year, 2, 21, 0, 12, 34, 0, TZ_UTC)
+                .truncatedTo(ChronoUnit.MILLIS)
+    }
+
+    private fun getTestHanke(id: Int?, tunnus: String?): Hanke {
+        return Hanke(id, tunnus,
+                true, "Testihanke", "Testihankkeen kuvaus",
+                getDatetimeAlku(), getDatetimeLoppu(), Vaihe.OHJELMOINTI, null,
+                1, "Risto", getCurrentTimeUTC(), null, null,
+                SaveType.DRAFT)
+    }
+
+}

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/security/HankeGeometriaControllerSecurityTests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/security/HankeGeometriaControllerSecurityTests.kt
@@ -1,0 +1,120 @@
+package fi.hel.haitaton.hanke.security
+
+import fi.hel.haitaton.hanke.IntegrationTestConfiguration
+import fi.hel.haitaton.hanke.IntegrationTestResourceServerConfig
+import fi.hel.haitaton.hanke.asJsonResource
+import fi.hel.haitaton.hanke.geometria.HankeGeometriaController
+import fi.hel.haitaton.hanke.geometria.HankeGeometriat
+import fi.hel.haitaton.hanke.geometria.HankeGeometriatService
+import fi.hel.haitaton.hanke.toJsonString
+import io.mockk.every
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.context.annotation.Import
+import org.springframework.http.MediaType
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors
+import org.springframework.security.test.web.servlet.response.SecurityMockMvcResultMatchers.unauthenticated
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.ResultActions
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+/**
+ * Tests to ensure HankeGeometriaController endpoints have correct authentication
+ * and authorization restrictions and handling.
+ *
+ * Currently the same rules as for HankeController.
+ *
+ * The actual activities in each test are not important, as long as they cause
+ * the relevant method to be called.
+ * "Perform" function implementations have been adapted from HankeGeometriatControllerITests.
+ * As long as the mocked operation goes through and returns something "ok" (when
+ * authenticated correctly), it will be usable as an authentication test's operation.
+ */
+@WebMvcTest(HankeGeometriaController::class)
+@Import(IntegrationTestConfiguration::class, IntegrationTestResourceServerConfig::class)
+@ActiveProfiles("itest")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class HankeGeometriaControllerSecurityTests(@Autowired val mockMvc: MockMvc) {
+
+    @Autowired
+    private lateinit var hankeGeometriatService: HankeGeometriatService
+
+    @Test
+    @WithMockUser(username = "test7358", roles = ["haitaton-user"])
+    fun `status ok with authenticated user with correct role`() {
+        performPostHankkeetTunnusGeometriat().andExpect(status().isOk)
+        performGetHankkeetTunnusGeometriat().andExpect(status().isOk)
+    }
+
+    @Test
+    // Without mock user, i.e. anonymous
+    fun `status unauthorized (401) without authenticated user`() {
+        performPostHankkeetTunnusGeometriat()
+                .andExpect(unauthenticated())
+                .andExpect(status().isUnauthorized)
+        performGetHankkeetTunnusGeometriat()
+                .andExpect(unauthenticated())
+                .andExpect(status().isUnauthorized)
+    }
+
+    @Test
+    @WithMockUser(username = "test7358", roles = ["bad role"])
+    fun `status forbidden (403) with authenticated user with bad role`() {
+        performPostHankkeetTunnusGeometriat().andExpect(status().isForbidden)
+        performGetHankkeetTunnusGeometriat().andExpect(status().isForbidden)
+    }
+
+    @Test
+    @WithMockUser(username = "test7358", roles = [])
+    fun `status forbidden (403) with authenticated user without roles`() {
+        performPostHankkeetTunnusGeometriat().andExpect(status().isForbidden)
+        performGetHankkeetTunnusGeometriat().andExpect(status().isForbidden)
+    }
+
+    // ---------- POST /hankkeet/{hankeTunnus}/geometriat ----------
+
+    private fun performPostHankkeetTunnusGeometriat(): ResultActions {
+        val hankeGeometriat = "/fi/hel/haitaton/hanke/hankeGeometriat.json".asJsonResource(HankeGeometriat::class.java)
+        hankeGeometriat.hankeId = null
+        hankeGeometriat.version = null
+        hankeGeometriat.createdAt = null
+        hankeGeometriat.modifiedAt = null
+        val hankeTunnus = "1234567"
+        val hankeId = 1
+        val savedHankeGeometriat =
+                "/fi/hel/haitaton/hanke/hankeGeometriat.json".asJsonResource(HankeGeometriat::class.java)
+        savedHankeGeometriat.hankeId = hankeId
+        savedHankeGeometriat.version = 1
+
+        every { hankeGeometriatService.saveGeometriat(hankeTunnus, any()) } returns savedHankeGeometriat
+
+        return mockMvc.perform(
+                post("/hankkeet/$hankeTunnus/geometriat")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .with(SecurityMockMvcRequestPostProcessors.csrf())
+                        .content(hankeGeometriat.toJsonString())
+                        .accept(MediaType.APPLICATION_JSON)
+        )
+    }
+
+    // ---------- GET /hankkeet/{hankeTunnus}/geometriat ----------
+
+    private fun performGetHankkeetTunnusGeometriat(): ResultActions {
+        val hankeTunnus = "1234567"
+        val hankeGeometriat = "/fi/hel/haitaton/hanke/hankeGeometriat.json".asJsonResource(HankeGeometriat::class.java)
+
+        every { hankeGeometriatService.loadGeometriat(hankeTunnus) } returns hankeGeometriat
+
+        return mockMvc.perform(
+                get("/hankkeet/$hankeTunnus/geometriat")
+                        .accept(MediaType.APPLICATION_JSON)
+        )
+    }
+
+}

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/security/OrganisaatioControllerSecurityTests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/security/OrganisaatioControllerSecurityTests.kt
@@ -1,0 +1,68 @@
+package fi.hel.haitaton.hanke.security
+
+import fi.hel.haitaton.hanke.IntegrationTestConfiguration
+import fi.hel.haitaton.hanke.IntegrationTestResourceServerConfig
+import fi.hel.haitaton.hanke.organisaatio.Organisaatio
+import fi.hel.haitaton.hanke.organisaatio.OrganisaatioController
+import fi.hel.haitaton.hanke.organisaatio.OrganisaatioService
+import io.mockk.every
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.context.annotation.Import
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.ResultActions
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+/**
+ * Tests to ensure OrganisaatioController has correct authentication and
+ * authorization restrictions and handling. (Currently not restricted at all.)
+ */
+@WebMvcTest(OrganisaatioController::class)
+@Import(IntegrationTestConfiguration::class, IntegrationTestResourceServerConfig::class)
+@ActiveProfiles("itest")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class OrganisaatioControllerSecurityTests(@Autowired val mockMvc: MockMvc) {
+
+    @Autowired
+    lateinit var organisaatioService: OrganisaatioService
+
+    @Test
+    @WithMockUser(username = "test7358", roles = ["haitaton-user"])
+    fun `status ok with authenticated user with correct role`() {
+        performGetOrganisaatiot().andExpect(status().isOk)
+    }
+
+    @Test
+    // Without mock user, i.e. anonymous
+    fun `status ok without authenticated user`() {
+        performGetOrganisaatiot().andExpect(status().isOk)
+    }
+
+    @Test
+    @WithMockUser(username = "test7358", roles = ["bad role"])
+    fun `status ok with authenticated user with bad role`() {
+        performGetOrganisaatiot().andExpect(status().isOk)
+    }
+
+    @Test
+    @WithMockUser(username = "test7358", roles = [])
+    fun `status ok with authenticated user without roles`() {
+        performGetOrganisaatiot().andExpect(status().isOk)
+    }
+
+    private fun performGetOrganisaatiot(): ResultActions {
+        val organisations = listOf(
+                Organisaatio(1, "DNA", "DNA Oy"),
+                Organisaatio(2, "WELHO", "DNA WELHO Oy")
+        )
+
+        every { organisaatioService.getOrganisaatiot() }.returns(organisations)
+
+        return mockMvc.perform(get("/organisaatiot/"))
+    }
+}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/security/AccessRules.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/security/AccessRules.kt
@@ -1,0 +1,17 @@
+package fi.hel.haitaton.hanke.security
+
+import org.springframework.http.HttpMethod
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+
+class AccessRules {
+    companion object {
+        fun configureHttpAccessRules(http: HttpSecurity) {
+            http.anonymous().and()
+                    .authorizeRequests()
+                    .mvcMatchers(HttpMethod.GET, "/organisaatiot").permitAll()
+                    .mvcMatchers(HttpMethod.POST, "/hankkeet", "/hankkeet/**").hasRole("haitaton-user")
+                    .mvcMatchers(HttpMethod.GET, "/hankkeet", "/hankkeet/**").hasRole("haitaton-user")
+                    .mvcMatchers(HttpMethod.PUT, "/hankkeet/**").hasRole("haitaton-user")
+        }
+    }
+}


### PR DESCRIPTION
Only tests the controller endpoints and their settings, not the actual authentication handling (JWT-token etc.) handling in front of it all. Also, if service-classes get method-level security later, these tests do not cover those.

Integration tests run.