### PR TITLE
HAI-628 similar annotation setups for integration tests

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeControllerITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeControllerITests.kt
@@ -32,7 +32,7 @@ import java.time.temporal.ChronoUnit
  *
  * This class should test only the weblayer (both HTTP server and context to be auto-mocked).
  */
-@WebMvcTest
+@WebMvcTest(HankeController::class)
 @Import(IntegrationTestConfiguration::class)
 @ActiveProfiles("itest")
 @WithMockUser("test", roles = ["haitaton-user"])

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/geometria/HankeGeometriaControllerITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/geometria/HankeGeometriaControllerITests.kt
@@ -23,7 +23,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
-@WebMvcTest
+@WebMvcTest(HankeGeometriaController::class)
 @Import(IntegrationTestConfiguration::class)
 @ActiveProfiles("itest")
 @WithMockUser("test", roles = ["haitaton-user"])

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/organisaatio/OrganisaatioControllerITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/organisaatio/OrganisaatioControllerITests.kt
@@ -15,7 +15,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
-@WebMvcTest
+@WebMvcTest(OrganisaatioController::class)
 @Import(IntegrationTestConfiguration::class)
 @ActiveProfiles("itest")
 @WithMockUser("test", roles = ["haitaton-user"])

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluControllerITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluControllerITests.kt
@@ -2,11 +2,8 @@ package fi.hel.haitaton.hanke.tormaystarkastelu
 
 import fi.hel.haitaton.hanke.*
 import fi.hel.haitaton.hanke.domain.Hanke
-import fi.hel.haitaton.hanke.geometria.HankeGeometriatService
 import io.mockk.every
 import io.mockk.verify
-import org.assertj.core.api.Assertions
-import org.junit.Assert
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
@@ -21,7 +18,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers
 import java.time.ZonedDateTime
 import java.time.temporal.ChronoUnit
 
-@WebMvcTest
+@WebMvcTest(TormaystarkasteluController::class)
 @Import(IntegrationTestConfiguration::class)
 @ActiveProfiles("itest")
 @WithMockUser("test", roles = ["haitaton-user"])

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/ResourceServerConfig.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/ResourceServerConfig.kt
@@ -1,9 +1,9 @@
 package fi.hel.haitaton.hanke
 
+import fi.hel.haitaton.hanke.security.AccessRules
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.http.HttpMethod
 import org.springframework.security.access.expression.SecurityExpressionHandler
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
@@ -28,12 +28,7 @@ class ResourceServerConfig : ResourceServerConfigurerAdapter() {
     lateinit var urlJwk: String
 
     override fun configure(http: HttpSecurity) {
-        http.anonymous().and()
-            .authorizeRequests()
-            .mvcMatchers(HttpMethod.GET, "/organisaatiot").permitAll()
-            .mvcMatchers(HttpMethod.POST, "/hankkeet", "/hankkeet/**").hasRole("haitaton-user")
-            .mvcMatchers(HttpMethod.GET, "/hankkeet", "/hankkeet/**").hasRole("haitaton-user")
-            .mvcMatchers(HttpMethod.PUT, "/hankkeet/**").hasRole("haitaton-user")
+        AccessRules.configureHttpAccessRules(http)
     }
 
     override fun configure(resources: ResourceServerSecurityConfigurer) {


### PR DESCRIPTION
and both tests and main code to use shared access rules.

Integration tests still pass.

The purpose of adding the class in the WebMvcTest annotation is to let spring-test to know that only the specified controller needs to be instantiated.