### PR TITLE
Hai 743 tormtark tietokanta

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/IntegrationTestConfiguration.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/IntegrationTestConfiguration.kt
@@ -49,5 +49,7 @@ class IntegrationTestConfiguration {
         luokitteluService: TormaystarkasteluLuokitteluService
     ): TormaystarkasteluLaskentaService = mockk()
 
+    @Bean
+    fun tormaystarkasteluTulosRepository(): TormaystarkasteluTulosRepository = mockk()
 
 }

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaysTarkasteluTulosRepositoryITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaysTarkasteluTulosRepositoryITests.kt
@@ -24,12 +24,13 @@ class TormaysTarkasteluTulosRepositoryITests @Autowired constructor(
 ) {
 
     val DATETIME = LocalDateTime.of(2020, 2, 20, 20, 20, 20)
-    val TESTINDEXVALUE = 3.3f
+    val TEST_INDEX_VALUE = 3.3f
+    val TEST_HANKE_TUNNUS = "TEST-123"
 
     @Test
     fun `findByHankeId returns existing tulos and hanke`() {
         // Create parent Hanke (with mostly null data), and a tulos connected with it, persist both:
-        val hankeEntity = persistHanke(HankeEntity(hankeTunnus = "TEST-123"))
+        val hankeEntity = persistHanke(HankeEntity(hankeTunnus = TEST_HANKE_TUNNUS))
         val hankeId = hankeEntity.id!!
         val tulosEntity = prepareTulos(hankeEntity)
         entityManager.persist(tulosEntity)
@@ -46,7 +47,7 @@ class TormaysTarkasteluTulosRepositoryITests @Autowired constructor(
     @Test
     fun `findByHankeId does not return anything for non-existing hanke`() {
         // Create parent Hanke (with mostly null data), and a tulos connected with it, persist both:
-        val hankeEntity = persistHanke(HankeEntity(hankeTunnus = "TEST-123"))
+        val hankeEntity = persistHanke(HankeEntity(hankeTunnus = TEST_HANKE_TUNNUS))
         val hankeId = hankeEntity.id!!
         val tulosEntity = prepareTulos(hankeEntity)
         entityManager.persist(tulosEntity)
@@ -60,7 +61,7 @@ class TormaysTarkasteluTulosRepositoryITests @Autowired constructor(
     @Test
     fun `All fields are saved and loaded correctly`() {
         // Create parent Hanke (with mostly null data), and a tulos connected with it, persist hanke only:
-        val hankeEntity = persistHanke(HankeEntity(hankeTunnus = "TEST-123"))
+        val hankeEntity = persistHanke(HankeEntity(hankeTunnus = TEST_HANKE_TUNNUS))
         val tulosEntity = prepareTulos(hankeEntity)
 
         // Save it (using our Repository):
@@ -81,7 +82,7 @@ class TormaysTarkasteluTulosRepositoryITests @Autowired constructor(
     @Test
     fun `Removing tulos from hanke works`() {
         // Create parent Hanke (with mostly null data), and a tulos connected with it, persist both:
-        val hankeEntity = persistHanke(HankeEntity(hankeTunnus = "TEST-123"))
+        val hankeEntity = persistHanke(HankeEntity(hankeTunnus = TEST_HANKE_TUNNUS))
         val hankeId = hankeEntity.id!!
         val tulosEntity = prepareTulos(hankeEntity)
         entityManager.persist(tulosEntity)
@@ -132,10 +133,10 @@ class TormaysTarkasteluTulosRepositoryITests @Autowired constructor(
      */
     private fun prepareTulos(hankeEntity: HankeEntity): TormaystarkasteluTulosEntity {
         val tulosEntity = TormaystarkasteluTulosEntity()
-        tulosEntity.liikennehaitta = LiikennehaittaIndeksiType(TESTINDEXVALUE, IndeksiType.JOUKKOLIIKENNEINDEKSI)
+        tulosEntity.liikennehaitta = LiikennehaittaIndeksiType(TEST_INDEX_VALUE, IndeksiType.JOUKKOLIIKENNEINDEKSI)
         tulosEntity.perus = 1.1f
         tulosEntity.pyoraily = 2.2f
-        tulosEntity.joukkoliikenne = TESTINDEXVALUE
+        tulosEntity.joukkoliikenne = TEST_INDEX_VALUE
         tulosEntity.tila = TormaystarkasteluTulosTila.VOIMASSA
         tulosEntity.tilaChangedAt = null
         tulosEntity.createdAt = DATETIME

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaysTarkasteluTulosRepositoryITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaysTarkasteluTulosRepositoryITests.kt
@@ -1,0 +1,148 @@
+package fi.hel.haitaton.hanke.tormaystarkastelu
+
+import assertk.assertThat
+import assertk.assertions.hasSize
+import assertk.assertions.isEmpty
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotNull
+import fi.hel.haitaton.hanke.HankeEntity
+import fi.hel.haitaton.hanke.HankeRepository
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager
+import java.time.LocalDateTime
+
+/**
+ * Testing the TormaysTarkasteluTulosRepository with a database.
+ */
+@DataJpaTest(properties = ["spring.liquibase.enabled=false"])
+class TormaysTarkasteluTulosRepositoryITests @Autowired constructor(
+        val entityManager: TestEntityManager,
+        val tormaystarkasteluTulosRepository: TormaystarkasteluTulosRepository,
+        val hankeRepository: HankeRepository
+) {
+
+    val DATETIME = LocalDateTime.of(2020, 2, 20, 20, 20, 20)
+    val TESTINDEXVALUE = 3.3f
+
+    @Test
+    fun `findByHankeId returns existing tulos and hanke`() {
+        // Create parent Hanke (with mostly null data), and a tulos connected with it, persist both:
+        val hankeEntity = persistHanke(HankeEntity(hankeTunnus = "TEST-123"))
+        val hankeId = hankeEntity.id!!
+        val tulosEntity = prepareTulos(hankeEntity)
+        entityManager.persist(tulosEntity)
+        entityManager.flush()
+        val tulosId = tulosEntity.id
+
+        // Try to find that (using our Repository implementation):
+        val testResultEntityList = tormaystarkasteluTulosRepository.findByHankeId(hankeId)
+        val testResultEntity = testResultEntityList[0]
+        assertThat(testResultEntity).isNotNull()
+        assertThat(testResultEntity.id).isEqualTo(tulosId)
+    }
+
+    @Test
+    fun `findByHankeId does not return anything for non-existing hanke`() {
+        // Create parent Hanke (with mostly null data), and a tulos connected with it, persist both:
+        val hankeEntity = persistHanke(HankeEntity(hankeTunnus = "TEST-123"))
+        val hankeId = hankeEntity.id!!
+        val tulosEntity = prepareTulos(hankeEntity)
+        entityManager.persist(tulosEntity)
+        entityManager.flush()
+
+        // Try to find something else than what was persisted
+        val testResultEntityList = tormaystarkasteluTulosRepository.findByHankeId(hankeId + 1000)
+        assertThat(testResultEntityList).isEmpty()
+    }
+
+    @Test
+    fun `All fields are saved and loaded correctly`() {
+        // Create parent Hanke (with mostly null data), and a tulos connected with it, persist hanke only:
+        val hankeEntity = persistHanke(HankeEntity(hankeTunnus = "TEST-123"))
+        val tulosEntity = prepareTulos(hankeEntity)
+
+        // Save it (using our Repository):
+        tormaystarkasteluTulosRepository.save(tulosEntity)
+        val tulosId = tulosEntity.id
+        assertThat(tulosId).isNotNull()
+        entityManager.flush() // Make sure the stuff is run to database (though not necessarily committed)
+        entityManager.clear() // Ensure the original entity is no longer in Hibernate's 1st level cache
+
+
+        // Load it back to different entity and check the fields
+        val testResultEntity = tormaystarkasteluTulosRepository.findById(tulosId!!).get()
+        assertThat(testResultEntity).isNotNull()
+
+        assertThat(testResultEntity).isEqualTo(tulosEntity) // Checks almost all fields
+    }
+
+    @Test
+    fun `Removing tulos from hanke works`() {
+        // Create parent Hanke (with mostly null data), and a tulos connected with it, persist both:
+        val hankeEntity = persistHanke(HankeEntity(hankeTunnus = "TEST-123"))
+        val hankeId = hankeEntity.id!!
+        val tulosEntity = prepareTulos(hankeEntity)
+        entityManager.persist(tulosEntity)
+        entityManager.flush()
+        val tulosId = tulosEntity.id
+
+        // Check that it was saved
+        val testResultEntity = tormaystarkasteluTulosRepository.findById(tulosId!!).get()
+        assertThat(testResultEntity).isNotNull()
+        assertThat(testResultEntity.hanke).isNotNull()
+        assertThat(testResultEntity.hanke!!.tormaystarkasteluTulokset).hasSize(1)
+
+        // Remove tulos from the hanke
+        val testResultEntitysParent = testResultEntity.hanke
+        testResultEntity.removeFromHanke()
+        hankeRepository.save(testResultEntitysParent!!) // If only saving/deleting the tulos, the hanke-side may revive the data..
+        // This delete call is optional; the saving of hanke will also update the tulos-table
+        //tormaystarkasteluTulosRepository.deleteById(testResultEntity.id!!)
+        entityManager.flush()
+
+        // Check that it got removed
+        val finalHankeEntity = hankeRepository.findById(hankeId).get()
+        assertThat(finalHankeEntity.tormaystarkasteluTulokset).isEmpty()
+        val finalTormaystarkasteluTulosEntityList = tormaystarkasteluTulosRepository.findByHankeId(hankeId)
+        assertThat(finalTormaystarkasteluTulosEntityList).isEmpty()
+    }
+
+//    @Test
+//    fun `Removing hanke removes related tulos`() {
+//        // TODO
+//    }
+
+
+    /**
+     * Persists given HankeEntity to get a valid hanke Id and entity
+     * (the relation between hanke and tormaystarkastelutulos things requires valid hanke id in the database)
+     */
+    private fun persistHanke(hankeEntity: HankeEntity): HankeEntity {
+        val hankeEntity2 = entityManager.persist(hankeEntity)
+        entityManager.flush()
+        val hankeId = hankeEntity2.id
+        assertThat(hankeId).isNotNull()
+        return hankeEntity2
+    }
+
+    /**
+     * Prepares a tulos entity and connects it with the given parent hanke, but does not save the new state.
+     */
+    private fun prepareTulos(hankeEntity: HankeEntity): TormaystarkasteluTulosEntity {
+        val tulosEntity = TormaystarkasteluTulosEntity()
+        tulosEntity.liikennehaitta = LiikennehaittaIndeksiType(TESTINDEXVALUE, IndeksiType.JOUKKOLIIKENNEINDEKSI)
+        tulosEntity.perus = 1.1f
+        tulosEntity.pyoraily = 2.2f
+        tulosEntity.joukkoliikenne = TESTINDEXVALUE
+        tulosEntity.tila = TormaystarkasteluTulosTila.VOIMASSA
+        tulosEntity.tilaChangedAt = null
+        tulosEntity.createdAt = DATETIME
+
+        tulosEntity.addToHanke(hankeEntity)
+
+        return tulosEntity
+    }
+
+}

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluLaskentaServiceImplITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluLaskentaServiceImplITest.kt
@@ -114,7 +114,7 @@ internal class TormaystarkasteluLaskentaServiceImplITest {
 
         // assert the results
         assertThat(tormaystarkasteluHanke.tormaystarkasteluTulos).isNotNull()
-        assertThat(tormaystarkasteluHanke.tormaystarkasteluTulos!!.liikennehaittaIndeksi!!.type)
+        assertThat(tormaystarkasteluHanke.tormaystarkasteluTulos!!.liikennehaittaIndeksi!!.tyyppi)
             .isEqualTo(IndeksiType.JOUKKOLIIKENNEINDEKSI)
     }
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Persistence.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Persistence.kt
@@ -226,10 +226,8 @@ class HankeEntity(
     }
 
     fun addTormaystarkasteluTulos(tormaystarkasteluTulosEntity: TormaystarkasteluTulosEntity) {
-        if (tormaystarkasteluTulosEntity.hanke != null) {
-            if (tormaystarkasteluTulosEntity.hanke != this) {
-                throw IllegalStateException("Given TormaystarkasteluTulosEntity has already a different parent Hanke.")
-            }
+        if (tormaystarkasteluTulosEntity.hanke != null && tormaystarkasteluTulosEntity.hanke != this) {
+            throw IllegalStateException("Given TormaystarkasteluTulosEntity has already a different parent Hanke.")
         }
         tormaystarkasteluTulosEntity.hanke = this
         // Check that exactly same entity (with same id) is not added twice;

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Persistence.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Persistence.kt
@@ -1,13 +1,19 @@
 package fi.hel.haitaton.hanke
 
+import fi.hel.haitaton.hanke.tormaystarkastelu.LiikennehaittaIndeksiType
+import fi.hel.haitaton.hanke.tormaystarkastelu.TormaystarkasteluTulosEntity
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import java.time.LocalDate
 import java.time.LocalDateTime
+import javax.persistence.AttributeOverride
+import javax.persistence.AttributeOverrides
 import javax.persistence.CascadeType
 import javax.persistence.CollectionTable
+import javax.persistence.Column
 import javax.persistence.ElementCollection
+import javax.persistence.Embedded
 import javax.persistence.Entity
 import javax.persistence.EnumType
 import javax.persistence.Enumerated
@@ -181,14 +187,28 @@ class HankeEntity(
     // Checking geometry requires lookup into another database table.
     // Checking for nearby other Hanke requires GIS database query.
     var tilaOnGeometrioita: Boolean = false
-
     // var tilaOnKaikkiPakollisetLuontiTiedot: Boolean = false
     // var tilaOnTiedotLiikenneHaittaIndeksille: Boolean = false
     // var tilaOnLiikenneHaittaIndeksi: Boolean = false
     var tilaOnViereisiaHankkeita: Boolean = false
     var tilaOnAsiakasryhmia: Boolean = false
 
-    // ---------------  Helper functions -----------------
+    // --------------- Törmaystarkastelu -------------------
+    // NOTE: the type-field has column name "liikennehaittaindeksityyppi",
+    // whereas the combined object has type LiikenneHaittaIndeksiType in Kotlin-side.
+    @Embedded
+    @AttributeOverrides(
+        AttributeOverride(name = "indeksi", column = Column(name = "liikennehaittaindeksi")),
+        AttributeOverride(name = "type", column = Column(name = "liikennehaittaindeksityyppi"))
+    )
+    var liikennehaittaIndeksi: LiikennehaittaIndeksiType? = null
+
+    // Made bidirectional relation mainly to allow cascaded delete.
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "hanke", cascade = [CascadeType.ALL], orphanRemoval = true)
+    var tormaystarkastelutulokset: MutableList<TormaystarkasteluTulosEntity>? = null
+
+
+    // ==================  Helper functions ================
 
     fun addYhteystieto(yhteystieto: HankeYhteystietoEntity) {
         listOfHankeYhteystieto.add(yhteystieto)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/Hanke.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/Hanke.kt
@@ -51,10 +51,6 @@ data class Hanke(
     constructor(id: Int, hankeTunnus: String) : this(id, hankeTunnus, null, null, null, null, null, null, null, null, null, null, null, null)
     constructor() : this(null, null, null, null, null, null, null, null, null, null, null, null, null, null)
 
-    // -------------- Tormaystarkastelu -------------
-    var tormaystarkasteluTulos: TormaystarkasteluTulos? = null
-    var liikennehaittaindeksi: LiikennehaittaIndeksiType? = null
-
     // --------------- Yhteystiedot -----------------
     var omistajat = mutableListOf<HankeYhteystieto>()
     var arvioijat = mutableListOf<HankeYhteystieto>()
@@ -91,6 +87,21 @@ data class Hanke(
         } else {
             null
         }
+
+    // -------------- Tormaystarkastelu -------------
+    /**
+     * Liikennehaittaindeksi is always available here if it has been calculated and is still valid.
+     * Might be around even if no longer valid.
+     * TODO: should the validity-state be part of this indeksitype, too? (I.e. would know that even
+     *  when not getting the full tulos-data (which does have that state).
+     */
+    var liikennehaittaindeksi: LiikennehaittaIndeksiType? = null
+
+    /**
+     * These are currently available only when Hanke is returned via Tormaystarkastelu controller/service.
+     * And if they have been calculated and are still valid.
+     */
+    var tormaystarkasteluTulos: TormaystarkasteluTulos? = null
 
     // --------------- State flags -------------------
     var tilat: HankeTilat = HankeTilat()

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/Persistence.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/Persistence.kt
@@ -1,6 +1,7 @@
 package fi.hel.haitaton.hanke.tormaystarkastelu
 
 import fi.hel.haitaton.hanke.HankeEntity
+import fi.hel.haitaton.hanke.getCurrentTimeUTCAsLocalTime
 import org.springframework.data.jpa.repository.JpaRepository
 import java.time.LocalDateTime
 import javax.persistence.Embedded
@@ -23,6 +24,7 @@ class TormaystarkasteluTulosEntity {
     var joukkoliikenne: Float? = null
 
     var tila: TormaystarkasteluTulosTila? = null
+    var tilaChangedAt: LocalDateTime? = null
     var createdAt: LocalDateTime? = null
 
     @Id
@@ -32,6 +34,59 @@ class TormaystarkasteluTulosEntity {
     @ManyToOne(optional = false, fetch = FetchType.LAZY)
     @JoinColumn(name = "hankeid")
     var hanke: HankeEntity? = null
+
+    // ========  functions  =======
+
+    // NOTE: there is no way to validate already invalidated result;
+    // instead, must recalculate the results and thus create a new result.
+    fun invalidate() {
+        tila = TormaystarkasteluTulosTila.EI_VOIMASSA
+        tilaChangedAt = getCurrentTimeUTCAsLocalTime()
+    }
+
+    fun addToHanke(hankeEntity: HankeEntity) {
+        if (hanke != null && hanke != hankeEntity) {
+            throw IllegalStateException("This TormaystarkasteluTulosEntity is already connected with another Hanke.")
+        }
+        hankeEntity.addTormaystarkasteluTulos(this)
+    }
+
+    fun removeFromHanke() {
+        if (hanke == null)
+            return
+        hanke!!.removeTormaystarkasteluTulos(this)
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is TormaystarkasteluTulosEntity) return false
+
+        // For persisted entities, checking id match is enough
+        if (id != null && id != other.id) return false
+
+        // For non-persisted, have to compare almost everything
+        if (hanke != null && hanke != other.hanke) return false
+        if (liikennehaitta != other.liikennehaitta) return false
+        if (perus != other.perus) return false
+        if (pyoraily != other.pyoraily) return false
+        if (joukkoliikenne != other.joukkoliikenne) return false
+        if (tila != other.tila) return false
+
+        // Ignoring differences in the timestamps on purpose.
+
+        return true;
+    }
+
+    override fun hashCode(): Int {
+        var result = id?.hashCode() ?: 0
+        result = 31 * result + (hanke?.hashCode() ?: 0)
+        result = 31 * result + (liikennehaitta?.hashCode() ?: 0)
+        result = 31 * result + (perus?.hashCode() ?: 0)
+        result = 31 * result + (pyoraily?.hashCode() ?: 0)
+        result = 31 * result + (joukkoliikenne?.hashCode() ?: 0)
+        result = 31 * result + (tila?.hashCode() ?: 0)
+        return result
+    }
 }
 
 interface TormaystarkasteluTulosRepository: JpaRepository<TormaystarkasteluTulosEntity, Int> {

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/Persistence.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/Persistence.kt
@@ -1,0 +1,43 @@
+package fi.hel.haitaton.hanke.tormaystarkastelu
+
+import fi.hel.haitaton.hanke.HankeEntity
+import org.springframework.data.jpa.repository.JpaRepository
+import java.time.LocalDateTime
+import javax.persistence.Embedded
+import javax.persistence.Entity
+import javax.persistence.FetchType
+import javax.persistence.GeneratedValue
+import javax.persistence.GenerationType
+import javax.persistence.Id
+import javax.persistence.JoinColumn
+import javax.persistence.ManyToOne
+import javax.persistence.Table
+
+@Entity
+@Table(name = "tormaystarkastelutulos")
+class TormaystarkasteluTulosEntity {
+    @Embedded
+    var liikennehaitta: LiikennehaittaIndeksiType? = null
+    var perus: Float? = null
+    var pyoraily: Float? = null
+    var joukkoliikenne: Float? = null
+
+    var tila: TormaystarkasteluTulosTila? = null
+    var createdAt: LocalDateTime? = null
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Int? = null
+
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
+    @JoinColumn(name = "hankeid")
+    var hanke: HankeEntity? = null
+}
+
+interface TormaystarkasteluTulosRepository: JpaRepository<TormaystarkasteluTulosEntity, Int> {
+    /**
+     * Note, as HankeEntity has lazy relation to the related set of tormaystarkastelutulos
+     * entities, if one has the Hanke entity already, no need to pick the id and use this.
+     */
+    fun findByHankeId(hankeId: Int): List<TormaystarkasteluTulosEntity>
+}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluTulos.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluTulos.kt
@@ -1,5 +1,10 @@
 package fi.hel.haitaton.hanke.tormaystarkastelu
 
+import javax.persistence.Column
+import javax.persistence.Embeddable
+import javax.persistence.EnumType
+import javax.persistence.Enumerated
+
 data class TormaystarkasteluTulos(val hankeTunnus: String) {
 
     var hankeId: Int = 0
@@ -37,10 +42,25 @@ data class TormaystarkasteluTulos(val hankeTunnus: String) {
     }
 }
 
-data class LiikennehaittaIndeksiType(var indeksi: Float, var type: IndeksiType)
+// This class is also used as part of entity-classes TormaystarkasteluTulosEntity and Hanke.
+// HankeEntity overrides the column names.
+@Embeddable
+data class LiikennehaittaIndeksiType(
+    @Column(name = "liikennehaitta")
+    var indeksi: Float,
+    @Column(name = "liikennehaittatyyppi")
+    @Enumerated(EnumType.STRING)
+    // TODO: pitäisikö tämän olla "tyyppi", kun "indeksi":kin on suomeksi, samoin kuin tämän arvot?
+    var type: IndeksiType
+)
 
 enum class IndeksiType {
     PERUSINDEKSI,
     PYORAILYINDEKSI,
     JOUKKOLIIKENNEINDEKSI
+}
+
+enum class TormaystarkasteluTulosTila {
+    VOIMASSA,
+    EI_VOIMASSA
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluTulos.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluTulos.kt
@@ -50,14 +50,14 @@ data class LiikennehaittaIndeksiType(
     var indeksi: Float,
     @Column(name = "liikennehaittatyyppi")
     @Enumerated(EnumType.STRING)
-    // TODO: pitäisikö tämän olla "tyyppi", kun "indeksi":kin on suomeksi, samoin kuin tämän arvot?
-    var type: IndeksiType
+    var tyyppi: IndeksiType
 )
 
 enum class IndeksiType {
     PERUSINDEKSI,
     PYORAILYINDEKSI,
     JOUKKOLIIKENNEINDEKSI
+    // TODO: will likely need a new option "MONTA" or "USEITA".
 }
 
 enum class TormaystarkasteluTulosTila {

--- a/services/hanke-service/src/main/resources/db/changelog/changesets/add-tormaystarkastelu-results.yml
+++ b/services/hanke-service/src/main/resources/db/changelog/changesets/add-tormaystarkastelu-results.yml
@@ -26,4 +26,5 @@ databaseChangeLog:
               - column: { name: pyoraily, type: float }
               - column: { name: joukkoliikenne, type: float }
               - column: { name: tila, type: varchar(20) }
+              - column: { name: tilachangedat, type: timestamp }
               - column: { name: createdat, type: timestamp }

--- a/services/hanke-service/src/main/resources/db/changelog/changesets/add-tormaystarkastelu-results.yml
+++ b/services/hanke-service/src/main/resources/db/changelog/changesets/add-tormaystarkastelu-results.yml
@@ -1,0 +1,29 @@
+databaseChangeLog:
+  - changeSet:
+      id: add-tormaystarkastelu-main-result-to-hanke-table
+      comment: Add main 'törmäystarkastelu' main result fields to hanke-table
+      author: Markku Hassinen
+      changes:
+        - addColumn:
+            tableName: hanke
+            columns:
+              - column: { name: liikennehaittaindeksi, type: float }
+              - column: { name: liikennehaittaindeksityyppi, type: varchar(30) }
+
+  - changeSet:
+      id: add-tormaystarkastelutulos-table
+      comment: Add 'törmäystarkastelu' results table
+      author: Markku Hassinen
+      changes:
+        - createTable:
+            tableName: tormaystarkastelutulos
+            columns:
+              - column: { name: id, type: int, autoIncrement: true, constraints: { primaryKey: true, nullable: false } }
+              - column: { name: hankeid, type: int, constraints: { nullable: false, foreignKeyName: fk_hanke_tormaystarkastelutulos, references: hanke(id) } }
+              - column: { name: liikennehaitta, type: float }
+              - column: { name: liikennehaittatyyppi, type: varchar(30) }
+              - column: { name: perus, type: float }
+              - column: { name: pyoraily, type: float }
+              - column: { name: joukkoliikenne, type: float }
+              - column: { name: tila, type: varchar(20) }
+              - column: { name: createdat, type: timestamp }

--- a/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -21,3 +21,5 @@ databaseChangeLog:
       file: db/changelog/changesets/add-hanke-flag-fields.yml
   - include:
       file: db/changelog/changesets/set-defaults-to-hanke-flag-fields.yml
+  - include:
+      file: db/changelog/changesets/add-tormaystarkastelu-results.yml

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluCalculatorTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluCalculatorTest.kt
@@ -138,7 +138,7 @@ internal class TormaystarkasteluCalculatorTest {
         assertThat(result.joukkoliikenneIndeksi).isEqualTo(4.0f)
 
         assertThat(result.liikennehaittaIndeksi?.indeksi).isEqualTo(4.0f)
-        assertThat(result.liikennehaittaIndeksi?.type).isEqualTo(IndeksiType.JOUKKOLIIKENNEINDEKSI)
+        assertThat(result.liikennehaittaIndeksi?.tyyppi).isEqualTo(IndeksiType.JOUKKOLIIKENNEINDEKSI)
     }
 
     @Test
@@ -157,7 +157,7 @@ internal class TormaystarkasteluCalculatorTest {
         assertThat(result.joukkoliikenneIndeksi).isEqualTo(1.0f)
 
         assertThat(result.liikennehaittaIndeksi?.indeksi).isEqualTo(3.0f)
-        assertThat(result.liikennehaittaIndeksi?.type).isEqualTo(IndeksiType.PYORAILYINDEKSI)
+        assertThat(result.liikennehaittaIndeksi?.tyyppi).isEqualTo(IndeksiType.PYORAILYINDEKSI)
     }
 
     @Test
@@ -191,7 +191,7 @@ internal class TormaystarkasteluCalculatorTest {
         assertThat(result.joukkoliikenneIndeksi).isEqualTo(1.0f)
 
         assertThat(result.liikennehaittaIndeksi?.indeksi).isEqualTo(4.0f)
-        assertThat(result.liikennehaittaIndeksi?.type).isEqualTo(IndeksiType.PERUSINDEKSI)
+        assertThat(result.liikennehaittaIndeksi?.tyyppi).isEqualTo(IndeksiType.PERUSINDEKSI)
     }
 }
 


### PR DESCRIPTION
# Description

Adds Liquibase, JPA entities, Repository for törmaystarkastelu results, and changes in related existing places.

Not tested with fully running application, due to not yet connected to actual service functionality. Coming next...

### Jira Issue: 

https://helsinkisolutionoffice.atlassian.net/browse/HAI-537

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
Currently the code is not yet connected to actual service-side functionality; integration tests do some tests for the repository and as a side effect, with the liquibase and entity mappings.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [X] I have made necessary changes to the documentation, link to confluence
 or other location: 
https://helsinkisolutionoffice.atlassian.net/wiki/spaces/HAI/pages/1468661795/T+rm+ystarkastelun+tietokantamallit

# Other relevant info
NOTE: changed field name from English to Finnish, which may affect REST API
tormaystarkasteluTulos.liikennehaittaIndeksi.type -> .tyyppi