### PR TITLE
Hai 793 henkilotietojen lokitukset

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
@@ -282,11 +282,9 @@ class HankeServiceITests {
         // A small side-check here for audit fields handling on load:
         assertThat(returnedHanke3.omistajat[0].createdAt).isEqualTo(returnedHanke.omistajat[0].createdAt)
         assertThat(returnedHanke3.omistajat[0].createdBy).isEqualTo(returnedHanke.omistajat[0].createdBy)
-        assertThat(returnedHanke3.omistajat[0].modifiedAt).isNotNull
-        assertThat(returnedHanke3.omistajat[0].modifiedAt!!.toEpochSecond() - currentDatetime.toEpochSecond())
-            .isBetween(-600, 600) // +/-10 minutes
-        assertThat(returnedHanke3.omistajat[0].modifiedBy).isNotNull
-        assertThat(returnedHanke3.omistajat[0].modifiedBy).isEqualTo(USER_NAME)
+        // The original omistajat-entry was not modified, so modifiedXx-fields must not get values:
+        assertThat(returnedHanke3.omistajat[0].modifiedAt).isNull()
+        assertThat(returnedHanke3.omistajat[0].modifiedBy).isNull()
     }
 
     @Test
@@ -312,6 +310,9 @@ class HankeServiceITests {
 
         // Change a value:
         returnedHanke.omistajat[1].sukunimi = "Som Et Hing"
+
+        // For checking audit field datetimes (with some minutes of margin for test running delay):
+        val currentDatetime = getCurrentTimeUTC()
 
         // Call update, get the returned object, make some general checks:
         val returnedHanke2 = hankeService.updateHanke(returnedHanke)
@@ -341,6 +342,13 @@ class HankeServiceITests {
         assertThat(returnedHanke3.omistajat[1].id).isEqualTo(ytid2)
         assertThat(returnedHanke3.omistajat[0].sukunimi).isEqualTo("suku1")
         assertThat(returnedHanke3.omistajat[1].sukunimi).isEqualTo("Som Et Hing")
+
+        // Check that audit modifiedXx-fields got updated:
+        assertThat(returnedHanke3.omistajat[1].modifiedAt).isNotNull
+        assertThat(returnedHanke3.omistajat[1].modifiedAt!!.toEpochSecond() - currentDatetime.toEpochSecond())
+            .isBetween(-600, 600) // +/-10 minutes
+        assertThat(returnedHanke3.omistajat[1].modifiedBy).isNotNull
+        assertThat(returnedHanke3.omistajat[1].modifiedBy).isEqualTo(USER_NAME)
     }
 
     @Test

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
@@ -3,10 +3,16 @@ package fi.hel.haitaton.hanke
 import fi.hel.haitaton.hanke.domain.Hanke
 import fi.hel.haitaton.hanke.domain.HankeSearch
 import fi.hel.haitaton.hanke.domain.HankeYhteystieto
+import fi.hel.haitaton.hanke.logging.AuditLogEntry
+import fi.hel.haitaton.hanke.logging.Action
+import fi.hel.haitaton.hanke.logging.ChangeLogEntry
+import fi.hel.haitaton.hanke.logging.PersonalDataAuditLogRepository
+import fi.hel.haitaton.hanke.logging.PersonalDataChangeLogRepository
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.data.domain.Example
 import org.springframework.security.test.context.support.WithMockUser
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.DynamicPropertyRegistry
@@ -48,6 +54,11 @@ class HankeServiceITests {
 
     @Autowired
     private lateinit var hankeService: HankeService
+    @Autowired
+    private lateinit var personalDataAuditLogRepository: PersonalDataAuditLogRepository
+    @Autowired
+    private lateinit var personalDataChangeLogRepository: PersonalDataChangeLogRepository
+
 
     // Some tests also use and check loadHanke()'s return value because at one time the update action
     // was returning different set of data than loadHanke (bug), so it is a sort of regression test.
@@ -554,8 +565,8 @@ class HankeServiceITests {
         // only one of the added hanke is between time period and should be returned
         assertThat(returnedHankeResult.size).isEqualTo(1)
         // couple of checks to make sure we got the wanted
-        assertThat(returnedHankeResult.get(0).id).isEqualTo(returnedHankeWithWantedDate.id)
-        assertThat(returnedHankeResult.get(0).nimi).isEqualTo(returnedHankeWithWantedDate.nimi)
+        assertThat(returnedHankeResult[0].id).isEqualTo(returnedHankeWithWantedDate.id)
+        assertThat(returnedHankeResult[0].nimi).isEqualTo(returnedHankeWithWantedDate.nimi)
     }
 
     @Test
@@ -597,8 +608,8 @@ class HankeServiceITests {
         // only one of the added hanke is between time period and should be returned
         assertThat(returnedHankeResult.size).isEqualTo(1)
         // couple of checks to make sure we got the wanted
-        assertThat(returnedHankeResult.get(0).id).isEqualTo(returnedHankeWithWantedDate.id)
-        assertThat(returnedHankeResult.get(0).nimi).isEqualTo(returnedHankeWithWantedDate.nimi)
+        assertThat(returnedHankeResult[0].id).isEqualTo(returnedHankeWithWantedDate.id)
+        assertThat(returnedHankeResult[0].nimi).isEqualTo(returnedHankeWithWantedDate.nimi)
     }
 
     @Test
@@ -640,8 +651,8 @@ class HankeServiceITests {
         // only one of the added hanke is between time period and should be returned
         assertThat(returnedHankeResult.size).isEqualTo(1)
         // couple of checks to make sure we got the wanted
-        assertThat(returnedHankeResult.get(0).id).isEqualTo(returnedHankeWithWantedDate.id)
-        assertThat(returnedHankeResult.get(0).nimi).isEqualTo(returnedHankeWithWantedDate.nimi)
+        assertThat(returnedHankeResult[0].id).isEqualTo(returnedHankeWithWantedDate.id)
+        assertThat(returnedHankeResult[0].nimi).isEqualTo(returnedHankeWithWantedDate.nimi)
     }
 
     @Test
@@ -683,8 +694,8 @@ class HankeServiceITests {
         // only one of the added hanke is between time period and should be returned
         assertThat(returnedHankeResult.size).isEqualTo(1)
         // couple of checks to make sure we got the wanted
-        assertThat(returnedHankeResult.get(0).id).isEqualTo(returnedHankeWithWantedDate.id)
-        assertThat(returnedHankeResult.get(0).nimi).isEqualTo(returnedHankeWithWantedDate.nimi)
+        assertThat(returnedHankeResult[0].id).isEqualTo(returnedHankeWithWantedDate.id)
+        assertThat(returnedHankeResult[0].nimi).isEqualTo(returnedHankeWithWantedDate.nimi)
     }
 
     @Test
@@ -718,9 +729,137 @@ class HankeServiceITests {
         // only one of the added hanke is between time period and should be returned
         assertThat(returnedHankeResult.size).isEqualTo(1)
         // couple of checks to make sure we got the wanted
-        assertThat(returnedHankeResult.get(0).id).isEqualTo(returnedHankeWithWantedDate.id)
-        assertThat(returnedHankeResult.get(0).nimi).isEqualTo(returnedHankeWithWantedDate.nimi)
+        assertThat(returnedHankeResult[0].id).isEqualTo(returnedHankeWithWantedDate.id)
+        assertThat(returnedHankeResult[0].nimi).isEqualTo(returnedHankeWithWantedDate.nimi)
     }
+
+    @Test
+    fun `test personal data logging`() {
+        // Create hanke with two yhteystietos, save, check logs (creates in both logs, null old data)
+        // Setup Hanke with two Yhteystietos in the same group:
+        val hanke: Hanke = getATestHanke("yksi", 1)
+        val yt1 = getATestYhteystieto(1)
+        val yt2 = getATestYhteystieto(2)
+        hanke.omistajat = arrayListOf(yt1, yt2)
+        // Call create, get the return object, and make some general checks:
+        val returnedHanke = hankeService.createHanke(hanke)
+        assertThat(returnedHanke).isNotNull
+        assertThat(returnedHanke).isNotSameAs(hanke)
+        assertThat(returnedHanke.id).isNotNull
+        // Check and record the Yhteystieto ids, and to-be-changed field's value
+        assertThat(returnedHanke.omistajat).hasSize(2)
+        assertThat(returnedHanke.omistajat[0].id).isNotNull
+        assertThat(returnedHanke.omistajat[1].id).isNotNull
+        val ytid1 = returnedHanke.omistajat[0].id!!
+        val ytid2 = returnedHanke.omistajat[1].id!!
+        assertThat(returnedHanke.omistajat[1].sukunimi).isEqualTo("suku2")
+
+        // Prepare example for searching entries by yhteystietoid:
+        val sample1auditlog = Example.of(AuditLogEntry(yhteystietoId = ytid1))
+        val sample1changelog = Example.of(ChangeLogEntry(yhteystietoId = ytid1))
+        val sample2auditlog = Example.of(AuditLogEntry(yhteystietoId = ytid2))
+        val sample2changelog = Example.of(ChangeLogEntry(yhteystietoId = ytid2))
+
+        // Check logs...
+        // Both logs must have 2 entries (two yhteystietos were created):
+        assertThat(personalDataAuditLogRepository.count()).isEqualTo(2)
+        assertThat(personalDataChangeLogRepository.count()).isEqualTo(2)
+        // Check that each yhteystieto has single entry in each log:
+        var auditLogEntries1 = personalDataAuditLogRepository.findAll(sample1auditlog)
+        var changeLogEntries1 = personalDataChangeLogRepository.findAll(sample1changelog)
+        var auditLogEntries2 = personalDataAuditLogRepository.findAll(sample2auditlog)
+        var changeLogEntries2 = personalDataChangeLogRepository.findAll(sample2changelog)
+        assertThat(auditLogEntries1.size).isEqualTo(1)
+        assertThat(changeLogEntries1.size).isEqualTo(1)
+        assertThat(auditLogEntries2.size).isEqualTo(1)
+        assertThat(changeLogEntries2.size).isEqualTo(1)
+        // Check that each entry has correct data (action CREATE,
+        // new data contains "suku1" or "suku2", and userid is that of the test user).
+        assertThat(auditLogEntries1[0].action).isEqualTo(Action.CREATE)
+        assertThat(auditLogEntries1[0].userId).isEqualTo(USER_NAME)
+        assertThat(changeLogEntries1[0].action).isEqualTo(Action.CREATE)
+        assertThat(changeLogEntries1[0].newData).contains("suku1")
+        assertThat(auditLogEntries2[0].action).isEqualTo(Action.CREATE)
+        assertThat(auditLogEntries2[0].userId).isEqualTo(USER_NAME)
+        assertThat(changeLogEntries2[0].action).isEqualTo(Action.CREATE)
+        assertThat(changeLogEntries2[0].oldData).isNull()
+        assertThat(changeLogEntries2[0].newData).contains("suku2")
+
+        // Update the other yhteystieto (one update in both logs, both datas exist and with correct values)
+        // Change a value:
+        returnedHanke.omistajat[1].sukunimi = "Som Et Hing"
+        // Call update, get the returned object, make some general checks:
+        val returnedHanke2 = hankeService.updateHanke(returnedHanke)
+        assertThat(returnedHanke2).isNotNull
+        assertThat(returnedHanke2).isNotSameAs(hanke)
+        assertThat(returnedHanke2).isNotSameAs(returnedHanke)
+        assertThat(returnedHanke2.id).isNotNull
+        // Check that both entries kept their ids, and the only change is where expected
+        assertThat(returnedHanke2.omistajat).hasSize(2)
+        assertThat(returnedHanke2.omistajat[0].id).isEqualTo(ytid1)
+        assertThat(returnedHanke2.omistajat[1].id).isEqualTo(ytid2)
+        assertThat(returnedHanke2.omistajat[0].sukunimi).isEqualTo("suku1")
+        assertThat(returnedHanke2.omistajat[1].sukunimi).isEqualTo("Som Et Hing")
+
+        // Check logs...
+        // Check that only 1 entry was added to each log (about the updated yhteystieto)
+        assertThat(personalDataAuditLogRepository.count()).isEqualTo(3)
+        assertThat(personalDataChangeLogRepository.count()).isEqualTo(3)
+        // Check that the second yhteystieto got a single entry in each log (and the other didn't)
+        auditLogEntries1 = personalDataAuditLogRepository.findAll(sample1auditlog)
+        changeLogEntries1 = personalDataChangeLogRepository.findAll(sample1changelog)
+        auditLogEntries2 = personalDataAuditLogRepository.findAll(sample2auditlog)
+        changeLogEntries2 = personalDataChangeLogRepository.findAll(sample2changelog)
+        assertThat(auditLogEntries1.size).isEqualTo(1)
+        assertThat(changeLogEntries1.size).isEqualTo(1)
+        assertThat(auditLogEntries2.size).isEqualTo(2)
+        assertThat(changeLogEntries2.size).isEqualTo(2)
+        // Check that the new entry has correct data (action UPDATE,
+        // old data contains "suku2", new data "Som Et Hing", and userid is that of the test user).
+        assertThat(auditLogEntries2[1].action).isEqualTo(Action.UPDATE)
+        assertThat(auditLogEntries2[1].userId).isEqualTo(USER_NAME)
+        assertThat(changeLogEntries2[1].action).isEqualTo(Action.UPDATE)
+        assertThat(changeLogEntries2[1].oldData).contains("suku2")
+        assertThat(changeLogEntries2[1].newData).contains("Som Et Hing")
+
+        // Delete the other yhteystieto (one update in both logs, null new data)
+        returnedHanke2.omistajat[1].apply {
+            etunimi = ""
+            sukunimi = ""
+            puhelinnumero = ""
+            email = ""
+            organisaatioNimi = ""
+            osasto = ""
+        }
+        // Call update, get the returned object:
+        val returnedHanke3 = hankeService.updateHanke(returnedHanke2)
+        // Check that first yhteystieto remains, second one got removed:
+        assertThat(returnedHanke3.omistajat).hasSize(1)
+        assertThat(returnedHanke3.omistajat[0].id).isEqualTo(ytid1)
+        assertThat(returnedHanke3.omistajat[0].sukunimi).isEqualTo("suku1")
+
+        // Check logs...
+        // Check that only 1 entry was added to each log (about the deleted yhteystieto)
+        assertThat(personalDataAuditLogRepository.count()).isEqualTo(4)
+        assertThat(personalDataChangeLogRepository.count()).isEqualTo(4)
+        // Check that the second yhteystieto got a single entry in each log (and the other didn't)
+        auditLogEntries1 = personalDataAuditLogRepository.findAll(sample1auditlog)
+        changeLogEntries1 = personalDataChangeLogRepository.findAll(sample1changelog)
+        auditLogEntries2 = personalDataAuditLogRepository.findAll(sample2auditlog)
+        changeLogEntries2 = personalDataChangeLogRepository.findAll(sample2changelog)
+        assertThat(auditLogEntries1.size).isEqualTo(1)
+        assertThat(changeLogEntries1.size).isEqualTo(1)
+        assertThat(auditLogEntries2.size).isEqualTo(3)
+        assertThat(changeLogEntries2.size).isEqualTo(3)
+        // Check that the new entry has correct data (action DELETE,
+        // old data contains "Som Et Hing", new data is null, and userid is that of the test user).
+        assertThat(auditLogEntries2[2].action).isEqualTo(Action.DELETE)
+        assertThat(auditLogEntries2[2].userId).isEqualTo(USER_NAME)
+        assertThat(changeLogEntries2[2].action).isEqualTo(Action.DELETE)
+        assertThat(changeLogEntries2[2].oldData).contains("Som Et Hing")
+        assertThat(changeLogEntries2[2].newData).isNull()
+    }
+
 
     /**
      * Just fills a new Hanke domain object with some crap (excluding any Yhteystieto entries) and returns it.

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/IntegrationTestConfiguration.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/IntegrationTestConfiguration.kt
@@ -2,6 +2,7 @@ package fi.hel.haitaton.hanke
 
 import fi.hel.haitaton.hanke.geometria.HankeGeometriatDao
 import fi.hel.haitaton.hanke.geometria.HankeGeometriatService
+import fi.hel.haitaton.hanke.logging.PersonalDataAuditLogRepository
 import fi.hel.haitaton.hanke.organisaatio.OrganisaatioService
 import fi.hel.haitaton.hanke.tormaystarkastelu.TormaystarkasteluDao
 import fi.hel.haitaton.hanke.tormaystarkastelu.TormaystarkasteluLaskentaService
@@ -29,6 +30,12 @@ class IntegrationTestConfiguration {
 
     @Bean
     fun hankeRepository(): HankeRepository = mockk()
+
+    @Bean
+    fun personalDataAuditLogRepository(): PersonalDataAuditLogRepository = mockk()
+
+    @Bean
+    fun personalDataChangeLogRepository(): PersonalDataAuditLogRepository = mockk()
 
     @Bean
     fun hanketunnusService(): HanketunnusService = mockk()

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/PersonalDataLogRepositoryITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/PersonalDataLogRepositoryITests.kt
@@ -1,0 +1,95 @@
+package fi.hel.haitaton.hanke
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotNull
+import fi.hel.haitaton.hanke.logging.AuditLogEntry
+import fi.hel.haitaton.hanke.logging.Action
+import fi.hel.haitaton.hanke.logging.ChangeLogEntry
+import fi.hel.haitaton.hanke.logging.PersonalDataAuditLogRepository
+import fi.hel.haitaton.hanke.logging.PersonalDataChangeLogRepository
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.springframework.transaction.annotation.Transactional
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import java.time.LocalDateTime
+import javax.persistence.EntityManager
+
+/**
+ * Testing the configurations and database setup for PersonalDataXxxxLogRepository classes
+ * with a database.
+ * The repositories have no additional code over the base JPARepository, so
+ * only the configs/setups get indirectly tested.
+ */
+// NOTE: using @DataJpaTest(properties = ["spring.liquibase.enabled=false"])
+//  fails; it seems the way it tries to use schemas is not compatible with H2.
+//  Thus, have to use the this test containers way, which uses the proper PostgreSQL.
+@Testcontainers
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("default")
+@Transactional
+class PersonalDataLogRepositoryITests @Autowired constructor(
+    val entityManager: EntityManager,
+    val auditLogRepository: PersonalDataAuditLogRepository,
+    val changeLogRepository: PersonalDataChangeLogRepository
+) {
+
+    companion object {
+        @Container
+        var container: HaitatonPostgreSQLContainer = HaitatonPostgreSQLContainer
+                .withExposedPorts(5433) // use non-default port
+                .withPassword("test")
+                .withUsername("test")
+
+        @JvmStatic
+        @DynamicPropertySource
+        fun postgresqlProperties(registry: DynamicPropertyRegistry) {
+            registry.add("spring.datasource.url", container::getJdbcUrl)
+            registry.add("spring.datasource.username", container::getUsername)
+            registry.add("spring.datasource.password", container::getPassword)
+            registry.add("spring.liquibase.url", container::getJdbcUrl)
+            registry.add("spring.liquibase.user", container::getUsername)
+            registry.add("spring.liquibase.password", container::getPassword)
+        }
+    }
+
+    @Test
+    fun `saving audit log entry works`() {
+        // Create a log entry, save it, flush, clear caches:
+        val datetime = LocalDateTime.of(2020, 2, 20, 20, 20, 20)
+        val audit = AuditLogEntry(datetime, "1234-1234", null, null, null, 333, Action.CREATE, "test create")
+        val savedAudit = auditLogRepository.save(audit)
+        val id = savedAudit.id
+        entityManager.flush() // Make sure the stuff is run to database (though not necessarily committed)
+        entityManager.clear() // Ensure the original entity is no longer in Hibernate's 1st level cache
+
+        // Check it is there (using something else than the repository):
+        val savedAudit2 = entityManager.find(AuditLogEntry::class.java, id)
+        assertThat(savedAudit2).isNotNull()
+        assertThat(savedAudit2.eventTime).isEqualTo(datetime)
+        assertThat(savedAudit2.userId).isEqualTo("1234-1234")
+    }
+
+    @Test
+    fun `saving change log entry works`() {
+        // Create a log entry, save it, flush, clear caches:
+        val datetime = LocalDateTime.of(2020, 2, 20, 20, 20, 20)
+        val audit = ChangeLogEntry(datetime, 444, Action.CREATE, "fake JSON", "new fake JSON")
+        val savedAudit = changeLogRepository.save(audit)
+        val id = savedAudit.id
+        entityManager.flush() // Make sure the stuff is run to database (though not necessarily committed)
+        entityManager.clear() // Ensure the original entity is no longer in Hibernate's 1st level cache
+
+        // Check it is there (using something else than the repository):
+        val savedAudit2 = entityManager.find(ChangeLogEntry::class.java, id)
+        assertThat(savedAudit2).isNotNull()
+        assertThat(savedAudit2.eventTime).isEqualTo(datetime)
+        assertThat(savedAudit2.oldData).isEqualTo("fake JSON")
+    }
+
+}

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/PersonalDataLogRepositoryITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/PersonalDataLogRepositoryITests.kt
@@ -28,7 +28,7 @@ import javax.persistence.EntityManager
  */
 // NOTE: using @DataJpaTest(properties = ["spring.liquibase.enabled=false"])
 //  fails; it seems the way it tries to use schemas is not compatible with H2.
-//  Thus, have to use the this test containers way, which uses the proper PostgreSQL.
+//  Thus, have to use this test containers -way, which uses the proper PostgreSQL.
 @Testcontainers
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("default")

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Configuration.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Configuration.kt
@@ -4,6 +4,8 @@ import fi.hel.haitaton.hanke.geometria.HankeGeometriatDao
 import fi.hel.haitaton.hanke.geometria.HankeGeometriatDaoImpl
 import fi.hel.haitaton.hanke.geometria.HankeGeometriatService
 import fi.hel.haitaton.hanke.geometria.HankeGeometriatServiceImpl
+import fi.hel.haitaton.hanke.logging.PersonalDataAuditLogRepository
+import fi.hel.haitaton.hanke.logging.PersonalDataChangeLogRepository
 import fi.hel.haitaton.hanke.organisaatio.OrganisaatioRepository
 import fi.hel.haitaton.hanke.organisaatio.OrganisaatioService
 import fi.hel.haitaton.hanke.organisaatio.OrganisaatioServiceImpl
@@ -28,8 +30,13 @@ class Configuration {
         HanketunnusServiceImpl(idCounterRepository)
 
     @Bean
-    fun hankeService(hankeRepository: HankeRepository, hanketunnusService: HanketunnusService): HankeService =
-        HankeServiceImpl(hankeRepository, hanketunnusService)
+    fun hankeService(
+        hankeRepository: HankeRepository,
+        hanketunnusService: HanketunnusService,
+        personalDataAuditLogRepository: PersonalDataAuditLogRepository,
+        personalDataChangeLogRepository: PersonalDataChangeLogRepository
+    ): HankeService =
+        HankeServiceImpl(hankeRepository, hanketunnusService, personalDataAuditLogRepository, personalDataChangeLogRepository)
 
     @Bean
     fun organisaatioService(organisaatioRepository: OrganisaatioRepository): OrganisaatioService =

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeYhteystietoEntity.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeYhteystietoEntity.kt
@@ -1,5 +1,6 @@
 package fi.hel.haitaton.hanke
 
+import com.fasterxml.jackson.annotation.JsonView
 import java.time.LocalDateTime
 import javax.persistence.*
 
@@ -12,31 +13,45 @@ enum class ContactType {
 @Entity
 @Table(name = "hankeyhteystieto")
 class HankeYhteystietoEntity (
+        @JsonView(ChangeLogView::class)
         @Enumerated(EnumType.STRING)
         var contactType: ContactType,
 
         // must have contact information
+        @JsonView(ChangeLogView::class)
         var sukunimi: String,
+        @JsonView(ChangeLogView::class)
         var etunimi: String,
+        @JsonView(ChangeLogView::class)
         var email: String,
+        @JsonView(ChangeLogView::class)
         var puhelinnumero: String,
 
+        @JsonView(ChangeLogView::class)
         var organisaatioId: Int? = 0,
+        @JsonView(ChangeLogView::class)
         var organisaatioNimi: String? = null,
+        @JsonView(ChangeLogView::class)
         var osasto: String? = null,
 
         // NOTE: createdByUserId must be non-null for valid data, but to allow creating instances with
         // no-arg constructor and programming convenience, this class allows it to be null (temporarily).
+        @JsonView(NotInChangeLogView::class)
         var createdByUserId: String? = null,
+        @JsonView(NotInChangeLogView::class)
         var createdAt: LocalDateTime? = null,
+        @JsonView(NotInChangeLogView::class)
         var modifiedByUserId: String? = null,
+        @JsonView(NotInChangeLogView::class)
         var modifiedAt: LocalDateTime? = null,
         // NOTE: using IDENTITY (i.e. db does auto-increments, Hibernate reads the result back)
         // can be a performance problem if there is a need to do bulk inserts.
         // Using SEQUENCE would allow getting multiple ids more efficiently.
+        @JsonView(NotInChangeLogView::class)
         @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
         var id: Int? = null,
 
+        @JsonView(NotInChangeLogView::class)
         @ManyToOne(fetch = FetchType.EAGER)
         @JoinColumn(name="hankeid")
         var hanke: HankeEntity? = null
@@ -74,4 +89,13 @@ class HankeYhteystietoEntity (
         result = 31 * result + (osasto?.hashCode() ?: 0)
         return result
     }
+
+
+    fun toChangeLogJsonString(): String =
+        OBJECT_MAPPER.writerWithView(ChangeLogView::class.java).writeValueAsString(this)
+
 }
+
+open class ChangeLogView {}
+
+class NotInChangeLogView : ChangeLogView() {}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeYhteystietoEntity.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeYhteystietoEntity.kt
@@ -90,12 +90,23 @@ class HankeYhteystietoEntity (
         return result
     }
 
+    /**
+     * Returns a new instance with the main fields copied.
+     * Main fields being the contact type, name, email, phone, organisation info.
+     */
+    fun cloneWithMainFields(): HankeYhteystietoEntity =
+        HankeYhteystietoEntity(
+            contactType, sukunimi, etunimi, email, puhelinnumero, organisaatioId, organisaatioNimi, osasto)
 
+    /**
+     * Serializes only the main personal data fields; not audit fields or the reference
+     * to the parent hanke.
+     */
     fun toChangeLogJsonString(): String =
         OBJECT_MAPPER.writerWithView(ChangeLogView::class.java).writeValueAsString(this)
-
 }
 
+// These marker classes are used to get a limited set of info for logging.
 open class ChangeLogView {}
 
 class NotInChangeLogView : ChangeLogView() {}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/Persistence.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/Persistence.kt
@@ -1,0 +1,58 @@
+package fi.hel.haitaton.hanke.logging
+
+import org.springframework.data.jpa.repository.JpaRepository
+import java.time.LocalDateTime
+import javax.persistence.Entity
+import javax.persistence.EnumType
+import javax.persistence.Enumerated
+import javax.persistence.GeneratedValue
+import javax.persistence.GenerationType
+import javax.persistence.Id
+import javax.persistence.Table
+
+/**
+ * Used in 'changelog'.
+ */
+enum class ChangeAction {
+    CREATE,
+    READ,
+    UPDATE,
+    DELETE
+}
+
+@Entity
+@Table(schema = "personaldatalogs", name = "auditlog" )
+class AuditLogEntry (
+    var eventTime: LocalDateTime? = null,
+    var userId: String? = null,
+    var actor: String? = null,
+    var ipNear: String? = null,
+    var ipFar: String? = null,
+    var yhteystietoId: Int = 0,
+    var description: String? = null
+) {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Int? = null
+}
+
+@Entity
+@Table(schema = "personaldatalogs", name = "changelog" )
+class ChangeLogEntry (
+    var eventTime: LocalDateTime? = null,
+    var yhteystietoId: Int = 0,
+    @Enumerated(EnumType.STRING)
+    var action: ChangeAction? = null,
+    var oldData: String? = null,
+    var newData: String? = null
+) {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Int? = null
+}
+
+interface PersonalDataAuditLogRepository : JpaRepository<AuditLogEntry, Int> {
+    // No need for additional functions. Only adding entries from Haitaton app.
+}
+
+interface PersonalDataChangeLogRepository : JpaRepository<ChangeLogEntry, Int> {
+    // No need for additional functions. Only adding entries from Haitaton app.
+}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/Persistence.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/Persistence.kt
@@ -28,7 +28,8 @@ class AuditLogEntry (
     var actor: String? = null,
     var ipNear: String? = null,
     var ipFar: String? = null,
-    var yhteystietoId: Int = 0,
+    // Note, this can be briefly null during creation of a new YhteystietoEntity
+    var yhteystietoId: Int? = 0,
     var description: String? = null
 ) {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -39,7 +40,8 @@ class AuditLogEntry (
 @Table(schema = "personaldatalogs", name = "changelog" )
 class ChangeLogEntry (
     var eventTime: LocalDateTime? = null,
-    var yhteystietoId: Int = 0,
+    // Note, this can be briefly null during creation of a new YhteystietoEntity
+    var yhteystietoId: Int? = 0,
     @Enumerated(EnumType.STRING)
     var action: ChangeAction? = null,
     var oldData: String? = null,

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/Persistence.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/Persistence.kt
@@ -10,10 +10,7 @@ import javax.persistence.GenerationType
 import javax.persistence.Id
 import javax.persistence.Table
 
-/**
- * Used in 'changelog'.
- */
-enum class ChangeAction {
+enum class Action {
     CREATE,
     READ,
     UPDATE,
@@ -30,6 +27,8 @@ class AuditLogEntry (
     var ipFar: String? = null,
     // Note, this can be briefly null during creation of a new YhteystietoEntity
     var yhteystietoId: Int? = 0,
+    @Enumerated(EnumType.STRING)
+    var action: Action? = null,
     var description: String? = null
 ) {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -43,7 +42,7 @@ class ChangeLogEntry (
     // Note, this can be briefly null during creation of a new YhteystietoEntity
     var yhteystietoId: Int? = 0,
     @Enumerated(EnumType.STRING)
-    var action: ChangeAction? = null,
+    var action: Action? = null,
     var oldData: String? = null,
     var newData: String? = null
 ) {

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/YhteystietoLoggingEntryHolder.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/YhteystietoLoggingEntryHolder.kt
@@ -1,0 +1,134 @@
+package fi.hel.haitaton.hanke.logging
+
+import fi.hel.haitaton.hanke.DatabaseStateException
+import fi.hel.haitaton.hanke.HankeYhteystietoEntity
+import fi.hel.haitaton.hanke.getCurrentTimeUTCAsLocalTime
+import org.springframework.web.context.request.RequestContextHolder
+import org.springframework.web.context.request.ServletRequestAttributes
+import kotlin.collections.HashSet
+
+/**
+ * Used to hold the maps of yhteystieto entities to logging entries during
+ * processing, so that new yhteystietos' ids can be applied after they have
+ * been saved and thus received those ids.
+ *
+ * Basic use:
+ * 1. Create instance of this class.
+ * 2. Init it (giving list of yhteystieto before doing changes to them).
+ * 3. Do actions, and call addLogEntriesForEvent() for delete and update actions as they are done.
+ * 4. After all actions are done, save the entities (this gives new entities their ids).
+ * 5. Call addLogEntriesForNewYhteystietos() (this picks their new ids into their log entries).
+ * 6. Optionally call applyIPaddresses().
+ * 7. saveLogEntries() (giving the repositories)
+ * 8. Forget them until someone asks something kinky about personal data (though it is good to occasionally
+ *    wipe some of the older data away, because Reasons...)
+ */
+class YhteystietoLoggingEntryHolder {
+
+    // To Constants? With name that refers to personal data logging IP?
+    val PERSONAL_DATA_LOGGING_MAX_IP_LENGTH = 40
+
+    val auditLogEntries: MutableList<AuditLogEntry> = mutableListOf()
+    val changeLogEntries: MutableList<ChangeLogEntry> = mutableListOf()
+
+    // Holds the ids of Yhteystietos that were in the Hanke before this request handling.
+    val previousYTids: HashSet<Int> = hashSetOf()
+
+    fun initWithOldYhteystietos(oldYTs: MutableList<HankeYhteystietoEntity>) {
+        oldYTs.forEach {
+            val ytid = it.id ?: throw DatabaseStateException("A persisted HankeYhteystietoEntity somehow missing id")
+            previousYTids.add(ytid)
+        }
+    }
+
+    /**
+     * Creates both the audit-log and change-log entries for the given action in to this holder.
+     * This function will not save them, or set IP to them; those must be done separately before
+     * returning from the relevant process.
+     *
+     * The yhteystieto's id will be taken from the oldEntity, unless it or its id is null
+     * and the newEntity is non-null, in which case it is taken from the newEntity. This
+     * rule handles all cases of create, update, and delete, _if_ this function is called
+     * after saving the entities for create action(s).
+     *
+     * No change-log entry will be made if the action is null or READ. Using null is meant
+     * for special cases or additional info. READ obviously does not change anything to be given
+     * such log entry.
+     *
+     * @param action can be null, in which case only the audit-log entry will be created.
+     * @param description for the audit-log
+     * @param oldEntity for logging the previous field values (make a clone/copy before making changes
+     *              to the persisted entity, if necessary); can be null (when creating new or reading)
+     * @param newEntity for logging the new state of field values; can be null (when deleting or reading)
+     */
+    fun addLogEntriesForEvent(
+            action: Action?,
+            description: String,
+            oldEntity: HankeYhteystietoEntity?,
+            newEntity: HankeYhteystietoEntity?,
+            userid: String
+    ) {
+        val time = getCurrentTimeUTCAsLocalTime()
+        // Note, first row works for delete and update; create-action is handled
+        // by the if-block.
+        var yhteystietoId = oldEntity?.id
+        if (yhteystietoId == null && newEntity != null)
+            yhteystietoId = newEntity.id
+        // Audit log (without personal data). IPs are applied in bulk later.
+        val audit = AuditLogEntry(time, userid, null, null, null, yhteystietoId, action, description)
+        auditLogEntries.add(audit)
+        // Data change log. Note, not made if the action is null (or READ). This allows creating just
+        // an audit-log entry with this function.
+        if (action != null || action == Action.READ) {
+            val oldData = oldEntity?.toChangeLogJsonString()
+            val newData = newEntity?.toChangeLogJsonString()
+            val change = ChangeLogEntry(time, yhteystietoId, action, oldData, newData)
+            changeLogEntries.add(change)
+        }
+    }
+
+    /**
+     * Goes through the entries that were new (have null yhteystietoid in the log entry,
+     * but non-null in the entity), and copies the new ids into the corresponding log entries.
+     */
+    fun addLogEntriesForNewYhteystietos(savedHankeYhteysTietoEntities: MutableList<HankeYhteystietoEntity>, userid: String) {
+        // Go through the saved yhteystietos, filter for processing those that didn't exist
+        // before, and add log entries for them now, as their id's are now known:
+        savedHankeYhteysTietoEntities
+            .filter { !previousYTids.contains(it.id) }
+            .forEach { newYhteystietoEntity ->
+                addLogEntriesForEvent(Action.CREATE, "create new hanke yhteystieto", null, newYhteystietoEntity, userid)
+            }
+    }
+
+    /**
+     * If request context (attributes) exists, gets the IP from it and applies
+     * to all the log entries currently held in this holder.
+     * NOTE: very very very simplified implementation. Needs a lot of improvement.
+     */
+    fun applyIPaddresses() {
+        val attribs = (RequestContextHolder.getRequestAttributes() as ServletRequestAttributes?) ?: return
+        val request = attribs.request
+        // Very simplified version for now.
+        // For starters, see e.g. https://stackoverflow.com/questions/22877350/how-to-extract-ip-address-in-spring-mvc-controller-get-call
+        // Combine all the various ideas into one, and note that even then it is not even half-way to
+        // proper solution. Hopefully one can find a ready-made fully thought out implementation.
+        var ip: String = request.getHeader("X-FORWARDED-FOR") ?: request.remoteAddr ?: return
+        // Just to make sure it won't break the db if someone put something silly long in the header:
+        if (ip.length > PERSONAL_DATA_LOGGING_MAX_IP_LENGTH)
+            ip = ip.substring(0, PERSONAL_DATA_LOGGING_MAX_IP_LENGTH)
+
+        auditLogEntries.forEach {
+            it.ipFar = ip
+            it.ipNear = ip
+        }
+    }
+
+    fun saveLogEntries(
+        personalDataAuditLogRepository: PersonalDataAuditLogRepository,
+        personalDataChangeLogRepository: PersonalDataChangeLogRepository
+    ) {
+        auditLogEntries.forEach { personalDataAuditLogRepository.save(it) }
+        changeLogEntries.forEach { personalDataChangeLogRepository.save(it) }
+    }
+}

--- a/services/hanke-service/src/main/resources/db/changelog/changesets/create-log-tables-for-personaldata.yml
+++ b/services/hanke-service/src/main/resources/db/changelog/changesets/create-log-tables-for-personaldata.yml
@@ -7,7 +7,7 @@ databaseChangeLog:
         # NOTE: Liquibase does not support creating schemas with its normal elements, must use SQL
         - sql:
             comment: Separate schema for personal data logs
-            dbms: postgresql
+            dbms: 'postgresql, h2'
             sql: CREATE SCHEMA personaldatalogs
         - createTable:
             schemaName: personaldatalogs
@@ -20,14 +20,20 @@ databaseChangeLog:
                   constraints:
                     primaryKey: true
                     nullable: false
-              - column: { name: eventtime, type: timestamp } # when
-              - column: { name: userid, type: varchar(40) } # whodid; null if not done by a user
-              - column: { name: actor, type: varchar(80) } # any other source of action, e.g. an import integration
-              - column: { name: ipnear, type: varchar(40) } # near IP (the backwards first "remote" outside server's known IP chain)
-              - column: { name: ipfar, type: varchar(40) } # far IP (e.g. behind proxy)
+              - column: { name: eventtime, type: timestamp }
+              - column: { name: userid, type: varchar(40) }
+              # 'actor' is for any other source of action than logged-in user, e.g. an import integration
+              - column: { name: actor, type: varchar(80) }
+              # a useful IP nearest to the server
+              - column: { name: ipnear, type: varchar(40) }
+              # a useful IP furthermost from the server (usually the user's device's current IP)
+              - column: { name: ipfar, type: varchar(40) }
               # NOTE: not foreign key definition; keeping the connection loose on purpose
-              - column: { name: yhteystietoid, type: int } # target yhteystieto
-              - column: { name: description, type: varchar(250) } # action (e.g. as JSON string, or normal string, "changed field 'name'")
+              - column: { name: yhteystietoid, type: int }
+              # what action was made (create, update, delete) (no read actions are logged for now)
+              - column: { name: action, type: varchar(10) }
+              # description of action (e.g. as JSON string, or normal string, "changed field 'name'")
+              - column: { name: description, type: varchar(250) }
         - createTable:
             schemaName: personaldatalogs
             tableName: changelog
@@ -39,11 +45,12 @@ databaseChangeLog:
                   constraints:
                     primaryKey: true
                     nullable: false
-              - column: { name: eventtime, type: timestamp } # when
-              - column: { name: yhteystietoid, type: int } # target yhteystieto
-              # what was made (create, modify, delete) (no read actions are logged for now)
+              - column: { name: eventtime, type: timestamp }
+              # NOTE: not foreign key definition; keeping the connection loose on purpose
+              - column: { name: yhteystietoid, type: int }
+              # what action was made (create, update, delete) (no read actions are logged for now)
               - column: { name: action, type: varchar(10) }
               # old data (if applicable; null for create)
               - column: { name: olddata, type: clob }
-              # new data (if applicable; null for delete or a failed action)
+              # new data (if applicable; null for delete or a failed but logged action)
               - column: { name: newdata, type: clob }

--- a/services/hanke-service/src/main/resources/db/changelog/changesets/create-log-tables-for-personaldata.yml
+++ b/services/hanke-service/src/main/resources/db/changelog/changesets/create-log-tables-for-personaldata.yml
@@ -1,0 +1,49 @@
+databaseChangeLog:
+  - changeSet:
+      id: create-log-tables-for-personaldata
+      comment: Create schema and tables for personal data audit and change logs
+      author: Markku Hassinen
+      changes:
+        # NOTE: Liquibase does not support creating schemas with its normal elements, must use SQL
+        - sql:
+            comment: Separate schema for personal data logs
+            dbms: postgresql
+            sql: CREATE SCHEMA personaldatalogs
+        - createTable:
+            schemaName: personaldatalogs
+            tableName: auditlog
+            columns:
+              - column:
+                  name: id
+                  type: int
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column: { name: eventtime, type: timestamp } # when
+              - column: { name: userid, type: varchar(40) } # whodid; null if not done by a user
+              - column: { name: actor, type: varchar(80) } # any other source of action, e.g. an import integration
+              - column: { name: ipnear, type: varchar(40) } # near IP (the backwards first "remote" outside server's known IP chain)
+              - column: { name: ipfar, type: varchar(40) } # far IP (e.g. behind proxy)
+              # NOTE: not foreign key definition; keeping the connection loose on purpose
+              - column: { name: yhteystietoid, type: int } # target yhteystieto
+              - column: { name: description, type: varchar(250) } # action (e.g. as JSON string, or normal string, "changed field 'name'")
+        - createTable:
+            schemaName: personaldatalogs
+            tableName: changelog
+            columns:
+              - column:
+                  name: id
+                  type: int
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column: { name: eventtime, type: timestamp } # when
+              - column: { name: yhteystietoid, type: int } # target yhteystieto
+              # what was made (create, modify, delete) (no read actions are logged for now)
+              - column: { name: action, type: varchar(10) }
+              # old data (if applicable; null for create)
+              - column: { name: olddata, type: clob }
+              # new data (if applicable; null for delete or a failed action)
+              - column: { name: newdata, type: clob }

--- a/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -23,3 +23,5 @@ databaseChangeLog:
       file: db/changelog/changesets/set-defaults-to-hanke-flag-fields.yml
   - include:
       file: db/changelog/changesets/add-tormaystarkastelu-results.yml
+  - include:
+      file: db/changelog/changesets/create-log-tables-for-personaldata.yml


### PR DESCRIPTION
# Description

Adds audit and change logging of personal data related events (except read access).

### Jira Issue: 

[HAI-793](https://helsinkisolutionoffice.atlassian.net/browse/HAI-793)
[HAI-799](https://helsinkisolutionoffice.atlassian.net/browse/HAI-799)
[HAI-800](https://helsinkisolutionoffice.atlassian.net/browse/HAI-800)
[HAI-801](https://helsinkisolutionoffice.atlassian.net/browse/HAI-801)

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing

Using the full setup with local docker-compose, start creating a new hanke, fill in to reach yhteystieto-page.
First add the owner info and 'tallenna luonnos'. Check the database (schema "personaldatalogs") that new row got added (for CREATE action) in both tables.
Then modify that same owner info and 'tallenna luonnos'. Check the database for a new row (UPDATE action) in both tables.
Finally, add a second yhteystieto, save, and delete that added yhteystieto by clearing all its fields and saving. Check the database (should now have entries for both its CREATE and DELETE actions).

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [X] I have made necessary changes to the documentation, link to confluence
 or other location: 
https://helsinkisolutionoffice.atlassian.net/wiki/spaces/HAI/pages/1148715496/Henkil+tietojen+k+sittely

# Other relevant info

Note, integration tests seem to show some hiccup during the tear down -phase; the DataJpaTest-annotated tests that use H2 apparently are not able to use schemas. However, since it is an embedded in-memory database, all the crap will be gone anyway (that is, problems during teardown do not matter). And tests will run through and the build/test is successful. But, the DataJpaTest-way of testing Repositories could not be used for the two new repositories because of that.