### PR TITLE
HAI-805 support for personal data processing restriction

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeRepositoryITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeRepositoryITests.kt
@@ -168,6 +168,8 @@ class HankeRepositoryITests @Autowired constructor(
             1,
             "org1",
             "osasto1",
+            false,
+            null,
             "1",
             datetime,
             "11",
@@ -184,6 +186,8 @@ class HankeRepositoryITests @Autowired constructor(
             2,
             "org2",
             "osasto2",
+            false,
+            null,
             "2",
             datetime,
             "22",
@@ -200,6 +204,8 @@ class HankeRepositoryITests @Autowired constructor(
             3,
             "org3",
             "osasto3",
+            false,
+            null,
             "3",
             datetime,
             "33",
@@ -302,6 +308,8 @@ class HankeRepositoryITests @Autowired constructor(
             1,
             "org1",
             "osasto1",
+            false,
+            null,
             "1",
             datetime,
             "11",
@@ -318,6 +326,8 @@ class HankeRepositoryITests @Autowired constructor(
             2,
             "org2",
             "osasto2",
+            false,
+            null,
             "2",
             datetime,
             "22",
@@ -360,5 +370,4 @@ class HankeRepositoryITests @Autowired constructor(
         assertThat(loadedHanke2.listOfHankeYhteystieto[0].organisaatioId).isEqualTo(loadedHankeYhteystietoOrgId2)
     }
 
-    // TODO: more tests (when more functions appear)
 }

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/PersonalDataLogRepositoryITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/PersonalDataLogRepositoryITests.kt
@@ -62,7 +62,7 @@ class PersonalDataLogRepositoryITests @Autowired constructor(
     fun `saving audit log entry works`() {
         // Create a log entry, save it, flush, clear caches:
         val datetime = LocalDateTime.of(2020, 2, 20, 20, 20, 20)
-        val audit = AuditLogEntry(datetime, "1234-1234", null, null, null, 333, Action.CREATE, "test create")
+        val audit = AuditLogEntry(datetime, "1234-1234", null, null, null, 333, Action.CREATE, false,"test create")
         val savedAudit = auditLogRepository.save(audit)
         val id = savedAudit.id
         entityManager.flush() // Make sure the stuff is run to database (though not necessarily committed)
@@ -79,7 +79,7 @@ class PersonalDataLogRepositoryITests @Autowired constructor(
     fun `saving change log entry works`() {
         // Create a log entry, save it, flush, clear caches:
         val datetime = LocalDateTime.of(2020, 2, 20, 20, 20, 20)
-        val audit = ChangeLogEntry(datetime, 444, Action.CREATE, "fake JSON", "new fake JSON")
+        val audit = ChangeLogEntry(datetime, 444, Action.CREATE, false, "fake JSON", "new fake JSON")
         val savedAudit = changeLogRepository.save(audit)
         val id = savedAudit.id
         entityManager.flush() // Make sure the stuff is run to database (though not necessarily committed)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/ControllerExceptionHandler.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/ControllerExceptionHandler.kt
@@ -43,6 +43,19 @@ class ControllerExceptionHandler {
         return HankeError.HAI1009
     }
 
+    @ExceptionHandler(HankeYhteystietoProcessingRestrictedException::class)
+    // Using 451 (since the restriction is typically due to legal reasons.
+    // However, in some cases 403 forbidden might be considered correct response, too.
+    @ResponseStatus(HttpStatus.UNAVAILABLE_FOR_LEGAL_REASONS)
+    fun hankeYhteystietoProcessingRestricted(ex: HankeYhteystietoProcessingRestrictedException): HankeError {
+        logger.warn {
+            ex.message
+        }
+        // TODO: the response body SHOULD include an explanation and link to server;
+        //  left as future exercise. See https://tools.ietf.org/html/rfc7725
+        return HankeError.HAI1029
+    }
+
     @ExceptionHandler(IllegalArgumentException::class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     fun illegalArgumentException(ex: IllegalArgumentException): HankeError {

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Domain.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Domain.kt
@@ -29,6 +29,7 @@ enum class HankeError(
     HAI1014("Internal error while loading Hanke geometry"),
     HAI1015("Hanke geometry not found"),
     HAI1020("HankeYhteystieto not found"),
+    HAI1029("HankeYhteystieto personal data processing restricted"),
     HAI1030("Problem with classification of geometries"),
     HAI1031("Invalid state: Missing needed data");
 
@@ -56,3 +57,5 @@ class HankeYhteystietoNotFoundException(val hankeId: Int, ytId: Int) :
 class DatabaseStateException(message: String) : RuntimeException(message)
 
 class TormaystarkasteluAlreadyCalculatedException(message: String) : RuntimeException(message)
+
+class HankeYhteystietoProcessingRestrictedException(message: String) : RuntimeException(message)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeYhteystietoEntity.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeYhteystietoEntity.kt
@@ -34,6 +34,12 @@ class HankeYhteystietoEntity (
         @JsonView(ChangeLogView::class)
         var osasto: String? = null,
 
+        // Personal data processing restriction (or other needs to prevent changes)
+        @JsonView(NotInChangeLogView::class)
+        var dataLocked: Boolean? = false,
+        @JsonView(NotInChangeLogView::class)
+        var dataLockInfo: String? = null,
+
         // NOTE: createdByUserId must be non-null for valid data, but to allow creating instances with
         // no-arg constructor and programming convenience, this class allows it to be null (temporarily).
         @JsonView(NotInChangeLogView::class)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/Persistence.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/Persistence.kt
@@ -10,11 +10,13 @@ import javax.persistence.GenerationType
 import javax.persistence.Id
 import javax.persistence.Table
 
-enum class Action {
-    CREATE,
-    READ,
-    UPDATE,
-    DELETE
+enum class Action(val isChange: Boolean) {
+    CREATE(true),
+    READ(false),
+    UPDATE(true),
+    DELETE(true),
+    LOCK(false),
+    UNLOCK(false)
 }
 
 @Entity
@@ -29,6 +31,7 @@ class AuditLogEntry (
     var yhteystietoId: Int? = 0,
     @Enumerated(EnumType.STRING)
     var action: Action? = null,
+    var failed: Boolean? = null,
     var description: String? = null
 ) {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -43,6 +46,7 @@ class ChangeLogEntry (
     var yhteystietoId: Int? = 0,
     @Enumerated(EnumType.STRING)
     var action: Action? = null,
+    var failed: Boolean? = null,
     var oldData: String? = null,
     var newData: String? = null
 ) {

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/YhteystietoLoggingEntryHolder.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/YhteystietoLoggingEntryHolder.kt
@@ -25,7 +25,7 @@ import kotlin.collections.HashSet
  */
 class YhteystietoLoggingEntryHolder {
 
-    // To Constants? With name that refers to personal data logging IP?
+    // To Constants?
     val PERSONAL_DATA_LOGGING_MAX_IP_LENGTH = 40
 
     val auditLogEntries: MutableList<AuditLogEntry> = mutableListOf()
@@ -33,6 +33,8 @@ class YhteystietoLoggingEntryHolder {
 
     // Holds the ids of Yhteystietos that were in the Hanke before this request handling.
     val previousYTids: HashSet<Int> = hashSetOf()
+
+    fun hasEntries() : Boolean = (auditLogEntries.size + changeLogEntries.size) > 0
 
     fun initWithOldYhteystietos(oldYTs: MutableList<HankeYhteystietoEntity>) {
         oldYTs.forEach {
@@ -51,11 +53,14 @@ class YhteystietoLoggingEntryHolder {
      * rule handles all cases of create, update, and delete, _if_ this function is called
      * after saving the entities for create action(s).
      *
-     * No change-log entry will be made if the action is null or READ. Using null is meant
-     * for special cases or additional info. READ obviously does not change anything to be given
-     * such log entry.
+     * No change-log entry will be made if the action is null or such that does not cause change
+     * (e.g. READ). Using null action is meant for special cases or additional info.
+     * READ obviously does not change anything to be given such log entry.
+     * Also, a failed/blocked DELETE is not given a change log entry, as the existing data
+     * remains the same, and the user's intent is obvious (to make everything go away).
      *
      * @param action can be null, in which case only the audit-log entry will be created.
+     * @param failed can be null e.g. for additional info, all normal actions must provide non-null value.
      * @param description for the audit-log
      * @param oldEntity for logging the previous field values (make a clone/copy before making changes
      *              to the persisted entity, if necessary); can be null (when creating new or reading)
@@ -63,6 +68,7 @@ class YhteystietoLoggingEntryHolder {
      */
     fun addLogEntriesForEvent(
             action: Action?,
+            failed: Boolean?,
             description: String,
             oldEntity: HankeYhteystietoEntity?,
             newEntity: HankeYhteystietoEntity?,
@@ -74,15 +80,19 @@ class YhteystietoLoggingEntryHolder {
         var yhteystietoId = oldEntity?.id
         if (yhteystietoId == null && newEntity != null)
             yhteystietoId = newEntity.id
+
         // Audit log (without personal data). IPs are applied in bulk later.
-        val audit = AuditLogEntry(time, userid, null, null, null, yhteystietoId, action, description)
+        val audit = AuditLogEntry(
+            time, userid, null, null, null, yhteystietoId, action, failed, description)
         auditLogEntries.add(audit)
-        // Data change log. Note, not made if the action is null (or READ). This allows creating just
-        // an audit-log entry with this function.
-        if (action != null || action == Action.READ) {
+
+        // Data change log. Note, not made if the action is null (or is not causing a change).
+        // This allows creating just an audit-log entry with this function.
+        // Also, failed DELETE is not given change log entry, since all relevant data is known/obvious.
+        if (action?.isChange == true && !(action == Action.DELETE && failed == true)) {
             val oldData = oldEntity?.toChangeLogJsonString()
             val newData = newEntity?.toChangeLogJsonString()
-            val change = ChangeLogEntry(time, yhteystietoId, action, oldData, newData)
+            val change = ChangeLogEntry(time, yhteystietoId, action, failed, oldData, newData)
             changeLogEntries.add(change)
         }
     }
@@ -93,11 +103,12 @@ class YhteystietoLoggingEntryHolder {
      */
     fun addLogEntriesForNewYhteystietos(savedHankeYhteysTietoEntities: MutableList<HankeYhteystietoEntity>, userid: String) {
         // Go through the saved yhteystietos, filter for processing those that didn't exist
-        // before, and add log entries for them now, as their id's are now known:
+        // before, and add log entries for them now, as their id's are now known.
+        // (Obviously, they all succeeded, since they have been saved already.)
         savedHankeYhteysTietoEntities
             .filter { !previousYTids.contains(it.id) }
             .forEach { newYhteystietoEntity ->
-                addLogEntriesForEvent(Action.CREATE, "create new hanke yhteystieto", null, newYhteystietoEntity, userid)
+                addLogEntriesForEvent(Action.CREATE, false, "create new hanke yhteystieto", null, newYhteystietoEntity, userid)
             }
     }
 

--- a/services/hanke-service/src/main/resources/db/changelog/changesets/add-personal-data-logs-failed-field.yml
+++ b/services/hanke-service/src/main/resources/db/changelog/changesets/add-personal-data-logs-failed-field.yml
@@ -1,0 +1,16 @@
+databaseChangeLog:
+  - changeSet:
+      id: add-field-for-indicating-failed-action-to-personal-data-log-tables
+      comment: Add a new field to personal data log tables, for indicating when a the logged action failed (due to error or blocked action etc.)
+      author: Markku Hassinen
+      changes:
+        - addColumn:
+            schemaName: personaldatalogs
+            tableName: auditlog
+            columns:
+              - column: { name: failed, type: boolean }
+        - addColumn:
+            schemaName: personaldatalogs
+            tableName: changelog
+            columns:
+              - column: { name: failed, type: boolean }

--- a/services/hanke-service/src/main/resources/db/changelog/changesets/add-personal-data-processing-restriction-support.yml
+++ b/services/hanke-service/src/main/resources/db/changelog/changesets/add-personal-data-processing-restriction-support.yml
@@ -1,0 +1,13 @@
+databaseChangeLog:
+  - changeSet:
+      id: add-fields-for-personal-data-processing-restriction
+      comment: Add new fields for "locking" personal data and for the related description
+      author: Markku Hassinen
+      changes:
+        - addColumn:
+            tableName: hankeyhteystieto
+            columns:
+              # If true, processing this particular personal data is forbidden (no changes, no delete)
+              - column: { name: datalocked, type: boolean }
+              # For recording any info about the processing restriction, e.g. date, reason, contact person for more info, etc.
+              - column: { name: datalockinfo, type: varchar(1000) }

--- a/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -25,3 +25,7 @@ databaseChangeLog:
       file: db/changelog/changesets/add-tormaystarkastelu-results.yml
   - include:
       file: db/changelog/changesets/create-log-tables-for-personaldata.yml
+  - include:
+      file: db/changelog/changesets/add-personal-data-processing-restriction-support.yml
+  - include:
+      file: db/changelog/changesets/add-personal-data-logs-failed-field.yml


### PR DESCRIPTION
# Description

Backend support for preventing changes to personal data (yhteystietos). W.I.P.

This version works (almost) as expected with integration tests, but not quite as wanted via UI. Specifically, it _does_ prevent changes to the "locked" yhteystietos, but it does _not_ prevent changes to the rest of Hanke data in the same request, and since there is no feedback in UI (in fact, UI has some trouble processing the response, leading to timeout), the behavior is not consistent.
Also, with integration tests, there will be entries in audit log (as expected) about the prevention, but no entries when used through UI.

Planned change: check and handle restrictions as a first separate step when doing hanke update, and only if there were no restrictions effects at all, continue with the normal update process (the same way as it used to go before these changes). This should keep the changes separate in such a way, that no matter how one returns from the update function, only the intended changes will be saved to database.

### Jira Issue: 

HAI-805

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing

Start creating a new hanke with one owner yhteystieto and another, e.g. arvioija yhteystieto (and save as draft). Manually set the "locked" flag for the non-owner yhteystieto in the database. Change e.g. first name on the non-owner yhteystieto in UI and save as draft... there might not be a popup about successfully saving, so wait a while, refresh the page (or return to the page via hanke list or such, forcing reload of hanke data), and check that the changed field has actually not changed.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 

# Other relevant info

The response to trying to change or delete a locked yhteystieto is currently 451; frontend might not be prepared to handle that in a sensible way.  Minor problem as long as the UI can somehow get back to show current/correct hanke data.