### PR TITLE
Hai 805 henkilotietojen kasittelyn kiellon tuki

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeRepositoryITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeRepositoryITests.kt
@@ -168,6 +168,8 @@ class HankeRepositoryITests @Autowired constructor(
             1,
             "org1",
             "osasto1",
+            false,
+            null,
             "1",
             datetime,
             "11",
@@ -184,6 +186,8 @@ class HankeRepositoryITests @Autowired constructor(
             2,
             "org2",
             "osasto2",
+            false,
+            null,
             "2",
             datetime,
             "22",
@@ -200,6 +204,8 @@ class HankeRepositoryITests @Autowired constructor(
             3,
             "org3",
             "osasto3",
+            false,
+            null,
             "3",
             datetime,
             "33",
@@ -302,6 +308,8 @@ class HankeRepositoryITests @Autowired constructor(
             1,
             "org1",
             "osasto1",
+            false,
+            null,
             "1",
             datetime,
             "11",
@@ -318,6 +326,8 @@ class HankeRepositoryITests @Autowired constructor(
             2,
             "org2",
             "osasto2",
+            false,
+            null,
             "2",
             datetime,
             "22",
@@ -360,5 +370,4 @@ class HankeRepositoryITests @Autowired constructor(
         assertThat(loadedHanke2.listOfHankeYhteystieto[0].organisaatioId).isEqualTo(loadedHankeYhteystietoOrgId2)
     }
 
-    // TODO: more tests (when more functions appear)
 }

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/PersonalDataLogRepositoryITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/PersonalDataLogRepositoryITests.kt
@@ -62,7 +62,7 @@ class PersonalDataLogRepositoryITests @Autowired constructor(
     fun `saving audit log entry works`() {
         // Create a log entry, save it, flush, clear caches:
         val datetime = LocalDateTime.of(2020, 2, 20, 20, 20, 20)
-        val audit = AuditLogEntry(datetime, "1234-1234", null, null, null, 333, Action.CREATE, "test create")
+        val audit = AuditLogEntry(datetime, "1234-1234", null, null, null, 333, Action.CREATE, false,"test create")
         val savedAudit = auditLogRepository.save(audit)
         val id = savedAudit.id
         entityManager.flush() // Make sure the stuff is run to database (though not necessarily committed)
@@ -79,7 +79,7 @@ class PersonalDataLogRepositoryITests @Autowired constructor(
     fun `saving change log entry works`() {
         // Create a log entry, save it, flush, clear caches:
         val datetime = LocalDateTime.of(2020, 2, 20, 20, 20, 20)
-        val audit = ChangeLogEntry(datetime, 444, Action.CREATE, "fake JSON", "new fake JSON")
+        val audit = ChangeLogEntry(datetime, 444, Action.CREATE, false, "fake JSON", "new fake JSON")
         val savedAudit = changeLogRepository.save(audit)
         val id = savedAudit.id
         entityManager.flush() // Make sure the stuff is run to database (though not necessarily committed)

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/logging/PersonalDataLogRepositoryITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/logging/PersonalDataLogRepositoryITests.kt
@@ -1,13 +1,9 @@
-package fi.hel.haitaton.hanke
+package fi.hel.haitaton.hanke.logging
 
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNotNull
-import fi.hel.haitaton.hanke.logging.Action
-import fi.hel.haitaton.hanke.logging.AuditLogEntry
-import fi.hel.haitaton.hanke.logging.ChangeLogEntry
-import fi.hel.haitaton.hanke.logging.PersonalDataAuditLogRepository
-import fi.hel.haitaton.hanke.logging.PersonalDataChangeLogRepository
+import fi.hel.haitaton.hanke.HaitatonPostgreSQLContainer
 import java.time.LocalDateTime
 import javax.persistence.EntityManager
 import org.junit.jupiter.api.Test

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/ControllerExceptionHandler.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/ControllerExceptionHandler.kt
@@ -43,6 +43,19 @@ class ControllerExceptionHandler {
         return HankeError.HAI1009
     }
 
+    @ExceptionHandler(HankeYhteystietoProcessingRestrictedException::class)
+    // Using 451 (since the restriction is typically due to legal reasons.
+    // However, in some cases 403 forbidden might be considered correct response, too.
+    @ResponseStatus(HttpStatus.UNAVAILABLE_FOR_LEGAL_REASONS)
+    fun hankeYhteystietoProcessingRestricted(ex: HankeYhteystietoProcessingRestrictedException): HankeError {
+        logger.warn {
+            ex.message
+        }
+        // TODO: the response body SHOULD include an explanation and link to server;
+        //  left as future exercise. See https://tools.ietf.org/html/rfc7725
+        return HankeError.HAI1029
+    }
+
     @ExceptionHandler(IllegalArgumentException::class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     fun illegalArgumentException(ex: IllegalArgumentException): HankeError {

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Domain.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Domain.kt
@@ -29,6 +29,7 @@ enum class HankeError(
     HAI1014("Internal error while loading Hanke geometry"),
     HAI1015("Hanke geometry not found"),
     HAI1020("HankeYhteystieto not found"),
+    HAI1029("HankeYhteystieto personal data processing restricted"),
     HAI1030("Problem with classification of geometries"),
     HAI1031("Invalid state: Missing needed data");
 
@@ -56,3 +57,5 @@ class HankeYhteystietoNotFoundException(val hankeId: Int, ytId: Int) :
 class DatabaseStateException(message: String) : RuntimeException(message)
 
 class TormaystarkasteluAlreadyCalculatedException(message: String) : RuntimeException(message)
+
+class HankeYhteystietoProcessingRestrictedException(message: String) : RuntimeException(message)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeServiceImpl.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeServiceImpl.kt
@@ -579,6 +579,8 @@ open class HankeServiceImpl(
             // Is the incoming Yhteystieto new (does not have id, create new) or old (has id, update existing)?
             if (hankeYht.id == null) {
                 // New Yhteystieto
+                // Note: don't need to (and can not) create audit-log entries during this create processing;
+                // they are done later, after the whole hanke has been saved and new yhteystietos got their db-ids.
                 processCreateYhteystieto(hankeYht, validYhteystieto, contactType, userid, hankeEntity)
             } else {
                 // Should be an existing Yhteystieto

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeYhteystietoEntity.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeYhteystietoEntity.kt
@@ -34,6 +34,12 @@ class HankeYhteystietoEntity (
         @JsonView(ChangeLogView::class)
         var osasto: String? = null,
 
+        // Personal data processing restriction (or other needs to prevent changes)
+        @JsonView(NotInChangeLogView::class)
+        var dataLocked: Boolean? = false,
+        @JsonView(NotInChangeLogView::class)
+        var dataLockInfo: String? = null,
+
         // NOTE: createdByUserId must be non-null for valid data, but to allow creating instances with
         // no-arg constructor and programming convenience, this class allows it to be null (temporarily).
         @JsonView(NotInChangeLogView::class)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/Persistence.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/Persistence.kt
@@ -10,11 +10,13 @@ import javax.persistence.GenerationType
 import javax.persistence.Id
 import javax.persistence.Table
 
-enum class Action {
-    CREATE,
-    READ,
-    UPDATE,
-    DELETE
+enum class Action(val isChange: Boolean) {
+    CREATE(true),
+    READ(false),
+    UPDATE(true),
+    DELETE(true),
+    LOCK(false),
+    UNLOCK(false)
 }
 
 @Entity
@@ -29,6 +31,7 @@ class AuditLogEntry (
     var yhteystietoId: Int? = 0,
     @Enumerated(EnumType.STRING)
     var action: Action? = null,
+    var failed: Boolean? = null,
     var description: String? = null
 ) {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -43,6 +46,7 @@ class ChangeLogEntry (
     var yhteystietoId: Int? = 0,
     @Enumerated(EnumType.STRING)
     var action: Action? = null,
+    var failed: Boolean? = null,
     var oldData: String? = null,
     var newData: String? = null
 ) {

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/Persistence.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/Persistence.kt
@@ -17,11 +17,34 @@ import javax.persistence.Table
  * will not get an entry in the changelog (but can still get one in the auditlog).
  */
 enum class Action(val isChange: Boolean) {
+    /**
+     * When some new "business data" object is created.
+     */
     CREATE(true),
+    /**
+     * When some (sensitive) "business data" is read.
+     */
     READ(false),
+    /**
+     * When some "business data" is changed.
+     */
     UPDATE(true),
+    /**
+     * When some "business data" object is deleted. (Note, the whole object,
+     * not just one or more fields in it.)
+     */
     DELETE(true),
+    /**
+     * To record a change of the datalocked-field to "true". Not done by
+     * Haitaton itself (for now), so add a row with this action when manually
+     * setting that restriction flag.
+     */
     LOCK(false),
+    /**
+     * To record a change of the datalocked-field from "true" to "false".
+     * Not done by Haitaton itself (for now), so add a row with this action
+     * when manually setting that restriction flag.
+     */
     UNLOCK(false)
 }
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/Persistence.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/Persistence.kt
@@ -31,6 +31,7 @@ class AuditLogEntry (
     var yhteystietoId: Int? = 0,
     @Enumerated(EnumType.STRING)
     var action: Action? = null,
+    // null is to be considered equal to false
     var failed: Boolean? = null,
     var description: String? = null
 ) {
@@ -46,6 +47,7 @@ class ChangeLogEntry (
     var yhteystietoId: Int? = 0,
     @Enumerated(EnumType.STRING)
     var action: Action? = null,
+    // null is to be considered equal to false
     var failed: Boolean? = null,
     var oldData: String? = null,
     var newData: String? = null

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/Persistence.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/Persistence.kt
@@ -10,6 +10,12 @@ import javax.persistence.GenerationType
 import javax.persistence.Id
 import javax.persistence.Table
 
+/**
+ * Type of action/event.
+ * isChange-value tells whether the action can or could have done changes
+ * to the business data it is about. Those that can not change such data
+ * will not get an entry in the changelog (but can still get one in the auditlog).
+ */
 enum class Action(val isChange: Boolean) {
     CREATE(true),
     READ(false),

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/YhteystietoLoggingEntryHolder.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/YhteystietoLoggingEntryHolder.kt
@@ -25,7 +25,7 @@ import kotlin.collections.HashSet
  */
 class YhteystietoLoggingEntryHolder {
 
-    // To Constants? With name that refers to personal data logging IP?
+    // To Constants?
     val PERSONAL_DATA_LOGGING_MAX_IP_LENGTH = 40
 
     val auditLogEntries: MutableList<AuditLogEntry> = mutableListOf()
@@ -33,6 +33,8 @@ class YhteystietoLoggingEntryHolder {
 
     // Holds the ids of Yhteystietos that were in the Hanke before this request handling.
     val previousYTids: HashSet<Int> = hashSetOf()
+
+    fun hasEntries() : Boolean = (auditLogEntries.size + changeLogEntries.size) > 0
 
     fun initWithOldYhteystietos(oldYTs: MutableList<HankeYhteystietoEntity>) {
         oldYTs.forEach {
@@ -51,11 +53,14 @@ class YhteystietoLoggingEntryHolder {
      * rule handles all cases of create, update, and delete, _if_ this function is called
      * after saving the entities for create action(s).
      *
-     * No change-log entry will be made if the action is null or READ. Using null is meant
-     * for special cases or additional info. READ obviously does not change anything to be given
-     * such log entry.
+     * No change-log entry will be made if the action is null or such that does not cause change
+     * (e.g. READ). Using null action is meant for special cases or additional info.
+     * READ obviously does not change anything to be given such log entry.
+     * Also, a failed/blocked DELETE is not given a change log entry, as the existing data
+     * remains the same, and the user's intent is obvious (to make everything go away).
      *
      * @param action can be null, in which case only the audit-log entry will be created.
+     * @param failed can be null e.g. for additional info, all normal actions must provide non-null value.
      * @param description for the audit-log
      * @param oldEntity for logging the previous field values (make a clone/copy before making changes
      *              to the persisted entity, if necessary); can be null (when creating new or reading)
@@ -63,6 +68,7 @@ class YhteystietoLoggingEntryHolder {
      */
     fun addLogEntriesForEvent(
             action: Action?,
+            failed: Boolean?,
             description: String,
             oldEntity: HankeYhteystietoEntity?,
             newEntity: HankeYhteystietoEntity?,
@@ -74,15 +80,19 @@ class YhteystietoLoggingEntryHolder {
         var yhteystietoId = oldEntity?.id
         if (yhteystietoId == null && newEntity != null)
             yhteystietoId = newEntity.id
+
         // Audit log (without personal data). IPs are applied in bulk later.
-        val audit = AuditLogEntry(time, userid, null, null, null, yhteystietoId, action, description)
+        val audit = AuditLogEntry(
+            time, userid, null, null, null, yhteystietoId, action, failed, description)
         auditLogEntries.add(audit)
-        // Data change log. Note, not made if the action is null (or READ). This allows creating just
-        // an audit-log entry with this function.
-        if (action != null || action == Action.READ) {
+
+        // Data change log. Note, not made if the action is null (or is not causing a change).
+        // This allows creating just an audit-log entry with this function.
+        // Also, failed DELETE is not given change log entry, since all relevant data is known/obvious.
+        if (action?.isChange == true && !(action == Action.DELETE && failed == true)) {
             val oldData = oldEntity?.toChangeLogJsonString()
             val newData = newEntity?.toChangeLogJsonString()
-            val change = ChangeLogEntry(time, yhteystietoId, action, oldData, newData)
+            val change = ChangeLogEntry(time, yhteystietoId, action, failed, oldData, newData)
             changeLogEntries.add(change)
         }
     }
@@ -93,11 +103,12 @@ class YhteystietoLoggingEntryHolder {
      */
     fun addLogEntriesForNewYhteystietos(savedHankeYhteysTietoEntities: MutableList<HankeYhteystietoEntity>, userid: String) {
         // Go through the saved yhteystietos, filter for processing those that didn't exist
-        // before, and add log entries for them now, as their id's are now known:
+        // before, and add log entries for them now, as their id's are now known.
+        // (Obviously, they all succeeded, since they have been saved already.)
         savedHankeYhteysTietoEntities
             .filter { !previousYTids.contains(it.id) }
             .forEach { newYhteystietoEntity ->
-                addLogEntriesForEvent(Action.CREATE, "create new hanke yhteystieto", null, newYhteystietoEntity, userid)
+                addLogEntriesForEvent(Action.CREATE, false, "create new hanke yhteystieto", null, newYhteystietoEntity, userid)
             }
     }
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/YhteystietoLoggingEntryHolder.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/YhteystietoLoggingEntryHolder.kt
@@ -7,6 +7,9 @@ import org.springframework.web.context.request.RequestContextHolder
 import org.springframework.web.context.request.ServletRequestAttributes
 import kotlin.collections.HashSet
 
+
+const val PERSONAL_DATA_LOGGING_MAX_IP_LENGTH = 40
+
 /**
  * Used to hold the maps of yhteystieto entities to logging entries during
  * processing, so that new yhteystietos' ids can be applied after they have
@@ -24,9 +27,6 @@ import kotlin.collections.HashSet
  *    wipe some of the older data away, because Reasons...)
  */
 class YhteystietoLoggingEntryHolder {
-
-    // To Constants?
-    val PERSONAL_DATA_LOGGING_MAX_IP_LENGTH = 40
 
     val auditLogEntries: MutableList<AuditLogEntry> = mutableListOf()
     val changeLogEntries: MutableList<ChangeLogEntry> = mutableListOf()

--- a/services/hanke-service/src/main/resources/db/changelog/changesets/add-personal-data-logs-failed-field.yml
+++ b/services/hanke-service/src/main/resources/db/changelog/changesets/add-personal-data-logs-failed-field.yml
@@ -8,9 +8,13 @@ databaseChangeLog:
             schemaName: personaldatalogs
             tableName: auditlog
             columns:
-              - column: { name: failed, type: boolean }
+              # NOTE: default value purposefully left unset, but setting possibly existing rows to false
+              # (as existing entries would all get false if done after this change).
+              - column: { name: failed, type: boolean, valueBoolean: false }
         - addColumn:
             schemaName: personaldatalogs
             tableName: changelog
             columns:
-              - column: { name: failed, type: boolean }
+              # NOTE: default value purposefully left unset, but setting possibly existing rows to false
+              # (as existing entries would all get false if done after this change).
+              - column: { name: failed, type: boolean, valueBoolean: false }

--- a/services/hanke-service/src/main/resources/db/changelog/changesets/add-personal-data-logs-failed-field.yml
+++ b/services/hanke-service/src/main/resources/db/changelog/changesets/add-personal-data-logs-failed-field.yml
@@ -1,0 +1,16 @@
+databaseChangeLog:
+  - changeSet:
+      id: add-field-for-indicating-failed-action-to-personal-data-log-tables
+      comment: Add a new field to personal data log tables, for indicating when a the logged action failed (due to error or blocked action etc.)
+      author: Markku Hassinen
+      changes:
+        - addColumn:
+            schemaName: personaldatalogs
+            tableName: auditlog
+            columns:
+              - column: { name: failed, type: boolean }
+        - addColumn:
+            schemaName: personaldatalogs
+            tableName: changelog
+            columns:
+              - column: { name: failed, type: boolean }

--- a/services/hanke-service/src/main/resources/db/changelog/changesets/add-personal-data-processing-restriction-support.yml
+++ b/services/hanke-service/src/main/resources/db/changelog/changesets/add-personal-data-processing-restriction-support.yml
@@ -1,0 +1,13 @@
+databaseChangeLog:
+  - changeSet:
+      id: add-fields-for-personal-data-processing-restriction
+      comment: Add new fields for "locking" personal data and for the related description
+      author: Markku Hassinen
+      changes:
+        - addColumn:
+            tableName: hankeyhteystieto
+            columns:
+              # If true, processing this particular personal data is forbidden (no changes, no delete)
+              - column: { name: datalocked, type: boolean }
+              # For recording any info about the processing restriction, e.g. date, reason, contact person for more info, etc.
+              - column: { name: datalockinfo, type: varchar(1000) }

--- a/services/hanke-service/src/main/resources/db/changelog/changesets/add-personal-data-processing-restriction-support.yml
+++ b/services/hanke-service/src/main/resources/db/changelog/changesets/add-personal-data-processing-restriction-support.yml
@@ -8,6 +8,7 @@ databaseChangeLog:
             tableName: hankeyhteystieto
             columns:
               # If true, processing this particular personal data is forbidden (no changes, no delete)
-              - column: { name: datalocked, type: boolean }
+              # null value is allowed, it is considered the same as false.
+              - column: { name: datalocked, type: boolean, defaultValueBoolean: false, valueBoolean: false }
               # For recording any info about the processing restriction, e.g. date, reason, contact person for more info, etc.
               - column: { name: datalockinfo, type: varchar(1000) }

--- a/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -25,3 +25,7 @@ databaseChangeLog:
       file: db/changelog/changesets/add-tormaystarkastelu-results.yml
   - include:
       file: db/changelog/changesets/create-log-tables-for-personaldata.yml
+  - include:
+      file: db/changelog/changesets/add-personal-data-processing-restriction-support.yml
+  - include:
+      file: db/changelog/changesets/add-personal-data-logs-failed-field.yml


### PR DESCRIPTION
# Description

Quite crude implementation for support of data processing restriction for Yhteystietos. Setting or unsetting the restriction flag needs manual database operation (instructions for which will be in confluence, soon..)
Once set, if an update to a Hanke would try to change or delete such restricted Yhteystieto, the attempt will be blocked and (audit) logged, and the whole update to the Hanke will also be prevented. User will see normal "something went wrong" popup in the UI.

### Jira Issue: 

https://helsinkisolutionoffice.atlassian.net/browse/HAI-805

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing

Have a hanke that can be modified, with e.g. two yhteystieto (easier to test with e.g. one owner and one arvioija). Manually set the datalocked-flag on the to-be-tested yhteystieto. Make sure the flag gets updated to backend (e.g. restart whole Haitaton or just the backend, so that old flag state isn't cached). Go back to the hanke editing on the yhteystieto-page and try to change the restricted yhteystieto and save... should give the warning popup. Check in the database that the audit and changelogs got the relevant entries (with failed-field true).  Trying to delete the yhteystieto (changing all its fields to empty) should give the same result, except no entry in the changelog-table, only an entry in the auditlog-table.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 

# Other relevant info
Do note the possible complications between making manual changes to the database and how spring-data/JPA/Hibernate can cache data in memory. Wasted plenty of time looking for non-existent bugs not realizing that...