### PR TITLE
Include users permissions in response

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeControllerITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeControllerITests.kt
@@ -12,6 +12,7 @@ import fi.hel.haitaton.hanke.permissions.PermissionService
 import io.mockk.every
 import io.mockk.verify
 import org.geojson.FeatureCollection
+import org.hamcrest.Matchers.hasSize
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -155,8 +156,14 @@ class HankeControllerITests(@Autowired val mockMvc: MockMvc) {
             .andExpect(content().contentType(MediaType.APPLICATION_JSON))
             .andExpect(jsonPath("$[0].hankeTunnus").value(mockedHankeTunnus))
             .andExpect(jsonPath("$[1].hankeTunnus").value("hanketunnus2"))
+            .andExpect(jsonPath("$[0].id").value(123))
+            .andExpect(jsonPath("$[1].id").value(444))
             .andExpect(jsonPath("$[0].geometriat").doesNotExist())
             .andExpect(jsonPath("$[1].geometriat").doesNotExist())
+            .andExpect(jsonPath("$[0].permissions").isArray)
+            .andExpect(jsonPath("$[0].permissions").value(hasSize<Array<Any>>(PermissionProfiles.HANKE_OWNER_PERMISSIONS.size)))
+            .andExpect(jsonPath("$[1].permissions").isArray)
+            .andExpect(jsonPath("$[1].permissions").value(hasSize<Array<Any>>(1)))
 
         verify { hankeService.loadHankkeetByIds(hankeIds) }
     }
@@ -211,8 +218,15 @@ class HankeControllerITests(@Autowired val mockMvc: MockMvc) {
             .andExpect(content().contentType(MediaType.APPLICATION_JSON))
             .andExpect(jsonPath("$[0].hankeTunnus").value(mockedHankeTunnus))
             .andExpect(jsonPath("$[1].hankeTunnus").value("hanketunnus2"))
+            .andExpect(jsonPath("$[0].id").value(123))
+            .andExpect(jsonPath("$[1].id").value(444))
             .andExpect(jsonPath("$[0].geometriat.id").value(1))
             .andExpect(jsonPath("$[1].geometriat.id").value(2))
+            .andExpect(jsonPath("$[0].permissions").isArray)
+            .andExpect(jsonPath("$[0].permissions").value(hasSize<Array<Any>>(PermissionProfiles.HANKE_OWNER_PERMISSIONS.size)))
+            .andExpect(jsonPath("$[1].permissions").isArray)
+            .andExpect(jsonPath("$[1].permissions").value(hasSize<Array<Any>>(1)))
+
 
         verify { hankeService.loadHankkeetByIds(hankeIds) }
         verify { hankeGeometriatService.loadGeometriat(Hanke(123, mockedHankeTunnus)) }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeController.kt
@@ -67,11 +67,11 @@ class HankeController(
     fun getHankeList(hankeSearch: HankeSearch? = null): ResponseEntity<Any> {
         val userid = SecurityContextHolder.getContext().authentication.name
 
-        val hankeIdsWithViewPermissions = permissionService.getPermissionsByUserId(userid)
-            .filter { it.permissions.contains(PermissionCode.VIEW) }
-            .map { it.hankeId }
+        val userPermissions = permissionService.getPermissionsByUserId(userid)
+                .filter { it.permissions.contains(PermissionCode.VIEW) }
 
-        val hankeList = hankeService.loadHankkeetByIds(hankeIdsWithViewPermissions)
+        val hankeList = hankeService.loadHankkeetByIds(userPermissions.map { it.hankeId })
+        includePermissions(hankeList, userPermissions)
 
         if (hankeSearch != null && hankeSearch.includeGeometry()) {
             includeGeometry(hankeList)
@@ -81,6 +81,11 @@ class HankeController(
             "Search results: ${hankeList.joinToString("\n") { it.toLogString() }}"
         }
         return ResponseEntity.status(HttpStatus.OK).body(hankeList)
+    }
+
+    private fun includePermissions(hankeList: List<Hanke>, userPermissions: List<Permission>) {
+        val permissionsByHankeId = userPermissions.associateBy { it.hankeId }
+        hankeList.forEach { it.permissions = permissionsByHankeId.get(it.id!!)?.permissions }
     }
 
     private fun includeGeometry(hankeList: List<Hanke>) {

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/Hanke.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/Hanke.kt
@@ -10,6 +10,7 @@ import fi.hel.haitaton.hanke.TyomaaKoko
 import fi.hel.haitaton.hanke.TyomaaTyyppi
 import fi.hel.haitaton.hanke.Vaihe
 import fi.hel.haitaton.hanke.geometria.HankeGeometriat
+import fi.hel.haitaton.hanke.permissions.PermissionCode
 import fi.hel.haitaton.hanke.tormaystarkastelu.LiikennehaittaIndeksiType
 import fi.hel.haitaton.hanke.tormaystarkastelu.TormaystarkasteluTulos
 
@@ -97,6 +98,8 @@ data class Hanke(
      * See 'tilaOnGeometrioita' field.
      */
     var geometriat: HankeGeometriat? = null
+
+    var permissions: List<PermissionCode>? = null
 
     /**
      * Number of days between haittaAlkuPvm and haittaLoppuPvm (incl. both days)

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/HankeControllerTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/HankeControllerTest.kt
@@ -115,7 +115,7 @@ class HankeControllerTest {
                 "user",
                 50,
                 listOf(
-                    PermissionCode.VIEW
+                    PermissionCode.VIEW, PermissionCode.EDIT
                 )
             )
         )
@@ -171,6 +171,8 @@ class HankeControllerTest {
         assertThat(responseList.body?.get(1)?.nimi).isEqualTo("Hämeenlinnanväylän uudistus")
         assertThat(responseList.body?.get(0)?.geometriat).isNull()
         assertThat(responseList.body?.get(1)?.geometriat).isNull()
+        assertThat(responseList.body?.get(0)?.permissions).isEqualTo(listOf(PermissionCode.VIEW))
+        assertThat(responseList.body?.get(1)?.permissions).isEqualTo(listOf(PermissionCode.VIEW, PermissionCode.EDIT))
     }
 
 


### PR DESCRIPTION
# Description

Include users permissions under `permissions` key for each hanke in response to `GET /hankkeet`

### Jira Issue: 

## Type of change

- [ ] Bug fix 
- [x] New feature 
- [ ] Other

# Instructions for testing
Please describe tests how this change or new feature can be tested.

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 

# Other relevant info
Please describe here if there is e.g. some requirements for this change or
 other info that the tester/user needs to know.