### PR TITLE
Check viewing permission when getting hanke by tunnus

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/security/HankeControllerSecurityTests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/security/HankeControllerSecurityTests.kt
@@ -213,6 +213,8 @@ class HankeControllerSecurityTests(@Autowired val mockMvc: MockMvc) {
     private fun performGetHankkeetTunnus(): ResultActions {
         every { hankeService.loadHanke(any()) }
             .returns(Hanke(123, "HAI-TEST-1"))
+        every { permissionService.getPermissionByHankeIdAndUserId(123, "test7358") }
+            .returns(Permission(1, "test7358", 123, PermissionProfiles.HANKE_OWNER_PERMISSIONS))
 
         return mockMvc.perform(
             get("/hankkeet/$testHankeTunnus")

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeController.kt
@@ -38,8 +38,18 @@ class HankeController(
 ) {
 
     @GetMapping("/{hankeTunnus}")
-    fun getHankeByTunnus(@PathVariable(name = "hankeTunnus") hankeTunnus: String): Hanke =
-            hankeService.loadHanke(hankeTunnus) ?: throw HankeNotFoundException(hankeTunnus)
+    fun getHankeByTunnus(@PathVariable(name = "hankeTunnus") hankeTunnus: String): Hanke {
+        val hanke = hankeService.loadHanke(hankeTunnus)
+                ?: throw HankeNotFoundException(hankeTunnus)
+
+        val userid = SecurityContextHolder.getContext().authentication.name
+        val permission = permissionService.getPermissionByHankeIdAndUserId(hanke.id!!, userid)
+        if (permission == null || !permission.permissions.contains(PermissionCode.VIEW)) {
+            throw HankeNotFoundException(hankeTunnus)
+        }
+
+        return hanke
+    }
 
     @GetMapping
     fun getHankeList(@RequestParam geometry: Boolean = false): List<Hanke> {

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeServiceImpl.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeServiceImpl.kt
@@ -24,19 +24,8 @@ open class HankeServiceImpl(
     private val personalDataChangeLogRepository: PersonalDataChangeLogRepository,
 ) : HankeService {
 
-    // WITH THIS ONE CAN AUTHORIZE ONLY THE OWNER TO LOAD A HANKE: @PostAuthorize("returnObject.createdBy == authentication.name")
-    override fun loadHanke(hankeTunnus: String): Hanke? {
-        // TODO: Find out all savetype matches and return the more recent draft vs. submit.
-        val entity = hankeRepository.findByHankeTunnus(hankeTunnus)
-        if (entity == null)
-            return null
-
-        if (entity.id == null) {
-            throw DatabaseStateException(hankeTunnus)
-        }
-
-        return createHankeDomainObjectFromEntity(entity)
-    }
+    override fun loadHanke(hankeTunnus: String) = hankeRepository.findByHankeTunnus(hankeTunnus)
+            ?.let { createHankeDomainObjectFromEntity(it) }
 
     override fun loadAllHanke() = hankeRepository.findAll()
             .map { createHankeDomainObjectFromEntity(it) }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/HankeControllerTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/HankeControllerTest.kt
@@ -66,10 +66,14 @@ class HankeControllerTest {
 
     @Test
     fun `test that the getHankebyTunnus returns ok`() {
+        val hankeId = 1234
+        val permission = Permission(1, "user", hankeId, listOf(PermissionCode.VIEW))
+
+        Mockito.`when`(permissionService.getPermissionByHankeIdAndUserId(hankeId, "user")).thenReturn(permission)
         Mockito.`when`(hankeService.loadHanke(mockedHankeTunnus))
             .thenReturn(
                 Hanke(
-                    1234,
+                    hankeId,
                     mockedHankeTunnus,
                     true,
                     "Mannerheimintien remontti remonttinen",


### PR DESCRIPTION
# Description

Add permission check to `GET /hankkeet/{hankeTunnus}`

### Jira Issue: 

## Type of change

- [ ] Bug fix 
- [x] New feature 
- [ ] Other

# Instructions for testing
Please describe tests how this change or new feature can be tested.

# Checklist:

- [ ] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 

# Other relevant info
Please describe here if there is e.g. some requirements for this change or
 other info that the tester/user needs to know.