### PR TITLE
Add dedicated liveness endpoint to hanke-service

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/StatusControllerITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/StatusControllerITests.kt
@@ -1,0 +1,47 @@
+package fi.hel.haitaton.hanke
+
+import fi.hel.haitaton.hanke.StatusController.Companion.QUERY
+import fi.hel.haitaton.hanke.StatusController.Companion.SUCCESS
+import fi.hel.haitaton.hanke.StatusController.Companion.ERROR
+import io.mockk.every
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.context.annotation.Import
+import org.springframework.jdbc.core.JdbcOperations
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers
+
+@WebMvcTest(StatusController::class)
+@Import(IntegrationTestConfiguration::class, IntegrationTestResourceServerConfig::class)
+@ActiveProfiles("itest")
+class StatusControllerITests(@Autowired val mockMvc: MockMvc) {
+
+    @Autowired
+    lateinit var jdbcOperations: JdbcOperations
+
+    @Test
+    fun testSuccess() {
+        every { jdbcOperations.queryForObject(QUERY, Int::class.java) } returns SUCCESS
+        mockMvc.perform(MockMvcRequestBuilders.get("/status"))
+                .andExpect(MockMvcResultMatchers.status().isOk)
+    }
+
+    @Test
+    fun testError() {
+        every { jdbcOperations.queryForObject(QUERY, Int::class.java) } returns ERROR
+        mockMvc.perform(MockMvcRequestBuilders.get("/status"))
+                .andExpect(MockMvcResultMatchers.status().is5xxServerError)
+    }
+
+    @Test
+    fun testException() {
+        every { jdbcOperations.queryForObject(QUERY, Int::class.java) } throws RuntimeException()
+        mockMvc.perform(MockMvcRequestBuilders.get("/status"))
+                .andExpect(MockMvcResultMatchers.status().is5xxServerError)
+    }
+
+}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/StatusController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/StatusController.kt
@@ -1,0 +1,38 @@
+package fi.hel.haitaton.hanke
+
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.jdbc.core.JdbcOperations
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/status")
+class StatusController(@Autowired private val jdbcOperations: JdbcOperations) {
+
+    companion object {
+        const val QUERY = "SELECT COUNT(*) FROM tormays_central_business_area_polys LIMIT 1"
+        const val SUCCESS = 1
+        const val ERROR = 0
+    }
+
+    @GetMapping
+    fun getStatus(): ResponseEntity<Void> =
+        if (getCount() == SUCCESS) {
+            ResponseEntity.ok().build()
+        } else {
+            ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build()
+        }
+
+    private fun getCount() =
+        try {
+             with(jdbcOperations) {
+                queryForObject(QUERY, Int::class.java) ?: ERROR
+             }
+        } catch (ignore: Throwable) {
+            ERROR
+        }
+
+}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/security/AccessRules.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/security/AccessRules.kt
@@ -12,7 +12,12 @@ private val logger = KotlinLogging.logger { }
 
 object AccessRules {
     fun configureHttpAccessRules(http: HttpSecurity) {
-        http.authorizeRequests().mvcMatchers(HttpMethod.GET, "/actuator/health", "/actuator/health/liveness", "/actuator/health/readiness").permitAll().and()
+        http.authorizeRequests().mvcMatchers(HttpMethod.GET,
+                "/actuator/health",
+                "/actuator/health/liveness",
+                "/actuator/health/readiness",
+                "/status"
+            ).permitAll().and()
             .authorizeRequests().anyRequest().authenticated().and()
             .exceptionHandling().authenticationEntryPoint { request, response, authenticationException ->
                 logger.warn {


### PR DESCRIPTION
# Description

Add `/api/status` endpoint for monitoring purposes. The functionality tests that database connections are working and also checks that the database is populated with at least some of the data required by the service.

### Jira Issue: 

## Type of change

- [ ] Bug fix 
- [x] New feature 
- [ ] Other

# Instructions for testing
Please describe tests how this change or new feature can be tested.

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 

# Other relevant info
Please describe here if there is e.g. some requirements for this change or
 other info that the tester/user needs to know.