### PR TITLE
HAI-1180 Refactor audit logging to use unified database table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/
+.DS_Store
 
 ### STS ###
 .apt_generated
@@ -32,3 +33,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### Local environment variables ###
+.env

--- a/scripts/HEL-GIS-data-import.sh
+++ b/scripts/HEL-GIS-data-import.sh
@@ -1,3 +1,4 @@
+# Needs maintenance VPN to access the fileshare.
 start=`date +%s`
 echo Importing tormays_buses_polys.gpkg...
 docker run --rm --network=haitaton-backend_backbone osgeo/gdal:alpine-small-latest ogr2ogr -overwrite -f PostgreSQL PG:"dbname='haitaton' host='db' port='5432' user='haitaton_user' password='haitaton'" http://haitaton-fileshare-dev.internal.apps.arodevtest.hel.fi/tormays_buses_polys.gpkg

--- a/services/hanke-service/README.md
+++ b/services/hanke-service/README.md
@@ -7,10 +7,12 @@ Using IDEA:
 * IntelliJ IDEA
    * it contains its own JDK, gradle, etc.
 * OpenJDK (version 11+) - for running things after they have been built
+* Docker
 
 Manual build
 * OpenJDK (version 11+)
 * Gradle
+* Docker
 
 ## How to compile, build and run
 
@@ -63,12 +65,12 @@ You can also run the whole haitaton stack with docker compose. Due to the
 ```
 
 In addition, an environment file is needed to set the build root. You can
- either set it in your own environment beforehand or just use the syntaks
-  with env file stated as in the steps below. 
+either set it in your own environment beforehand or just use the syntax
+with env file stated as in the steps below.
   
 If you need to change the build context, you can do so in .env.local file.   
   
-### How tu run docker-compose
+### How to run docker-compose
 
 - Install [docker-compose](https://docs.docker.com/compose/install/)  according
  to your operating system instructions. 
@@ -96,7 +98,8 @@ If you need to change the build context, you can do so in .env.local file.
 ```
 
 ### GIS data import
-In order to run Törmäystarkastelus locally one needs to import GIS data. This can be done after docker-compose is up and running (at least `db`):
+In order to run Törmäystarkastelus locally one needs to import GIS data. This can be done after docker-compose is up and running (at least `db`).
+Maintenance VPN (`huolto.hel.fi`) is needed to access the files.
 ```shell
 cd haitaton-backend
 sh scripts/HEL-GIS-data-import.sh

--- a/services/hanke-service/build.gradle.kts
+++ b/services/hanke-service/build.gradle.kts
@@ -78,7 +78,7 @@ dependencies {
 	testImplementation("io.mockk:mockk:$mockkVersion")
 	testImplementation("com.ninja-squad:springmockk:$springmockkVersion")
 	testImplementation("com.willowtreeapps.assertk:assertk-jvm:$assertkVersion")
-	testImplementation("org.testcontainers:junit-jupiter:1.15.2")
+	testImplementation("org.testcontainers:junit-jupiter:1.15.3")
 	testImplementation("org.testcontainers:postgresql:1.15.2")
 	testImplementation("com.squareup.okhttp3:okhttp:4.9.3")
 	testImplementation("com.squareup.okhttp3:mockwebserver:4.9.3")

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
@@ -2,11 +2,13 @@ package fi.hel.haitaton.hanke
 
 import fi.hel.haitaton.hanke.domain.Hanke
 import fi.hel.haitaton.hanke.domain.HankeYhteystieto
-import fi.hel.haitaton.hanke.logging.AuditLogEntry
 import fi.hel.haitaton.hanke.logging.Action
-import fi.hel.haitaton.hanke.logging.ChangeLogEntry
-import fi.hel.haitaton.hanke.logging.PersonalDataAuditLogRepository
-import fi.hel.haitaton.hanke.logging.PersonalDataChangeLogRepository
+import fi.hel.haitaton.hanke.logging.AuditLogEntry
+import fi.hel.haitaton.hanke.logging.AuditLogRepository
+import fi.hel.haitaton.hanke.logging.ObjectType
+import fi.hel.haitaton.hanke.logging.Status
+import java.time.ZonedDateTime
+import java.time.temporal.ChronoUnit
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.junit.jupiter.api.Test
@@ -20,8 +22,6 @@ import org.springframework.test.context.DynamicPropertySource
 import org.springframework.transaction.annotation.Transactional
 import org.testcontainers.junit.jupiter.Container
 import org.testcontainers.junit.jupiter.Testcontainers
-import java.time.ZonedDateTime
-import java.time.temporal.ChronoUnit
 
 @Testcontainers
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
@@ -54,10 +54,10 @@ class HankeServiceITests {
 
     @Autowired
     private lateinit var hankeService: HankeService
+
     @Autowired
-    private lateinit var personalDataAuditLogRepository: PersonalDataAuditLogRepository
-    @Autowired
-    private lateinit var personalDataChangeLogRepository: PersonalDataChangeLogRepository
+    private lateinit var auditLogRepository: AuditLogRepository
+
     @Autowired
     private lateinit var hankeRepository: HankeRepository
 
@@ -521,98 +521,90 @@ class HankeServiceITests {
         // Create hanke with two yhteystietos, save, check logs (creates in both logs, null old data)
         // Setup Hanke with two Yhteystietos in the same group:
         val hanke: Hanke = getATestHanke("yksi", 1)
-        val yt1 = getATestYhteystieto(1)
-        val yt2 = getATestYhteystieto(2)
-        hanke.omistajat = arrayListOf(yt1, yt2)
+        val yhteystieto1 = getATestYhteystieto(1)
+        val yhteystieto2 = getATestYhteystieto(2)
+        hanke.omistajat = arrayListOf(yhteystieto1, yhteystieto2)
         // Call create, get the return object, and make some general checks:
-        val returnedHanke = hankeService.createHanke(hanke)
-        assertThat(returnedHanke).isNotNull
-        assertThat(returnedHanke).isNotSameAs(hanke)
-        assertThat(returnedHanke.id).isNotNull
+        val createdHanke = hankeService.createHanke(hanke)
+        assertThat(createdHanke).isNotNull
+        assertThat(createdHanke).isNotSameAs(hanke)
+        assertThat(createdHanke.id).isNotNull
         // Check and record the Yhteystieto ids, and to-be-changed field's value
-        assertThat(returnedHanke.omistajat).hasSize(2)
-        assertThat(returnedHanke.omistajat[0].id).isNotNull
-        assertThat(returnedHanke.omistajat[1].id).isNotNull
-        val ytid1 = returnedHanke.omistajat[0].id!!
-        val ytid2 = returnedHanke.omistajat[1].id!!
-        assertThat(returnedHanke.omistajat[1].sukunimi).isEqualTo("suku2")
+        assertThat(createdHanke.omistajat).hasSize(2)
+        assertThat(createdHanke.omistajat[0].id).isNotNull
+        assertThat(createdHanke.omistajat[1].id).isNotNull
+        val yhteystietoId1 = createdHanke.omistajat[0].id!!
+        val yhteystietoId2 = createdHanke.omistajat[1].id!!
+        assertThat(createdHanke.omistajat[1].sukunimi).isEqualTo("suku2")
 
-        // Prepare example for searching entries by yhteystietoid:
-        val sample1auditlog = Example.of(AuditLogEntry(yhteystietoId = ytid1))
-        val sample1changelog = Example.of(ChangeLogEntry(yhteystietoId = ytid1))
-        val sample2auditlog = Example.of(AuditLogEntry(yhteystietoId = ytid2))
-        val sample2changelog = Example.of(ChangeLogEntry(yhteystietoId = ytid2))
+        // Prepare example for searching entries by yhteystietoId:
+        val exampleForYhteystieto1 = Example.of(AuditLogEntry(id = null, eventTime = null, objectId = yhteystietoId1))
+        val exampleForYhteystieto2 = Example.of(AuditLogEntry(id = null, eventTime = null, objectId = yhteystietoId2))
 
         // Check logs...
-        // Both logs must have 2 entries (two yhteystietos were created):
-        assertThat(personalDataAuditLogRepository.count()).isEqualTo(2)
-        assertThat(personalDataChangeLogRepository.count()).isEqualTo(2)
-        // Check that each yhteystieto has single entry in each log:
-        var auditLogEntries1 = personalDataAuditLogRepository.findAll(sample1auditlog)
-        var changeLogEntries1 = personalDataChangeLogRepository.findAll(sample1changelog)
-        var auditLogEntries2 = personalDataAuditLogRepository.findAll(sample2auditlog)
-        var changeLogEntries2 = personalDataChangeLogRepository.findAll(sample2changelog)
+        // The log must have 2 entries (two yhteystietos were created):
+        assertThat(auditLogRepository.count()).isEqualTo(2)
+
+        // Check that each yhteystieto has single entry in log:
+        var auditLogEntries1 = auditLogRepository.findAll(exampleForYhteystieto1)
+        var auditLogEntries2 = auditLogRepository.findAll(exampleForYhteystieto2)
         assertThat(auditLogEntries1.size).isEqualTo(1)
-        assertThat(changeLogEntries1.size).isEqualTo(1)
         assertThat(auditLogEntries2.size).isEqualTo(1)
-        assertThat(changeLogEntries2.size).isEqualTo(1)
+
         // Check that each entry has correct data (action CREATE,
         // new data contains "suku1" or "suku2", and userid is that of the test user).
         assertThat(auditLogEntries1[0].action).isEqualTo(Action.CREATE)
         assertThat(auditLogEntries1[0].userId).isEqualTo(USER_NAME)
-        assertThat(changeLogEntries1[0].action).isEqualTo(Action.CREATE)
-        assertThat(changeLogEntries1[0].newData).contains("suku1")
+        assertThat(auditLogEntries1[0].status).isEqualTo(Status.SUCCESS)
+        assertThat(auditLogEntries1[0].failureDescription).isNull()
+        assertThat(auditLogEntries1[0].objectType).isEqualTo(ObjectType.YHTEYSTIETO)
+        assertThat(auditLogEntries1[0].objectBefore).isNull()
+        assertThat(auditLogEntries1[0].objectAfter).contains("suku1")
+
         assertThat(auditLogEntries2[0].action).isEqualTo(Action.CREATE)
         assertThat(auditLogEntries2[0].userId).isEqualTo(USER_NAME)
-        assertThat(changeLogEntries2[0].action).isEqualTo(Action.CREATE)
-        assertThat(changeLogEntries2[0].oldData).isNull()
-        assertThat(changeLogEntries2[0].newData).contains("suku2")
-        assertThat(auditLogEntries1[0].failed).isFalse
-        assertThat(auditLogEntries2[0].failed).isFalse
-        assertThat(changeLogEntries1[0].failed).isFalse
-        assertThat(changeLogEntries2[0].failed).isFalse
+        assertThat(auditLogEntries2[0].status).isEqualTo(Status.SUCCESS)
+        assertThat(auditLogEntries2[0].failureDescription).isNull()
+        assertThat(auditLogEntries2[0].objectType).isEqualTo(ObjectType.YHTEYSTIETO)
+        assertThat(auditLogEntries2[0].objectBefore).isNull()
+        assertThat(auditLogEntries2[0].objectAfter).contains("suku2")
 
-        // Update the other yhteystieto (one update in both logs, both datas exist and with correct values)
+        // Update the other yhteystieto (one update in logs, both datas exist and with correct values)
         // Change a value:
-        returnedHanke.omistajat[1].sukunimi = "Som Et Hing"
+        createdHanke.omistajat[1].sukunimi = "Som Et Hing"
         // Call update, get the returned object, make some general checks:
-        val returnedHanke2 = hankeService.updateHanke(returnedHanke)
-        assertThat(returnedHanke2).isNotNull
-        assertThat(returnedHanke2).isNotSameAs(hanke)
-        assertThat(returnedHanke2).isNotSameAs(returnedHanke)
-        assertThat(returnedHanke2.id).isNotNull
+        val hankeAfterUpdate = hankeService.updateHanke(createdHanke)
+        assertThat(hankeAfterUpdate).isNotNull
+        assertThat(hankeAfterUpdate).isNotSameAs(hanke)
+        assertThat(hankeAfterUpdate).isNotSameAs(createdHanke)
+        assertThat(hankeAfterUpdate.id).isNotNull
         // Check that both entries kept their ids, and the only change is where expected
-        assertThat(returnedHanke2.omistajat).hasSize(2)
-        assertThat(returnedHanke2.omistajat[0].id).isEqualTo(ytid1)
-        assertThat(returnedHanke2.omistajat[1].id).isEqualTo(ytid2)
-        assertThat(returnedHanke2.omistajat[0].sukunimi).isEqualTo("suku1")
-        assertThat(returnedHanke2.omistajat[1].sukunimi).isEqualTo("Som Et Hing")
+        assertThat(hankeAfterUpdate.omistajat).hasSize(2)
+        assertThat(hankeAfterUpdate.omistajat[0].id).isEqualTo(yhteystietoId1)
+        assertThat(hankeAfterUpdate.omistajat[1].id).isEqualTo(yhteystietoId2)
+        assertThat(hankeAfterUpdate.omistajat[0].sukunimi).isEqualTo("suku1")
+        assertThat(hankeAfterUpdate.omistajat[1].sukunimi).isEqualTo("Som Et Hing")
 
         // Check logs...
-        // Check that only 1 entry was added to each log (about the updated yhteystieto)
-        assertThat(personalDataAuditLogRepository.count()).isEqualTo(3)
-        assertThat(personalDataChangeLogRepository.count()).isEqualTo(3)
-        // Check that the second yhteystieto got a single entry in each log (and the other didn't)
-        auditLogEntries1 = personalDataAuditLogRepository.findAll(sample1auditlog)
-        changeLogEntries1 = personalDataChangeLogRepository.findAll(sample1changelog)
-        auditLogEntries2 = personalDataAuditLogRepository.findAll(sample2auditlog)
-        changeLogEntries2 = personalDataChangeLogRepository.findAll(sample2changelog)
+        // Check that only 1 entry was added to log (about the updated yhteystieto)
+        assertThat(auditLogRepository.count()).isEqualTo(3)
+        // Check that the second yhteystieto got a single entry in log (and the other didn't)
+        auditLogEntries1 = auditLogRepository.findAll(exampleForYhteystieto1)
+        auditLogEntries2 = auditLogRepository.findAll(exampleForYhteystieto2)
         assertThat(auditLogEntries1.size).isEqualTo(1)
-        assertThat(changeLogEntries1.size).isEqualTo(1)
         assertThat(auditLogEntries2.size).isEqualTo(2)
-        assertThat(changeLogEntries2.size).isEqualTo(2)
         // Check that the new entry has correct data (action UPDATE,
         // old data contains "suku2", new data "Som Et Hing", and userid is that of the test user).
         assertThat(auditLogEntries2[1].action).isEqualTo(Action.UPDATE)
         assertThat(auditLogEntries2[1].userId).isEqualTo(USER_NAME)
-        assertThat(changeLogEntries2[1].action).isEqualTo(Action.UPDATE)
-        assertThat(changeLogEntries2[1].oldData).contains("suku2")
-        assertThat(changeLogEntries2[1].newData).contains("Som Et Hing")
-        assertThat(auditLogEntries2[1].failed).isFalse
-        assertThat(changeLogEntries2[1].failed).isFalse
+        assertThat(auditLogEntries2[1].status).isEqualTo(Status.SUCCESS)
+        assertThat(auditLogEntries2[1].failureDescription).isNull()
+        assertThat(auditLogEntries2[1].objectType).isEqualTo(ObjectType.YHTEYSTIETO)
+        assertThat(auditLogEntries2[1].objectBefore).contains("suku2")
+        assertThat(auditLogEntries2[1].objectAfter).contains("Som Et Hing")
 
         // Delete the other yhteystieto (one update in both logs, null new data)
-        returnedHanke2.omistajat[1].apply {
+        hankeAfterUpdate.omistajat[1].apply {
             etunimi = ""
             sukunimi = ""
             puhelinnumero = ""
@@ -621,50 +613,44 @@ class HankeServiceITests {
             osasto = ""
         }
         // Call update, get the returned object:
-        val returnedHanke3 = hankeService.updateHanke(returnedHanke2)
+        val hankeAfterDelete = hankeService.updateHanke(hankeAfterUpdate)
         // Check that first yhteystieto remains, second one got removed:
-        assertThat(returnedHanke3.omistajat).hasSize(1)
-        assertThat(returnedHanke3.omistajat[0].id).isEqualTo(ytid1)
-        assertThat(returnedHanke3.omistajat[0].sukunimi).isEqualTo("suku1")
+        assertThat(hankeAfterDelete.omistajat).hasSize(1)
+        assertThat(hankeAfterDelete.omistajat[0].id).isEqualTo(yhteystietoId1)
+        assertThat(hankeAfterDelete.omistajat[0].sukunimi).isEqualTo("suku1")
 
         // Check logs...
-        // Check that only 1 entry was added to each log (about the deleted yhteystieto)
-        assertThat(personalDataAuditLogRepository.count()).isEqualTo(4)
-        assertThat(personalDataChangeLogRepository.count()).isEqualTo(4)
-        // Check that the second yhteystieto got a single entry in each log (and the other didn't)
-        auditLogEntries1 = personalDataAuditLogRepository.findAll(sample1auditlog)
-        changeLogEntries1 = personalDataChangeLogRepository.findAll(sample1changelog)
-        auditLogEntries2 = personalDataAuditLogRepository.findAll(sample2auditlog)
-        changeLogEntries2 = personalDataChangeLogRepository.findAll(sample2changelog)
+        // Check that only 1 entry was added to log (about the deleted yhteystieto)
+        assertThat(auditLogRepository.count()).isEqualTo(4)
+        // Check that the second yhteystieto got a single entry in log (and the other didn't)
+        auditLogEntries1 = auditLogRepository.findAll(exampleForYhteystieto1)
+        auditLogEntries2 = auditLogRepository.findAll(exampleForYhteystieto2)
         assertThat(auditLogEntries1.size).isEqualTo(1)
-        assertThat(changeLogEntries1.size).isEqualTo(1)
         assertThat(auditLogEntries2.size).isEqualTo(3)
-        assertThat(changeLogEntries2.size).isEqualTo(3)
         // Check that the new entry has correct data (action DELETE,
         // old data contains "Som Et Hing", new data is null, and userid is that of the test user).
         assertThat(auditLogEntries2[2].action).isEqualTo(Action.DELETE)
         assertThat(auditLogEntries2[2].userId).isEqualTo(USER_NAME)
-        assertThat(changeLogEntries2[2].action).isEqualTo(Action.DELETE)
-        assertThat(changeLogEntries2[2].oldData).contains("Som Et Hing")
-        assertThat(changeLogEntries2[2].newData).isNull()
-        assertThat(auditLogEntries2[2].failed).isFalse
-        assertThat(changeLogEntries2[2].failed).isFalse
+        assertThat(auditLogEntries2[2].status).isEqualTo(Status.SUCCESS)
+        assertThat(auditLogEntries2[2].failureDescription).isNull()
+        assertThat(auditLogEntries2[2].objectType).isEqualTo(ObjectType.YHTEYSTIETO)
+        assertThat(auditLogEntries2[2].objectBefore).contains("Som Et Hing")
+        assertThat(auditLogEntries2[2].objectAfter).isNull()
     }
 
     @Test
     fun `test personal data processing restriction`() {
         // Setup Hanke with two Yhteystietos in different groups (will only manipulate the non-owner):
         val hanke: Hanke = getATestHanke("yksi", 1)
-        val yt1 = getATestYhteystieto(1)
-        val yt2 = getATestYhteystieto(2)
-        hanke.omistajat = arrayListOf(yt1)
-        hanke.arvioijat = arrayListOf(yt2)
+        val omistaja = getATestYhteystieto(1)
+        val arvioija = getATestYhteystieto(2)
+        hanke.omistajat = arrayListOf(omistaja)
+        hanke.arvioijat = arrayListOf(arvioija)
         // Call create, get the return object:
         val returnedHanke = hankeService.createHanke(hanke)
         // Check logs...
-        // Both logs must have 2 entries (two yhteystietos were created):
-        assertThat(personalDataAuditLogRepository.count()).isEqualTo(2)
-        assertThat(personalDataChangeLogRepository.count()).isEqualTo(2)
+        // Logs must have 2 entries (two yhteystietos were created):
+        assertThat(auditLogRepository.count()).isEqualTo(2)
 
         // Get the non-owner yhteystieto,
         // and set the processing restriction (i.e. locked) -flag (must be done via entities):
@@ -672,9 +658,9 @@ class HankeServiceITests {
         val hankeId = returnedHanke.id
         var hankeEntity = hankeRepository.findById(hankeId!!).get()
         var yhteystietos = hankeEntity.listOfHankeYhteystieto
-        var yhteystietoEntity = yhteystietos.filter { it.contactType == ContactType.ARVIOIJA }[0]
-        val ytid = yhteystietoEntity.id
-        yhteystietoEntity.dataLocked = true
+        var arvioijaEntity = yhteystietos.filter { it.contactType == ContactType.ARVIOIJA }[0]
+        val arvioijaId = arvioijaEntity.id
+        arvioijaEntity.dataLocked = true
         // (Not setting the info field, or adding audit log entry, since the idea
         // is to only test that the locking actually prevents processing.)
         // Saving the hanke will save the yhteystieto in it, too:
@@ -688,24 +674,20 @@ class HankeServiceITests {
             hankeService.updateHanke(hankeWithLockedYT)
         }
         // Check logs
-        // The initial create has created two entries to each log, and now
-        // the failed update should have added one more to each log.
-        assertThat(personalDataAuditLogRepository.count()).isEqualTo(3)
-        assertThat(personalDataChangeLogRepository.count()).isEqualTo(3)
-        val sampleauditlog = Example.of(AuditLogEntry(yhteystietoId = ytid))
-        val samplechangelog = Example.of(ChangeLogEntry(yhteystietoId = ytid))
-        var auditLogEntries = personalDataAuditLogRepository.findAll(sampleauditlog)
-        var changeLogEntries = personalDataChangeLogRepository.findAll(samplechangelog)
+        // The initial create has created two entries to the log, and now
+        // the failed update should have added one more.
+        assertThat(auditLogRepository.count()).isEqualTo(3)
+        val exampleForArvioija = Example.of(AuditLogEntry(id = null, eventTime = null, objectId = arvioijaId))
+        var auditLogEntries = auditLogRepository.findAll(exampleForArvioija)
         // For the second yhteystieto, 1 entry for the earlier creation, another for this failed update:
         assertThat(auditLogEntries.size).isEqualTo(2)
-        assertThat(changeLogEntries.size).isEqualTo(2)
         assertThat(auditLogEntries[1].action).isEqualTo(Action.UPDATE)
         assertThat(auditLogEntries[1].userId).isEqualTo(USER_NAME)
-        assertThat(changeLogEntries[1].action).isEqualTo(Action.UPDATE)
-        assertThat(changeLogEntries[1].oldData).contains("suku2")
-        assertThat(changeLogEntries[1].newData).contains("Muhaha-Evil-Change")
-        assertThat(auditLogEntries[1].failed).isTrue
-        assertThat(changeLogEntries[1].failed).isTrue
+        assertThat(auditLogEntries[1].status).isEqualTo(Status.FAILED)
+        assertThat(auditLogEntries[1].failureDescription).isEqualTo("update hanke yhteystieto BLOCKED by data processing restriction")
+        assertThat(auditLogEntries[1].objectType).isEqualTo(ObjectType.YHTEYSTIETO)
+        assertThat(auditLogEntries[1].objectBefore).contains("suku2")
+        assertThat(auditLogEntries[1].objectAfter).contains("Muhaha-Evil-Change")
 
         // Try to delete the yhteystieto; should fail and add only audit log entry (nothing to change log):
         hankeWithLockedYT.arvioijat[0].apply {
@@ -720,16 +702,17 @@ class HankeServiceITests {
             hankeService.updateHanke(hankeWithLockedYT)
         }
         // Check logs (should have one more entry in the audit log)
-        assertThat(personalDataAuditLogRepository.count()).isEqualTo(4)
-        assertThat(personalDataChangeLogRepository.count()).isEqualTo(3)
-        auditLogEntries = personalDataAuditLogRepository.findAll(sampleauditlog)
-        changeLogEntries = personalDataChangeLogRepository.findAll(samplechangelog)
+        assertThat(auditLogRepository.count()).isEqualTo(4)
+        auditLogEntries = auditLogRepository.findAll(exampleForArvioija)
         // For the second yhteystieto, 1 more audit log entry for this failed deletion:
         assertThat(auditLogEntries.size).isEqualTo(3)
-        assertThat(changeLogEntries.size).isEqualTo(2)
         assertThat(auditLogEntries[2].action).isEqualTo(Action.DELETE)
         assertThat(auditLogEntries[2].userId).isEqualTo(USER_NAME)
-        assertThat(auditLogEntries[2].failed).isTrue
+        assertThat(auditLogEntries[2].status).isEqualTo(Status.FAILED)
+        assertThat(auditLogEntries[2].failureDescription).isEqualTo("delete hanke yhteystieto BLOCKED by data processing restriction")
+        assertThat(auditLogEntries[2].objectType).isEqualTo(ObjectType.YHTEYSTIETO)
+        assertThat(auditLogEntries[2].objectBefore).contains("suku2")
+        assertThat(auditLogEntries[2].objectAfter).isNull()
 
         // Check that both yhteystietos still exist and the values have not gotten changed:
         val returnedHankeAfterBlockedActions = hankeService.loadHanke(returnedHanke.hankeTunnus!!)
@@ -740,8 +723,8 @@ class HankeServiceITests {
         // Unset the processing restriction flag:
         hankeEntity = hankeRepository.findById(hankeId).get()
         yhteystietos = hankeEntity.listOfHankeYhteystieto
-        yhteystietoEntity = yhteystietos.filter { it.contactType == ContactType.ARVIOIJA }[0]
-        yhteystietoEntity.dataLocked = false
+        arvioijaEntity = yhteystietos.filter { it.contactType == ContactType.ARVIOIJA }[0]
+        arvioijaEntity.dataLocked = false
         hankeRepository.save(hankeEntity)
 
         // Updating the yhteystieto should now work:
@@ -751,14 +734,11 @@ class HankeServiceITests {
 
         // Check that the change went through:
         assertThat(finalHanke.arvioijat[0].etunimi).isEqualTo("Hopefully-Not-Evil-Change")
-        // Check logs (should have one more entry in both logs)
-        assertThat(personalDataAuditLogRepository.count()).isEqualTo(5)
-        assertThat(personalDataChangeLogRepository.count()).isEqualTo(4)
-        auditLogEntries = personalDataAuditLogRepository.findAll(sampleauditlog)
-        changeLogEntries = personalDataChangeLogRepository.findAll(samplechangelog)
-        // For the second yhteystieto, 1 more entry in both logs:
+        // Check logs (should have one more entry in the log)
+        assertThat(auditLogRepository.count()).isEqualTo(5)
+        auditLogEntries = auditLogRepository.findAll(exampleForArvioija)
+        // For the second yhteystieto, 1 more entry in the log:
         assertThat(auditLogEntries.size).isEqualTo(4)
-        assertThat(changeLogEntries.size).isEqualTo(3)
     }
 
 

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/IntegrationTestConfiguration.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/IntegrationTestConfiguration.kt
@@ -2,11 +2,11 @@ package fi.hel.haitaton.hanke
 
 import fi.hel.haitaton.hanke.geometria.HankeGeometriatDao
 import fi.hel.haitaton.hanke.geometria.HankeGeometriatService
-import fi.hel.haitaton.hanke.logging.PersonalDataAuditLogRepository
+import fi.hel.haitaton.hanke.logging.AuditLogRepository
 import fi.hel.haitaton.hanke.organisaatio.OrganisaatioService
 import fi.hel.haitaton.hanke.permissions.PermissionService
-import fi.hel.haitaton.hanke.tormaystarkastelu.TormaystarkasteluTormaysService
 import fi.hel.haitaton.hanke.tormaystarkastelu.TormaystarkasteluLaskentaService
+import fi.hel.haitaton.hanke.tormaystarkastelu.TormaystarkasteluTormaysService
 import fi.hel.haitaton.hanke.tormaystarkastelu.TormaystarkasteluTormaysServicePG
 import io.mockk.every
 import io.mockk.mockk
@@ -31,10 +31,7 @@ class IntegrationTestConfiguration {
     fun hankeRepository(): HankeRepository = mockk()
 
     @Bean
-    fun personalDataAuditLogRepository(): PersonalDataAuditLogRepository = mockk()
-
-    @Bean
-    fun personalDataChangeLogRepository(): PersonalDataAuditLogRepository = mockk()
+    fun auditLogRepository(): AuditLogRepository = mockk()
 
     @Bean
     fun hanketunnusService(): HanketunnusService = mockk()

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Configuration.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Configuration.kt
@@ -8,12 +8,17 @@ import fi.hel.haitaton.hanke.geometria.HankeGeometriatDao
 import fi.hel.haitaton.hanke.geometria.HankeGeometriatDaoImpl
 import fi.hel.haitaton.hanke.geometria.HankeGeometriatService
 import fi.hel.haitaton.hanke.geometria.HankeGeometriatServiceImpl
-import fi.hel.haitaton.hanke.logging.PersonalDataAuditLogRepository
-import fi.hel.haitaton.hanke.logging.PersonalDataChangeLogRepository
+import fi.hel.haitaton.hanke.logging.AuditLogRepository
 import fi.hel.haitaton.hanke.organisaatio.OrganisaatioRepository
 import fi.hel.haitaton.hanke.organisaatio.OrganisaatioService
 import fi.hel.haitaton.hanke.permissions.PermissionService
-import fi.hel.haitaton.hanke.tormaystarkastelu.*
+import fi.hel.haitaton.hanke.tormaystarkastelu.LuokitteluRajaArvotService
+import fi.hel.haitaton.hanke.tormaystarkastelu.LuokitteluRajaArvotServiceHardCoded
+import fi.hel.haitaton.hanke.tormaystarkastelu.PerusIndeksiPainotService
+import fi.hel.haitaton.hanke.tormaystarkastelu.PerusIndeksiPainotServiceHardCoded
+import fi.hel.haitaton.hanke.tormaystarkastelu.TormaystarkasteluLaskentaService
+import fi.hel.haitaton.hanke.tormaystarkastelu.TormaystarkasteluTormaysService
+import fi.hel.haitaton.hanke.tormaystarkastelu.TormaystarkasteluTormaysServicePG
 import io.netty.handler.ssl.SslContextBuilder
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory
 import org.springframework.beans.factory.annotation.Value
@@ -71,12 +76,10 @@ class Configuration {
         hankeRepository: HankeRepository,
         tormaystarkasteluLaskentaService: TormaystarkasteluLaskentaService,
         hanketunnusService: HanketunnusService,
-        personalDataAuditLogRepository: PersonalDataAuditLogRepository,
-        personalDataChangeLogRepository: PersonalDataChangeLogRepository,
+        auditLogRepository: AuditLogRepository,
         permissionService: PermissionService
     ): HankeService =
-        HankeServiceImpl(hankeRepository, tormaystarkasteluLaskentaService,
-                hanketunnusService, personalDataAuditLogRepository, personalDataChangeLogRepository)
+        HankeServiceImpl(hankeRepository, tormaystarkasteluLaskentaService, hanketunnusService, auditLogRepository)
 
     @Bean
     fun organisaatioService(organisaatioRepository: OrganisaatioRepository): OrganisaatioService =

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/Persistence.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/Persistence.kt
@@ -1,20 +1,19 @@
 package fi.hel.haitaton.hanke.logging
 
-import org.springframework.data.jpa.repository.JpaRepository
-import java.time.LocalDateTime
+import java.time.OffsetDateTime
+import java.util.*
+import javax.persistence.Column
 import javax.persistence.Entity
 import javax.persistence.EnumType
 import javax.persistence.Enumerated
-import javax.persistence.GeneratedValue
-import javax.persistence.GenerationType
 import javax.persistence.Id
 import javax.persistence.Table
+import org.springframework.data.jpa.repository.JpaRepository
 
 /**
  * Type of action/event.
- * isChange-value tells whether the action can or could have done changes
- * to the business data it is about. Those that can not change such data
- * will not get an entry in the changelog (but can still get one in the auditlog).
+ *
+ * @param isChange tells whether the action can change the business data
  */
 enum class Action(val isChange: Boolean) {
     /**
@@ -35,60 +34,57 @@ enum class Action(val isChange: Boolean) {
      */
     DELETE(true),
     /**
-     * To record a change of the datalocked-field to "true". Not done by
+     * To record a change of the data locked -field to "true". Not done by
      * Haitaton itself (for now), so add a row with this action when manually
      * setting that restriction flag.
      */
     LOCK(false),
     /**
-     * To record a change of the datalocked-field from "true" to "false".
+     * To record a change of the data locked -field from "true" to "false".
      * Not done by Haitaton itself (for now), so add a row with this action
      * when manually setting that restriction flag.
      */
     UNLOCK(false)
 }
 
+enum class Status {
+    SUCCESS, FAILED
+}
+
+enum class ObjectType {
+    YHTEYSTIETO
+}
+
 @Entity
-@Table(schema = "personaldatalogs", name = "auditlog" )
-class AuditLogEntry (
-    var eventTime: LocalDateTime? = null,
+@Table(name = "audit_log")
+class AuditLogEntry(
+    @Id
+    var id: UUID? = UUID.randomUUID(),
+    @Column(name = "event_time")
+    var eventTime: OffsetDateTime? = OffsetDateTime.now(),
+    @Column(name = "user_id")
     var userId: String? = null,
-    var actor: String? = null,
+    @Column(name = "ip_near")
     var ipNear: String? = null,
+    @Column(name = "ip_far")
     var ipFar: String? = null,
-    // Note, this can be briefly null during creation of a new YhteystietoEntity
-    var yhteystietoId: Int? = 0,
     @Enumerated(EnumType.STRING)
     var action: Action? = null,
-    // null is to be considered equal to false
-    var failed: Boolean? = null,
-    var description: String? = null
-) {
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-    var id: Int? = null
-}
-
-@Entity
-@Table(schema = "personaldatalogs", name = "changelog" )
-class ChangeLogEntry (
-    var eventTime: LocalDateTime? = null,
-    // Note, this can be briefly null during creation of a new YhteystietoEntity
-    var yhteystietoId: Int? = 0,
     @Enumerated(EnumType.STRING)
-    var action: Action? = null,
-    // null is to be considered equal to false
-    var failed: Boolean? = null,
-    var oldData: String? = null,
-    var newData: String? = null
-) {
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-    var id: Int? = null
-}
+    var status: Status? = null,
+    @Column(name = "failure_description")
+    var failureDescription: String? = null,
+    @Enumerated(EnumType.STRING)
+    @Column(name = "object_type")
+    var objectType: ObjectType? = null,
+    @Column(name = "object_id")
+    var objectId: Int? = null,
+    @Column(name = "object_before")
+    var objectBefore: String? = null,
+    @Column(name = "object_after")
+    var objectAfter: String? = null
+)
 
-interface PersonalDataAuditLogRepository : JpaRepository<AuditLogEntry, Int> {
-    // No need for additional functions. Only adding entries from Haitaton app.
-}
-
-interface PersonalDataChangeLogRepository : JpaRepository<ChangeLogEntry, Int> {
+interface AuditLogRepository : JpaRepository<AuditLogEntry, UUID> {
     // No need for additional functions. Only adding entries from Haitaton app.
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/YhteystietoLoggingEntryHolder.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/YhteystietoLoggingEntryHolder.kt
@@ -2,18 +2,15 @@ package fi.hel.haitaton.hanke.logging
 
 import fi.hel.haitaton.hanke.DatabaseStateException
 import fi.hel.haitaton.hanke.HankeYhteystietoEntity
-import fi.hel.haitaton.hanke.getCurrentTimeUTCAsLocalTime
 import org.springframework.web.context.request.RequestContextHolder
 import org.springframework.web.context.request.ServletRequestAttributes
-import kotlin.collections.HashSet
-
 
 const val PERSONAL_DATA_LOGGING_MAX_IP_LENGTH = 40
 
 /**
- * Used to hold the maps of yhteystieto entities to logging entries during
- * processing, so that new yhteystietos' ids can be applied after they have
- * been saved and thus received those ids.
+ * Used to hold the map of yhteystieto entities to logging entries during processing,
+ * so that new ids of new yhteystietos can be applied after they have been saved and
+ * thus received those ids.
  *
  * Basic use:
  * 1. Create instance of this class.
@@ -21,94 +18,91 @@ const val PERSONAL_DATA_LOGGING_MAX_IP_LENGTH = 40
  * 3. Do actions, and call addLogEntriesForEvent() for delete and update actions as they are done.
  * 4. After all actions are done, save the entities (this gives new entities their ids).
  * 5. Call addLogEntriesForNewYhteystietos() (this picks their new ids into their log entries).
- * 6. Optionally call applyIPaddresses().
+ * 6. Optionally call applyIpAddresses().
  * 7. saveLogEntries() (giving the repositories)
- * 8. Forget them until someone asks something kinky about personal data (though it is good to occasionally
- *    wipe some of the older data away, because Reasons...)
+ * 8. Forget them until a timed event sends them to Elasticsearch and removes the rows.
  */
 class YhteystietoLoggingEntryHolder {
 
-    val auditLogEntries: MutableList<AuditLogEntry> = mutableListOf()
-    val changeLogEntries: MutableList<ChangeLogEntry> = mutableListOf()
+    private val auditLogEntries: MutableList<AuditLogEntry> = mutableListOf()
 
     // Holds the ids of Yhteystietos that were in the Hanke before this request handling.
-    val previousYTids: HashSet<Int> = hashSetOf()
+    private val previousYhteystietoIds: HashSet<Int> = hashSetOf()
 
-    fun hasEntries() : Boolean = (auditLogEntries.size + changeLogEntries.size) > 0
+    fun hasEntries() : Boolean = auditLogEntries.isNotEmpty()
+
+    fun idList() : String {
+        return auditLogEntries.map { it.id }.joinToString()
+    }
 
     fun initWithOldYhteystietos(oldYTs: MutableList<HankeYhteystietoEntity>) {
         oldYTs.forEach {
-            val ytid = it.id ?: throw DatabaseStateException("A persisted HankeYhteystietoEntity somehow missing id")
-            previousYTids.add(ytid)
+            val yhteystietoId =
+                it.id ?: throw DatabaseStateException("A persisted HankeYhteystietoEntity somehow missing id")
+            previousYhteystietoIds.add(yhteystietoId)
         }
     }
 
     /**
-     * Creates both the audit-log and change-log entries for the given action in to this holder.
-     * This function will not save them, or set IP to them; those must be done separately before
-     * returning from the relevant process.
+     * Creates audit log entries for the given action to this holder. This
+     * function will not save them, or set IP to them; those must be done
+     * separately before returning from the relevant process.
      *
-     * The yhteystieto's id will be taken from the oldEntity, unless it or its id is null
-     * and the newEntity is non-null, in which case it is taken from the newEntity. This
-     * rule handles all cases of create, update, and delete, _if_ this function is called
-     * after saving the entities for create action(s).
+     * The id of the yhteystieto will be taken from the oldEntity, unless it or
+     * its id is null and the newEntity is non-null, in which case it is taken
+     * from the newEntity. This rule handles all cases of create, update, and
+     * delete, _if_ this function is called after saving the entities for create
+     * action(s).
      *
-     * No change-log entry will be made if the action is null or such that does not cause change
-     * (e.g. READ). Using null action is meant for special cases or additional info.
-     * READ obviously does not change anything to be given such log entry.
-     * Also, a failed/blocked DELETE is not given a change log entry, as the existing data
-     * remains the same, and the user's intent is obvious (to make everything go away).
-     *
-     * @param action can be null, in which case only the audit-log entry will be created.
-     * @param failed can be null e.g. for additional info, all normal actions must provide non-null value.
-     * @param description for the audit-log
+     * @param action can not be null
+     * @param failed can not be null
+     * @param failureDescription description for the failure, if one is available
      * @param oldEntity for logging the previous field values (make a clone/copy before making changes
-     *              to the persisted entity, if necessary); can be null (when creating new or reading)
+     *              to the persisted entity, if necessary); can be null (when creating new)
      * @param newEntity for logging the new state of field values; can be null (when deleting or reading)
+     * @param userId ID of the user making the API call
      */
     fun addLogEntriesForEvent(
-            action: Action?,
-            failed: Boolean?,
-            description: String,
-            oldEntity: HankeYhteystietoEntity?,
-            newEntity: HankeYhteystietoEntity?,
-            userid: String
+        action: Action,
+        failed: Boolean = false,
+        failureDescription: String? = null,
+        oldEntity: HankeYhteystietoEntity?,
+        newEntity: HankeYhteystietoEntity?,
+        userId: String
     ) {
-        val time = getCurrentTimeUTCAsLocalTime()
-        // Note, first row works for delete and update; create-action is handled
-        // by the if-block.
-        var yhteystietoId = oldEntity?.id
-        if (yhteystietoId == null && newEntity != null)
-            yhteystietoId = newEntity.id
+        // Note, use oldEntity delete and update and newEntity for create-action.
+        val yhteystietoId = oldEntity?.id ?: newEntity?.id
 
-        // Audit log (without personal data). IPs are applied in bulk later.
-        val audit = AuditLogEntry(
-            time, userid, null, null, null, yhteystietoId, action, failed, description)
-        auditLogEntries.add(audit)
-
-        // Data change log. Note, not made if the action is null (or is not causing a change).
-        // This allows creating just an audit-log entry with this function.
-        // Also, failed DELETE is not given change log entry, since all relevant data is known/obvious.
-        if (action?.isChange == true && !(action == Action.DELETE && failed == true)) {
-            val oldData = oldEntity?.toChangeLogJsonString()
-            val newData = newEntity?.toChangeLogJsonString()
-            val change = ChangeLogEntry(time, yhteystietoId, action, failed, oldData, newData)
-            changeLogEntries.add(change)
-        }
+        val auditLogEntry = AuditLogEntry(
+            userId = userId,
+            action = action,
+            status = if(failed) Status.FAILED else Status.SUCCESS,
+            failureDescription = failureDescription,
+            objectType = ObjectType.YHTEYSTIETO,
+            objectId = yhteystietoId,
+            objectBefore = oldEntity?.toChangeLogJsonString(),
+            objectAfter = newEntity?.toChangeLogJsonString(),
+        )
+        auditLogEntries.add(auditLogEntry)
     }
 
     /**
-     * Goes through the entries that were new (have null yhteystietoid in the log entry,
+     * Goes through the entries that were new (have null yhteystietoId in the log entry,
      * but non-null in the entity), and copies the new ids into the corresponding log entries.
      */
-    fun addLogEntriesForNewYhteystietos(savedHankeYhteysTietoEntities: MutableList<HankeYhteystietoEntity>, userid: String) {
+    fun addLogEntriesForNewYhteystietos(savedHankeYhteystietoEntities: MutableList<HankeYhteystietoEntity>, userid: String) {
         // Go through the saved yhteystietos, filter for processing those that didn't exist
         // before, and add log entries for them now, as their id's are now known.
         // (Obviously, they all succeeded, since they have been saved already.)
-        savedHankeYhteysTietoEntities
-            .filter { !previousYTids.contains(it.id) }
+        savedHankeYhteystietoEntities
+            .filter { !previousYhteystietoIds.contains(it.id) }
             .forEach { newYhteystietoEntity ->
-                addLogEntriesForEvent(Action.CREATE, false, "create new hanke yhteystieto", null, newYhteystietoEntity, userid)
+                addLogEntriesForEvent(
+                    action = Action.CREATE,
+                    oldEntity = null,
+                    newEntity = newYhteystietoEntity,
+                    userId = userid,
+                )
             }
     }
 
@@ -117,7 +111,7 @@ class YhteystietoLoggingEntryHolder {
      * to all the log entries currently held in this holder.
      * NOTE: very very very simplified implementation. Needs a lot of improvement.
      */
-    fun applyIPaddresses() {
+    fun applyIpAddresses() {
         val attribs = (RequestContextHolder.getRequestAttributes() as ServletRequestAttributes?) ?: return
         val request = attribs.request
         // Very simplified version for now.
@@ -135,11 +129,7 @@ class YhteystietoLoggingEntryHolder {
         }
     }
 
-    fun saveLogEntries(
-        personalDataAuditLogRepository: PersonalDataAuditLogRepository,
-        personalDataChangeLogRepository: PersonalDataChangeLogRepository
-    ) {
-        auditLogEntries.forEach { personalDataAuditLogRepository.save(it) }
-        changeLogEntries.forEach { personalDataChangeLogRepository.save(it) }
+    fun saveLogEntries(auditLogRepository: AuditLogRepository) {
+        auditLogEntries.forEach { auditLogRepository.save(it) }
     }
 }

--- a/services/hanke-service/src/main/resources/application.properties
+++ b/services/hanke-service/src/main/resources/application.properties
@@ -13,6 +13,8 @@ spring.datasource.password=${HAITATON_PASSWORD:haitaton}
 spring.jpa.database-platform=org.hibernate.dialect.PostgreSQL94Dialect
 # This makes the database field names to match the entity member names
 spring.jpa.hibernate.naming.physical-strategy=org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
+# Don't log SQL queries. This is the default, but left here to make it easy to enable while developing.
+spring.jpa.show-sql=false
 
 # Spring Boot Actuator Management for Kubernetes (see https://docs.spring.io/spring-boot/docs/2.3.4.RELEASE/reference/html/production-ready-features.html#production-ready-kubernetes-probes)
 # Use separate HTTP port for probes

--- a/services/hanke-service/src/main/resources/db/changelog/changesets/010-create-table-for-database-logging.yml
+++ b/services/hanke-service/src/main/resources/db/changelog/changesets/010-create-table-for-database-logging.yml
@@ -1,0 +1,62 @@
+databaseChangeLog:
+  - changeSet:
+      id: 010-create-table-for-audit-logging
+      comment: Create a table for unified audit logs
+      author: Topias Heinonen
+      changes:
+        - createTable:
+            tableName: audit_log
+            remarks: "Table for caching audit logs before sending them to a centralized logging service"
+            columns:
+              - column:
+                  name: id
+                  type: UUID
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+                  remarks: "Unique ID for this log row"
+              - column:
+                  name: event_time
+                  type: "timestamp with time zone"
+                  defaultValueComputed: CURRENT_TIMESTAMP
+                  remarks: "Time of the event"
+              - column:
+                  name: user_id
+                  type: varchar(40)
+                  remarks: "ID of the user who performed the action"
+              - column:
+                  name: ip_near
+                  type: varchar(40)
+                  remarks: "A useful IP nearest to the server"
+              - column:
+                  name: ip_far
+                  type: varchar(40)
+                  remarks: "a useful IP furthermost from the server (usually the user's device's current IP)"
+              - column:
+                  name: action
+                  type: varchar(10) # enum
+                  remarks: "What action was made (CREATE / UPDATE / READ / DELETE / LOCK / UNLOCK)"
+              - column:
+                  name: status
+                  type: varchar(10) # enum
+                  remarks: "Whether the action was successful or not (SUCCESS / FAILURE), with room for expansion"
+              - column:
+                  name: failure_description
+                  type: varchar
+                  remarks: "Description of the failure, if one is available"
+              - column:
+                  name: object_type
+                  type: varchar(250) # enum
+                  remarks: "What type of object the target is"
+              - column:
+                  name: object_id
+                  type: int
+                  remarks: "ID of the target object"
+              - column:
+                  name: object_before
+                  type: clob
+                  remarks: "JSON representation of the object before it was changed, null for new objects"
+              - column:
+                  name: object_after
+                  type: clob
+                  remarks: "JSON representation of the object after it was changed, null for reads and deletes. If the operation fails, this shows how the object would have been if it had succeeded."

--- a/services/hanke-service/src/main/resources/db/changelog/changesets/011-drop-old-personal-data-log-tables.yml
+++ b/services/hanke-service/src/main/resources/db/changelog/changesets/011-drop-old-personal-data-log-tables.yml
@@ -1,0 +1,16 @@
+databaseChangeLog:
+  - changeSet:
+      id: 011-drop-old-personal-data-log-tables
+      comment: Drop old personal data log tables in favor of the unified audit log table
+      author: Topias Heinonen
+      changes:
+        - dropTable:
+            schemaName: personaldatalogs
+            tableName: auditlog
+        - dropTable:
+            schemaName: personaldatalogs
+            tableName: changelog
+        - sql:
+            comment: Drop separate schema for personal data logs
+            dbms: 'postgresql, h2'
+            sql: DROP SCHEMA personaldatalogs

--- a/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -47,3 +47,7 @@ databaseChangeLog:
       file: db/changelog/changesets/008-suunnitteluvaihe-enumtype-string.sql
   - include:
       file: db/changelog/changesets/009-create-table-applications.yml
+  - include:
+      file: db/changelog/changesets/010-create-table-for-database-logging.yml
+  - include:
+      file: db/changelog/changesets/011-drop-old-personal-data-log-tables.yml


### PR DESCRIPTION
# Description

Unify all existing audit logging to log to a single table. This is done
in preparation for transferring the logs to a centralized storage.

The logging principles are described at
https://helsinkisolutionoffice.atlassian.net/wiki/spaces/HAI/pages/7990181897/Lokituksista

The old logs are simply deleted, since we don't have full audit logs
anyway, and we're not really in production yet. I'm still waiting on
confirmation if this is ok.

Also fix some issues that stopped the service working on a Silicon-based
mac.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1180

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [X] Other

# Instructions for testing
Please describe tests how this change or new feature can be tested.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [x] I have made necessary changes to the documentation, link to confluence
 or other location: https://helsinkisolutionoffice.atlassian.net/wiki/spaces/HAI/pages/7990181897/Lokituksista