### PR TITLE
HAI-1222 Add ktfmt for automated formatting

### DIFF
--- a/services/hanke-service/README.md
+++ b/services/hanke-service/README.md
@@ -39,10 +39,39 @@ setup can not currently support authentication, so can not test the actions with
 > http://localhost:8080/swagger-ui.html \
 > http://localhost:8080/v3/api-docs
 
+### Spotless formatter
+
+The Spotless Gradle plugin checks during the build stage that all code is formatted with ktfmt. If
+the code is not formatted correctly, the build will fail.
+
+Only code changed since the origin/dev branch will be checked and formatted. When a file is touched,
+the whole file needs to be reformatted, though.
+
+The formatting can be checked with:
+```
+./gradlew spotlessCheck`
+```
+And the code can be reformatted with:
+```
+./gradlew spotlessApply
+```
+
+Installing the ktfmt plugin to IDEA is recommended.
+
+If you really, really need to format something manually, you can disable Spotless for a code block:
+```
+// spotless: off
+val table = arrayOf(
+     0,  1,  2,  3,  4,  5,  6,  7,  8,  9,
+    10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+    )
+// spotless: on
+```
 
 ## PostgreSQL + PostGis locally
+
 The repository includes support for local development with a docker-postgres
- without the need to install postgres locally. 
+without the need to install postgres locally.
 
 To run the postgres in localhost
 ```

--- a/services/hanke-service/build.gradle.kts
+++ b/services/hanke-service/build.gradle.kts
@@ -39,9 +39,19 @@ springBoot {
 	buildInfo()
 }
 
+spotless {
+	ratchetFrom("origin/dev") // only format files which have changed since origin/dev
+
+	kotlin {
+		ktfmt("0.39").kotlinlangStyle()
+		toggleOffOn()
+	}
+}
+
 plugins {
 	id("org.springframework.boot") version "2.3.4.RELEASE"
 	id("io.spring.dependency-management") version "1.0.10.RELEASE"
+	id("com.diffplug.spotless") version "6.10.0"
 	kotlin("jvm") version "1.6.10"
 	// Gives kotlin-allopen, which auto-opens classes with certain annotations
 	kotlin("plugin.spring") version "1.6.10"

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
@@ -35,10 +35,11 @@ class HankeServiceITests {
 
     companion object {
         @Container
-        var container: HaitatonPostgreSQLContainer = HaitatonPostgreSQLContainer()
-            .withExposedPorts(5433) // use non-default port
-            .withPassword("test")
-            .withUsername("test")
+        var container: HaitatonPostgreSQLContainer =
+            HaitatonPostgreSQLContainer()
+                .withExposedPorts(5433) // use non-default port
+                .withPassword("test")
+                .withUsername("test")
 
         @JvmStatic
         @DynamicPropertySource
@@ -52,17 +53,14 @@ class HankeServiceITests {
         }
     }
 
-    @Autowired
-    private lateinit var hankeService: HankeService
+    @Autowired private lateinit var hankeService: HankeService
 
-    @Autowired
-    private lateinit var auditLogRepository: AuditLogRepository
+    @Autowired private lateinit var auditLogRepository: AuditLogRepository
 
-    @Autowired
-    private lateinit var hankeRepository: HankeRepository
+    @Autowired private lateinit var hankeRepository: HankeRepository
 
-
-    // Some tests also use and check loadHanke()'s return value because at one time the update action
+    // Some tests also use and check loadHanke()'s return value because at one time the update
+    // action
     // was returning different set of data than loadHanke (bug), so it is a sort of regression test.
 
     @Test
@@ -94,8 +92,10 @@ class HankeServiceITests {
 
         // Check the fields:
         // Note, "pvm" values should have become truncated to begin of the day
-        val expectedDateAlku = datetimeAlku!!.truncatedTo(ChronoUnit.DAYS) // nextyear.2.20 00:00:00Z
-        val expectedDateLoppu = datetimeLoppu!!.truncatedTo(ChronoUnit.DAYS) // nextyear.2.21 00:00:00Z
+        val expectedDateAlku = // nextyear.2.20 00:00:00Z
+            datetimeAlku!!.truncatedTo(ChronoUnit.DAYS)
+        val expectedDateLoppu = // nextyear.2.21 00:00:00Z
+            datetimeLoppu!!.truncatedTo(ChronoUnit.DAYS)
 
         assertThat(returnedHanke.saveType).isEqualTo(SaveType.DRAFT)
         assertThat(returnedHanke.nimi).isEqualTo("testihanke yksi")
@@ -110,7 +110,8 @@ class HankeServiceITests {
         assertThat(returnedHanke.tyomaaKoko).isEqualTo(TyomaaKoko.LAAJA_TAI_USEA_KORTTELI)
         assertThat(returnedHanke.haittaAlkuPvm).isEqualTo(expectedDateAlku)
         assertThat(returnedHanke.haittaLoppuPvm).isEqualTo(expectedDateLoppu)
-        assertThat(returnedHanke.kaistaHaitta).isEqualTo(TodennakoinenHaittaPaaAjoRatojenKaistajarjestelyihin.KAKSI)
+        assertThat(returnedHanke.kaistaHaitta)
+            .isEqualTo(TodennakoinenHaittaPaaAjoRatojenKaistajarjestelyihin.KAKSI)
         assertThat(returnedHanke.kaistaPituusHaitta).isEqualTo(KaistajarjestelynPituus.NELJA)
         assertThat(returnedHanke.meluHaitta).isEqualTo(Haitta13.YKSI)
         assertThat(returnedHanke.polyHaitta).isEqualTo(Haitta13.KAKSI)
@@ -249,7 +250,8 @@ class HankeServiceITests {
         assertThat(returnedHanke2.omistajat).hasSize(2)
         assertThat(returnedHanke2.arvioijat).hasSize(1)
         // Check that the first Yhteystieto has not changed, and the two new ones are as expected:
-        // (Not checking all fields, just ensuring the code is not accidentally mixing whole entries).
+        // (Not checking all fields, just ensuring the code is not accidentally mixing whole
+        // entries).
         assertThat(returnedHanke2.omistajat[0].id).isEqualTo(ytid)
         assertThat(returnedHanke2.omistajat[0].sukunimi).isEqualTo("suku1")
         assertThat(returnedHanke2.omistajat[1].sukunimi).isEqualTo("suku2")
@@ -278,8 +280,10 @@ class HankeServiceITests {
         assertThat(returnedHanke3.arvioijat[0].id).isNotEqualTo(returnedHanke3.omistajat[1].id)
 
         // A small side-check here for audit fields handling on load:
-        assertThat(returnedHanke3.omistajat[0].createdAt).isEqualTo(returnedHanke.omistajat[0].createdAt)
-        assertThat(returnedHanke3.omistajat[0].createdBy).isEqualTo(returnedHanke.omistajat[0].createdBy)
+        assertThat(returnedHanke3.omistajat[0].createdAt)
+            .isEqualTo(returnedHanke.omistajat[0].createdAt)
+        assertThat(returnedHanke3.omistajat[0].createdBy)
+            .isEqualTo(returnedHanke.omistajat[0].createdBy)
         // The original omistajat-entry was not modified, so modifiedXx-fields must not get values:
         assertThat(returnedHanke3.omistajat[0].modifiedAt).isNull()
         assertThat(returnedHanke3.omistajat[0].modifiedBy).isNull()
@@ -343,7 +347,10 @@ class HankeServiceITests {
 
         // Check that audit modifiedXx-fields got updated:
         assertThat(returnedHanke3.omistajat[1].modifiedAt).isNotNull
-        assertThat(returnedHanke3.omistajat[1].modifiedAt!!.toEpochSecond() - currentDatetime.toEpochSecond())
+        assertThat(
+                returnedHanke3.omistajat[1].modifiedAt!!.toEpochSecond() -
+                    currentDatetime.toEpochSecond()
+            )
             .isBetween(-600, 600) // +/-10 minutes
         assertThat(returnedHanke3.omistajat[1].modifiedBy).isNotNull
         assertThat(returnedHanke3.omistajat[1].modifiedBy).isEqualTo(USER_NAME)
@@ -384,7 +391,8 @@ class HankeServiceITests {
         assertThat(returnedHanke2).isNotSameAs(returnedHanke)
         assertThat(returnedHanke2.id).isNotNull
 
-        // Check that one yhteystieto got removed, the first one remaining, and its fields not affected:
+        // Check that one yhteystieto got removed, the first one remaining, and its fields not
+        // affected:
         assertThat(returnedHanke2.omistajat).hasSize(1)
         assertThat(returnedHanke2.omistajat[0].id).isEqualTo(ytid1)
         assertThat(returnedHanke2.omistajat[0].sukunimi).isEqualTo("suku1")
@@ -442,7 +450,8 @@ class HankeServiceITests {
         assertThat(returnedHanke2).isNotSameAs(returnedHanke)
         assertThat(returnedHanke2.id).isNotNull
 
-        // Check that arvioija-yhteystieto got removed, the first one remaining, and its fields not affected:
+        // Check that arvioija-yhteystieto got removed, the first one remaining, and its fields not
+        // affected:
         assertThat(returnedHanke2.arvioijat).hasSize(0)
         assertThat(returnedHanke2.omistajat).hasSize(1)
         assertThat(returnedHanke2.omistajat[0].id).isEqualTo(ytid1)
@@ -467,8 +476,8 @@ class HankeServiceITests {
     fun `test that sending the same Yhteystieto twice without id does not create duplicates`() {
         // Old version of the Yhteystieto should get removed, id increases in response,
         // get-operation returns the new one.
-        // NOTE: UI is not supposed to do that, but this situation came up during development/testing,
-        // so it is a sort of regression test for the logic.
+        // NOTE: UI is not supposed to do that, but this situation came up during
+        // development/testing, so it is a sort of regression test for the logic.
 
         // Setup Hanke with one Yhteystieto:
         val hanke: Hanke = getATestHanke("yksi", 1)
@@ -518,7 +527,8 @@ class HankeServiceITests {
 
     @Test
     fun `test personal data logging`() {
-        // Create hanke with two yhteystietos, save, check logs (creates in both logs, null old data)
+        // Create hanke with two yhteystietos, save and check logs. There should be two rows and the
+        // objectBefore fields should be null in them.
         // Setup Hanke with two Yhteystietos in the same group:
         val hanke: Hanke = getATestHanke("yksi", 1)
         val yhteystieto1 = getATestYhteystieto(1)
@@ -538,11 +548,12 @@ class HankeServiceITests {
         assertThat(createdHanke.omistajat[1].sukunimi).isEqualTo("suku2")
 
         // Prepare example for searching entries by yhteystietoId:
-        val exampleForYhteystieto1 = Example.of(AuditLogEntry(id = null, eventTime = null, objectId = yhteystietoId1))
-        val exampleForYhteystieto2 = Example.of(AuditLogEntry(id = null, eventTime = null, objectId = yhteystietoId2))
+        val exampleForYhteystieto1 =
+            Example.of(AuditLogEntry(id = null, eventTime = null, objectId = yhteystietoId1))
+        val exampleForYhteystieto2 =
+            Example.of(AuditLogEntry(id = null, eventTime = null, objectId = yhteystietoId2))
 
-        // Check logs...
-        // The log must have 2 entries (two yhteystietos were created):
+        // The log must have 2 entries since two yhteystietos were created.
         assertThat(auditLogRepository.count()).isEqualTo(2)
 
         // Check that each yhteystieto has single entry in log:
@@ -551,8 +562,7 @@ class HankeServiceITests {
         assertThat(auditLogEntries1.size).isEqualTo(1)
         assertThat(auditLogEntries2.size).isEqualTo(1)
 
-        // Check that each entry has correct data (action CREATE,
-        // new data contains "suku1" or "suku2", and userid is that of the test user).
+        // Check that each entry has correct data.
         assertThat(auditLogEntries1[0].action).isEqualTo(Action.CREATE)
         assertThat(auditLogEntries1[0].userId).isEqualTo(USER_NAME)
         assertThat(auditLogEntries1[0].status).isEqualTo(Status.SUCCESS)
@@ -569,7 +579,8 @@ class HankeServiceITests {
         assertThat(auditLogEntries2[0].objectBefore).isNull()
         assertThat(auditLogEntries2[0].objectAfter).contains("suku2")
 
-        // Update the other yhteystieto (one update in logs, both datas exist and with correct values)
+        // Update one yhteystieto. This should create one update row in the log. ObjectBefore and
+        // objectAfter fields should exist and have correct values.
         // Change a value:
         createdHanke.omistajat[1].sukunimi = "Som Et Hing"
         // Call update, get the returned object, make some general checks:
@@ -585,16 +596,14 @@ class HankeServiceITests {
         assertThat(hankeAfterUpdate.omistajat[0].sukunimi).isEqualTo("suku1")
         assertThat(hankeAfterUpdate.omistajat[1].sukunimi).isEqualTo("Som Et Hing")
 
-        // Check logs...
-        // Check that only 1 entry was added to log (about the updated yhteystieto)
+        // Check that only 1 entry was added to log, about the updated yhteystieto.
         assertThat(auditLogRepository.count()).isEqualTo(3)
-        // Check that the second yhteystieto got a single entry in log (and the other didn't)
+        // Check that the second yhteystieto got a single entry in log and the other didn't.
         auditLogEntries1 = auditLogRepository.findAll(exampleForYhteystieto1)
         auditLogEntries2 = auditLogRepository.findAll(exampleForYhteystieto2)
         assertThat(auditLogEntries1.size).isEqualTo(1)
         assertThat(auditLogEntries2.size).isEqualTo(2)
-        // Check that the new entry has correct data (action UPDATE,
-        // old data contains "suku2", new data "Som Et Hing", and userid is that of the test user).
+        // Check that the new entry has correct data.
         assertThat(auditLogEntries2[1].action).isEqualTo(Action.UPDATE)
         assertThat(auditLogEntries2[1].userId).isEqualTo(USER_NAME)
         assertThat(auditLogEntries2[1].status).isEqualTo(Status.SUCCESS)
@@ -603,7 +612,8 @@ class HankeServiceITests {
         assertThat(auditLogEntries2[1].objectBefore).contains("suku2")
         assertThat(auditLogEntries2[1].objectAfter).contains("Som Et Hing")
 
-        // Delete the other yhteystieto (one update in both logs, null new data)
+        // Delete the other yhteystieto. This should create one update in log, with null
+        // objectAfter.
         hankeAfterUpdate.omistajat[1].apply {
             etunimi = ""
             sukunimi = ""
@@ -619,16 +629,14 @@ class HankeServiceITests {
         assertThat(hankeAfterDelete.omistajat[0].id).isEqualTo(yhteystietoId1)
         assertThat(hankeAfterDelete.omistajat[0].sukunimi).isEqualTo("suku1")
 
-        // Check logs...
-        // Check that only 1 entry was added to log (about the deleted yhteystieto)
+        // Check that only 1 entry was added to log, about the deleted yhteystieto.
         assertThat(auditLogRepository.count()).isEqualTo(4)
-        // Check that the second yhteystieto got a single entry in log (and the other didn't)
+        // Check that the second yhteystieto got a single entry in log and the other didn't.
         auditLogEntries1 = auditLogRepository.findAll(exampleForYhteystieto1)
         auditLogEntries2 = auditLogRepository.findAll(exampleForYhteystieto2)
         assertThat(auditLogEntries1.size).isEqualTo(1)
         assertThat(auditLogEntries2.size).isEqualTo(3)
-        // Check that the new entry has correct data (action DELETE,
-        // old data contains "Som Et Hing", new data is null, and userid is that of the test user).
+        // Check that the new entry has correct data.
         assertThat(auditLogEntries2[2].action).isEqualTo(Action.DELETE)
         assertThat(auditLogEntries2[2].userId).isEqualTo(USER_NAME)
         assertThat(auditLogEntries2[2].status).isEqualTo(Status.SUCCESS)
@@ -640,7 +648,8 @@ class HankeServiceITests {
 
     @Test
     fun `test personal data processing restriction`() {
-        // Setup Hanke with two Yhteystietos in different groups (will only manipulate the non-owner):
+        // Setup Hanke with two Yhteystietos in different groups. The test will only manipulate the
+        // arvioija.
         val hanke: Hanke = getATestHanke("yksi", 1)
         val omistaja = getATestYhteystieto(1)
         val arvioija = getATestYhteystieto(2)
@@ -648,48 +657,49 @@ class HankeServiceITests {
         hanke.arvioijat = arrayListOf(arvioija)
         // Call create, get the return object:
         val returnedHanke = hankeService.createHanke(hanke)
-        // Check logs...
         // Logs must have 2 entries (two yhteystietos were created):
         assertThat(auditLogRepository.count()).isEqualTo(2)
 
-        // Get the non-owner yhteystieto,
-        // and set the processing restriction (i.e. locked) -flag (must be done via entities):
-        // (Fetching the yhteystieto is kind of clumsy as we don't have separate YhteystietoRepository.)
+        // Get the non-owner yhteystieto, and set the processing restriction (i.e. locked) -flag
+        // (must be done via entities):
+        // Fetching the yhteystieto is a bit clumsy since we don't have separate a
+        // YhteystietoRepository.
         val hankeId = returnedHanke.id
         var hankeEntity = hankeRepository.findById(hankeId!!).get()
         var yhteystietos = hankeEntity.listOfHankeYhteystieto
         var arvioijaEntity = yhteystietos.filter { it.contactType == ContactType.ARVIOIJA }[0]
         val arvioijaId = arvioijaEntity.id
         arvioijaEntity.dataLocked = true
-        // (Not setting the info field, or adding audit log entry, since the idea
-        // is to only test that the locking actually prevents processing.)
+        // Not setting the info field, or adding audit log entry, since the idea is to only test
+        // that the locking actually prevents processing.
         // Saving the hanke will save the yhteystieto in it, too:
         hankeRepository.save(hankeEntity)
 
-        // Try to update the yhteystieto; should fail and add audit and change log entries:
+        // Try to update the yhteystieto. It should fail and add a new log entry.
         val hankeWithLockedYT = hankeService.loadHanke(returnedHanke.hankeTunnus!!)
         hankeWithLockedYT!!.arvioijat[0].etunimi = "Muhaha-Evil-Change"
 
-        assertThatExceptionOfType(HankeYhteystietoProcessingRestrictedException::class.java).isThrownBy {
-            hankeService.updateHanke(hankeWithLockedYT)
-        }
-        // Check logs
-        // The initial create has created two entries to the log, and now
-        // the failed update should have added one more.
+        assertThatExceptionOfType(HankeYhteystietoProcessingRestrictedException::class.java)
+            .isThrownBy { hankeService.updateHanke(hankeWithLockedYT) }
+        // The initial create has created two entries to the log, and now the failed update should
+        // have added one more.
         assertThat(auditLogRepository.count()).isEqualTo(3)
-        val exampleForArvioija = Example.of(AuditLogEntry(id = null, eventTime = null, objectId = arvioijaId))
+        val exampleForArvioija =
+            Example.of(AuditLogEntry(id = null, eventTime = null, objectId = arvioijaId))
         var auditLogEntries = auditLogRepository.findAll(exampleForArvioija)
-        // For the second yhteystieto, 1 entry for the earlier creation, another for this failed update:
+        // For the second yhteystieto, there should be one entry for the earlier creation and
+        // another for this failed update.
         assertThat(auditLogEntries.size).isEqualTo(2)
         assertThat(auditLogEntries[1].action).isEqualTo(Action.UPDATE)
         assertThat(auditLogEntries[1].userId).isEqualTo(USER_NAME)
         assertThat(auditLogEntries[1].status).isEqualTo(Status.FAILED)
-        assertThat(auditLogEntries[1].failureDescription).isEqualTo("update hanke yhteystieto BLOCKED by data processing restriction")
+        assertThat(auditLogEntries[1].failureDescription)
+            .isEqualTo("update hanke yhteystieto BLOCKED by data processing restriction")
         assertThat(auditLogEntries[1].objectType).isEqualTo(ObjectType.YHTEYSTIETO)
         assertThat(auditLogEntries[1].objectBefore).contains("suku2")
         assertThat(auditLogEntries[1].objectAfter).contains("Muhaha-Evil-Change")
 
-        // Try to delete the yhteystieto; should fail and add only audit log entry (nothing to change log):
+        // Try to delete the yhteystieto. It should fail and add a new log entry.
         hankeWithLockedYT.arvioijat[0].apply {
             etunimi = ""
             sukunimi = ""
@@ -698,23 +708,24 @@ class HankeServiceITests {
             organisaatioNimi = ""
             osasto = ""
         }
-        assertThatExceptionOfType(HankeYhteystietoProcessingRestrictedException::class.java).isThrownBy {
-            hankeService.updateHanke(hankeWithLockedYT)
-        }
-        // Check logs (should have one more entry in the audit log)
+        assertThatExceptionOfType(HankeYhteystietoProcessingRestrictedException::class.java)
+            .isThrownBy { hankeService.updateHanke(hankeWithLockedYT) }
+        // There should be one more entry in the audit log.
         assertThat(auditLogRepository.count()).isEqualTo(4)
         auditLogEntries = auditLogRepository.findAll(exampleForArvioija)
-        // For the second yhteystieto, 1 more audit log entry for this failed deletion:
+        // For the second yhteystieto, there should be one more audit log entry for this failed
+        // deletion:
         assertThat(auditLogEntries.size).isEqualTo(3)
         assertThat(auditLogEntries[2].action).isEqualTo(Action.DELETE)
         assertThat(auditLogEntries[2].userId).isEqualTo(USER_NAME)
         assertThat(auditLogEntries[2].status).isEqualTo(Status.FAILED)
-        assertThat(auditLogEntries[2].failureDescription).isEqualTo("delete hanke yhteystieto BLOCKED by data processing restriction")
+        assertThat(auditLogEntries[2].failureDescription)
+            .isEqualTo("delete hanke yhteystieto BLOCKED by data processing restriction")
         assertThat(auditLogEntries[2].objectType).isEqualTo(ObjectType.YHTEYSTIETO)
         assertThat(auditLogEntries[2].objectBefore).contains("suku2")
         assertThat(auditLogEntries[2].objectAfter).isNull()
 
-        // Check that both yhteystietos still exist and the values have not gotten changed:
+        // Check that both yhteystietos still exist and the values have not gotten changed.
         val returnedHankeAfterBlockedActions = hankeService.loadHanke(returnedHanke.hankeTunnus!!)
         val arvioijat = returnedHankeAfterBlockedActions!!.arvioijat
         assertThat(arvioijat).hasSize(1)
@@ -734,45 +745,47 @@ class HankeServiceITests {
 
         // Check that the change went through:
         assertThat(finalHanke.arvioijat[0].etunimi).isEqualTo("Hopefully-Not-Evil-Change")
-        // Check logs (should have one more entry in the log)
+        // There should be one more entry in the log.
         assertThat(auditLogRepository.count()).isEqualTo(5)
         auditLogEntries = auditLogRepository.findAll(exampleForArvioija)
-        // For the second yhteystieto, 1 more entry in the log:
+        // For the second yhteystieto, there should be one more entry in the log:
         assertThat(auditLogEntries.size).isEqualTo(4)
     }
 
-
     /**
-     * Just fills a new Hanke domain object with some crap (excluding any Yhteystieto entries) and returns it.
-     * The audit and id/tunnus fields are left at null.
+     * Fills a new Hanke domain object with test values and returns it. The audit and id/tunnus
+     * fields are left at null. No Yhteystieto entries are created.
      */
     private fun getATestHanke(stringValue: String, intValue: Int): Hanke {
-        // These time values should reveal possible timezone shifts, and not get affected by database time rounding.
-        // (That is, if timezone handling causes even 1 hour shift one or the other, either one of these values
-        // will flip over to previous/next day with the date-truncation effect done in the service.)
+        // These time values should reveal possible timezone shifts, and not get affected by
+        // database time rounding.
+        // That is, if timezone handling causes even 1-hour shift one way or the other, either the
+        // start or end time will flip over to the previous or next day with the date-truncation
+        // effect done in the service.
         val year = getCurrentTimeUTC().year + 1
 
-        val dateAlku = ZonedDateTime.of(year, 2, 20, 23, 45, 56, 0, TZ_UTC)
-            .truncatedTo(ChronoUnit.MILLIS)
-        val dateLoppu = ZonedDateTime.of(year, 2, 21, 0, 12, 34, 0, TZ_UTC)
-            .truncatedTo(ChronoUnit.MILLIS)
-        val hanke = Hanke(
-            id = null,
-            hankeTunnus = null,
-            nimi = "testihanke $stringValue",
-            kuvaus = "lorem ipsum dolor sit amet...",
-            onYKTHanke = false,
-            alkuPvm = dateAlku,
-            loppuPvm = dateLoppu,
-            vaihe = Vaihe.SUUNNITTELU,
-            suunnitteluVaihe = SuunnitteluVaihe.RAKENNUS_TAI_TOTEUTUS,
-            version = null,
-            createdBy = null,
-            createdAt = null,
-            modifiedBy = null,
-            modifiedAt = null,
-            saveType = SaveType.DRAFT
-        )
+        val dateAlku =
+            ZonedDateTime.of(year, 2, 20, 23, 45, 56, 0, TZ_UTC).truncatedTo(ChronoUnit.MILLIS)
+        val dateLoppu =
+            ZonedDateTime.of(year, 2, 21, 0, 12, 34, 0, TZ_UTC).truncatedTo(ChronoUnit.MILLIS)
+        val hanke =
+            Hanke(
+                id = null,
+                hankeTunnus = null,
+                nimi = "testihanke $stringValue",
+                kuvaus = "lorem ipsum dolor sit amet...",
+                onYKTHanke = false,
+                alkuPvm = dateAlku,
+                loppuPvm = dateLoppu,
+                vaihe = Vaihe.SUUNNITTELU,
+                suunnitteluVaihe = SuunnitteluVaihe.RAKENNUS_TAI_TOTEUTUS,
+                version = null,
+                createdBy = null,
+                createdAt = null,
+                modifiedBy = null,
+                modifiedAt = null,
+                saveType = SaveType.DRAFT
+            )
 
         hanke.tyomaaKatuosoite = "Testikatu $intValue"
         hanke.tyomaaTyyppi.add(TyomaaTyyppi.VESI)
@@ -790,8 +803,8 @@ class HankeServiceITests {
     }
 
     /**
-     * Returns a new Yhteystieto with values set to include the given integer value.
-     * The audit and id fields are left null.
+     * Returns a new Yhteystieto with values set to include the given integer value. The audit and
+     * id fields are left null.
      */
     private fun getATestYhteystieto(intValue: Int): HankeYhteystieto {
         return HankeYhteystieto(

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/IntegrationTestConfiguration.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/IntegrationTestConfiguration.kt
@@ -24,40 +24,33 @@ import org.springframework.jdbc.core.JdbcOperations
 @Profile("itest")
 class IntegrationTestConfiguration {
 
-    @Bean
-    fun jdbcOperations(): JdbcOperations = mockk()
+    @Bean fun jdbcOperations(): JdbcOperations = mockk()
+
+    @Bean fun hankeRepository(): HankeRepository = mockk()
+
+    @Bean fun auditLogRepository(): AuditLogRepository = mockk()
+
+    @Bean fun hanketunnusService(): HanketunnusService = mockk()
+
+    @Bean fun hankeService(): HankeService = mockk()
+
+    @Bean fun permissionService(): PermissionService = mockk()
+
+    @Bean fun organisaatioService(): OrganisaatioService = mockk()
+
+    @Bean fun hankeGeometriatDao(jdbcOperations: JdbcOperations): HankeGeometriatDao = mockk()
 
     @Bean
-    fun hankeRepository(): HankeRepository = mockk()
-
-    @Bean
-    fun auditLogRepository(): AuditLogRepository = mockk()
-
-    @Bean
-    fun hanketunnusService(): HanketunnusService = mockk()
-
-    @Bean
-    fun hankeService(): HankeService = mockk()
-
-    @Bean
-    fun permissionService(): PermissionService = mockk()
-
-    @Bean
-    fun organisaatioService(): OrganisaatioService = mockk()
-
-    @Bean
-    fun hankeGeometriatDao(jdbcOperations: JdbcOperations): HankeGeometriatDao = mockk()
-
-    @Bean
-    fun hankeGeometriatService(service: HankeService, hankeGeometriatDao: HankeGeometriatDao): HankeGeometriatService =
-        mockk()
+    fun hankeGeometriatService(
+        service: HankeService,
+        hankeGeometriatDao: HankeGeometriatDao
+    ): HankeGeometriatService = mockk()
 
     @Bean
     fun tormaysService(jdbcOperations: JdbcOperations): TormaystarkasteluTormaysService =
-            TormaystarkasteluTormaysServicePG(jdbcOperations)
+        TormaystarkasteluTormaysServicePG(jdbcOperations)
 
-    @Bean
-    fun tormaystarkasteluLaskentaService(): TormaystarkasteluLaskentaService = mockk()
+    @Bean fun tormaystarkasteluLaskentaService(): TormaystarkasteluLaskentaService = mockk()
 
     @EventListener
     fun onApplicationEvent(event: ContextRefreshedEvent) {

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/logging/PersonalDataLogRepositoryITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/logging/PersonalDataLogRepositoryITests.kt
@@ -22,9 +22,9 @@ import org.testcontainers.junit.jupiter.Container
 import org.testcontainers.junit.jupiter.Testcontainers
 
 /**
- * Testing the configurations and database setup for AuditLogRepository class
- * with a database. The repositories have no additional code over the base
- * JPARepository, so only the configs/setups get indirectly tested.
+ * Testing the configurations and database setup for AuditLogRepository class with a database. The
+ * repositories have no additional code over the base JPARepository, so only the configs/setups get
+ * indirectly tested.
  */
 // NOTE: using @DataJpaTest(properties = ["spring.liquibase.enabled=false"])
 //  fails; it seems the way it tries to use schemas is not compatible with H2.
@@ -33,17 +33,20 @@ import org.testcontainers.junit.jupiter.Testcontainers
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("default")
 @Transactional
-class PersonalDataLogRepositoryITests @Autowired constructor(
+class PersonalDataLogRepositoryITests
+@Autowired
+constructor(
     val entityManager: EntityManager,
     val auditLogRepository: AuditLogRepository,
 ) {
 
     companion object {
         @Container
-        var container: HaitatonPostgreSQLContainer = HaitatonPostgreSQLContainer()
-            .withExposedPorts(5433) // use non-default port
-            .withPassword("test")
-            .withUsername("test")
+        var container: HaitatonPostgreSQLContainer =
+            HaitatonPostgreSQLContainer()
+                .withExposedPorts(5433) // use non-default port
+                .withPassword("test")
+                .withUsername("test")
 
         @JvmStatic
         @DynamicPropertySource
@@ -58,7 +61,7 @@ class PersonalDataLogRepositoryITests @Autowired constructor(
     }
 
     fun Assert<OffsetDateTime?>.isRecent(offset: TemporalAmount) = given { actual ->
-        if(actual == null) return
+        if (actual == null) return
         val now = OffsetDateTime.now()
         if (actual.isBefore(now) && actual.isAfter(now.minus(offset))) return
         expected("after:${show(now.minus(offset))} but was:${show(actual)}")
@@ -67,18 +70,21 @@ class PersonalDataLogRepositoryITests @Autowired constructor(
     @Test
     fun `saving audit log entry works`() {
         // Create a log entry, save it, flush, clear caches:
-        val auditLogEntry = AuditLogEntry(
-            userId = "1234-1234",
-            action = Action.CREATE,
-            status = Status.SUCCESS,
-            objectType = ObjectType.YHTEYSTIETO,
-            objectId = 333,
-            objectAfter = "fake JSON"
-        )
+        val auditLogEntry =
+            AuditLogEntry(
+                userId = "1234-1234",
+                action = Action.CREATE,
+                status = Status.SUCCESS,
+                objectType = ObjectType.YHTEYSTIETO,
+                objectId = 333,
+                objectAfter = "fake JSON"
+            )
         val savedAuditLogEntry = auditLogRepository.save(auditLogEntry)
         val id = savedAuditLogEntry.id
-        entityManager.flush() // Make sure the stuff is run to database (though not necessarily committed)
-        entityManager.clear() // Ensure the original entity is no longer in Hibernate's 1st level cache
+        // Make sure the stuff is run to database (though not necessarily committed)
+        entityManager.flush()
+        // Ensure the original entity is no longer in Hibernate's 1st level cache
+        entityManager.clear()
 
         // Check it is there (using something else than the repository):
         val foundAuditLogEntry = entityManager.find(AuditLogEntry::class.java, id)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Configuration.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Configuration.kt
@@ -34,38 +34,32 @@ import reactor.netty.http.client.HttpClient
 @Profile("default")
 class Configuration {
 
-    @Value("\${haitaton.allu.baseUrl}")
-    lateinit var alluBaseUrl : String
-    @Value("\${haitaton.allu.username}")
-    lateinit var alluUsername : String
-    @Value("\${haitaton.allu.password}")
-    lateinit var alluPassword : String
-    @Value("\${haitaton.allu.insecure}")
-    var alluTrustInsecure: Boolean = false
+    @Value("\${haitaton.allu.baseUrl}") lateinit var alluBaseUrl: String
+    @Value("\${haitaton.allu.username}") lateinit var alluUsername: String
+    @Value("\${haitaton.allu.password}") lateinit var alluPassword: String
+    @Value("\${haitaton.allu.insecure}") var alluTrustInsecure: Boolean = false
 
     @Bean
     fun cableReportServiceAllu(): CableReportServiceAllu {
-        val webClient = if (alluTrustInsecure) createInsecureTrustingWebClient() else WebClient.create()
-        val alluProps = AlluProperties(
-                baseUrl = alluBaseUrl,
-                username = alluUsername,
-                password = alluPassword
-        )
+        val webClient =
+            if (alluTrustInsecure) createInsecureTrustingWebClient() else WebClient.create()
+        val alluProps =
+            AlluProperties(baseUrl = alluBaseUrl, username = alluUsername, password = alluPassword)
         return CableReportServiceAllu(webClient, alluProps)
     }
 
     private fun createInsecureTrustingWebClient(): WebClient {
-        val sslContext = SslContextBuilder
-                .forClient()
-                .trustManager(InsecureTrustManagerFactory.INSTANCE)
-                .build()
+        val sslContext =
+            SslContextBuilder.forClient().trustManager(InsecureTrustManagerFactory.INSTANCE).build()
         val httpClient = HttpClient.create().secure { t -> t.sslContext(sslContext) }
         return WebClient.builder().clientConnector(ReactorClientHttpConnector(httpClient)).build()
     }
 
     @Bean
-    fun applicationService(applicationRepository: ApplicationRepository, cableReportServiceAllu: CableReportServiceAllu) : ApplicationService = ApplicationService(applicationRepository, cableReportServiceAllu)
-
+    fun applicationService(
+        applicationRepository: ApplicationRepository,
+        cableReportServiceAllu: CableReportServiceAllu
+    ): ApplicationService = ApplicationService(applicationRepository, cableReportServiceAllu)
 
     @Bean
     fun hanketunnusService(idCounterRepository: IdCounterRepository): HanketunnusService =
@@ -79,34 +73,46 @@ class Configuration {
         auditLogRepository: AuditLogRepository,
         permissionService: PermissionService
     ): HankeService =
-        HankeServiceImpl(hankeRepository, tormaystarkasteluLaskentaService, hanketunnusService, auditLogRepository)
+        HankeServiceImpl(
+            hankeRepository,
+            tormaystarkasteluLaskentaService,
+            hanketunnusService,
+            auditLogRepository
+        )
 
     @Bean
     fun organisaatioService(organisaatioRepository: OrganisaatioRepository): OrganisaatioService =
         OrganisaatioService(organisaatioRepository)
 
     @Bean
-    fun hankeGeometriatDao(jdbcOperations: JdbcOperations): HankeGeometriatDao = HankeGeometriatDaoImpl(jdbcOperations)
+    fun hankeGeometriatDao(jdbcOperations: JdbcOperations): HankeGeometriatDao =
+        HankeGeometriatDaoImpl(jdbcOperations)
 
     @Bean
-    fun hankeGeometriatService(
-        hankeGeometriatDao: HankeGeometriatDao
-    ): HankeGeometriatService = HankeGeometriatServiceImpl(hankeGeometriatDao)
+    fun hankeGeometriatService(hankeGeometriatDao: HankeGeometriatDao): HankeGeometriatService =
+        HankeGeometriatServiceImpl(hankeGeometriatDao)
 
     @Bean
     fun tormaysService(jdbcOperations: JdbcOperations): TormaystarkasteluTormaysService =
         TormaystarkasteluTormaysServicePG(jdbcOperations)
 
     @Bean
-    fun perusIndeksiPainotService(): PerusIndeksiPainotService = PerusIndeksiPainotServiceHardCoded()
+    fun perusIndeksiPainotService(): PerusIndeksiPainotService =
+        PerusIndeksiPainotServiceHardCoded()
 
     @Bean
-    fun luokitteluRajaArvotService(): LuokitteluRajaArvotService = LuokitteluRajaArvotServiceHardCoded()
+    fun luokitteluRajaArvotService(): LuokitteluRajaArvotService =
+        LuokitteluRajaArvotServiceHardCoded()
 
     @Bean
     fun tormaystarkasteluLaskentaService(
-            luokitteluRajaArvotService: LuokitteluRajaArvotService,
-            perusIndeksiPainotService: PerusIndeksiPainotService,
-            tormaystarkasteluDao: TormaystarkasteluTormaysService): TormaystarkasteluLaskentaService =
-            TormaystarkasteluLaskentaService(luokitteluRajaArvotService, perusIndeksiPainotService, tormaystarkasteluDao)
+        luokitteluRajaArvotService: LuokitteluRajaArvotService,
+        perusIndeksiPainotService: PerusIndeksiPainotService,
+        tormaystarkasteluDao: TormaystarkasteluTormaysService
+    ): TormaystarkasteluLaskentaService =
+        TormaystarkasteluLaskentaService(
+            luokitteluRajaArvotService,
+            perusIndeksiPainotService,
+            tormaystarkasteluDao
+        )
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeServiceImpl.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeServiceImpl.kt
@@ -12,7 +12,7 @@ import java.time.ZonedDateTime
 import mu.KotlinLogging
 import org.springframework.security.core.context.SecurityContextHolder
 
-private val logger = KotlinLogging.logger { }
+private val logger = KotlinLogging.logger {}
 
 open class HankeServiceImpl(
     private val hankeRepository: HankeRepository,
@@ -21,18 +21,18 @@ open class HankeServiceImpl(
     private val auditLogRepository: AuditLogRepository,
 ) : HankeService {
 
-    override fun loadHanke(hankeTunnus: String) = hankeRepository.findByHankeTunnus(hankeTunnus)
-            ?.let { createHankeDomainObjectFromEntity(it) }
+    override fun loadHanke(hankeTunnus: String) =
+        hankeRepository.findByHankeTunnus(hankeTunnus)?.let {
+            createHankeDomainObjectFromEntity(it)
+        }
 
-    override fun loadAllHanke() = hankeRepository.findAll()
-            .map { createHankeDomainObjectFromEntity(it) }
+    override fun loadAllHanke() =
+        hankeRepository.findAll().map { createHankeDomainObjectFromEntity(it) }
 
-    override fun loadHankkeetByIds(ids: List<Int>) = hankeRepository.findAllById(ids)
-            .map { createHankeDomainObjectFromEntity(it) }
+    override fun loadHankkeetByIds(ids: List<Int>) =
+        hankeRepository.findAllById(ids).map { createHankeDomainObjectFromEntity(it) }
 
-    /**
-     * @return a new Hanke instance with the added and possibly modified values.
-     */
+    /** @return a new Hanke instance with the added and possibly modified values. */
     override fun createHanke(hanke: Hanke): Hanke {
         // TODO: Only create that hanke-tunnus if a specific set of fields are non-empty/set.
 
@@ -59,30 +59,28 @@ open class HankeServiceImpl(
         // Create a new hanketunnus for it and save it:
         val hanketunnus = hanketunnusService.newHanketunnus()
         entity.hankeTunnus = hanketunnus
-        logger.debug {
-            "Creating Hanke ${hanke.hankeTunnus}: ${hanke.toLogString()}"
-        }
+        logger.debug { "Creating Hanke ${hanke.hankeTunnus}: ${hanke.toLogString()}" }
         val savedHankeEntity = hankeRepository.save(entity)
-        logger.debug {
-            "Created Hanke ${hanke.hankeTunnus}."
-        }
+        logger.debug { "Created Hanke ${hanke.hankeTunnus}." }
 
         postProcessAndSaveLogging(loggingEntryHolder, savedHankeEntity, userid)
 
-        // Creating a new domain object for the return value; it will have the updated values from the database,
-        // e.g. the main date values truncated to midnight, and the added id and hanketunnus.
+        // Creating a new domain object for the return value; it will have the updated values from
+        // the database, e.g. the main date values truncated to midnight, and the added id and
+        // hanketunnus.
         return createHankeDomainObjectFromEntity(entity)
     }
 
-    // WITH THIS ONE CAN AUTHORIZE ONLY THE OWNER TO UPDATE A HANKE: @PreAuthorize("#hanke.createdBy == authentication.name")
+    // WITH THIS ONE CAN AUTHORIZE ONLY THE OWNER TO UPDATE A HANKE:
+    // @PreAuthorize("#hanke.createdBy == authentication.name")
     override fun updateHanke(hanke: Hanke): Hanke {
-        if (hanke.hankeTunnus == null)
-            error("Somehow got here with hanke without hanke-tunnus")
+        if (hanke.hankeTunnus == null) error("Somehow got here with hanke without hanke-tunnus")
 
         val userid = SecurityContextHolder.getContext().authentication.name
 
         // Both checks that the hanke already exists, and get its old fields to transfer data into
-        val entity = hankeRepository.findByHankeTunnus(hanke.hankeTunnus!!)
+        val entity =
+            hankeRepository.findByHankeTunnus(hanke.hankeTunnus!!)
                 ?: throw HankeNotFoundException(hanke.hankeTunnus!!)
 
         val existingYTs = prepareMapOfExistingYhteystietos(entity)
@@ -102,27 +100,25 @@ open class HankeServiceImpl(
 
         tormaystarkasteluService.calculateTormaystarkastelu(hanke)?.let {
             entity.tormaystarkasteluTulokset.clear()
-            val tte = TormaystarkasteluTulosEntity(
+            val tte =
+                TormaystarkasteluTulosEntity(
                     it.perusIndeksi,
                     it.pyorailyIndeksi,
                     it.joukkoliikenneIndeksi,
-                    entity)
+                    entity
+                )
             entity.tormaystarkasteluTulokset.add(tte)
         }
 
         // Save changes:
-        logger.debug {
-            "Saving Hanke ${hanke.hankeTunnus}: ${hanke.toLogString()}"
-        }
+        logger.debug { "Saving Hanke ${hanke.hankeTunnus}: ${hanke.toLogString()}" }
         val savedHankeEntity = hankeRepository.save(entity)
-        logger.debug {
-            "Saved Hanke ${hanke.hankeTunnus}."
-        }
+        logger.debug { "Saved Hanke ${hanke.hankeTunnus}." }
 
         postProcessAndSaveLogging(loggingEntryHolder, savedHankeEntity, userid)
 
-        // Creating a new domain object for the return value; it will have the updated values from the database,
-        // e.g. the main date values truncated to midnight.
+        // Creating a new domain object for the return value; it will have the updated values from
+        // the database, e.g. the main date values truncated to midnight.
         return createHankeDomainObjectFromEntity(entity)
     }
 
@@ -141,7 +137,8 @@ open class HankeServiceImpl(
 
     companion object Converters {
         internal fun createHankeDomainObjectFromEntity(hankeEntity: HankeEntity): Hanke {
-            val h = Hanke(
+            val h =
+                Hanke(
                     hankeEntity.id,
                     hankeEntity.hankeTunnus,
                     hankeEntity.onYKTHanke,
@@ -151,19 +148,22 @@ open class HankeServiceImpl(
                     hankeEntity.loppuPvm?.atStartOfDay(TZ_UTC),
                     hankeEntity.vaihe,
                     hankeEntity.suunnitteluVaihe,
-
                     hankeEntity.version,
-                    // TODO: will need in future to actually fetch the username from another service.. (or whatever we choose to pass out here)
+                    // TODO: will need in future to actually fetch the username from another
+                    //   service.. (or whatever we choose to pass out here)
                     //   Do it below, outside this construction call.
                     hankeEntity.createdByUserId ?: "",
                     // From UTC without timezone info to UTC with timezone info
-                    if (hankeEntity.createdAt != null) ZonedDateTime.of(hankeEntity.createdAt, TZ_UTC) else null,
+                    if (hankeEntity.createdAt != null)
+                        ZonedDateTime.of(hankeEntity.createdAt, TZ_UTC)
+                    else null,
                     hankeEntity.modifiedByUserId,
-                    if (hankeEntity.modifiedAt != null) ZonedDateTime.of(hankeEntity.modifiedAt, TZ_UTC) else null,
-
+                    if (hankeEntity.modifiedAt != null)
+                        ZonedDateTime.of(hankeEntity.modifiedAt, TZ_UTC)
+                    else null,
                     hankeEntity.saveType
-            )
-            createSeparateYhteystietolistsFromEntityData(h, hankeEntity)
+                )
+            createSeparateYhteystietoListsFromEntityData(h, hankeEntity)
 
             h.tyomaaKatuosoite = hankeEntity.tyomaaKatuosoite
             h.tyomaaTyyppi = hankeEntity.tyomaaTyyppi
@@ -177,20 +177,26 @@ open class HankeServiceImpl(
             h.polyHaitta = hankeEntity.polyHaitta
             h.tarinaHaitta = hankeEntity.tarinaHaitta
 
-            hankeEntity.tormaystarkasteluTulokset.firstOrNull()
-                ?.let { h.tormaystarkasteluTulos = TormaystarkasteluTulos(it.perus, it.pyoraily, it.joukkoliikenne) }
+            hankeEntity.tormaystarkasteluTulokset.firstOrNull()?.let {
+                h.tormaystarkasteluTulos =
+                    TormaystarkasteluTulos(it.perus, it.pyoraily, it.joukkoliikenne)
+            }
 
             return h
         }
 
         /**
-         * createSeparateYhteystietolistsFromEntityData splits entity's one list to three different contact information
-         * lists and adds them for Hanke domain object
+         * createSeparateYhteystietoListsFromEntityData splits entity's one list to three different
+         * contact information lists and adds them for Hanke domain object
          */
-        private fun createSeparateYhteystietolistsFromEntityData(hanke: Hanke, hankeEntity: HankeEntity) {
+        private fun createSeparateYhteystietoListsFromEntityData(
+            hanke: Hanke,
+            hankeEntity: HankeEntity
+        ) {
 
             hankeEntity.listOfHankeYhteystieto.forEach { hankeYhteysEntity ->
-                val hankeYhteystieto = createHankeYhteystietoDomainObjectFromEntity(hankeYhteysEntity)
+                val hankeYhteystieto =
+                    createHankeYhteystietoDomainObjectFromEntity(hankeYhteysEntity)
 
                 if (hankeYhteysEntity.contactType == ContactType.OMISTAJA)
                     hanke.omistajat.add(hankeYhteystieto)
@@ -201,7 +207,9 @@ open class HankeServiceImpl(
             }
         }
 
-        private fun createHankeYhteystietoDomainObjectFromEntity(hankeYhteystietoEntity: HankeYhteystietoEntity): HankeYhteystieto {
+        private fun createHankeYhteystietoDomainObjectFromEntity(
+            hankeYhteystietoEntity: HankeYhteystietoEntity
+        ): HankeYhteystieto {
             var createdAt: ZonedDateTime? = null
 
             if (hankeYhteystietoEntity.createdAt != null)
@@ -212,44 +220,42 @@ open class HankeServiceImpl(
                 modifiedAt = ZonedDateTime.of(hankeYhteystietoEntity.modifiedAt, TZ_UTC)
 
             return HankeYhteystieto(
-                    id = hankeYhteystietoEntity.id,
-                    etunimi = hankeYhteystietoEntity.etunimi,
-                    sukunimi = hankeYhteystietoEntity.sukunimi,
-                    email = hankeYhteystietoEntity.email,
-                    puhelinnumero = hankeYhteystietoEntity.puhelinnumero,
-                    organisaatioId = hankeYhteystietoEntity.organisaatioId,
-                    organisaatioNimi = hankeYhteystietoEntity.organisaatioNimi,
-                    osasto = hankeYhteystietoEntity.osasto,
-                    createdBy = hankeYhteystietoEntity.createdByUserId,
-                    modifiedBy = hankeYhteystietoEntity.modifiedByUserId,
-                    createdAt = createdAt,
-                    modifiedAt = modifiedAt
+                id = hankeYhteystietoEntity.id,
+                etunimi = hankeYhteystietoEntity.etunimi,
+                sukunimi = hankeYhteystietoEntity.sukunimi,
+                email = hankeYhteystietoEntity.email,
+                puhelinnumero = hankeYhteystietoEntity.puhelinnumero,
+                organisaatioId = hankeYhteystietoEntity.organisaatioId,
+                organisaatioNimi = hankeYhteystietoEntity.organisaatioNimi,
+                osasto = hankeYhteystietoEntity.osasto,
+                createdBy = hankeYhteystietoEntity.createdByUserId,
+                modifiedBy = hankeYhteystietoEntity.modifiedByUserId,
+                createdAt = createdAt,
+                modifiedAt = modifiedAt
             )
         }
-
     }
 
     // --------------- Helpers for data transfer towards database ------------
 
     /**
-     * Checks if some to be changed or deleted yhteystieto has "datalocked" field set
-     * in the currently persisted entry.
-     * If so, creates audit- and changelog-entries and throws an exception.
-     * The exception prevents any other changes to the Hanke or other yhteystietos
-     * to be saved. (The restricted yhteystietos would need to be left as is in order
-     * to make any other changes to Hanke data). (NOTE: the current implementation may
-     * have insufficient feedback in the UI about the situation.)
+     * Checks if some to be changed or deleted yhteystieto has "datalocked" field set in the
+     * currently persisted entry. If so, creates audit- and changelog-entries and throws an
+     * exception. The exception prevents any other changes to the Hanke or other yhteystietos to be
+     * saved. (The restricted yhteystietos would need to be left as is in order to make any other
+     * changes to Hanke data). (NOTE: the current implementation may have insufficient feedback in
+     * the UI about the situation.)
      *
-     * The datalocked field can be used e.g. to handle GDPR "personal data processing
-     * restriction" requirement. It can be used for other "prevent changes" purposes,
-     * too, but current implementation has been done with GDPR mostly in mind, so
-     * e.g. some messages/comments/log entry info could be misleading for other uses.
+     * The dataLocked field can be used e.g. to handle GDPR "personal data processing restriction"
+     * requirement. It can be used for other "prevent changes" purposes, too, but current
+     * implementation has been done with GDPR mostly in mind, so e.g. some messages/comments/log
+     * entry info could be misleading for other uses.
      */
     private fun checkAndHandleDataProcessingRestrictions(
-            incomingHanke: Hanke,
-            persistedEntity: HankeEntity,
-            existingYTs: MutableMap<Int, HankeYhteystietoEntity>,
-            userid: String
+        incomingHanke: Hanke,
+        persistedEntity: HankeEntity,
+        existingYTs: MutableMap<Int, HankeYhteystietoEntity>,
+        userid: String
     ) {
         logger.debug {
             "Checking for processing restrictions. Have ${existingYTs.size} existing Yhteystietos."
@@ -278,43 +284,62 @@ open class HankeServiceImpl(
         // certain deleted entries as remainder:
         val tempLockedExistingYts = lockedExistingYTs.toMutableMap()
         findAndLogAffectedBlockedYhteystietos(
-            incomingHanke.omistajat, tempLockedExistingYts, loggingEntryHolderForRestrictedActions, userid)
+            incomingHanke.omistajat,
+            tempLockedExistingYts,
+            loggingEntryHolderForRestrictedActions,
+            userid
+        )
         findAndLogAffectedBlockedYhteystietos(
-            incomingHanke.arvioijat, tempLockedExistingYts, loggingEntryHolderForRestrictedActions, userid)
+            incomingHanke.arvioijat,
+            tempLockedExistingYts,
+            loggingEntryHolderForRestrictedActions,
+            userid
+        )
         findAndLogAffectedBlockedYhteystietos(
-            incomingHanke.toteuttajat, tempLockedExistingYts, loggingEntryHolderForRestrictedActions, userid)
+            incomingHanke.toteuttajat,
+            tempLockedExistingYts,
+            loggingEntryHolderForRestrictedActions,
+            userid
+        )
 
-        // If no entries were blocked, and there is nothing left in the tempLockedExistingYts, all clear to proceed:
-        if (!loggingEntryHolderForRestrictedActions.hasEntries() && tempLockedExistingYts.isEmpty()) {
+        // If no entries were blocked, and there is nothing left in the tempLockedExistingYts, all
+        // clear to proceed:
+        if (
+            !loggingEntryHolderForRestrictedActions.hasEntries() && tempLockedExistingYts.isEmpty()
+        ) {
             logger.debug {
                 "No actual changes to the restricted Yhteystietos. Hanke update can continue."
             }
             return
         }
 
-        // Any remaining entries in the tempLockedExistingYts means those would be deleted, if not locked;
+        // Any remaining entries in the tempLockedExistingYts means those would be deleted, if not
+        // locked;
         // create audit log entries for them:
         tempLockedExistingYts.values.forEach {
             loggingEntryHolderForRestrictedActions.addLogEntriesForEvent(
                 action = Action.DELETE,
                 failed = true,
-                failureDescription = "delete hanke yhteystieto BLOCKED by data processing restriction",
+                failureDescription =
+                    "delete hanke yhteystieto BLOCKED by data processing restriction",
                 oldEntity = it,
                 newEntity = null,
                 userId = userid,
             )
         }
-        logger.warn { "Hanke update with actions on processing restricted data, saving details to audit and change logs. Hanke id ${incomingHanke.id} will be left unchanged" }
+        logger.warn {
+            "Hanke update with actions on processing restricted data, saving details to audit and change logs. Hanke id ${incomingHanke.id} will be left unchanged"
+        }
         // This will throw exception (after saving the entries) and prevents
         // the Hanke update from continuing to actual changes to it.
         postProcessAndSaveLoggingForRestrictions(loggingEntryHolderForRestrictedActions)
     }
 
     private fun findAndLogAffectedBlockedYhteystietos(
-            incomingYts: MutableList<HankeYhteystieto>,
-            tempLockedExistingYts: MutableMap<Int, HankeYhteystietoEntity>,
-            loggingEntryHolderForRestrictedActions: YhteystietoLoggingEntryHolder,
-            userid: String
+        incomingYts: MutableList<HankeYhteystieto>,
+        tempLockedExistingYts: MutableMap<Int, HankeYhteystietoEntity>,
+        loggingEntryHolderForRestrictedActions: YhteystietoLoggingEntryHolder,
+        userid: String
     ) {
         incomingYts.forEach { yhteystieto ->
             val lockedExistingYt = tempLockedExistingYts[yhteystieto.id]
@@ -325,7 +350,8 @@ open class HankeServiceImpl(
                     loggingEntryHolderForRestrictedActions.addLogEntriesForEvent(
                         action = Action.DELETE,
                         failed = true,
-                        failureDescription = "delete hanke yhteystieto BLOCKED by data processing restriction",
+                        failureDescription =
+                            "delete hanke yhteystieto BLOCKED by data processing restriction",
                         oldEntity = tempLockedExistingYts[yhteystieto.id],
                         newEntity = null,
                         userId = userid,
@@ -343,7 +369,8 @@ open class HankeServiceImpl(
                     loggingEntryHolderForRestrictedActions.addLogEntriesForEvent(
                         action = Action.UPDATE,
                         failed = true,
-                        failureDescription = "update hanke yhteystieto BLOCKED by data processing restriction",
+                        failureDescription =
+                            "update hanke yhteystieto BLOCKED by data processing restriction",
                         oldEntity = lockedExistingYt,
                         newEntity = unsavedNewData,
                         userId = userid,
@@ -355,18 +382,18 @@ open class HankeServiceImpl(
     }
 
     /**
-     * Does NOT copy the id and hankeTunnus fields because one is supposed to find
-     * the HankeEntity instance from the database with those values, and after that,
-     * the values are filled by the database and should not be changed.
-     * Also, version, createdByUserId, createdAt, modifiedByUserId, modifiedAt, version are not
-     * set here, as they are to be set internally, and depends on which operation
-     * is being done.
+     * Does NOT copy the id and hankeTunnus fields because one is supposed to find the HankeEntity
+     * instance from the database with those values, and after that, the values are filled by the
+     * database and should not be changed. Also, version, createdByUserId, createdAt,
+     * modifiedByUserId, modifiedAt, version are not set here, as they are to be set internally, and
+     * depends on which operation is being done.
      */
     private fun copyNonNullHankeFieldsToEntity(hanke: Hanke, entity: HankeEntity) {
         hanke.onYKTHanke?.let { entity.onYKTHanke = hanke.onYKTHanke }
         hanke.nimi?.let { entity.nimi = hanke.nimi }
         hanke.kuvaus?.let { entity.kuvaus = hanke.kuvaus }
-        // Assuming the incoming date, while being zoned date and time, is in UTC and time value can be simply dropped here.
+        // Assuming the incoming date, while being zoned date and time, is in UTC and time value can
+        // be simply dropped here.
         // Note, .toLocalDate() does not do any time zone conversion.
         hanke.alkuPvm?.let { entity.alkuPvm = hanke.alkuPvm?.toLocalDate() }
         hanke.loppuPvm?.let { entity.loppuPvm = hanke.loppuPvm?.toLocalDate() }
@@ -378,7 +405,8 @@ open class HankeServiceImpl(
         entity.tyomaaTyyppi = hanke.tyomaaTyyppi
         hanke.tyomaaKoko?.let { entity.tyomaaKoko = hanke.tyomaaKoko }
 
-        // Assuming the incoming date, while being zoned date and time, is in UTC and time value can be simply dropped here.
+        // Assuming the incoming date, while being zoned date and time, is in UTC and time value can
+        // be simply dropped here.
         // Note, .toLocalDate() does not do any time zone conversion.
         hanke.haittaAlkuPvm?.let { entity.haittaAlkuPvm = hanke.haittaAlkuPvm?.toLocalDate() }
         hanke.haittaLoppuPvm?.let { entity.haittaLoppuPvm = hanke.haittaLoppuPvm?.toLocalDate() }
@@ -390,21 +418,25 @@ open class HankeServiceImpl(
     }
 
     /**
-     * Creates a temporary id-to-existingyhteystieto -map. It can be used to find
-     * quickly whether an incoming Yhteystieto is new or already in the database.
-     * (Also, copyYhteystietosToEntity() and its subfunctions remove entries from such map
-     * as they process them, and any remaining entries in it are considered as to
-     * be removed.)
-     * The given hankeEntity and its yhteystietos MUST be in persisted state (have their id's set).
+     * Creates a temporary id-to-existingyhteystieto -map. It can be used to find quickly whether an
+     * incoming Yhteystieto is new or already in the database. (Also, copyYhteystietosToEntity() and
+     * its subfunctions remove entries from such map as they process them, and any remaining entries
+     * in it are considered as to be removed.) The given hankeEntity and its yhteystietos MUST be in
+     * persisted state (have their id's set).
      */
-    private fun prepareMapOfExistingYhteystietos(hankeEntity: HankeEntity): MutableMap<Int, HankeYhteystietoEntity> {
-        // Create temporary id-to-existingyhteystieto -map, used to find quickly whether an incoming Yhteystieto is new or exists already.
+    private fun prepareMapOfExistingYhteystietos(
+        hankeEntity: HankeEntity
+    ): MutableMap<Int, HankeYhteystietoEntity> {
+        // Create temporary id-to-existingyhteystieto -map, used to find quickly whether an incoming
+        // Yhteystieto is new or exists already.
         // YT = Yhteystieto
         val existingYTs: MutableMap<Int, HankeYhteystietoEntity> = mutableMapOf()
         for (existingYT in hankeEntity.listOfHankeYhteystieto) {
             val ytid = existingYT.id
             if (ytid == null) {
-                throw DatabaseStateException("A persisted HankeYhteystietoEntity somehow missing id, Hanke id ${hankeEntity.id}")
+                throw DatabaseStateException(
+                    "A persisted HankeYhteystietoEntity somehow missing id, Hanke id ${hankeEntity.id}"
+                )
             } else {
                 existingYTs[ytid] = existingYT
             }
@@ -413,37 +445,65 @@ open class HankeServiceImpl(
     }
 
     /**
-     * Transfers yhteystieto fields from domain to (new or existing) entity object,
-     * combines the three lists into one list, and sets the audit fields as relevant.
+     * Transfers yhteystieto fields from domain to (new or existing) entity object, combines the
+     * three lists into one list, and sets the audit fields as relevant.
      */
     private fun copyYhteystietosToEntity(
-        hanke: Hanke, entity: HankeEntity, userid: String,
+        hanke: Hanke,
+        entity: HankeEntity,
+        userid: String,
         loggingEntryHolder: YhteystietoLoggingEntryHolder,
         existingYTs: MutableMap<Int, HankeYhteystietoEntity>
     ) {
-        // Note, if the incoming data indicates it is an already saved yhteystieto (id-field is set), should try
-        // to transfer the business fields to the same old corresponding entity. Pretty much a must in order to
-        // preserve createdBy and createdAt field values without having to rely on the client-side to hold
-        // the values for us (bad design), which would also require checks on those (to prevent tampering).
+        // Note, if the incoming data indicates it is an already saved yhteystieto (id-field is
+        // set), should try to transfer the business fields to the same old corresponding entity.
+        // Pretty much a must in order to preserve createdBy and createdAt field values without
+        // having to rely on the client-side to hold the values for us (bad design), which would
+        // also require checks on those (to prevent tampering).
 
-        // Check each incoming yhteystieto (from three lists) for being new or an update to existing one,
-        // and add to the main entity's single list if necessary:
-        processIncomingHankeYhteystietosOfSpecificTypeToEntity(hanke.omistajat, entity, ContactType.OMISTAJA, userid, existingYTs, loggingEntryHolder)
-        processIncomingHankeYhteystietosOfSpecificTypeToEntity(hanke.arvioijat, entity, ContactType.ARVIOIJA, userid, existingYTs, loggingEntryHolder)
-        processIncomingHankeYhteystietosOfSpecificTypeToEntity(hanke.toteuttajat, entity, ContactType.TOTEUTTAJA, userid, existingYTs, loggingEntryHolder)
+        // Check each incoming yhteystieto (from three lists) for being new or an update to existing
+        // one, and add to the main entity's single list if necessary:
+        processIncomingHankeYhteystietosOfSpecificTypeToEntity(
+            hanke.omistajat,
+            entity,
+            ContactType.OMISTAJA,
+            userid,
+            existingYTs,
+            loggingEntryHolder
+        )
+        processIncomingHankeYhteystietosOfSpecificTypeToEntity(
+            hanke.arvioijat,
+            entity,
+            ContactType.ARVIOIJA,
+            userid,
+            existingYTs,
+            loggingEntryHolder
+        )
+        processIncomingHankeYhteystietosOfSpecificTypeToEntity(
+            hanke.toteuttajat,
+            entity,
+            ContactType.TOTEUTTAJA,
+            userid,
+            existingYTs,
+            loggingEntryHolder
+        )
 
-        // TODO: this method of removing entries if they are missing in the incoming data is different to
-        //     behavior of the other simpler fields, where missing or null field is considered "keep the existing value,
-        //     and return it back in response".
-        //     However, those simpler fields can not be removed as a whole, so they _can_ behave so.
-        //     For clarity, yhteystieto-entries should have separate action for removal (but then they should also
-        //     have separate action for addition, i.e. own API endpoint in controller).
-        //     So, consider the code below as "for now".
-        // TODO: Yhteystietos should not be in a list, but a "bag", or ensure it is e.g. linkedlist instead of arraylist (or similars).
-        //    The order of Yhteystietos does not matter(?), and removing things from e.g. array list
-        //    gets inefficient. Since there are so few entries, this crude solution works, for now.
-        // If there is anything left in the existingYTs map, they have been removed in the incoming data,
-        // so remove them from the entity's list and make the back-reference null (and thus delete from the database).
+        // TODO: this method of removing entries if they are missing in the incoming data is
+        //  different to behavior of the other simpler fields, where missing or null field is
+        //  considered "keep the existing value, and return it back in response". However, those
+        //  simpler fields can not be removed as a whole, so they _can_ behave so. For clarity,
+        //  yhteystieto-entries should have separate action for removal (but then they should also
+        //  have separate action for addition, i.e. own API endpoint in controller). So, consider
+        //  the code below as "for now".
+        //
+        // TODO: Yhteystietos should not be in a list, but a "bag", or ensure it is e.g. linked list
+        //  instead of arraylist (or similar). The order of Yhteystietos does not matter(?), and
+        //  removing things from e.g. array list gets inefficient. Since there are so few entries,
+        //  this crude solution works, for now.
+        //
+        // If there is anything left in the existingYTs map, they have been removed in the incoming
+        // data, so remove them from the entity's list and make the back-reference null (and thus
+        // delete from the database).
         for (hankeYht in existingYTs.values) {
             entity.removeYhteystieto(hankeYht)
             loggingEntryHolder.addLogEntriesForEvent(
@@ -454,7 +514,6 @@ open class HankeServiceImpl(
             )
         }
     }
-
 
     private fun processIncomingHankeYhteystietosOfSpecificTypeToEntity(
         listOfHankeYhteystiedot: List<HankeYhteystieto>,
@@ -467,27 +526,46 @@ open class HankeServiceImpl(
         for (hankeYht in listOfHankeYhteystiedot) {
             val someFieldsSet = hankeYht.isAnyFieldSet()
             var validYhteystieto = false
-            // TODO: yhteystietovalidation is as of now a mess, due to multiple reasons.
+            // TODO: yhteystieto validation is as of now a mess, due to multiple reasons.
             //   Just rethink it all everywhere before trying to implement something..
-            // The UI has currently bigger problems implementing it so that Yhteystieto entries that haven't even been touched
-            //   would not be sent to backend as a group of ""-fields, so the condition here is to make
-            //   such fully-empty entry considered as non-existent (i.e. skip it).
+            //
+            // The UI has currently bigger problems implementing it so that Yhteystieto entries that
+            // haven't even been touched would not be sent to backend as a group of ""-fields, so
+            // the condition here is to make such fully-empty entry considered as non-existent (i.e.
+            // skip it).
+            //
             // If any field is given (not empty and not only whitespace)...
             if (someFieldsSet) {
                 validYhteystieto = hankeYht.isAnyFieldSet()
                 // Check if at least the 4 mandatory fields are given
-                //validYhteystieto = hankeYht.isValid()
+                // validYhteystieto = hankeYht.isValid()
             }
 
-            // Is the incoming Yhteystieto new (does not have id, create new) or old (has id, update existing)?
+            // Is the incoming Yhteystieto new (does not have id, create new) or old (has id, update
+            // existing)?
             if (hankeYht.id == null) {
                 // New Yhteystieto
-                // Note: don't need to (and can not) create audit-log entries during this create processing;
-                // they are done later, after the whole hanke has been saved and new yhteystietos got their db-ids.
-                processCreateYhteystieto(hankeYht, validYhteystieto, contactType, userid, hankeEntity)
+                // Note: don't need to (and can not) create audit-log entries during this create
+                // processing; they are done later, after the whole hanke has been saved and new
+                // yhteystietos got their db-ids.
+                processCreateYhteystieto(
+                    hankeYht,
+                    validYhteystieto,
+                    contactType,
+                    userid,
+                    hankeEntity
+                )
             } else {
                 // Should be an existing Yhteystieto
-                processUpdateYhteystieto(hankeYht, existingYTs, someFieldsSet, validYhteystieto, userid, hankeEntity, loggingEntryHolder)
+                processUpdateYhteystieto(
+                    hankeYht,
+                    existingYTs,
+                    someFieldsSet,
+                    validYhteystieto,
+                    userid,
+                    hankeEntity,
+                    loggingEntryHolder
+                )
             }
         }
     }
@@ -501,25 +579,25 @@ open class HankeServiceImpl(
     ) {
         if (validYhteystieto) {
             // ... it is valid, so create a new Yhteystieto
-            val hankeYhtEntity = HankeYhteystietoEntity(
-                    contactType,
-                    hankeYht.sukunimi,
-                    hankeYht.etunimi,
-                    hankeYht.email,
-                    hankeYht.puhelinnumero,
-                    hankeYht.organisaatioId,
-                    hankeYht.organisaatioNimi,
-                    hankeYht.osasto,
-
-                    false,
-                    null,
-
-                    userid, // createdByUserId
-                    getCurrentTimeUTCAsLocalTime(), // createdAt
-                    null,
-                    null,
-                    null, // will be set by the database
-                    hankeEntity) // reference back to parent hanke
+            val hankeYhtEntity =
+                HankeYhteystietoEntity(
+                    contactType = contactType,
+                    sukunimi = hankeYht.sukunimi,
+                    etunimi = hankeYht.etunimi,
+                    email = hankeYht.email,
+                    puhelinnumero = hankeYht.puhelinnumero,
+                    organisaatioId = hankeYht.organisaatioId,
+                    organisaatioNimi = hankeYht.organisaatioNimi,
+                    osasto = hankeYht.osasto,
+                    dataLocked = false,
+                    dataLockInfo = null,
+                    createdByUserId = userid,
+                    createdAt = getCurrentTimeUTCAsLocalTime(),
+                    modifiedByUserId = null,
+                    modifiedAt = null,
+                    id = null, // will be set by the database
+                    hanke = hankeEntity // reference back to parent hanke
+                )
             hankeEntity.addYhteystieto(hankeYhtEntity)
             // Logging of creating new yhteystietos is done after the hanke gets saved.
         } else {
@@ -539,13 +617,16 @@ open class HankeServiceImpl(
         hankeEntity: HankeEntity,
         loggingEntryHolder: YhteystietoLoggingEntryHolder
     ) {
-        // If incoming Yhteystieto has id set, it _should_ be among the existing Yhteystietos, or some kind of error has happened.
+        // If incoming Yhteystieto has id set, it _should_ be among the existing Yhteystietos, or
+        // some kind of error has happened.
         val incomingId: Int = hankeYht.id!!
         val existingYT: HankeYhteystietoEntity? = existingYTs[incomingId]
         if (existingYT == null) {
             // Some sort of error situation;
-            // - simultaneous edits to the same hanke by someone else (the Yhteystieto could have been removed in the database)
-            // - the incoming ids are for different hanke (i.e. incorrect data in the incoming request)
+            // - simultaneous edits to the same hanke by someone else (the Yhteystieto could have
+            //   been removed in the database)
+            // - the incoming ids are for different hanke (i.e. incorrect data in the incoming
+            //   request)
             throw HankeYhteystietoNotFoundException(hankeEntity.id!!, incomingId)
         }
 
@@ -562,7 +643,9 @@ open class HankeServiceImpl(
                 existingYT.email = hankeYht.email
                 existingYT.puhelinnumero = hankeYht.puhelinnumero
                 existingYT.organisaatioId = hankeYht.organisaatioId
-                hankeYht.organisaatioNimi?.let { existingYT.organisaatioNimi = hankeYht.organisaatioNimi }
+                hankeYht.organisaatioNimi?.let {
+                    existingYT.organisaatioNimi = hankeYht.organisaatioNimi
+                }
                 hankeYht.osasto?.let { existingYT.osasto = hankeYht.osasto }
 
                 // (Not changing createdBy/At fields)
@@ -578,16 +661,19 @@ open class HankeServiceImpl(
                 )
             }
 
-            // No need to add the existing Yhteystieto entity to the hanke's list; it is already in it.
-            // Remove the corresponding entry from the map. (Afterwards, the entries remaining in the map
-            // were not in the incoming data, so should be removed from the database.)
+            // No need to add the existing Yhteystieto entity to the hanke's list; it is already in
+            // it.
+            //
+            // Remove the corresponding entry from the map. (Afterwards, the entries remaining in
+            // the map were not in the incoming data, so should be removed from the database.)
             existingYTs.remove(incomingId)
         } else {
-            // Trying to update an Yhteystieto with one or more empty mandatory data fields.
-            // If we do not change anything, the response will send back to previous stored values.
-            // However, checking one special case; all fields being empty. This corresponds to initial state,
-            // where the corresponding Yhteystieto is not set. Therefore, for now, considering it as "please delete".
-            // (Handling it by reversed logic using the existingYTs map, see the comment above in the do-update -case.)
+            // Trying to update an Yhteystieto with one or more empty mandatory data fields. If we
+            // do not change anything, the response will send back to previous stored values.
+            // However, checking one special case; all fields being empty. This corresponds to
+            // initial state, where the corresponding Yhteystieto is not set. Therefore, for now,
+            // considering it as "please delete". (Handling it by reversed logic using the
+            // existingYTs map, see the comment above in the do-update -case.)
             if (someFieldsSet) {
                 logger.error {
                     "Got a new Yhteystieto object with one or more empty mandatory fields, skipping it. HankeId ${hankeEntity.id}"
@@ -598,7 +684,10 @@ open class HankeServiceImpl(
         }
     }
 
-    private fun areEqualIncomingVsExistingYhteystietos(incoming: HankeYhteystieto, existing: HankeYhteystietoEntity): Boolean {
+    private fun areEqualIncomingVsExistingYhteystietos(
+        incoming: HankeYhteystieto,
+        existing: HankeYhteystietoEntity
+    ): Boolean {
         if (incoming.etunimi != existing.etunimi) return false
         if (incoming.sukunimi != existing.sukunimi) return false
         if (incoming.email != existing.email) return false
@@ -610,8 +699,8 @@ open class HankeServiceImpl(
     }
 
     /**
-     * Creates the entry holder object and initializes the old Yhteystieto id set
-     * (so that it can know later which yhteystietos are created during the ongoing request).
+     * Creates the entry holder object and initializes the old Yhteystieto id set (so that it can
+     * know later which yhteystietos are created during the ongoing request).
      */
     private fun prepareLogging(entity: HankeEntity): YhteystietoLoggingEntryHolder {
         val loggingEntryHolder = YhteystietoLoggingEntryHolder()
@@ -620,35 +709,42 @@ open class HankeServiceImpl(
     }
 
     /**
-     * Handles post-processing of logging entries about restricted actions.
-     * Applies request's IP to all given logging entries, saves them, and creates
-     * and throws an exception which indicates that restricted yhteystietos
-     * can not be changed/deleted.
+     * Handles post-processing of logging entries about restricted actions. Applies request's IP to
+     * all given logging entries, saves them, and creates and throws an exception which indicates
+     * that restricted yhteystietos can not be changed/deleted.
      */
-    private fun postProcessAndSaveLoggingForRestrictions(loggingEntryHolderForRestrictedActions: YhteystietoLoggingEntryHolder) {
+    private fun postProcessAndSaveLoggingForRestrictions(
+        loggingEntryHolderForRestrictedActions: YhteystietoLoggingEntryHolder
+    ) {
         loggingEntryHolderForRestrictedActions.applyIpAddresses()
         loggingEntryHolderForRestrictedActions.saveLogEntries(auditLogRepository)
         val idList = loggingEntryHolderForRestrictedActions.idList()
-        throw HankeYhteystietoProcessingRestrictedException("Can not modify/delete yhteystieto which has data processing restricted (id: $idList)")
+        throw HankeYhteystietoProcessingRestrictedException(
+            "Can not modify/delete yhteystieto which has data processing restricted (id: $idList)"
+        )
     }
 
     /**
      * Handles logging of all newly created Yhteystietos, applies request's IP to all log entries,
      * and saves all the log entries.
+     *
      * Do not use this for the "restricted action" log events; see
-     * postProcessAndSaveLoggingForRestrictions() for that.
+     * [postProcessAndSaveLoggingForRestrictions] for that.
      */
     private fun postProcessAndSaveLogging(
         loggingEntryHolder: YhteystietoLoggingEntryHolder,
         savedHankeEntity: HankeEntity,
         userid: String
     ) {
-        // It would be possible to process all action types the same way afterwards
-        // like for creating new yhteystietos, but that would cause some (relatively)
-        // minor extra work, and, the proper solution would be to handle personal data
-        // access in its own separate service and do the logging there independently...
-        // So, the current way of doing things should be good enough for now.
-        loggingEntryHolder.addLogEntriesForNewYhteystietos(savedHankeEntity.listOfHankeYhteystieto, userid)
+        // It would be possible to process all action types the same way afterwards like for
+        // creating new yhteystietos, but that would cause some (relatively) minor extra work, and,
+        // the proper solution would be to handle personal data access in its own separate service
+        // and do the logging there independently... So, the current way of doing things should be
+        // good enough for now.
+        loggingEntryHolder.addLogEntriesForNewYhteystietos(
+            savedHankeEntity.listOfHankeYhteystieto,
+            userid
+        )
         loggingEntryHolder.applyIpAddresses()
         loggingEntryHolder.saveLogEntries(auditLogRepository)
     }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/Persistence.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/Persistence.kt
@@ -16,39 +16,37 @@ import org.springframework.data.jpa.repository.JpaRepository
  * @param isChange tells whether the action can change the business data
  */
 enum class Action(val isChange: Boolean) {
-    /**
-     * When some new "business data" object is created.
-     */
+    /** When some new "business data" object is created. */
     CREATE(true),
-    /**
-     * When some (sensitive) "business data" is read.
-     */
+
+    /** When some (sensitive) "business data" is read. */
     READ(false),
-    /**
-     * When some "business data" is changed.
-     */
+
+    /** When some "business data" is changed. */
     UPDATE(true),
+
     /**
-     * When some "business data" object is deleted. (Note, the whole object,
-     * not just one or more fields in it.)
+     * When some "business data" object is deleted. (Note, the whole object, not just one or more
+     * fields in it.)
      */
     DELETE(true),
+
     /**
-     * To record a change of the data locked -field to "true". Not done by
-     * Haitaton itself (for now), so add a row with this action when manually
-     * setting that restriction flag.
+     * To record a change of the data locked -field to "true". Not done by Haitaton itself (for
+     * now), so add a row with this action when manually setting that restriction flag.
      */
     LOCK(false),
+
     /**
-     * To record a change of the data locked -field from "true" to "false".
-     * Not done by Haitaton itself (for now), so add a row with this action
-     * when manually setting that restriction flag.
+     * To record a change of the data locked -field from "true" to "false". Not done by Haitaton
+     * itself (for now), so add a row with this action when manually setting that restriction flag.
      */
     UNLOCK(false)
 }
 
 enum class Status {
-    SUCCESS, FAILED
+    SUCCESS,
+    FAILED
 }
 
 enum class ObjectType {
@@ -58,31 +56,18 @@ enum class ObjectType {
 @Entity
 @Table(name = "audit_log")
 class AuditLogEntry(
-    @Id
-    var id: UUID? = UUID.randomUUID(),
-    @Column(name = "event_time")
-    var eventTime: OffsetDateTime? = OffsetDateTime.now(),
-    @Column(name = "user_id")
-    var userId: String? = null,
-    @Column(name = "ip_near")
-    var ipNear: String? = null,
-    @Column(name = "ip_far")
-    var ipFar: String? = null,
-    @Enumerated(EnumType.STRING)
-    var action: Action? = null,
-    @Enumerated(EnumType.STRING)
-    var status: Status? = null,
-    @Column(name = "failure_description")
-    var failureDescription: String? = null,
-    @Enumerated(EnumType.STRING)
-    @Column(name = "object_type")
-    var objectType: ObjectType? = null,
-    @Column(name = "object_id")
-    var objectId: Int? = null,
-    @Column(name = "object_before")
-    var objectBefore: String? = null,
-    @Column(name = "object_after")
-    var objectAfter: String? = null
+    @Id var id: UUID? = UUID.randomUUID(),
+    @Column(name = "event_time") var eventTime: OffsetDateTime? = OffsetDateTime.now(),
+    @Column(name = "user_id") var userId: String? = null,
+    @Column(name = "ip_near") var ipNear: String? = null,
+    @Column(name = "ip_far") var ipFar: String? = null,
+    @Enumerated(EnumType.STRING) var action: Action? = null,
+    @Enumerated(EnumType.STRING) var status: Status? = null,
+    @Column(name = "failure_description") var failureDescription: String? = null,
+    @Enumerated(EnumType.STRING) @Column(name = "object_type") var objectType: ObjectType? = null,
+    @Column(name = "object_id") var objectId: Int? = null,
+    @Column(name = "object_before") var objectBefore: String? = null,
+    @Column(name = "object_after") var objectAfter: String? = null
 )
 
 interface AuditLogRepository : JpaRepository<AuditLogEntry, UUID> {

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/YhteystietoLoggingEntryHolder.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/YhteystietoLoggingEntryHolder.kt
@@ -8,9 +8,8 @@ import org.springframework.web.context.request.ServletRequestAttributes
 const val PERSONAL_DATA_LOGGING_MAX_IP_LENGTH = 40
 
 /**
- * Used to hold the map of yhteystieto entities to logging entries during processing,
- * so that new ids of new yhteystietos can be applied after they have been saved and
- * thus received those ids.
+ * Used to hold the map of yhteystieto entities to logging entries during processing, so that new
+ * ids of new yhteystietos can be applied after they have been saved and thus received those ids.
  *
  * Basic use:
  * 1. Create instance of this class.
@@ -29,37 +28,42 @@ class YhteystietoLoggingEntryHolder {
     // Holds the ids of Yhteystietos that were in the Hanke before this request handling.
     private val previousYhteystietoIds: HashSet<Int> = hashSetOf()
 
-    fun hasEntries() : Boolean = auditLogEntries.isNotEmpty()
+    fun hasEntries(): Boolean = auditLogEntries.isNotEmpty()
 
-    fun idList() : String {
+    fun idList(): String {
         return auditLogEntries.map { it.id }.joinToString()
     }
 
     fun initWithOldYhteystietos(oldYTs: MutableList<HankeYhteystietoEntity>) {
         oldYTs.forEach {
             val yhteystietoId =
-                it.id ?: throw DatabaseStateException("A persisted HankeYhteystietoEntity somehow missing id")
+                it.id
+                    ?: throw DatabaseStateException(
+                        "A persisted HankeYhteystietoEntity somehow missing id"
+                    )
             previousYhteystietoIds.add(yhteystietoId)
         }
     }
 
     /**
-     * Creates audit log entries for the given action to this holder. This
-     * function will not save them, or set IP to them; those must be done
-     * separately before returning from the relevant process.
+     * Creates audit log entries for the given action to this holder. This function will not save
+     * them, or set IP to them; those must be done separately before returning from the relevant
+     * process.
      *
-     * The id of the yhteystieto will be taken from the oldEntity, unless it or
-     * its id is null and the newEntity is non-null, in which case it is taken
-     * from the newEntity. This rule handles all cases of create, update, and
-     * delete, _if_ this function is called after saving the entities for create
-     * action(s).
+     * The id of the yhteystieto will be taken from the oldEntity, unless it or its id is null and
+     * the newEntity is non-null, in which case it is taken from the newEntity. This rule handles
+     * all cases of create, update, and delete, _if_ this function is called after saving the
+     * entities for create action(s).
+     *
+     * For the old entity value, make a clone/copy of the persisted entity before making changes to
+     * it, if necessary.
      *
      * @param action can not be null
      * @param failed can not be null
      * @param failureDescription description for the failure, if one is available
-     * @param oldEntity for logging the previous field values (make a clone/copy before making changes
-     *              to the persisted entity, if necessary); can be null (when creating new)
-     * @param newEntity for logging the new state of field values; can be null (when deleting or reading)
+     * @param oldEntity for logging the previous field values; can be null (when creating new)
+     * @param newEntity for logging the new state of field values; can be null (when deleting or
+     * reading)
      * @param userId ID of the user making the API call
      */
     fun addLogEntriesForEvent(
@@ -73,26 +77,30 @@ class YhteystietoLoggingEntryHolder {
         // Note, use oldEntity delete and update and newEntity for create-action.
         val yhteystietoId = oldEntity?.id ?: newEntity?.id
 
-        val auditLogEntry = AuditLogEntry(
-            userId = userId,
-            action = action,
-            status = if(failed) Status.FAILED else Status.SUCCESS,
-            failureDescription = failureDescription,
-            objectType = ObjectType.YHTEYSTIETO,
-            objectId = yhteystietoId,
-            objectBefore = oldEntity?.toChangeLogJsonString(),
-            objectAfter = newEntity?.toChangeLogJsonString(),
-        )
+        val auditLogEntry =
+            AuditLogEntry(
+                userId = userId,
+                action = action,
+                status = if (failed) Status.FAILED else Status.SUCCESS,
+                failureDescription = failureDescription,
+                objectType = ObjectType.YHTEYSTIETO,
+                objectId = yhteystietoId,
+                objectBefore = oldEntity?.toChangeLogJsonString(),
+                objectAfter = newEntity?.toChangeLogJsonString(),
+            )
         auditLogEntries.add(auditLogEntry)
     }
 
     /**
-     * Goes through the entries that were new (have null yhteystietoId in the log entry,
-     * but non-null in the entity), and copies the new ids into the corresponding log entries.
+     * Goes through the entries that were new (have null yhteystietoId in the log entry, but
+     * non-null in the entity), and copies the new ids into the corresponding log entries.
      */
-    fun addLogEntriesForNewYhteystietos(savedHankeYhteystietoEntities: MutableList<HankeYhteystietoEntity>, userid: String) {
+    fun addLogEntriesForNewYhteystietos(
+        savedHankeYhteystietoEntities: MutableList<HankeYhteystietoEntity>,
+        userid: String
+    ) {
         // Go through the saved yhteystietos, filter for processing those that didn't exist
-        // before, and add log entries for them now, as their id's are now known.
+        // before, and add log entries for them now, as their IDs are now known.
         // (Obviously, they all succeeded, since they have been saved already.)
         savedHankeYhteystietoEntities
             .filter { !previousYhteystietoIds.contains(it.id) }
@@ -107,19 +115,24 @@ class YhteystietoLoggingEntryHolder {
     }
 
     /**
-     * If request context (attributes) exists, gets the IP from it and applies
-     * to all the log entries currently held in this holder.
+     * If request context (attributes) exists, gets the IP from it and applies to all the log
+     * entries currently held in this holder.
+     *
      * NOTE: very very very simplified implementation. Needs a lot of improvement.
      */
     fun applyIpAddresses() {
-        val attribs = (RequestContextHolder.getRequestAttributes() as ServletRequestAttributes?) ?: return
+        val attribs =
+            (RequestContextHolder.getRequestAttributes() as ServletRequestAttributes?) ?: return
         val request = attribs.request
         // Very simplified version for now.
-        // For starters, see e.g. https://stackoverflow.com/questions/22877350/how-to-extract-ip-address-in-spring-mvc-controller-get-call
-        // Combine all the various ideas into one, and note that even then it is not even half-way to
-        // proper solution. Hopefully one can find a ready-made fully thought out implementation.
+        // For starters, see e.g.
+        // https://stackoverflow.com/questions/22877350/how-to-extract-ip-address-in-spring-mvc-controller-get-call
+        // Combine all the various ideas into one, and note that even then it is not even half-way
+        // to a proper solution. Hopefully one can find a ready-made fully thought out
+        // implementation.
         var ip: String = request.getHeader("X-FORWARDED-FOR") ?: request.remoteAddr ?: return
-        // Just to make sure it won't break the db if someone put something silly long in the header:
+        // Just to make sure it won't break the db if someone put something silly long in the
+        // header:
         if (ip.length > PERSONAL_DATA_LOGGING_MAX_IP_LENGTH)
             ip = ip.substring(0, PERSONAL_DATA_LOGGING_MAX_IP_LENGTH)
 


### PR DESCRIPTION
Use the Spotless Gradle plugin to run ktfmt on the codebase. Ktfmt is a
opinionated formatter for Kotlin code that's non-customizable by design.

Spotless checks during the build stage that all code is formatted with
ktfmt. If the code is not formatted correctly, the build will fail.

Only code changed since the origin/dev will be checked and formatted.
When a file is touched, the whole file needs to be reformatted, though.

The formatting can be checked with:
```
./gradlew spotlessCheck
```
And the code can be reformatted with:
```
./gradlew :services:hanke-service:spotlessApply
```

The formatting broke the line wrapping on some comments, so I fixed them
and rewrote some comments to make them shorter and/or more informative.

# Description

Please include definition of what was done. 

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1222

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [X] Other

# Checklist:

- [ ] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [X] I have made necessary changes to the documentation, link to confluence
 or other location: README