### PR TITLE
HAI-1257 Allow anonymous access to public hankkeet

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/domain/PublicHankeControllerITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/domain/PublicHankeControllerITests.kt
@@ -1,0 +1,154 @@
+package fi.hel.haitaton.hanke.domain
+
+import fi.hel.haitaton.hanke.HankeService
+import fi.hel.haitaton.hanke.IntegrationTestConfiguration
+import fi.hel.haitaton.hanke.IntegrationTestResourceServerConfig
+import fi.hel.haitaton.hanke.SaveType
+import fi.hel.haitaton.hanke.TZ_UTC
+import fi.hel.haitaton.hanke.Vaihe
+import fi.hel.haitaton.hanke.geometria.HankeGeometriatService
+import fi.hel.haitaton.hanke.getCurrentTimeUTC
+import fi.hel.haitaton.hanke.tormaystarkastelu.TormaystarkasteluTulos
+import io.mockk.every
+import java.time.ZonedDateTime
+import java.time.temporal.ChronoUnit
+import mu.KotlinLogging
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.context.annotation.Import
+import org.springframework.http.MediaType
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.ResultActions
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+
+private val logger = KotlinLogging.logger {}
+
+@WebMvcTest(PublicHankeController::class)
+@Import(IntegrationTestConfiguration::class, IntegrationTestResourceServerConfig::class)
+@ActiveProfiles("itest")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class PublicHankeControllerITests(@Autowired val mockMvc: MockMvc) {
+
+    @Autowired private lateinit var hankeService: HankeService
+
+    @Autowired private lateinit var hankeGeometriatService: HankeGeometriatService
+
+    private val testHankeTunnus = "HAI21-TEST-1"
+
+    @Test
+    // Without mock user, i.e. anonymous
+    fun `status ok with unauthenticated user`() {
+        performGetHankkeet(listOf()).andExpect(MockMvcResultMatchers.status().isOk)
+    }
+
+    @Test
+    // Without mock user, i.e. anonymous
+    fun `only returns hankkeet with tormaystarkasteluTulos`() {
+        performGetHankkeet(
+                listOf(
+                    getTestHanke(123, testHankeTunnus, getTestTormaystarkasteluTulos()),
+                    getTestHanke(444, "HAI-TEST-2", null)
+                )
+            )
+            .andExpect(MockMvcResultMatchers.status().isOk)
+            .andExpect(jsonPath("[0]").exists())
+            .andExpect(jsonPath("[1]").doesNotExist())
+            .andExpect(jsonPath("[0].id").value(123))
+    }
+
+    @Test
+    // Without mock user, i.e. anonymous
+    fun `doesn't return personal information from yhteystiedot`() {
+        performGetHankkeet(
+                listOf(getTestHanke(123, testHankeTunnus, getTestTormaystarkasteluTulos()))
+            )
+            .andExpect(MockMvcResultMatchers.status().isOk)
+            .andExpect(jsonPath("[0]").exists())
+            .andExpect(jsonPath("[0].omistajat[0]").exists())
+            .andExpect(jsonPath("[0].omistajat[0].organisaatioId").value(1))
+            .andExpect(jsonPath("[0].omistajat[0].sukunimi").doesNotExist())
+            .andExpect(jsonPath("[0].omistajat[0].etunimi").doesNotExist())
+            .andExpect(jsonPath("[0].omistajat[0].email").doesNotExist())
+            .andExpect(jsonPath("[0].omistajat[0].puhelinnumero").doesNotExist())
+            .andExpect(jsonPath("[0].toteuttajat").doesNotExist())
+            .andExpect(jsonPath("[0].arvioijat").doesNotExist())
+    }
+
+    private fun performGetHankkeet(hankkeet: List<Hanke>): ResultActions {
+        every { hankeService.loadAllHanke() }.returns(hankkeet)
+
+        every { hankeGeometriatService.loadGeometriat(any()) }.returns(null)
+
+        return mockMvc.perform(
+            MockMvcRequestBuilders.get("/public-hankkeet").accept(MediaType.APPLICATION_JSON)
+        )
+    }
+
+    private fun getTestHanke(
+        id: Int?,
+        tunnus: String?,
+        tormaystarkasteluTulos: TormaystarkasteluTulos?
+    ): Hanke {
+        val hanke =
+            Hanke(
+                id,
+                tunnus,
+                true,
+                "Testihanke",
+                "Testihankkeen kuvaus",
+                getDatetimeAlku(),
+                getDatetimeLoppu(),
+                Vaihe.OHJELMOINTI,
+                null,
+                1,
+                "test7358",
+                getCurrentTimeUTC(),
+                null,
+                null,
+                SaveType.DRAFT
+            )
+        hanke.haittaAlkuPvm = getDatetimeAlku()
+        hanke.haittaLoppuPvm = getDatetimeLoppu()
+        hanke.omistajat = mutableListOf(getTestYhteystieto(id))
+        hanke.arvioijat = mutableListOf(getTestYhteystieto(id))
+        hanke.toteuttajat = mutableListOf(getTestYhteystieto(id))
+        hanke.tormaystarkasteluTulos = tormaystarkasteluTulos
+        return hanke
+    }
+
+    private fun getTestTormaystarkasteluTulos(): TormaystarkasteluTulos {
+        return TormaystarkasteluTulos(1f, 1f, 1f)
+    }
+
+    private fun getTestYhteystieto(id: Int?): HankeYhteystieto {
+        return HankeYhteystieto(
+            id = id,
+            sukunimi = "Testihenkilö",
+            etunimi = "Teppo",
+            email = "teppo@example.test",
+            puhelinnumero = "1234",
+            organisaatioId = 1,
+            organisaatioNimi = "Organisaatio",
+            osasto = "Osasto",
+            createdBy = "test7358",
+            createdAt = getCurrentTimeUTC(),
+            modifiedBy = "test7358",
+            modifiedAt = getCurrentTimeUTC()
+        )
+    }
+
+    private fun getDatetimeAlku(): ZonedDateTime {
+        val year = getCurrentTimeUTC().year + 1
+        return ZonedDateTime.of(year, 2, 20, 23, 45, 56, 0, TZ_UTC).truncatedTo(ChronoUnit.MILLIS)
+    }
+
+    private fun getDatetimeLoppu(): ZonedDateTime {
+        val year = getCurrentTimeUTC().year + 1
+        return ZonedDateTime.of(year, 2, 21, 0, 12, 34, 0, TZ_UTC).truncatedTo(ChronoUnit.MILLIS)
+    }
+}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/PublicHanke.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/PublicHanke.kt
@@ -5,63 +5,66 @@ import fi.hel.haitaton.hanke.geometria.HankeGeometriat
 import fi.hel.haitaton.hanke.geometria.HankeGeometriatService
 import fi.hel.haitaton.hanke.tormaystarkastelu.LiikennehaittaIndeksiType
 import fi.hel.haitaton.hanke.tormaystarkastelu.TormaystarkasteluTulos
+import java.time.ZonedDateTime
 import org.geojson.FeatureCollection
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
-import java.time.ZonedDateTime
 
 data class PublicHankeYhteystieto(
-        val organisaatioId: Int?,
-        val organisaatioNimi: String?,
-        val osasto: String?
+    val organisaatioId: Int?,
+    val organisaatioNimi: String?,
+    val osasto: String?
 )
 
-fun hankeYhteystietoToPublic(yhteystieto: HankeYhteystieto) = PublicHankeYhteystieto(
+fun hankeYhteystietoToPublic(yhteystieto: HankeYhteystieto) =
+    PublicHankeYhteystieto(
         yhteystieto.organisaatioId,
         yhteystieto.organisaatioNimi,
         yhteystieto.osasto
-)
+    )
 
 data class PublicHankeGeometriat(
-        val id: Int,
-        val version: Int,
-        val hankeId: Int,
-        val createdAt: ZonedDateTime,
-        val modifiedAt: ZonedDateTime?,
-        val featureCollection: FeatureCollection?
+    val id: Int,
+    val version: Int,
+    val hankeId: Int,
+    val createdAt: ZonedDateTime,
+    val modifiedAt: ZonedDateTime?,
+    val featureCollection: FeatureCollection?
 )
 
-fun hankeGeometriatToPublic(geometriat: HankeGeometriat) = PublicHankeGeometriat(
+fun hankeGeometriatToPublic(geometriat: HankeGeometriat) =
+    PublicHankeGeometriat(
         geometriat.id!!,
         geometriat.version!!,
         geometriat.hankeId!!,
         geometriat.createdAt!!,
         geometriat.modifiedAt,
         geometriat.featureCollection
-)
+    )
 
 data class PublicHanke(
-        val id: Int,
-        val hankeTunnus: String,
-        val nimi: String,
-        val kuvaus: String,
-        val alkuPvm: ZonedDateTime,
-        val loppuPvm: ZonedDateTime,
-        val haittaAlkuPvm: ZonedDateTime,
-        val haittaLoppuPvm: ZonedDateTime,
-        val vaihe: Vaihe,
-        val suunnitteluVaihe: SuunnitteluVaihe?,
-        val tyomaaTyyppi: MutableSet<TyomaaTyyppi>,
-        val liikennehaittaindeksi: LiikennehaittaIndeksiType,
-        val tormaystarkasteluTulos: TormaystarkasteluTulos,
-        val omistajat: List<PublicHankeYhteystieto>,
-        val geometriat: PublicHankeGeometriat?
+    val id: Int,
+    val hankeTunnus: String,
+    val nimi: String,
+    val kuvaus: String,
+    val alkuPvm: ZonedDateTime,
+    val loppuPvm: ZonedDateTime,
+    val haittaAlkuPvm: ZonedDateTime,
+    val haittaLoppuPvm: ZonedDateTime,
+    val vaihe: Vaihe,
+    val suunnitteluVaihe: SuunnitteluVaihe?,
+    val tyomaaTyyppi: MutableSet<TyomaaTyyppi>,
+    val liikennehaittaindeksi: LiikennehaittaIndeksiType,
+    val tormaystarkasteluTulos: TormaystarkasteluTulos,
+    val omistajat: List<PublicHankeYhteystieto>,
+    val geometriat: PublicHankeGeometriat?
 )
 
 fun hankeToPublic(hanke: Hanke): PublicHanke {
-    val omistajat = hanke.omistajat
+    val omistajat =
+        hanke.omistajat
             .filter { it.organisaatioNimi != null || it.organisaatioId != null }
             .map { hankeYhteystietoToPublic(it) }
 
@@ -69,39 +72,35 @@ fun hankeToPublic(hanke: Hanke): PublicHanke {
     val publicGeometriat = if (geometriat != null) hankeGeometriatToPublic(geometriat) else null
 
     return PublicHanke(
-            hanke.id!!,
-            hanke.hankeTunnus!!,
-            hanke.nimi!!,
-            hanke.kuvaus!!,
-            hanke.alkuPvm!!,
-            hanke.loppuPvm!!,
-            hanke.haittaAlkuPvm!!,
-            hanke.haittaLoppuPvm!!,
-            hanke.vaihe!!,
-            hanke.suunnitteluVaihe,
-            hanke.tyomaaTyyppi,
-            hanke.liikennehaittaindeksi!!,
-            hanke.tormaystarkasteluTulos!!,
-            omistajat,
-            publicGeometriat
+        hanke.id!!,
+        hanke.hankeTunnus!!,
+        hanke.nimi!!,
+        hanke.kuvaus!!,
+        hanke.alkuPvm!!,
+        hanke.loppuPvm!!,
+        hanke.haittaAlkuPvm!!,
+        hanke.haittaLoppuPvm!!,
+        hanke.vaihe!!,
+        hanke.suunnitteluVaihe,
+        hanke.tyomaaTyyppi,
+        hanke.liikennehaittaindeksi!!,
+        hanke.tormaystarkasteluTulos!!,
+        omistajat,
+        publicGeometriat
     )
 }
-
-
 
 @RestController
 @RequestMapping("/public-hankkeet")
 class PublicHankeController(
-        @Autowired private val hankeService: HankeService,
-        @Autowired private val hankeGeometriatService: HankeGeometriatService
+    @Autowired private val hankeService: HankeService,
+    @Autowired private val hankeGeometriatService: HankeGeometriatService
 ) {
 
     @GetMapping
     fun getAll(): List<PublicHanke> {
-        val hankkeet = hankeService.loadAllHanke()
-                .filter { it.tormaystarkasteluTulos != null }
+        val hankkeet = hankeService.loadAllHanke().filter { it.tormaystarkasteluTulos != null }
         hankkeet.forEach { it.geometriat = hankeGeometriatService.loadGeometriat(it) }
         return hankkeet.map { hankeToPublic(it) }
     }
-
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/security/AccessRules.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/security/AccessRules.kt
@@ -8,21 +8,31 @@ import mu.KotlinLogging
 import org.springframework.http.HttpMethod
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 
-private val logger = KotlinLogging.logger { }
+private val logger = KotlinLogging.logger {}
 
 object AccessRules {
     fun configureHttpAccessRules(http: HttpSecurity) {
-        http.authorizeRequests().mvcMatchers(HttpMethod.GET,
+        http
+            .authorizeRequests()
+            .mvcMatchers(
+                HttpMethod.GET,
                 "/actuator/health",
                 "/actuator/health/liveness",
                 "/actuator/health/readiness",
-                "/status"
-            ).permitAll().and()
-            .authorizeRequests().anyRequest().authenticated().and()
-            .exceptionHandling().authenticationEntryPoint { request, response, authenticationException ->
+                "/status",
+                "/public-hankkeet",
+            )
+            .permitAll()
+            .and()
+            .authorizeRequests()
+            .anyRequest()
+            .authenticated()
+            .and()
+            .exceptionHandling()
+            .authenticationEntryPoint { request, response, authenticationException ->
                 logger.warn {
                     "User has to be authenticated " +
-                            "to access ${request.method} ${request.requestURI}"
+                        "to access ${request.method} ${request.requestURI}"
                 }
                 Sentry.captureException(authenticationException)
                 response.writer.print(OBJECT_MAPPER.writeValueAsString(HankeError.HAI0001))


### PR DESCRIPTION
# Description

Allow anonymous access to the /public-hankkeet endpoint. Also add some tests that verify this endpoint exists and is accessible to all.

The new front page for unregistered users should still show the list of public hankkeet. Access to the endpoint seems to have been removed by accident. There were no tests in place to notice the mistake.

### Jira Issue: 

## Type of change

- [X] Bug fix 
- [ ] New feature 
- [ ] Other

# Instructions for testing
Call `/public-hankkeet` on the backend server after logging out.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [X] I have made necessary changes to the documentation, link to confluence
 or other location: -

