### PR TITLE
HAI Fix status endpoint

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/StatusControllerITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/StatusControllerITests.kt
@@ -1,15 +1,12 @@
 package fi.hel.haitaton.hanke
 
 import fi.hel.haitaton.hanke.StatusController.Companion.QUERY
-import fi.hel.haitaton.hanke.StatusController.Companion.SUCCESS
-import fi.hel.haitaton.hanke.StatusController.Companion.ERROR
 import io.mockk.every
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.jdbc.core.JdbcOperations
-import org.springframework.security.test.context.support.WithMockUser
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
@@ -20,28 +17,30 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers
 @ActiveProfiles("itest")
 class StatusControllerITests(@Autowired val mockMvc: MockMvc) {
 
-    @Autowired
-    lateinit var jdbcOperations: JdbcOperations
+    @Autowired lateinit var jdbcOperations: JdbcOperations
 
     @Test
     fun testSuccess() {
-        every { jdbcOperations.queryForObject(QUERY, Int::class.java) } returns SUCCESS
-        mockMvc.perform(MockMvcRequestBuilders.get("/status"))
-                .andExpect(MockMvcResultMatchers.status().isOk)
+        every { jdbcOperations.queryForObject(QUERY, Boolean::class.java) } returns true
+        mockMvc
+            .perform(MockMvcRequestBuilders.get("/status"))
+            .andExpect(MockMvcResultMatchers.status().isOk)
     }
 
     @Test
     fun testError() {
-        every { jdbcOperations.queryForObject(QUERY, Int::class.java) } returns ERROR
-        mockMvc.perform(MockMvcRequestBuilders.get("/status"))
-                .andExpect(MockMvcResultMatchers.status().is5xxServerError)
+        every { jdbcOperations.queryForObject(QUERY, Boolean::class.java) } returns false
+        mockMvc
+            .perform(MockMvcRequestBuilders.get("/status"))
+            .andExpect(MockMvcResultMatchers.status().is5xxServerError)
     }
 
     @Test
     fun testException() {
-        every { jdbcOperations.queryForObject(QUERY, Int::class.java) } throws RuntimeException()
-        mockMvc.perform(MockMvcRequestBuilders.get("/status"))
-                .andExpect(MockMvcResultMatchers.status().is5xxServerError)
+        every { jdbcOperations.queryForObject(QUERY, Boolean::class.java) } throws
+            RuntimeException()
+        mockMvc
+            .perform(MockMvcRequestBuilders.get("/status"))
+            .andExpect(MockMvcResultMatchers.status().is5xxServerError)
     }
-
 }


### PR DESCRIPTION
# Description

Change the status endpoint to check for existence of any rows in the `tormays_central_business_area_polys` table, instead of checking that the table has one row.

Currently, there are 116 rows in that table at least on dev and staging environments. The check for one row fails, so the status endpoint always return 500 Internal Error. This stops us from using it as a health check endpoint. Old availability checks are calling `/organisaatiot/`, but that has required logging in for a while now, so they all fail.

## Type of change

- [X] Bug fix 
- [ ] New feature 
- [ ] Other

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 
