### PR TITLE
HAI-1238 Add factories to create test data

### DIFF
--- a/.github/workflows/hanke-service-feature.yml
+++ b/.github/workflows/hanke-service-feature.yml
@@ -6,8 +6,8 @@ env:
 on:
   push:
     branches:
-      - HAI*
-      - hai*
+      - HAI**
+      - hai**
     paths:
       - services/hanke-service/**
       - .github/workflows/hanke-service-feature.yml

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/DateFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/DateFactory.kt
@@ -1,0 +1,36 @@
+package fi.hel.haitaton.hanke.factory
+
+import fi.hel.haitaton.hanke.TZ_UTC
+import fi.hel.haitaton.hanke.getCurrentTimeUTC
+import java.time.ZonedDateTime
+import java.time.temporal.ChronoUnit
+
+object DateFactory {
+    /**
+     * Get a static date for future start dates. The returned date is February 20th 23:45:56.000 of
+     * next year.
+     *
+     * Either this or [getEndDatetime] will change dates if timezone handling is not done properly
+     * in e.g. database.
+     *
+     * The date is truncated to millis to match database time granularity.
+     */
+    fun getStartDatetime(): ZonedDateTime {
+        val year = getCurrentTimeUTC().year + 1
+        return ZonedDateTime.of(year, 2, 20, 23, 45, 56, 0, TZ_UTC).truncatedTo(ChronoUnit.MILLIS)
+    }
+
+    /**
+     * Get a static date for future end dates. The returned date is February 21st 00:12:34.000 of
+     * next year.
+     *
+     * Either this or [getStartDatetime] will change dates if timezone handling is not done properly
+     * in e.g. database.
+     *
+     * The date is truncated to millis to match database time granularity.
+     */
+    fun getEndDatetime(): ZonedDateTime {
+        val year = getCurrentTimeUTC().year + 1
+        return ZonedDateTime.of(year, 2, 21, 0, 12, 34, 0, TZ_UTC).truncatedTo(ChronoUnit.MILLIS)
+    }
+}

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeFactory.kt
@@ -1,0 +1,219 @@
+package fi.hel.haitaton.hanke.factory
+
+import fi.hel.haitaton.hanke.Haitta13
+import fi.hel.haitaton.hanke.KaistajarjestelynPituus
+import fi.hel.haitaton.hanke.SaveType
+import fi.hel.haitaton.hanke.SuunnitteluVaihe
+import fi.hel.haitaton.hanke.TodennakoinenHaittaPaaAjoRatojenKaistajarjestelyihin
+import fi.hel.haitaton.hanke.TyomaaKoko
+import fi.hel.haitaton.hanke.TyomaaTyyppi
+import fi.hel.haitaton.hanke.Vaihe
+import fi.hel.haitaton.hanke.domain.Hanke
+import fi.hel.haitaton.hanke.getCurrentTimeUTC
+import java.time.ZonedDateTime
+
+object HankeFactory {
+
+    const val defaultHankeTunnus = "HAI21-1"
+    const val defaultNimi = "Hämeentien perusparannus ja katuvalot"
+    const val defaultId = 123
+    const val defaultUser = "Risto"
+
+    /**
+     * Create a simple Hanke with test values. The default values can be overridden with named
+     * parameters.
+     *
+     * Example:
+     * ```
+     * HankeFactory.create(id = null, hankeTunnus = null, nimi = "Testihanke")
+     * ```
+     */
+    fun create(
+        id: Int? = defaultId,
+        hankeTunnus: String? = defaultHankeTunnus,
+        nimi: String? = defaultNimi,
+        alkuPvm: ZonedDateTime? = DateFactory.getStartDatetime(),
+        loppuPvm: ZonedDateTime? = DateFactory.getEndDatetime(),
+        vaihe: Vaihe? = Vaihe.OHJELMOINTI,
+        suunnitteluVaihe: SuunnitteluVaihe? = null,
+        version: Int? = 1,
+        createdBy: String? = defaultUser,
+        createdAt: ZonedDateTime? = getCurrentTimeUTC(),
+    ): Hanke =
+        Hanke(
+            id,
+            hankeTunnus,
+            true,
+            nimi,
+            "lorem ipsum dolor sit amet...",
+            alkuPvm,
+            loppuPvm,
+            vaihe,
+            suunnitteluVaihe,
+            version,
+            createdBy,
+            createdAt,
+            null,
+            null,
+            SaveType.DRAFT
+        )
+
+    /**
+     * Add a haitta to a test Hanke.
+     *
+     * Example:
+     * ```
+     * HankeFactory.create().withHaitta()
+     * ```
+     */
+    fun Hanke.withHaitta(): Hanke {
+        this.tyomaaKatuosoite = "Testikatu 1"
+        this.tyomaaTyyppi.add(TyomaaTyyppi.VESI)
+        this.tyomaaTyyppi.add(TyomaaTyyppi.MUU)
+        this.tyomaaKoko = TyomaaKoko.LAAJA_TAI_USEA_KORTTELI
+        this.haittaAlkuPvm = DateFactory.getStartDatetime()
+        this.haittaLoppuPvm = DateFactory.getEndDatetime()
+        this.kaistaHaitta = TodennakoinenHaittaPaaAjoRatojenKaistajarjestelyihin.KAKSI
+        this.kaistaPituusHaitta = KaistajarjestelynPituus.NELJA
+        this.meluHaitta = Haitta13.YKSI
+        this.polyHaitta = Haitta13.KAKSI
+        this.tarinaHaitta = Haitta13.KOLME
+        return this
+    }
+
+    /**
+     * Add yhteystiedot to a test Hanke. Generates the yhteystiedot with
+     * [HankeYhteystietoFactory.createDifferentiated] using the given ints for differentiating the
+     * yhteystiedot from each other.
+     *
+     * Without parameters, will add one contact for each role.
+     *
+     * Examples:
+     * ```
+     * HankeFactory.create().withYhteystiedot()
+     *
+     * HankeFactory.create().withYhteystiedot(
+     *     omistajat = listOf(1,2),
+     *     arvioijat = listOf(3,4),
+     *     toteuttajat = listOf(2,5),
+     * )
+     * ```
+     *
+     * Using the withGeneratedX methods is probably cleaner than overriding the parameters of this
+     * method.
+     */
+    fun Hanke.withYhteystiedot(
+        omistajat: List<Int> = listOf(1),
+        arvioijat: List<Int> = listOf(2),
+        toteuttajat: List<Int> = listOf(3),
+    ): Hanke =
+        this.withGeneratedOmistajat(omistajat)
+            .withGeneratedArvioijat(arvioijat)
+            .withGeneratedToteuttajat(toteuttajat)
+
+    /**
+     * Add a number of omistaja to a hanke. Generates the yhteystiedot with
+     * [HankeYhteystietoFactory.createDifferentiated] using the given ints for differentiating the
+     * yhteystiedot from each other.
+     *
+     * Example:
+     * ```
+     * HankeFactory.create().withGeneratedOmistajat(listOf(1,2))
+     * ```
+     */
+    fun Hanke.withGeneratedOmistajat(ids: List<Int>): Hanke {
+        omistajat.addAll(HankeYhteystietoFactory.createDifferentiated(ids))
+        return this
+    }
+
+    /**
+     * Same as [Hanke.withGeneratedOmistajat] but using varargs instead of a list.
+     *
+     * Example:
+     * ```
+     * HankeFactory.create().withGeneratedOmistajat(1,2)
+     * ```
+     */
+    fun Hanke.withGeneratedOmistajat(vararg ids: Int): Hanke = withGeneratedOmistajat(ids.toList())
+
+    /**
+     * Same as [Hanke.withGeneratedOmistajat] but adds a single omistaja.
+     *
+     * Example:
+     * ```
+     * HankeFactory.create().withGeneratedOmistaja(1)
+     * ```
+     */
+    fun Hanke.withGeneratedOmistaja(id: Int): Hanke = withGeneratedOmistajat(id)
+
+    /**
+     * Add a number of arvioija to a hanke. Generates the yhteystiedot with
+     * [HankeYhteystietoFactory.createDifferentiated] using the given ints for differentiating the
+     * yhteystiedot from each other.
+     *
+     * Example:
+     * ```
+     * HankeFactory.create().withGeneratedArvioijat(listOf(1,2))
+     * ```
+     */
+    fun Hanke.withGeneratedArvioijat(ids: List<Int>): Hanke {
+        arvioijat.addAll(HankeYhteystietoFactory.createDifferentiated(ids))
+        return this
+    }
+
+    /**
+     * Same as [Hanke.withGeneratedArvioijat] but using varargs instead of a list.
+     *
+     * Example:
+     * ```
+     * HankeFactory.create().withGeneratedArvioijat(1,2)
+     * ```
+     */
+    fun Hanke.withGeneratedArvioijat(vararg ids: Int): Hanke = withGeneratedArvioijat(ids.toList())
+
+    /**
+     * Same as [Hanke.withGeneratedArvioijat] but adds a single arvioija.
+     *
+     * Example:
+     * ```
+     * HankeFactory.create().withGeneratedArvioija(1)
+     * ```
+     */
+    fun Hanke.withGeneratedArvioija(id: Int): Hanke = withGeneratedArvioijat(id)
+
+    /**
+     * Add a number of toteuttaja to a hanke. Generates the yhteystiedot with
+     * [HankeYhteystietoFactory.createDifferentiated] using the given ints for differentiating the
+     * yhteystiedot from each other.
+     *
+     * Example:
+     * ```
+     * HankeFactory.create().withGeneratedToteuttajat(listOf(1,2))
+     * ```
+     */
+    fun Hanke.withGeneratedToteuttajat(ids: List<Int>): Hanke {
+        toteuttajat.addAll(HankeYhteystietoFactory.createDifferentiated(ids))
+        return this
+    }
+
+    /**
+     * Same as [Hanke.withGeneratedToteuttajat] but using varargs instead of a list.
+     *
+     * Example:
+     * ```
+     * HankeFactory.create().withGeneratedToteuttajat(1,2)
+     * ```
+     */
+    fun Hanke.withGeneratedToteuttajat(vararg ids: Int): Hanke =
+        withGeneratedToteuttajat(ids.toList())
+
+    /**
+     * Same as [Hanke.withGeneratedToteuttajat] but adds a single toteuttaja.
+     *
+     * Example:
+     * ```
+     * HankeFactory.create().withGeneratedToteuttaja(1)
+     * ```
+     */
+    fun Hanke.withGeneratedToteuttaja(id: Int): Hanke = withGeneratedToteuttajat(id)
+}

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeYhteystietoFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeYhteystietoFactory.kt
@@ -1,0 +1,49 @@
+package fi.hel.haitaton.hanke.factory
+
+import fi.hel.haitaton.hanke.domain.HankeYhteystieto
+import fi.hel.haitaton.hanke.getCurrentTimeUTC
+
+object HankeYhteystietoFactory {
+
+    /** Create a test yhteystieto with values in all fields. */
+    fun create(): HankeYhteystieto {
+        return HankeYhteystieto(
+            id = 1,
+            sukunimi = "Testihenkilö",
+            etunimi = "Teppo",
+            email = "teppo@example.test",
+            puhelinnumero = "1234",
+            organisaatioId = 1,
+            organisaatioNimi = "Organisaatio",
+            osasto = "Osasto",
+            createdBy = "test7358",
+            createdAt = getCurrentTimeUTC(),
+            modifiedBy = "test7358",
+            modifiedAt = getCurrentTimeUTC()
+        )
+    }
+
+    /**
+     * Create a new Yhteystieto with values differentiated by the given integer. The audit and id
+     * fields are left null.
+     */
+    fun createDifferentiated(intValue: Int): HankeYhteystieto {
+        return HankeYhteystieto(
+            null,
+            "suku$intValue",
+            "etu$intValue",
+            "email$intValue",
+            "010$intValue$intValue$intValue$intValue$intValue$intValue$intValue",
+            intValue,
+            "org$intValue",
+            "osasto$intValue"
+        )
+    }
+
+    /**
+     * Create a list of test yhteystiedot. The values of the created yhteystiedot are differentiated
+     * by the given integers.
+     */
+    fun createDifferentiated(intValues: List<Int>): MutableList<HankeYhteystieto> =
+        intValues.map { createDifferentiated(it) }.toMutableList()
+}

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/PermissionFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/PermissionFactory.kt
@@ -8,14 +8,14 @@ object PermissionFactory {
     const val defaultId = 1
 
     /**
-     * Creates a new permission with default values. The default values can be overridden with named parameters.
+     * Creates a new permission with default values. The default values can be overridden with named
+     * parameters.
      *
      * Examples:
      * ```
      * PermissionFactory.create()
      * PermissionFactory.create(hankeId = 12, userId = "testuser")
      * ```
-     *
      */
     fun create(
         id: Int = defaultId,

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/PermissionFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/PermissionFactory.kt
@@ -1,0 +1,26 @@
+package fi.hel.haitaton.hanke.factory
+
+import fi.hel.haitaton.hanke.permissions.Permission
+import fi.hel.haitaton.hanke.permissions.PermissionCode
+import fi.hel.haitaton.hanke.permissions.PermissionProfiles
+
+object PermissionFactory {
+    const val defaultId = 1
+
+    /**
+     * Creates a new permission with default values. The default values can be overridden with named parameters.
+     *
+     * Examples:
+     * ```
+     * PermissionFactory.create()
+     * PermissionFactory.create(hankeId = 12, userId = "testuser")
+     * ```
+     *
+     */
+    fun create(
+        id: Int = defaultId,
+        userId: String = HankeFactory.defaultUser,
+        hankeId: Int = HankeFactory.defaultId,
+        permissions: List<PermissionCode> = PermissionProfiles.HANKE_OWNER_PERMISSIONS,
+    ): Permission = Permission(id, userId, hankeId, permissions)
+}


### PR DESCRIPTION
# Description

Add factories to make it easier to create some test data. Instead of creating e.g. a hanke from scratch and having to list all of its fields, factories enable the developer to create a hanke with sensible default values and override those defaults when necessary.

Also add methods to those factories that make it easier to create contact information to any test hanke.

Some tests didn't pass when run individually because of missing mocking. This also means that mocks were leaking between tests. Added a `@AfterEach` method for cleaning mocks in a few test classes to stop the leaking. This is something that should be kept in mind when writing new tests or editing old ones.
