### PR TITLE
HAI-1076 Create audit log entries when hankeyhteystiedot are given to users

### DIFF
--- a/services/hanke-service/Dockerfile-local
+++ b/services/hanke-service/Dockerfile-local
@@ -1,10 +1,16 @@
 FROM openjdk:11.0.9.1-jdk as builder
 USER root
+
+# Copy gradle to avoid redownloading it
+COPY *.gradle gradle.* gradlew /builder/
+COPY gradle /builder/gradle
+WORKDIR /builder
+RUN ./gradlew --version
+
 ADD . /builder
 WORKDIR /builder
 # Add GRADLE_OPTS to prevent JVM forking while building
-# Skip integration tests when building the local docker image
-RUN GRADLE_OPTS="-XX:MaxMetaspaceSize=256m -XX:+HeapDumpOnOutOfMemoryError -Xms256m -Xmx512m" ./gradlew build --no-daemon -x :services:hanke-service:integrationTest
+RUN GRADLE_OPTS="-XX:MaxMetaspaceSize=256m -XX:+HeapDumpOnOutOfMemoryError -Xms256m -Xmx512m" ./gradlew assemble --no-daemon
 
 FROM openjdk:11
 WORKDIR /app

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/IntegrationTestConfiguration.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/IntegrationTestConfiguration.kt
@@ -5,6 +5,7 @@ import fi.hel.haitaton.hanke.gdpr.GdprJsonConverter
 import fi.hel.haitaton.hanke.geometria.HankeGeometriatDao
 import fi.hel.haitaton.hanke.geometria.HankeGeometriatService
 import fi.hel.haitaton.hanke.logging.AuditLogRepository
+import fi.hel.haitaton.hanke.logging.YhteystietoLoggingService
 import fi.hel.haitaton.hanke.organisaatio.OrganisaatioService
 import fi.hel.haitaton.hanke.permissions.PermissionService
 import fi.hel.haitaton.hanke.profiili.ProfiiliClient
@@ -60,6 +61,8 @@ class IntegrationTestConfiguration {
         TormaystarkasteluTormaysServicePG(jdbcOperations)
 
     @Bean fun tormaystarkasteluLaskentaService(): TormaystarkasteluLaskentaService = mockk()
+
+    @Bean fun yhteystietoLoggingService(): YhteystietoLoggingService = mockk()
 
     @EventListener
     fun onApplicationEvent(event: ContextRefreshedEvent) {

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/security/HankeControllerSecurityTests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/security/HankeControllerSecurityTests.kt
@@ -11,12 +11,14 @@ import fi.hel.haitaton.hanke.Vaihe
 import fi.hel.haitaton.hanke.domain.Hanke
 import fi.hel.haitaton.hanke.geometria.HankeGeometriatService
 import fi.hel.haitaton.hanke.getCurrentTimeUTC
+import fi.hel.haitaton.hanke.logging.YhteystietoLoggingService
 import fi.hel.haitaton.hanke.permissions.Permission
 import fi.hel.haitaton.hanke.permissions.PermissionCode
 import fi.hel.haitaton.hanke.permissions.PermissionProfiles
 import fi.hel.haitaton.hanke.permissions.PermissionService
 import fi.hel.haitaton.hanke.toJsonString
 import io.mockk.every
+import io.mockk.justRun
 import java.time.ZonedDateTime
 import java.time.temporal.ChronoUnit
 import org.junit.jupiter.api.Test
@@ -38,19 +40,17 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
 /**
- * Tests to ensure HankeController endpoints have correct authentication and
- * authorization restrictions and handling.
+ * Tests to ensure HankeController endpoints have correct authentication and authorization
+ * restrictions and handling.
  *
- * The actual activities in each test are not important, as long as they cause
- * the relevant method to be called.
- * "Perform" function implementations have been adapted from HankeControllerITests.
- * As long as the mocked operation goes through and returns something "ok" (when
- * authenticated correctly), it will be usable as an authentication test's operation.
+ * The actual activities in each test are not important, as long as they cause the relevant method
+ * to be called. "Perform" function implementations have been adapted from HankeControllerITests. As
+ * long as the mocked operation goes through and returns something "ok" (when authenticated
+ * correctly), it will be usable as an authentication test's operation.
  *
- * TODO
- * Note, HankeService's method-based security is to be tested separately, (in own test class),
- * once it gets any activated. For now, testing the Controller is enough as the service's
- * finer things are not implemented.
+ * TODO Note, HankeService's method-based security is to be tested separately, (in own test class),
+ * once it gets any activated. For now, testing the Controller is enough as the service's finer
+ * things are not implemented.
  */
 @WebMvcTest(HankeController::class)
 @Import(IntegrationTestConfiguration::class, IntegrationTestResourceServerConfig::class)
@@ -58,14 +58,13 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class HankeControllerSecurityTests(@Autowired val mockMvc: MockMvc) {
 
-    @Autowired
-    private lateinit var hankeService: HankeService
+    @Autowired private lateinit var hankeService: HankeService
 
-    @Autowired
-    lateinit var permissionService: PermissionService
+    @Autowired lateinit var permissionService: PermissionService
 
-    @Autowired
-    private lateinit var hankeGeometriatService: HankeGeometriatService
+    @Autowired private lateinit var hankeGeometriatService: HankeGeometriatService
+
+    @Autowired private lateinit var yhteystietoLoggingService: YhteystietoLoggingService
 
     private val testHankeTunnus = "HAI21-TEST-1"
 
@@ -75,7 +74,7 @@ class HankeControllerSecurityTests(@Autowired val mockMvc: MockMvc) {
         performGetHankkeet().andExpect(status().isOk)
         performPostHankkeet().andExpect(status().isOk)
         performPutHankkeetTunnus().andExpect(status().isOk)
-        performGetHankkeetTunnus().andExpect(status().isOk)
+        performGetHankeByTunnus().andExpect(status().isOk)
     }
 
     @Test
@@ -93,7 +92,7 @@ class HankeControllerSecurityTests(@Autowired val mockMvc: MockMvc) {
             .andExpect(unauthenticated())
             .andExpect(status().isUnauthorized)
             .andExpectHankeError(HankeError.HAI0001)
-        performGetHankkeetTunnus()
+        performGetHankeByTunnus()
             .andExpect(unauthenticated())
             .andExpect(status().isUnauthorized)
             .andExpectHankeError(HankeError.HAI0001)
@@ -102,35 +101,19 @@ class HankeControllerSecurityTests(@Autowired val mockMvc: MockMvc) {
     // --------- GET /hankkeet/ --------------
 
     private fun performGetHankkeet(): ResultActions {
-        val hankeIds = listOf(123,444)
-        every { hankeService.loadHankkeetByIds(hankeIds) }.returns(
-            listOf(
-                Hanke(123, testHankeTunnus),
-                Hanke(444, "HAI-TEST-2")
-            )
-        )
-        every { permissionService.getPermissionsByUserId("test7358") }.returns(
-            listOf(
-                Permission(
-                1,
-                "test7358",
-                123,
-                PermissionProfiles.HANKE_OWNER_PERMISSIONS
-            ),
-                Permission(
-                    1,
-                    "test7358",
-                    444,
-                    listOf(PermissionCode.VIEW)
+        val hankeIds = listOf(123, 444)
+        every { hankeService.loadHankkeetByIds(hankeIds) }
+            .returns(listOf(Hanke(123, testHankeTunnus), Hanke(444, "HAI-TEST-2")))
+        every { permissionService.getPermissionsByUserId("test7358") }
+            .returns(
+                listOf(
+                    Permission(1, "test7358", 123, PermissionProfiles.HANKE_OWNER_PERMISSIONS),
+                    Permission(1, "test7358", 444, listOf(PermissionCode.VIEW))
                 )
             )
-        )
+        justRun { yhteystietoLoggingService.saveDisclosureLogsForUser(any(), "test7358") }
 
-
-        return mockMvc.perform(
-            get("/hankkeet")
-                .accept(MediaType.APPLICATION_JSON)
-        )
+        return mockMvc.perform(get("/hankkeet").accept(MediaType.APPLICATION_JSON))
     }
 
     // --------- POST /hankkeet/ --------------
@@ -140,19 +123,22 @@ class HankeControllerSecurityTests(@Autowired val mockMvc: MockMvc) {
         val content = hanke.toJsonString()
 
         every { hankeService.createHanke(any()) }.returns(hanke)
-        every { permissionService.setPermission(12, "test7358", PermissionProfiles.HANKE_OWNER_PERMISSIONS) }.returns(
-            Permission(
-                1,
-                "test7358",
-                12,
-                PermissionProfiles.HANKE_OWNER_PERMISSIONS
-            )
-        )
+        every {
+                permissionService.setPermission(
+                    12,
+                    "test7358",
+                    PermissionProfiles.HANKE_OWNER_PERMISSIONS
+                )
+            }
+            .returns(Permission(1, "test7358", 12, PermissionProfiles.HANKE_OWNER_PERMISSIONS))
         every { hankeGeometriatService.loadGeometriat(any()) }.returns(null)
+        justRun { yhteystietoLoggingService.saveDisclosureLogForUser(any(), "test7358") }
 
         return mockMvc.perform(
             post("/hankkeet")
-                .contentType(MediaType.APPLICATION_JSON).characterEncoding("UTF-8").content(content)
+                .contentType(MediaType.APPLICATION_JSON)
+                .characterEncoding("UTF-8")
+                .content(content)
                 .with(SecurityMockMvcRequestPostProcessors.csrf())
                 .accept(MediaType.APPLICATION_JSON)
         )
@@ -164,11 +150,14 @@ class HankeControllerSecurityTests(@Autowired val mockMvc: MockMvc) {
         val hanke = getTestHanke(123, testHankeTunnus)
         val content = hanke.toJsonString()
 
-        every { hankeService.updateHanke(any()) }.returns(hanke)
+        every { hankeService.updateHanke(any()) }.returns(hanke.copy(modifiedBy = "test7358"))
+        justRun { yhteystietoLoggingService.saveDisclosureLogForUser(any(), "test7358") }
 
         return mockMvc.perform(
             put("/hankkeet/$testHankeTunnus")
-                .contentType(MediaType.APPLICATION_JSON).characterEncoding("UTF-8").content(content)
+                .contentType(MediaType.APPLICATION_JSON)
+                .characterEncoding("UTF-8")
+                .content(content)
                 .with(SecurityMockMvcRequestPostProcessors.csrf())
                 .accept(MediaType.APPLICATION_JSON)
         )
@@ -176,49 +165,51 @@ class HankeControllerSecurityTests(@Autowired val mockMvc: MockMvc) {
 
     // --------- GET /hankkeet/{hankeTunnus} --------------
 
-    private fun performGetHankkeetTunnus(): ResultActions {
-        every { hankeService.loadHanke(any()) }
-            .returns(Hanke(123, "HAI-TEST-1"))
+    private fun performGetHankeByTunnus(): ResultActions {
+        every { hankeService.loadHanke(any()) }.returns(Hanke(123, "HAI-TEST-1"))
         every { permissionService.getPermissionByHankeIdAndUserId(123, "test7358") }
             .returns(Permission(1, "test7358", 123, PermissionProfiles.HANKE_OWNER_PERMISSIONS))
+        justRun { yhteystietoLoggingService.saveDisclosureLogForUser(any(), "test7358") }
 
-        return mockMvc.perform(
-            get("/hankkeet/$testHankeTunnus")
-                .accept(MediaType.APPLICATION_JSON)
-        )
+        return mockMvc.perform(get("/hankkeet/$testHankeTunnus").accept(MediaType.APPLICATION_JSON))
     }
 
     // ===================== HELPERS ========================
 
     private fun getDatetimeAlku(): ZonedDateTime {
         val year = getCurrentTimeUTC().year + 1
-        return ZonedDateTime.of(year, 2, 20, 23, 45, 56, 0, TZ_UTC)
-            .truncatedTo(ChronoUnit.MILLIS)
+        return ZonedDateTime.of(year, 2, 20, 23, 45, 56, 0, TZ_UTC).truncatedTo(ChronoUnit.MILLIS)
     }
 
     private fun getDatetimeLoppu(): ZonedDateTime {
         val year = getCurrentTimeUTC().year + 1
-        return ZonedDateTime.of(year, 2, 21, 0, 12, 34, 0, TZ_UTC)
-            .truncatedTo(ChronoUnit.MILLIS)
+        return ZonedDateTime.of(year, 2, 21, 0, 12, 34, 0, TZ_UTC).truncatedTo(ChronoUnit.MILLIS)
     }
 
     private fun getTestHanke(id: Int?, tunnus: String?): Hanke {
         return Hanke(
-            id, tunnus,
-            true, "Testihanke", "Testihankkeen kuvaus",
-            getDatetimeAlku(), getDatetimeLoppu(), Vaihe.OHJELMOINTI, null,
-            1, "test7358", getCurrentTimeUTC(), null, null,
+            id,
+            tunnus,
+            true,
+            "Testihanke",
+            "Testihankkeen kuvaus",
+            getDatetimeAlku(),
+            getDatetimeLoppu(),
+            Vaihe.OHJELMOINTI,
+            null,
+            1,
+            "test7358",
+            getCurrentTimeUTC(),
+            null,
+            null,
             SaveType.DRAFT
         )
     }
 
     private fun ResultActions.andExpectHankeError(hankeError: HankeError): ResultActions {
-        return andExpect(
-            MockMvcResultMatchers.jsonPath("$.errorCode")
-                .value(hankeError.errorCode)
-        ).andExpect(
-            MockMvcResultMatchers.jsonPath("$.errorMessage")
-                .value(hankeError.errorMessage)
-        )
+        return andExpect(MockMvcResultMatchers.jsonPath("$.errorCode").value(hankeError.errorCode))
+            .andExpect(
+                MockMvcResultMatchers.jsonPath("$.errorMessage").value(hankeError.errorMessage)
+            )
     }
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeError.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeError.kt
@@ -4,9 +4,7 @@ import com.fasterxml.jackson.annotation.JsonFormat
 import javax.validation.ConstraintViolation
 
 @JsonFormat(shape = JsonFormat.Shape.OBJECT)
-enum class HankeError(
-    val errorMessage: String
-) {
+enum class HankeError(val errorMessage: String) {
     HAI0001("Access denied"),
     HAI0002("Internal error"),
     HAI0003("Invalid data"),
@@ -44,7 +42,10 @@ enum class HankeError(
     }
 }
 
-class HankeNotFoundException(val hankeTunnus: String) : RuntimeException("Hanke $hankeTunnus not found")
+class HankeNotFoundException(val hankeTunnus: String) :
+    RuntimeException("Hanke $hankeTunnus not found")
+
+class HankeArgumentException(message: String) : RuntimeException(message)
 
 class HankeYhteystietoNotFoundException(val hankeId: Int, ytId: Int) :
     RuntimeException("HankeYhteystiedot $ytId not found for Hanke $hankeId")

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/Persistence.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/Persistence.kt
@@ -55,7 +55,7 @@ enum class ObjectType {
 
 @Entity
 @Table(name = "audit_log")
-class AuditLogEntry(
+data class AuditLogEntry(
     @Id var id: UUID? = UUID.randomUUID(),
     @Column(name = "event_time") var eventTime: OffsetDateTime? = OffsetDateTime.now(),
     @Column(name = "user_id") var userId: String? = null,

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/YhteystietoLoggingEntryHolder.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/YhteystietoLoggingEntryHolder.kt
@@ -114,35 +114,41 @@ class YhteystietoLoggingEntryHolder {
             }
     }
 
-    /**
-     * If request context (attributes) exists, gets the IP from it and applies to all the log
-     * entries currently held in this holder.
-     *
-     * NOTE: very very very simplified implementation. Needs a lot of improvement.
-     */
     fun applyIpAddresses() {
-        val attribs =
-            (RequestContextHolder.getRequestAttributes() as ServletRequestAttributes?) ?: return
-        val request = attribs.request
-        // Very simplified version for now.
-        // For starters, see e.g.
-        // https://stackoverflow.com/questions/22877350/how-to-extract-ip-address-in-spring-mvc-controller-get-call
-        // Combine all the various ideas into one, and note that even then it is not even half-way
-        // to a proper solution. Hopefully one can find a ready-made fully thought out
-        // implementation.
-        var ip: String = request.getHeader("X-FORWARDED-FOR") ?: request.remoteAddr ?: return
-        // Just to make sure it won't break the db if someone put something silly long in the
-        // header:
-        if (ip.length > PERSONAL_DATA_LOGGING_MAX_IP_LENGTH)
-            ip = ip.substring(0, PERSONAL_DATA_LOGGING_MAX_IP_LENGTH)
-
-        auditLogEntries.forEach {
-            it.ipFar = ip
-            it.ipNear = ip
-        }
+        Companion.applyIpAddresses(auditLogEntries)
     }
 
     fun saveLogEntries(auditLogRepository: AuditLogRepository) {
-        auditLogEntries.forEach { auditLogRepository.save(it) }
+        auditLogRepository.saveAll(auditLogEntries)
+    }
+
+    companion object {
+        /**
+         * If request context (attributes) exists, gets the IP from it and applies to all the log
+         * entries currently held in this holder.
+         *
+         * TODO: very very very simplified implementation. Needs a lot of improvement.
+         */
+        fun applyIpAddresses(auditLogEntries: List<AuditLogEntry>) {
+            val attribs =
+                (RequestContextHolder.getRequestAttributes() as ServletRequestAttributes?) ?: return
+            val request = attribs.request
+            // Very simplified version for now.
+            // For starters, see e.g.
+            // https://stackoverflow.com/questions/22877350/how-to-extract-ip-address-in-spring-mvc-controller-get-call
+            // Combine all the various ideas into one, and note that even then it is not even
+            // half-way to a proper solution. Hopefully one can find a ready-made fully thought out
+            // implementation.
+            var ip: String = request.getHeader("X-FORWARDED-FOR") ?: request.remoteAddr ?: return
+            // Just to make sure it won't break the db if someone put something silly long in the
+            // header:
+            if (ip.length > PERSONAL_DATA_LOGGING_MAX_IP_LENGTH)
+                ip = ip.substring(0, PERSONAL_DATA_LOGGING_MAX_IP_LENGTH)
+
+            auditLogEntries.forEach {
+                it.ipFar = ip
+                it.ipNear = ip
+            }
+        }
     }
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/YhteystietoLoggingService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/YhteystietoLoggingService.kt
@@ -1,0 +1,44 @@
+package fi.hel.haitaton.hanke.logging
+
+import fi.hel.haitaton.hanke.domain.Hanke
+import fi.hel.haitaton.hanke.domain.HankeYhteystieto
+import fi.hel.haitaton.hanke.toJsonString
+import java.time.OffsetDateTime
+import org.springframework.stereotype.Service
+
+@Service
+class YhteystietoLoggingService(private val auditLogRepository: AuditLogRepository) {
+
+    fun saveDisclosureLogForUser(hanke: Hanke, userId: String) {
+        saveDisclosureLogs(extractYhteystiedot(hanke), userId)
+    }
+
+    fun saveDisclosureLogsForUser(hankkeet: List<Hanke>, userId: String) {
+        saveDisclosureLogs(hankkeet.flatMap { extractYhteystiedot(it) }, userId)
+    }
+
+    private fun extractYhteystiedot(hanke: Hanke) =
+        hanke.omistajat + hanke.arvioijat + hanke.toteuttajat
+
+    private fun saveDisclosureLogs(yhteystiedot: List<HankeYhteystieto>, userId: String) {
+        if (yhteystiedot.isEmpty()) {
+            return
+        }
+
+        val eventTime = OffsetDateTime.now()
+        val entries =
+            yhteystiedot.toSet().map {
+                AuditLogEntry(
+                    userId = userId,
+                    eventTime = eventTime,
+                    action = Action.READ,
+                    status = Status.SUCCESS,
+                    objectType = ObjectType.YHTEYSTIETO,
+                    objectId = it.id,
+                    objectBefore = it.toJsonString()
+                )
+            }
+        YhteystietoLoggingEntryHolder.applyIpAddresses(entries)
+        auditLogRepository.saveAll(entries)
+    }
+}

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/ExtensionsKtTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/ExtensionsKtTest.kt
@@ -2,15 +2,20 @@ package fi.hel.haitaton.hanke
 
 import assertk.assertThat
 import assertk.assertions.isEqualTo
+import assertk.assertions.isGreaterThan
+import assertk.assertions.isLessThan
 import org.junit.jupiter.api.Test
 
 internal class ExtensionsKtTest {
 
     @Test
     fun floatRoundToOneDecimal() {
-        assertThat(3.1415926f.roundToOneDecimal()).isEqualTo(3.1f)
-        assertThat(3.4999999f.roundToOneDecimal()).isEqualTo(3.5f)
-        assertThat(3.5000001f.roundToOneDecimal()).isEqualTo(3.5f)
+        assertThat(3.141592f.roundToOneDecimal()).isEqualTo(3.1f)
+        // Make sure the rounding actually does something, e.g. 3.4999999f == 3.5f
+        assertThat(3.499999f).isLessThan(3.5f)
+        assertThat(3.500001f).isGreaterThan(3.5f)
+        assertThat(3.499999f.roundToOneDecimal()).isEqualTo(3.5f)
+        assertThat(3.500001f.roundToOneDecimal()).isEqualTo(3.5f)
         assertThat(0.0000009f.roundToOneDecimal()).isEqualTo(0.0f)
         assertThat(0.0499999f.roundToOneDecimal()).isEqualTo(0.0f)
         assertThat(0.19999f.roundToOneDecimal()).isEqualTo(0.2f)

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/HankeControllerTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/HankeControllerTest.kt
@@ -3,12 +3,22 @@ package fi.hel.haitaton.hanke
 import fi.hel.haitaton.hanke.domain.Hanke
 import fi.hel.haitaton.hanke.domain.HankeYhteystieto
 import fi.hel.haitaton.hanke.geometria.HankeGeometriatService
+import fi.hel.haitaton.hanke.logging.YhteystietoLoggingService
 import fi.hel.haitaton.hanke.permissions.Permission
 import fi.hel.haitaton.hanke.permissions.PermissionCode
 import fi.hel.haitaton.hanke.permissions.PermissionProfiles
 import fi.hel.haitaton.hanke.permissions.PermissionService
+import io.mockk.Called
+import io.mockk.clearAllMocks
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.verify
+import java.time.ZonedDateTime
+import java.time.temporal.ChronoUnit
+import javax.validation.ConstraintViolationException
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mockito
@@ -16,14 +26,9 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Import
-import org.springframework.http.HttpStatus
-import org.springframework.http.ResponseEntity
 import org.springframework.security.test.context.support.WithMockUser
 import org.springframework.test.context.junit.jupiter.SpringExtension
 import org.springframework.validation.beanvalidation.MethodValidationPostProcessor
-import java.time.ZonedDateTime
-import java.time.temporal.ChronoUnit
-import javax.validation.ConstraintViolationException
 
 @ExtendWith(SpringExtension::class)
 @Import(HankeControllerTest.TestConfiguration::class)
@@ -33,43 +38,56 @@ class HankeControllerTest {
     @Configuration
     class TestConfiguration {
         // makes validation happen here in unit test as well
-        @Bean
-        fun bean(): MethodValidationPostProcessor = MethodValidationPostProcessor()
+        @Bean fun bean(): MethodValidationPostProcessor = MethodValidationPostProcessor()
+
+        @Bean fun hankeService(): HankeService = Mockito.mock(HankeService::class.java)
 
         @Bean
-        fun hankeService(): HankeService = Mockito.mock(HankeService::class.java)
-
-        @Bean
-        fun hankeGeometriatService(): HankeGeometriatService = Mockito.mock(HankeGeometriatService::class.java)
+        fun hankeGeometriatService(): HankeGeometriatService =
+            Mockito.mock(HankeGeometriatService::class.java)
 
         @Bean
         fun permissionService(): PermissionService = Mockito.mock(PermissionService::class.java)
+
+        @Bean fun yhteystietoLoggingService(): YhteystietoLoggingService = mockk()
 
         @Bean
         fun hankeController(
             hankeService: HankeService,
             hankeGeometriatService: HankeGeometriatService,
-            permissionService: PermissionService
-        ): HankeController = HankeController(hankeService, hankeGeometriatService, permissionService)
+            permissionService: PermissionService,
+            yhteystietoLoggingService: YhteystietoLoggingService,
+        ): HankeController =
+            HankeController(
+                hankeService,
+                hankeGeometriatService,
+                permissionService,
+                yhteystietoLoggingService
+            )
     }
 
     private val mockedHankeTunnus = "AFC1234"
 
-    @Autowired
-    private lateinit var hankeService: HankeService
+    @Autowired private lateinit var hankeService: HankeService
 
-    @Autowired
-    private lateinit var permissionService: PermissionService
+    @Autowired private lateinit var permissionService: PermissionService
 
-    @Autowired
-    private lateinit var hankeController: HankeController
+    @Autowired private lateinit var hankeController: HankeController
+
+    @Autowired private lateinit var yhteystietoLoggingService: YhteystietoLoggingService
+
+    @BeforeEach
+    fun resetMockks() {
+        clearAllMocks()
+    }
 
     @Test
-    fun `test that the getHankebyTunnus returns ok`() {
+    fun `test that the getHankeByTunnus returns ok`() {
         val hankeId = 1234
         val permission = Permission(1, "user", hankeId, listOf(PermissionCode.VIEW))
 
-        Mockito.`when`(permissionService.getPermissionByHankeIdAndUserId(hankeId, "user")).thenReturn(permission)
+        Mockito.`when`(permissionService.getPermissionByHankeIdAndUserId(hankeId, "user"))
+            .thenReturn(permission)
         Mockito.`when`(hankeService.loadHanke(mockedHankeTunnus))
             .thenReturn(
                 Hanke(
@@ -90,71 +108,63 @@ class HankeControllerTest {
                     SaveType.DRAFT
                 )
             )
+        justRun { yhteystietoLoggingService.saveDisclosureLogForUser(any(), "user") }
 
         val response = hankeController.getHankeByTunnus(mockedHankeTunnus)
 
         assertThat(response).isNotNull
-        assertThat(response.nimi).isNotEmpty()
+        assertThat(response.nimi).isNotEmpty
+        verify { yhteystietoLoggingService.saveDisclosureLogForUser(any(), eq("user")) }
     }
 
     @WithMockUser
     @Test
     fun `test when called without parameters then getHankeList returns ok and two items without geometry`() {
-        val permissions = listOf(
-            Permission(
-                1,
-                "user",
-                1234,
-                listOf(
-                    PermissionCode.VIEW
-                )
-            ),
-            Permission(
-                2,
-                "user",
-                50,
-                listOf(
-                    PermissionCode.VIEW, PermissionCode.EDIT
+        val permissions =
+            listOf(
+                Permission(1, "user", 1234, listOf(PermissionCode.VIEW)),
+                Permission(2, "user", 50, listOf(PermissionCode.VIEW, PermissionCode.EDIT))
+            )
+        val listOfHanke =
+            listOf(
+                Hanke(
+                    1234,
+                    mockedHankeTunnus,
+                    true,
+                    "Mannerheimintien remontti remonttinen",
+                    "Lorem ipsum dolor sit amet...",
+                    getDatetimeAlku(),
+                    getDatetimeLoppu(),
+                    Vaihe.OHJELMOINTI,
+                    null,
+                    1,
+                    "Risto",
+                    getCurrentTimeUTC(),
+                    null,
+                    null,
+                    SaveType.DRAFT
+                ),
+                Hanke(
+                    50,
+                    "HAME50",
+                    true,
+                    "Hämeenlinnanväylän uudistus",
+                    "Lorem ipsum dolor sit amet...",
+                    getDatetimeAlku(),
+                    getDatetimeLoppu(),
+                    Vaihe.SUUNNITTELU,
+                    SuunnitteluVaihe.KATUSUUNNITTELU_TAI_ALUEVARAUS,
+                    1,
+                    "Paavo",
+                    getCurrentTimeUTC(),
+                    null,
+                    null,
+                    SaveType.SUBMIT
                 )
             )
-        )
-        val listOfHanke = listOf(
-            Hanke(
-                1234,
-                mockedHankeTunnus,
-                true,
-                "Mannerheimintien remontti remonttinen", "Lorem ipsum dolor sit amet...",
-                getDatetimeAlku(),
-                getDatetimeLoppu(),
-                Vaihe.OHJELMOINTI,
-                null,
-                1,
-                "Risto",
-                getCurrentTimeUTC(),
-                null,
-                null,
-                SaveType.DRAFT
-            ),
-            Hanke(
-                50,
-                "HAME50",
-                true,
-                "Hämeenlinnanväylän uudistus",
-                "Lorem ipsum dolor sit amet...",
-                getDatetimeAlku(),
-                getDatetimeLoppu(),
-                Vaihe.SUUNNITTELU,
-                SuunnitteluVaihe.KATUSUUNNITTELU_TAI_ALUEVARAUS,
-                1,
-                "Paavo",
-                getCurrentTimeUTC(),
-                null,
-                null,
-                SaveType.SUBMIT
-            )
-        )
         Mockito.`when`(permissionService.getPermissionsByUserId("user")).thenReturn(permissions)
-        Mockito.`when`(hankeService.loadHankkeetByIds(listOf(1234,50))).thenReturn(listOfHanke)
+        Mockito.`when`(hankeService.loadHankkeetByIds(listOf(1234, 50))).thenReturn(listOfHanke)
+        justRun { yhteystietoLoggingService.saveDisclosureLogsForUser(any(), "user") }
 
         val hankeList = hankeController.getHankeList(false)
 
@@ -163,109 +173,115 @@ class HankeControllerTest {
         assertThat(hankeList[0].geometriat).isNull()
         assertThat(hankeList[1].geometriat).isNull()
         assertThat(hankeList[0].permissions).isEqualTo(listOf(PermissionCode.VIEW))
-        assertThat(hankeList[1].permissions).isEqualTo(listOf(PermissionCode.VIEW, PermissionCode.EDIT))
+        assertThat(hankeList[1].permissions)
+            .isEqualTo(listOf(PermissionCode.VIEW, PermissionCode.EDIT))
+        verify { yhteystietoLoggingService.saveDisclosureLogsForUser(any(), eq("user")) }
     }
 
     @Test
     fun `test that the updateHanke can be called with hanke data and response will be 200`() {
-        val partialHanke = Hanke(
-            id = 123,
-            hankeTunnus = "id123",
-            nimi = "hankkeen nimi",
-            kuvaus = "lorem ipsum dolor sit amet...",
-            onYKTHanke = false,
-            alkuPvm = getDatetimeAlku(),
-            loppuPvm = getDatetimeLoppu(),
-            vaihe = Vaihe.SUUNNITTELU,
-            suunnitteluVaihe = SuunnitteluVaihe.KATUSUUNNITTELU_TAI_ALUEVARAUS,
-            version = 1,
-            createdBy = "Tiina",
-            createdAt = getCurrentTimeUTC(),
-            modifiedBy = null,
-            modifiedAt = null,
-            saveType = SaveType.DRAFT
-        )
+        val partialHanke =
+            Hanke(
+                id = 123,
+                hankeTunnus = "id123",
+                nimi = "hankkeen nimi",
+                kuvaus = "lorem ipsum dolor sit amet...",
+                onYKTHanke = false,
+                alkuPvm = getDatetimeAlku(),
+                loppuPvm = getDatetimeLoppu(),
+                vaihe = Vaihe.SUUNNITTELU,
+                suunnitteluVaihe = SuunnitteluVaihe.KATUSUUNNITTELU_TAI_ALUEVARAUS,
+                version = 1,
+                createdBy = "Tiina",
+                createdAt = getCurrentTimeUTC(),
+                modifiedBy = null,
+                modifiedAt = null,
+                saveType = SaveType.DRAFT
+            )
 
         // mock HankeService response
-        Mockito.`when`(hankeService.updateHanke(partialHanke)).thenReturn(partialHanke)
+        Mockito.`when`(hankeService.updateHanke(partialHanke))
+            .thenReturn(partialHanke.copy(modifiedBy = "user", modifiedAt = getCurrentTimeUTC()))
+        justRun { yhteystietoLoggingService.saveDisclosureLogForUser(any(), "user") }
 
         // Actual call
-        val response: ResponseEntity<Any> = hankeController.updateHanke(partialHanke, "id123")
+        val response: Hanke = hankeController.updateHanke(partialHanke, "id123")
 
-        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
-        assertThat(response.body).isNotNull
-        // If the status is ok, we expect ResponseEntity<Hanke>
-        @Suppress("UNCHECKED_CAST")
-        val responseHanke = response as ResponseEntity<Hanke>
-        assertThat(responseHanke.body).isNotNull
-        assertThat(responseHanke.body?.nimi).isEqualTo("hankkeen nimi")
+        assertThat(response).isNotNull
+        assertThat(response.nimi).isEqualTo("hankkeen nimi")
+        verify { yhteystietoLoggingService.saveDisclosureLogForUser(any(), eq("user")) }
     }
 
     @Test
     fun `test that the updateHanke will give validation errors from invalid hanke data for name`() {
-        val partialHanke = Hanke(
-            id = 0,
-            hankeTunnus = "id123",
-            nimi = "",
-            kuvaus = "",
-            onYKTHanke = false,
-            alkuPvm = null,
-            loppuPvm = null,
-            vaihe = Vaihe.OHJELMOINTI,
-            suunnitteluVaihe = null,
-            version = 1,
-            createdBy = "",
-            createdAt = null,
-            modifiedBy = null,
-            modifiedAt = null,
-            saveType = SaveType.DRAFT
-        )
+        val partialHanke =
+            Hanke(
+                id = 0,
+                hankeTunnus = "id123",
+                nimi = "",
+                kuvaus = "",
+                onYKTHanke = false,
+                alkuPvm = null,
+                loppuPvm = null,
+                vaihe = Vaihe.OHJELMOINTI,
+                suunnitteluVaihe = null,
+                version = 1,
+                createdBy = "",
+                createdAt = null,
+                modifiedBy = null,
+                modifiedAt = null,
+                saveType = SaveType.DRAFT
+            )
         // mock HankeService response
         Mockito.`when`(hankeService.updateHanke(partialHanke)).thenReturn(partialHanke)
 
         // Actual call
-        assertThatExceptionOfType(ConstraintViolationException::class.java).isThrownBy {
-            hankeController.updateHanke(partialHanke, "id123")
-        }.withMessageContaining("updateHanke.hanke.nimi: " + HankeError.HAI1002.toString())
+        assertThatExceptionOfType(ConstraintViolationException::class.java)
+            .isThrownBy { hankeController.updateHanke(partialHanke, "id123") }
+            .withMessageContaining("updateHanke.hanke.nimi: " + HankeError.HAI1002.toString())
+
+        verify { yhteystietoLoggingService wasNot Called }
     }
 
     // sending of sub types
     @Test
     fun `test that create with listOfOmistaja can be sent to controller and is responded with 200`() {
-        val hanke = Hanke(
-            id = null,
-            hankeTunnus = null,
-            nimi = "hankkeen nimi",
-            kuvaus = "lorem ipsum dolor sit amet...",
-            onYKTHanke = false,
-            alkuPvm = getDatetimeAlku(),
-            loppuPvm = getDatetimeLoppu(),
-            vaihe = Vaihe.OHJELMOINTI,
-            suunnitteluVaihe = null,
-            version = 1,
-            createdBy = "Tiina",
-            createdAt = getCurrentTimeUTC(),
-            modifiedBy = null,
-            modifiedAt = null,
-            saveType = SaveType.DRAFT
-        )
-
-        hanke.omistajat = arrayListOf(
-            HankeYhteystieto(
-                null,
-                "Pekkanen",
-                "Pekka",
-                "pekka@pekka.fi",
-                "3212312",
-                null,
-                "Kaivuri ja mies",
-                null,
-                null,
-                null,
-                null,
-                null
+        val hanke =
+            Hanke(
+                id = null,
+                hankeTunnus = null,
+                nimi = "hankkeen nimi",
+                kuvaus = "lorem ipsum dolor sit amet...",
+                onYKTHanke = false,
+                alkuPvm = getDatetimeAlku(),
+                loppuPvm = getDatetimeLoppu(),
+                vaihe = Vaihe.OHJELMOINTI,
+                suunnitteluVaihe = null,
+                version = 1,
+                createdBy = "Tiina",
+                createdAt = getCurrentTimeUTC(),
+                modifiedBy = null,
+                modifiedAt = null,
+                saveType = SaveType.DRAFT
             )
-        )
+
+        hanke.omistajat =
+            arrayListOf(
+                HankeYhteystieto(
+                    null,
+                    "Pekkanen",
+                    "Pekka",
+                    "pekka@pekka.fi",
+                    "3212312",
+                    null,
+                    "Kaivuri ja mies",
+                    null,
+                    null,
+                    null,
+                    null,
+                    null
+                )
+            )
 
         val mockedHanke = hanke.copy()
         mockedHanke.omistajat = mutableListOf(hanke.omistajat[0])
@@ -275,97 +291,97 @@ class HankeControllerTest {
 
         // mock HankeService response
         Mockito.`when`(hankeService.createHanke(hanke)).thenReturn(mockedHanke)
+        justRun { yhteystietoLoggingService.saveDisclosureLogForUser(any(), "Tiina") }
 
         // Actual call
-        val response: ResponseEntity<Any> = hankeController.createHanke(hanke)
+        val response: Hanke = hankeController.createHanke(hanke)
 
-        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
-        assertThat(response.body).isNotNull
-        // If the status is ok, we expect ResponseEntity<Hanke>
-        @Suppress("UNCHECKED_CAST")
-        val responseHanke = response as ResponseEntity<Hanke>
-        assertThat(responseHanke.body).isNotNull
-        assertThat(responseHanke.body?.id).isEqualTo(12)
-        assertThat(responseHanke.body?.hankeTunnus).isEqualTo("JOKU12")
-        assertThat(responseHanke.body?.nimi).isEqualTo("hankkeen nimi")
-        assertThat(responseHanke.body?.omistajat).isNotNull
-        assertThat(responseHanke.body?.omistajat).hasSize(1)
-        assertThat(responseHanke.body?.omistajat!![0].id).isEqualTo(1)
-        assertThat(responseHanke.body?.omistajat!![0].sukunimi).isEqualTo("Pekkanen")
+        assertThat(response).isNotNull
+        assertThat(response.id).isEqualTo(12)
+        assertThat(response.hankeTunnus).isEqualTo("JOKU12")
+        assertThat(response.nimi).isEqualTo("hankkeen nimi")
+        assertThat(response.omistajat).isNotNull
+        assertThat(response.omistajat).hasSize(1)
+        assertThat(response.omistajat[0].id).isEqualTo(1)
+        assertThat(response.omistajat[0].sukunimi).isEqualTo("Pekkanen")
+        verify { yhteystietoLoggingService.saveDisclosureLogForUser(any(), eq("Tiina")) }
     }
 
     @Test
     fun `test that the updateHanke will give validation errors from null enum values`() {
-        val partialHanke = Hanke(
-            id = 0,
-            hankeTunnus = "id123",
-            nimi = "",
-            kuvaus = "",
-            onYKTHanke = false,
-            alkuPvm = null,
-            loppuPvm = null,
-            vaihe = null,
-            suunnitteluVaihe = null,
-            version = 1,
-            createdBy = "",
-            createdAt = null,
-            modifiedBy = null,
-            modifiedAt = null,
-            saveType = null
-        )
+        val partialHanke =
+            Hanke(
+                id = 0,
+                hankeTunnus = "id123",
+                nimi = "",
+                kuvaus = "",
+                onYKTHanke = false,
+                alkuPvm = null,
+                loppuPvm = null,
+                vaihe = null,
+                suunnitteluVaihe = null,
+                version = 1,
+                createdBy = "",
+                createdAt = null,
+                modifiedBy = null,
+                modifiedAt = null,
+                saveType = null
+            )
         // mock HankeService response
         Mockito.`when`(hankeService.updateHanke(partialHanke)).thenReturn(partialHanke)
 
         // Actual call
-        assertThatExceptionOfType(ConstraintViolationException::class.java).isThrownBy {
-            hankeController.updateHanke(partialHanke, "id123")
-        }.withMessageContaining("updateHanke.hanke.vaihe: " + HankeError.HAI1002.toString())
+        assertThatExceptionOfType(ConstraintViolationException::class.java)
+            .isThrownBy { hankeController.updateHanke(partialHanke, "id123") }
+            .withMessageContaining("updateHanke.hanke.vaihe: " + HankeError.HAI1002.toString())
             .withMessageContaining("updateHanke.hanke.saveType: " + HankeError.HAI1002.toString())
+
+        verify { yhteystietoLoggingService wasNot Called }
     }
 
     @Test
     fun `test that creating a Hanke also adds owner permissions for creating user`() {
-        val hanke = Hanke(
-            id = null,
-            hankeTunnus = null,
-            nimi = "hankkeen nimi",
-            kuvaus = "lorem ipsum dolor sit amet...",
-            onYKTHanke = false,
-            alkuPvm = getDatetimeAlku(),
-            loppuPvm = getDatetimeLoppu(),
-            vaihe = Vaihe.OHJELMOINTI,
-            suunnitteluVaihe = null,
-            version = 1,
-            createdBy = "Tiina",
-            createdAt = getCurrentTimeUTC(),
-            modifiedBy = null,
-            modifiedAt = null,
-            saveType = SaveType.DRAFT
-        )
+        val hanke =
+            Hanke(
+                id = null,
+                hankeTunnus = null,
+                nimi = "hankkeen nimi",
+                kuvaus = "lorem ipsum dolor sit amet...",
+                onYKTHanke = false,
+                alkuPvm = getDatetimeAlku(),
+                loppuPvm = getDatetimeLoppu(),
+                vaihe = Vaihe.OHJELMOINTI,
+                suunnitteluVaihe = null,
+                version = 1,
+                createdBy = "Tiina",
+                createdAt = getCurrentTimeUTC(),
+                modifiedBy = null,
+                modifiedAt = null,
+                saveType = SaveType.DRAFT
+            )
 
         val mockedHanke = hanke.copy()
         mockedHanke.id = 12
         mockedHanke.hankeTunnus = "JOKU12"
 
         Mockito.`when`(hankeService.createHanke(hanke)).thenReturn(mockedHanke)
+        justRun { yhteystietoLoggingService.saveDisclosureLogForUser(any(), "Tiina") }
 
-        val response: ResponseEntity<Any> = hankeController.createHanke(hanke)
+        val response: Hanke = hankeController.createHanke(hanke)
 
-        Mockito.verify(permissionService).setPermission(12, hanke.createdBy!!, PermissionProfiles.HANKE_OWNER_PERMISSIONS)
-
-        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
-        assertThat(response.body).isNotNull
+        assertThat(response).isNotNull
+        Mockito.verify(permissionService)
+            .setPermission(12, hanke.createdBy!!, PermissionProfiles.HANKE_OWNER_PERMISSIONS)
+        verify { yhteystietoLoggingService.saveDisclosureLogForUser(any(), eq("Tiina")) }
     }
 
     private fun getDatetimeAlku(): ZonedDateTime {
         val year = getCurrentTimeUTC().year + 1
-        return ZonedDateTime.of(year, 2, 20, 23, 45, 56, 0, TZ_UTC)
-            .truncatedTo(ChronoUnit.MILLIS)
+        return ZonedDateTime.of(year, 2, 20, 23, 45, 56, 0, TZ_UTC).truncatedTo(ChronoUnit.MILLIS)
     }
 
     private fun getDatetimeLoppu(): ZonedDateTime {
         val year = getCurrentTimeUTC().year + 1
-        return ZonedDateTime.of(year, 2, 21, 0, 12, 34, 0, TZ_UTC)
-            .truncatedTo(ChronoUnit.MILLIS)
+        return ZonedDateTime.of(year, 2, 21, 0, 12, 34, 0, TZ_UTC).truncatedTo(ChronoUnit.MILLIS)
     }
 }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/AuditLogEntryFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/AuditLogEntryFactory.kt
@@ -1,0 +1,37 @@
+package fi.hel.haitaton.hanke.factory
+
+import fi.hel.haitaton.hanke.domain.Hanke
+import fi.hel.haitaton.hanke.logging.Action
+import fi.hel.haitaton.hanke.logging.AuditLogEntry
+import fi.hel.haitaton.hanke.logging.ObjectType
+import fi.hel.haitaton.hanke.logging.Status
+import fi.hel.haitaton.hanke.toJsonString
+
+object AuditLogEntryFactory : Factory<AuditLogEntry>() {
+
+    fun createReadEntry(
+        userId: String? = "test",
+        action: Action = Action.READ,
+        status: Status = Status.SUCCESS,
+        objectType: ObjectType = ObjectType.YHTEYSTIETO,
+        objectId: Int? = 1,
+        objectBefore: String? = null,
+        ipNear: String? = null,
+        ipFar: String? = null,
+    ) =
+        AuditLogEntry(
+            userId = userId,
+            action = action,
+            status = status,
+            objectType = objectType,
+            objectId = objectId,
+            objectBefore = objectBefore,
+            ipNear = ipNear,
+            ipFar = ipFar,
+        )
+
+    fun createReadEntriesForHanke(hanke: Hanke): List<AuditLogEntry> =
+        (hanke.omistajat + hanke.arvioijat + hanke.toteuttajat).map {
+            createReadEntry(objectId = it.id, objectBefore = it.toJsonString())
+        }
+}

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeFactory.kt
@@ -127,8 +127,11 @@ object HankeFactory : Factory<Hanke>() {
      * HankeFactory.create().withGeneratedOmistajat(listOf(1,2))
      * ```
      */
-    fun Hanke.withGeneratedOmistajat(ids: List<Int>): Hanke {
-        omistajat.addAll(HankeYhteystietoFactory.createDifferentiated(ids))
+    fun Hanke.withGeneratedOmistajat(
+        ids: List<Int>,
+        mutator: (HankeYhteystieto) -> Unit = {}
+    ): Hanke {
+        omistajat.addAll(HankeYhteystietoFactory.createDifferentiated(ids, mutator))
         return this
     }
 
@@ -140,7 +143,10 @@ object HankeFactory : Factory<Hanke>() {
      * HankeFactory.create().withGeneratedOmistajat(1,2)
      * ```
      */
-    fun Hanke.withGeneratedOmistajat(vararg ids: Int): Hanke = withGeneratedOmistajat(ids.toList())
+    fun Hanke.withGeneratedOmistajat(
+        vararg ids: Int,
+        mutator: (HankeYhteystieto) -> Unit = {}
+    ): Hanke = withGeneratedOmistajat(ids.toList(), mutator)
 
     /**
      * Same as [Hanke.withGeneratedOmistajat] but adds a single omistaja.
@@ -150,7 +156,8 @@ object HankeFactory : Factory<Hanke>() {
      * HankeFactory.create().withGeneratedOmistaja(1)
      * ```
      */
-    fun Hanke.withGeneratedOmistaja(id: Int): Hanke = withGeneratedOmistajat(id)
+    fun Hanke.withGeneratedOmistaja(id: Int, mutator: (HankeYhteystieto) -> Unit = {}): Hanke =
+        withGeneratedOmistajat(listOf(id), mutator)
 
     /**
      * Add a number of arvioija to a hanke. Generates the yhteystiedot with
@@ -162,8 +169,11 @@ object HankeFactory : Factory<Hanke>() {
      * HankeFactory.create().withGeneratedArvioijat(listOf(1,2))
      * ```
      */
-    fun Hanke.withGeneratedArvioijat(ids: List<Int>): Hanke {
-        arvioijat.addAll(HankeYhteystietoFactory.createDifferentiated(ids))
+    fun Hanke.withGeneratedArvioijat(
+        ids: List<Int>,
+        mutator: (HankeYhteystieto) -> Unit = {}
+    ): Hanke {
+        arvioijat.addAll(HankeYhteystietoFactory.createDifferentiated(ids, mutator))
         return this
     }
 
@@ -175,7 +185,10 @@ object HankeFactory : Factory<Hanke>() {
      * HankeFactory.create().withGeneratedArvioijat(1,2)
      * ```
      */
-    fun Hanke.withGeneratedArvioijat(vararg ids: Int): Hanke = withGeneratedArvioijat(ids.toList())
+    fun Hanke.withGeneratedArvioijat(
+        vararg ids: Int,
+        mutator: (HankeYhteystieto) -> Unit = {}
+    ): Hanke = withGeneratedArvioijat(ids.toList(), mutator)
 
     /**
      * Same as [Hanke.withGeneratedArvioijat] but adds a single arvioija.
@@ -185,7 +198,8 @@ object HankeFactory : Factory<Hanke>() {
      * HankeFactory.create().withGeneratedArvioija(1)
      * ```
      */
-    fun Hanke.withGeneratedArvioija(id: Int): Hanke = withGeneratedArvioijat(id)
+    fun Hanke.withGeneratedArvioija(id: Int, mutator: (HankeYhteystieto) -> Unit = {}): Hanke =
+        withGeneratedArvioijat(listOf(id), mutator)
 
     /**
      * Add a number of toteuttaja to a hanke. Generates the yhteystiedot with
@@ -197,8 +211,11 @@ object HankeFactory : Factory<Hanke>() {
      * HankeFactory.create().withGeneratedToteuttajat(listOf(1,2))
      * ```
      */
-    fun Hanke.withGeneratedToteuttajat(ids: List<Int>): Hanke {
-        toteuttajat.addAll(HankeYhteystietoFactory.createDifferentiated(ids))
+    fun Hanke.withGeneratedToteuttajat(
+        ids: List<Int>,
+        mutator: (HankeYhteystieto) -> Unit = {}
+    ): Hanke {
+        toteuttajat.addAll(HankeYhteystietoFactory.createDifferentiated(ids, mutator))
         return this
     }
 
@@ -210,8 +227,10 @@ object HankeFactory : Factory<Hanke>() {
      * HankeFactory.create().withGeneratedToteuttajat(1,2)
      * ```
      */
-    fun Hanke.withGeneratedToteuttajat(vararg ids: Int): Hanke =
-        withGeneratedToteuttajat(ids.toList())
+    fun Hanke.withGeneratedToteuttajat(
+        vararg ids: Int,
+        mutator: (HankeYhteystieto) -> Unit = {}
+    ): Hanke = withGeneratedToteuttajat(ids.toList(), mutator)
 
     /**
      * Same as [Hanke.withGeneratedToteuttajat] but adds a single toteuttaja.
@@ -221,5 +240,6 @@ object HankeFactory : Factory<Hanke>() {
      * HankeFactory.create().withGeneratedToteuttaja(1)
      * ```
      */
-    fun Hanke.withGeneratedToteuttaja(id: Int): Hanke = withGeneratedToteuttajat(id)
+    fun Hanke.withGeneratedToteuttaja(id: Int, mutator: (HankeYhteystieto) -> Unit = {}): Hanke =
+        withGeneratedToteuttajat(listOf(id), mutator)
 }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeYhteystietoFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeYhteystietoFactory.kt
@@ -29,7 +29,7 @@ object HankeYhteystietoFactory : Factory<HankeYhteystieto>() {
      */
     fun createDifferentiated(intValue: Int): HankeYhteystieto {
         return HankeYhteystieto(
-            id = null,
+            id = intValue,
             sukunimi = "suku$intValue",
             etunimi = "etu$intValue",
             email = "email$intValue",

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/logging/YhteystietoLoggingServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/logging/YhteystietoLoggingServiceTest.kt
@@ -1,0 +1,153 @@
+package fi.hel.haitaton.hanke.logging
+
+import fi.hel.haitaton.hanke.factory.AuditLogEntryFactory
+import fi.hel.haitaton.hanke.factory.HankeFactory
+import fi.hel.haitaton.hanke.factory.HankeFactory.mutate
+import fi.hel.haitaton.hanke.factory.HankeFactory.withGeneratedArvioija
+import fi.hel.haitaton.hanke.factory.HankeFactory.withGeneratedOmistaja
+import fi.hel.haitaton.hanke.factory.HankeFactory.withGeneratedToteuttaja
+import fi.hel.haitaton.hanke.factory.HankeFactory.withYhteystiedot
+import fi.hel.haitaton.hanke.factory.HankeYhteystietoFactory
+import fi.hel.haitaton.hanke.toJsonString
+import io.mockk.Called
+import io.mockk.clearAllMocks
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class YhteystietoLoggingServiceTest {
+
+    private val userId = "test"
+
+    private val auditLogRepository: AuditLogRepository = mockk()
+    private val yhteystietoLoggingService = YhteystietoLoggingService(auditLogRepository)
+
+    @BeforeEach
+    fun clearMockks() {
+        clearAllMocks()
+    }
+
+    @AfterEach
+    fun checkStubs() {
+        // TODO: Needs newer MockK, which needs newer Spring test dependencies
+        // checkUnnecessaryStub()
+        confirmVerified()
+    }
+
+    @Test
+    fun `saveDisclosureLogForUser with hanke with no yhteystiedot doesn't do anything`() {
+        val hanke = HankeFactory.create()
+
+        yhteystietoLoggingService.saveDisclosureLogForUser(hanke, userId)
+
+        verify { auditLogRepository wasNot Called }
+    }
+
+    @Test
+    fun `saveDisclosureLogForUser saves audit logs for all yhteystiedot`() {
+        val hanke = HankeFactory.create().withYhteystiedot()
+        val expectedLogs = AuditLogEntryFactory.createReadEntriesForHanke(hanke)
+        every {
+            auditLogRepository.saveAll(match(containsAllWithoutGeneratedFields(expectedLogs)))
+        } returns expectedLogs
+
+        yhteystietoLoggingService.saveDisclosureLogForUser(hanke, userId)
+
+        verify {
+            auditLogRepository.saveAll(match(containsAllWithoutGeneratedFields(expectedLogs)))
+        }
+    }
+
+    @Test
+    fun `saveDisclosureLogForUser saves identical audit logs only once`() {
+        val yhteystieto = HankeYhteystietoFactory.createDifferentiated(1)
+        val hanke =
+            HankeFactory.create().mutate {
+                it.omistajat = mutableListOf(yhteystieto)
+                it.arvioijat = mutableListOf(yhteystieto)
+                it.toteuttajat = mutableListOf(yhteystieto)
+            }
+        val expectedLogs =
+            listOf(AuditLogEntryFactory.createReadEntry(objectBefore = yhteystieto.toJsonString()))
+        every {
+            auditLogRepository.saveAll(match(containsAllWithoutGeneratedFields(expectedLogs)))
+        } returns expectedLogs
+
+        yhteystietoLoggingService.saveDisclosureLogForUser(hanke, userId)
+
+        verify {
+            auditLogRepository.saveAll(match(containsAllWithoutGeneratedFields(expectedLogs)))
+        }
+    }
+
+    @Test
+    fun `saveDisclosureLogsForUser without hankkeet does nothing`() {
+        yhteystietoLoggingService.saveDisclosureLogsForUser(listOf(), userId)
+
+        verify { auditLogRepository wasNot Called }
+    }
+
+    @Test
+    fun `saveDisclosureLogsForUser with hankkeet without yhteystiedot does nothing`() {
+        val hankkeet = listOf(HankeFactory.create(), HankeFactory.create())
+
+        yhteystietoLoggingService.saveDisclosureLogsForUser(hankkeet, userId)
+
+        verify { auditLogRepository wasNot Called }
+    }
+
+    @Test
+    fun `saveDisclosureLogsForUser saves audit logs for all yhteystiedot in all hankkeet`() {
+        val hankkeet =
+            listOf(
+                HankeFactory.create().withYhteystiedot(),
+                HankeFactory.create()
+                    .withGeneratedOmistaja(4)
+                    .withGeneratedArvioija(5)
+                    .withGeneratedToteuttaja(6)
+            )
+        val expectedLogs = hankkeet.flatMap { AuditLogEntryFactory.createReadEntriesForHanke(it) }
+        every {
+            auditLogRepository.saveAll(match(containsAllWithoutGeneratedFields(expectedLogs)))
+        } returns expectedLogs
+
+        yhteystietoLoggingService.saveDisclosureLogsForUser(hankkeet, userId)
+
+        verify {
+            auditLogRepository.saveAll(match(containsAllWithoutGeneratedFields(expectedLogs)))
+        }
+    }
+
+    @Test
+    fun `saveDisclosureLogsForUser saves identical audit logs only once`() {
+        val hankkeet =
+            listOf(
+                HankeFactory.create().withYhteystiedot(),
+                HankeFactory.create().withYhteystiedot()
+            )
+        val expectedLogs = AuditLogEntryFactory.createReadEntriesForHanke(hankkeet[0])
+        every {
+            auditLogRepository.saveAll(match(containsAllWithoutGeneratedFields(expectedLogs)))
+        } returns expectedLogs
+
+        yhteystietoLoggingService.saveDisclosureLogsForUser(hankkeet, userId)
+
+        verify {
+            auditLogRepository.saveAll(match(containsAllWithoutGeneratedFields(expectedLogs)))
+        }
+    }
+
+    private fun containsAllWithoutGeneratedFields(
+        expectedLogs: List<AuditLogEntry>
+    ): (List<AuditLogEntry>) -> Boolean = { entries ->
+        withoutGeneratedFields(entries) == withoutGeneratedFields(expectedLogs)
+    }
+
+    private fun withoutGeneratedFields(entries: List<AuditLogEntry>): List<AuditLogEntry> {
+        return entries.map { it.copy(eventTime = null, id = null) }
+    }
+}


### PR DESCRIPTION
# Description

Add entries to audit logs whenever users read contacts from hankket. This is done, because we need to know who has accessed personal information and what that information was.

### Jira Issue:  https://helsinkisolutionoffice.atlassian.net/browse/HAI-1076

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [X] Other

# Instructions for testing
Check that READ type audit logs are added to DB whenever yhteystiedot are returned to the user. Ie. when hankkeet are read, listed, updated or created (if they have yhteystiedot).

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [X] I have made necessary changes to the documentation, link to confluence
 or other location: Already documented in https://helsinkisolutionoffice.atlassian.net/wiki/spaces/HAI/pages/7990181897/Lokituksista