### PR TITLE
HAI-1076 Create audit logs when application data is sent to Allu

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/logging/PersonalDataLogRepositoryITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/logging/PersonalDataLogRepositoryITests.kt
@@ -73,10 +73,11 @@ constructor(
         val auditLogEntry =
             AuditLogEntry(
                 userId = "1234-1234",
+                userRole = UserRole.USER,
                 action = Action.CREATE,
                 status = Status.SUCCESS,
                 objectType = ObjectType.YHTEYSTIETO,
-                objectId = 333,
+                objectId = "333",
                 objectAfter = "fake JSON"
             )
         val savedAuditLogEntry = auditLogRepository.save(auditLogEntry)
@@ -91,10 +92,11 @@ constructor(
         assertThat(foundAuditLogEntry).isNotNull()
         assertThat(foundAuditLogEntry.eventTime).isRecent(Duration.ofMinutes(1))
         assertThat(foundAuditLogEntry.userId).isEqualTo("1234-1234")
+        assertThat(foundAuditLogEntry.userRole).isEqualTo(UserRole.USER)
         assertThat(foundAuditLogEntry.action).isEqualTo(Action.CREATE)
         assertThat(foundAuditLogEntry.status).isEqualTo(Status.SUCCESS)
         assertThat(foundAuditLogEntry.objectType).isEqualTo(ObjectType.YHTEYSTIETO)
-        assertThat(foundAuditLogEntry.objectId).isEqualTo(333)
+        assertThat(foundAuditLogEntry.objectId).isEqualTo("333")
         assertThat(foundAuditLogEntry.objectAfter).isEqualTo("fake JSON")
     }
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Configuration.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Configuration.kt
@@ -9,6 +9,7 @@ import fi.hel.haitaton.hanke.geometria.HankeGeometriatDaoImpl
 import fi.hel.haitaton.hanke.geometria.HankeGeometriatService
 import fi.hel.haitaton.hanke.geometria.HankeGeometriatServiceImpl
 import fi.hel.haitaton.hanke.logging.AuditLogRepository
+import fi.hel.haitaton.hanke.logging.DisclosureLogService
 import fi.hel.haitaton.hanke.organisaatio.OrganisaatioRepository
 import fi.hel.haitaton.hanke.organisaatio.OrganisaatioService
 import fi.hel.haitaton.hanke.permissions.PermissionService
@@ -58,8 +59,10 @@ class Configuration {
     @Bean
     fun applicationService(
         applicationRepository: ApplicationRepository,
-        cableReportServiceAllu: CableReportServiceAllu
-    ): ApplicationService = ApplicationService(applicationRepository, cableReportServiceAllu)
+        cableReportServiceAllu: CableReportServiceAllu,
+        disclosureLogService: DisclosureLogService,
+    ): ApplicationService =
+        ApplicationService(applicationRepository, cableReportServiceAllu, disclosureLogService)
 
     @Bean
     fun hanketunnusService(idCounterRepository: IdCounterRepository): HanketunnusService =

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/ApplicationService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/ApplicationService.kt
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.module.kotlin.treeToValue
 import fi.hel.haitaton.hanke.OBJECT_MAPPER
 import fi.hel.haitaton.hanke.currentUserId
-import fi.hel.haitaton.hanke.logging.ALLU_AUDIT_LOG_USERID
 import fi.hel.haitaton.hanke.logging.DisclosureLogService
 import fi.hel.haitaton.hanke.logging.Status
 import org.springframework.data.jpa.repository.JpaRepository
@@ -131,19 +130,11 @@ class ApplicationService(
             // There was an exception outside logging, so there was at least an attempt to send the
             // application to Allu. Allu might have read it and rejected it, so we should log this
             // as a disclosure event.
-            disclosureLogService.saveDisclosureLogsForCableReportApplication(
-                application = cableReportApplication,
-                userId = ALLU_AUDIT_LOG_USERID,
-                status = Status.FAILED
-            )
+            disclosureLogService.saveDisclosureLogsForAllu(cableReportApplication, Status.FAILED)
             throw e
         }
         // There were no exceptions, so log this as a successful disclosure.
-        disclosureLogService.saveDisclosureLogsForCableReportApplication(
-            application = cableReportApplication,
-            userId = ALLU_AUDIT_LOG_USERID,
-            status = Status.SUCCESS
-        )
+        disclosureLogService.saveDisclosureLogsForAllu(cableReportApplication, Status.SUCCESS)
     }
 }
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/CableReportApplication.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/CableReportApplication.kt
@@ -1,39 +1,39 @@
 package fi.hel.haitaton.hanke.allu
 
-import org.geojson.GeometryCollection
 import java.time.ZonedDateTime
+import org.geojson.GeometryCollection
 
-class CableReportApplication(
-        // Common, required
-        val name: String,
-        val customerWithContacts: CustomerWithContacts,
-        val geometry: GeometryCollection,
-        val startTime: ZonedDateTime,
-        val endTime: ZonedDateTime,
-        var pendingOnClient: Boolean,
-        val identificationNumber: String,
+data class CableReportApplication(
+    // Common, required
+    val name: String,
+    val customerWithContacts: CustomerWithContacts,
+    val geometry: GeometryCollection,
+    val startTime: ZonedDateTime,
+    val endTime: ZonedDateTime,
+    var pendingOnClient: Boolean,
+    val identificationNumber: String,
 
-        // CableReport specific, required
-        val clientApplicationKind: String,
-        val workDescription: String,
-        val contractorWithContacts: CustomerWithContacts, // työn suorittaja
-) {
+    // CableReport specific, required
+    val clientApplicationKind: String,
+    val workDescription: String,
+    val contractorWithContacts: CustomerWithContacts, // työn suorittaja
+
     // Common, not required
-    var postalAddress: PostalAddress? = null
-    var representativeWithContacts: CustomerWithContacts? = null
-    var invoicingCustomer: Customer? = null
-    var customerReference: String? = null
-    var area: Double? = null
+    var postalAddress: PostalAddress? = null,
+    var representativeWithContacts: CustomerWithContacts? = null,
+    var invoicingCustomer: Customer? = null,
+    var customerReference: String? = null,
+    var area: Double? = null,
 
     // CableReport specific, not required
-    var propertyDeveloperWithContacts: CustomerWithContacts? = null // rakennuttaja
-    var constructionWork: Boolean = false
-    var maintenanceWork: Boolean = false
-    var emergencyWork: Boolean = false
-    var propertyConnectivity: Boolean = false // tontti-/kiinteistöliitos
-}
+    var propertyDeveloperWithContacts: CustomerWithContacts? = null, // rakennuttaja
+    var constructionWork: Boolean = false,
+    var maintenanceWork: Boolean = false,
+    var emergencyWork: Boolean = false,
+    var propertyConnectivity: Boolean = false, // tontti-/kiinteistöliitos
+)
 
 data class CableReportInformationRequestResponse(
-        val applicationData: CableReportApplication,
-        val updatedFields: List<InformationRequestFieldKey>
+    val applicationData: CableReportApplication,
+    val updatedFields: List<InformationRequestFieldKey>
 )

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/CableReportServiceAllu.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/CableReportServiceAllu.kt
@@ -1,92 +1,101 @@
 package fi.hel.haitaton.hanke.allu
 
+import java.time.ZonedDateTime
 import org.springframework.core.io.ByteArrayResource
 import org.springframework.http.MediaType
 import org.springframework.http.client.MultipartBodyBuilder
 import org.springframework.web.reactive.function.BodyInserters
 import org.springframework.web.reactive.function.client.*
 import reactor.core.publisher.Mono
-import java.time.ZonedDateTime
 
 class CableReportServiceAllu(
-        private val webClient: WebClient,
-        private val properties: AlluProperties
+    private val webClient: WebClient,
+    private val properties: AlluProperties
 ) : CableReportService {
 
     private val baseUrl = properties.baseUrl
 
     private fun login(): String? {
-        return webClient.post()
-                .uri(baseUrl + "/v2/login")
+        try {
+            return webClient
+                .post()
+                .uri("$baseUrl/v2/login")
                 .contentType(MediaType.APPLICATION_JSON)
                 .accept(MediaType.TEXT_PLAIN)
                 .body(Mono.just(LoginInfo(properties.username, properties.password)))
                 .retrieve()
                 .bodyToMono(String::class.java)
                 .block()
+        } catch (e: Throwable) {
+            throw AlluLoginException(e)
+        }
     }
 
     override fun getCurrentStatus(applicationId: Int): ApplicationStatus? {
         return getApplicationStatusHistory(applicationId, null)
-                .block()
-                ?.events
-                ?.maxWithOrNull( compareByDescending { it.eventTime })
-                ?.newStatus
+            .block()
+            ?.events
+            ?.maxWithOrNull(compareByDescending { it.eventTime })
+            ?.newStatus
     }
 
     override fun getApplicationStatusEvents(
-            applicationId: Int,
-            eventsAfter: ZonedDateTime?
+        applicationId: Int,
+        eventsAfter: ZonedDateTime?
     ): List<ApplicationStatusEvent> {
-        return getApplicationStatusHistory(applicationId, eventsAfter)
-                .block()?.events ?: emptyList()
+        return getApplicationStatusHistory(applicationId, eventsAfter).block()?.events
+            ?: emptyList()
     }
 
     private fun getApplicationStatusHistory(
-            applicationId: Int,
-            eventsAfter: ZonedDateTime?): Mono<ApplicationHistory> {
+        applicationId: Int,
+        eventsAfter: ZonedDateTime?
+    ): Mono<ApplicationHistory> {
         val token = login()!!
         val search = ApplicationHistorySearch(listOf(applicationId), eventsAfter)
-        return webClient.post()
-                .uri(baseUrl + "/v2/applicationhistory")
-                .contentType(MediaType.APPLICATION_JSON)
-                .accept(MediaType.APPLICATION_JSON)
-                .headers { it.setBearerAuth(token) }
-                .body(Mono.just(search))
-                .retrieve()
-                // API returns an array of ApplicationHistory objects (one for each requested applicationId)
-                .bodyToFlux(ApplicationHistory::class.java)
-                // As this function always requests just one take the first
-                .next()
+        return webClient
+            .post()
+            .uri("$baseUrl/v2/applicationhistory")
+            .contentType(MediaType.APPLICATION_JSON)
+            .accept(MediaType.APPLICATION_JSON)
+            .headers { it.setBearerAuth(token) }
+            .body(Mono.just(search))
+            .retrieve()
+            // API returns an array of ApplicationHistory objects (one for each requested
+            // applicationId)
+            .bodyToFlux(ApplicationHistory::class.java)
+            // As this function always requests just one take the first
+            .next()
     }
 
     override fun create(cableReport: CableReportApplication): Int {
         val token = login()!!
-        return webClient.post()
-                .uri(baseUrl + "/v2/cablereports")
-                .contentType(MediaType.APPLICATION_JSON)
-                .accept(MediaType.APPLICATION_JSON)
-                .headers { it.setBearerAuth(token) }
-                .bodyValue(cableReport)
-                .retrieve()
-                .bodyToMono(Int::class.java)
-                .blockOptional()
-                .orElseThrow()
+        return webClient
+            .post()
+            .uri("$baseUrl/v2/cablereports")
+            .contentType(MediaType.APPLICATION_JSON)
+            .accept(MediaType.APPLICATION_JSON)
+            .headers { it.setBearerAuth(token) }
+            .bodyValue(cableReport)
+            .retrieve()
+            .bodyToMono(Int::class.java)
+            .blockOptional()
+            .orElseThrow()
     }
 
     override fun update(applicationId: Int, cableReport: CableReportApplication) {
         val token = login()!!
-        webClient.put()
-                .uri(baseUrl + "/v2/cablereports/{applicationId}", applicationId)
-                .contentType(MediaType.APPLICATION_JSON)
-                .accept(MediaType.APPLICATION_JSON)
-                .headers { it.setBearerAuth(token) }
-                .body(Mono.just(cableReport))
-                .retrieve()
-                .bodyToMono(Int::class.java)
-                .blockOptional()
-                .orElseThrow()
-
+        webClient
+            .put()
+            .uri("$baseUrl/v2/cablereports/$applicationId")
+            .contentType(MediaType.APPLICATION_JSON)
+            .accept(MediaType.APPLICATION_JSON)
+            .headers { it.setBearerAuth(token) }
+            .body(Mono.just(cableReport))
+            .retrieve()
+            .bodyToMono(Int::class.java)
+            .blockOptional()
+            .orElseThrow()
     }
 
     override fun addAttachment(applicationId: Int, metadata: AttachmentInfo, file: ByteArray) {
@@ -97,91 +106,102 @@ class CableReportServiceAllu(
         builder.part("file", ByteArrayResource(file), MediaType.APPLICATION_PDF).filename("file")
         val multipartData = builder.build()
 
-        webClient.post()
-                .uri(baseUrl + "/v2/applications/{applicationId}/attachments", applicationId)
-                .contentType(MediaType.MULTIPART_FORM_DATA)
-                .accept(MediaType.APPLICATION_JSON)
-                .headers { it.setBearerAuth(token) }
-                .body(BodyInserters.fromMultipartData(multipartData))
-                .exchange()
-                .blockOptional()
-                .orElseThrow()
+        webClient
+            .post()
+            .uri("$baseUrl/v2/applications/{applicationId}/attachments", applicationId)
+            .contentType(MediaType.MULTIPART_FORM_DATA)
+            .accept(MediaType.APPLICATION_JSON)
+            .headers { it.setBearerAuth(token) }
+            .body(BodyInserters.fromMultipartData(multipartData))
+            .exchange()
+            .blockOptional()
+            .orElseThrow()
     }
 
     override fun getInformationRequests(applicationId: Int): List<InformationRequest> {
         val token = login()!!
-        return webClient.get()
-                .uri(baseUrl + "/v2/applications/{applicationId}/informationrequests", applicationId)
-                .accept(MediaType.APPLICATION_JSON)
-                .headers { it.setBearerAuth(token) }
-                .retrieve()
-                .bodyToFlux(InformationRequest::class.java)
-                .collectList()
-                .blockOptional()
-                .orElseThrow()
+        return webClient
+            .get()
+            .uri("$baseUrl/v2/applications/{applicationId}/informationrequests", applicationId)
+            .accept(MediaType.APPLICATION_JSON)
+            .headers { it.setBearerAuth(token) }
+            .retrieve()
+            .bodyToFlux(InformationRequest::class.java)
+            .collectList()
+            .blockOptional()
+            .orElseThrow()
     }
 
     override fun respondToInformationRequest(
-            applicationId: Int,
-            requestId: Int,
-            cableReport: CableReportApplication,
-            updatedFields: List<InformationRequestFieldKey>
+        applicationId: Int,
+        requestId: Int,
+        cableReport: CableReportApplication,
+        updatedFields: List<InformationRequestFieldKey>
     ) {
         val token = login()!!
-        webClient.post()
-                .uri(baseUrl + "/v2/cablereports/{applicationId}/informationrequests/{requestId}/response",
-                        applicationId, requestId)
-                .contentType(MediaType.APPLICATION_JSON)
-                .accept(MediaType.APPLICATION_JSON)
-                .headers { it.setBearerAuth(token) }
-                .body(Mono.just(CableReportInformationRequestResponse(cableReport, updatedFields)))
-                .retrieve()
-                .toBodilessEntity()
-                .blockOptional()
-                .orElseThrow()
+        webClient
+            .post()
+            .uri(
+                "$baseUrl/v2/cablereports/{applicationId}/informationrequests/{requestId}/response",
+                applicationId,
+                requestId
+            )
+            .contentType(MediaType.APPLICATION_JSON)
+            .accept(MediaType.APPLICATION_JSON)
+            .headers { it.setBearerAuth(token) }
+            .body(Mono.just(CableReportInformationRequestResponse(cableReport, updatedFields)))
+            .retrieve()
+            .toBodilessEntity()
+            .blockOptional()
+            .orElseThrow()
     }
 
     override fun getDecisionPDF(applicationId: Int): ByteArray {
         val token = login()!!
-        return webClient.get()
-                .uri(baseUrl + "/v2/cablereports/{applicationId}/decision", applicationId)
-                .accept(MediaType.APPLICATION_PDF)
-                .headers { it.setBearerAuth(token) }
-                .exchange()
-                .flatMap { it.bodyToMono(ByteArrayResource::class.java) }
-                .map { it.byteArray }
-                .blockOptional()
-                .orElseThrow()
+        return webClient
+            .get()
+            .uri("$baseUrl/v2/cablereports/{applicationId}/decision", applicationId)
+            .accept(MediaType.APPLICATION_PDF)
+            .headers { it.setBearerAuth(token) }
+            .exchange()
+            .flatMap { it.bodyToMono(ByteArrayResource::class.java) }
+            .map { it.byteArray }
+            .blockOptional()
+            .orElseThrow()
     }
 
     override fun getDecisionAttachments(applicationId: Int): List<AttachmentInfo> {
         val token = login()!!
         System.out.println(token)
-        return webClient.get()
-                .uri(baseUrl + "/v2/applications/{applicationId}/attachments", applicationId)
-                .accept(MediaType.APPLICATION_JSON)
-                .headers { it.setBearerAuth(token) }
-                .retrieve()
-                .bodyToFlux(AttachmentInfo::class.java)
-                .collectList()
-                .blockOptional()
-                .orElseThrow()
+        return webClient
+            .get()
+            .uri("$baseUrl/v2/applications/{applicationId}/attachments", applicationId)
+            .accept(MediaType.APPLICATION_JSON)
+            .headers { it.setBearerAuth(token) }
+            .retrieve()
+            .bodyToFlux(AttachmentInfo::class.java)
+            .collectList()
+            .blockOptional()
+            .orElseThrow()
     }
 
     override fun getDecisionAttachmentData(applicationId: Int, attachmentId: Int): ByteArray {
         val token = login()!!
-        return webClient.get()
-                .uri(baseUrl + "/v2/applications/{applicationId}/attachments/{attachentId}",
-                        applicationId, attachmentId)
-                .accept(MediaType.APPLICATION_PDF)
-                .headers { it.setBearerAuth(token) }
-                .exchange()
-                .flatMap { it.bodyToMono(ByteArrayResource::class.java) }
-                .map { it.byteArray }
-                .blockOptional()
-                .orElseThrow()
+        return webClient
+            .get()
+            .uri(
+                "$baseUrl/v2/applications/{applicationId}/attachments/{attachentId}",
+                applicationId,
+                attachmentId
+            )
+            .accept(MediaType.APPLICATION_PDF)
+            .headers { it.setBearerAuth(token) }
+            .exchange()
+            .flatMap { it.bodyToMono(ByteArrayResource::class.java) }
+            .map { it.byteArray }
+            .blockOptional()
+            .orElseThrow()
     }
-
 }
 
 data class AlluProperties(val baseUrl: String, val username: String, val password: String)
@@ -190,6 +210,8 @@ data class LoginInfo(val username: String, val password: String)
 
 class AlluException(val errors: List<ErrorInfo>) : RuntimeException()
 
+class AlluLoginException(cause: Throwable) : RuntimeException(cause)
+
 data class ErrorInfo(val errorMessage: String, val additionalInfo: String)
 
 class ErrorFilter : ExchangeFilterFunction {
@@ -197,13 +219,13 @@ class ErrorFilter : ExchangeFilterFunction {
     override fun filter(request: ClientRequest, next: ExchangeFunction): Mono<ClientResponse> {
         return next.exchange(request).flatMap { resp ->
             if (resp.statusCode() != null && resp.statusCode().isError) {
-                resp.bodyToMono(String::class.java)
-                        .defaultIfEmpty(resp.statusCode().reasonPhrase)
-                        .flatMap { body -> Mono.error(AlluException(listOf(ErrorInfo(body,"")))) }
+                resp
+                    .bodyToMono(String::class.java)
+                    .defaultIfEmpty(resp.statusCode().reasonPhrase)
+                    .flatMap { body -> Mono.error(AlluException(listOf(ErrorInfo(body, "")))) }
             } else {
                 Mono.just(resp)
             }
         }
     }
-
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/CableReportServiceAllu.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/CableReportServiceAllu.kt
@@ -5,7 +5,12 @@ import org.springframework.core.io.ByteArrayResource
 import org.springframework.http.MediaType
 import org.springframework.http.client.MultipartBodyBuilder
 import org.springframework.web.reactive.function.BodyInserters
-import org.springframework.web.reactive.function.client.*
+import org.springframework.web.reactive.function.client.ClientRequest
+import org.springframework.web.reactive.function.client.ClientResponse
+import org.springframework.web.reactive.function.client.ExchangeFilterFunction
+import org.springframework.web.reactive.function.client.ExchangeFunction
+import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.body
 import reactor.core.publisher.Mono
 
 class CableReportServiceAllu(
@@ -108,7 +113,7 @@ class CableReportServiceAllu(
 
         webClient
             .post()
-            .uri("$baseUrl/v2/applications/{applicationId}/attachments", applicationId)
+            .uri("$baseUrl/v2/applications/$applicationId/attachments")
             .contentType(MediaType.MULTIPART_FORM_DATA)
             .accept(MediaType.APPLICATION_JSON)
             .headers { it.setBearerAuth(token) }
@@ -122,7 +127,7 @@ class CableReportServiceAllu(
         val token = login()!!
         return webClient
             .get()
-            .uri("$baseUrl/v2/applications/{applicationId}/informationrequests", applicationId)
+            .uri("$baseUrl/v2/applications/$applicationId/informationrequests")
             .accept(MediaType.APPLICATION_JSON)
             .headers { it.setBearerAuth(token) }
             .retrieve()
@@ -141,11 +146,7 @@ class CableReportServiceAllu(
         val token = login()!!
         webClient
             .post()
-            .uri(
-                "$baseUrl/v2/cablereports/{applicationId}/informationrequests/{requestId}/response",
-                applicationId,
-                requestId
-            )
+            .uri("$baseUrl/v2/cablereports/$applicationId/informationrequests/$requestId/response")
             .contentType(MediaType.APPLICATION_JSON)
             .accept(MediaType.APPLICATION_JSON)
             .headers { it.setBearerAuth(token) }
@@ -160,7 +161,7 @@ class CableReportServiceAllu(
         val token = login()!!
         return webClient
             .get()
-            .uri("$baseUrl/v2/cablereports/{applicationId}/decision", applicationId)
+            .uri("$baseUrl/v2/cablereports/$applicationId/decision", applicationId)
             .accept(MediaType.APPLICATION_PDF)
             .headers { it.setBearerAuth(token) }
             .exchange()
@@ -172,10 +173,9 @@ class CableReportServiceAllu(
 
     override fun getDecisionAttachments(applicationId: Int): List<AttachmentInfo> {
         val token = login()!!
-        System.out.println(token)
         return webClient
             .get()
-            .uri("$baseUrl/v2/applications/{applicationId}/attachments", applicationId)
+            .uri("$baseUrl/v2/applications/$applicationId/attachments", applicationId)
             .accept(MediaType.APPLICATION_JSON)
             .headers { it.setBearerAuth(token) }
             .retrieve()
@@ -189,11 +189,7 @@ class CableReportServiceAllu(
         val token = login()!!
         return webClient
             .get()
-            .uri(
-                "$baseUrl/v2/applications/{applicationId}/attachments/{attachentId}",
-                applicationId,
-                attachmentId
-            )
+            .uri("$baseUrl/v2/applications/$applicationId/attachments/$attachmentId")
             .accept(MediaType.APPLICATION_PDF)
             .headers { it.setBearerAuth(token) }
             .exchange()

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/Persistence.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/Persistence.kt
@@ -55,19 +55,25 @@ enum class ObjectType {
     ALLU_CONTACT,
 }
 
+enum class UserRole {
+    USER,
+    SERVICE,
+}
+
 @Entity
 @Table(name = "audit_log")
 data class AuditLogEntry(
     @Id var id: UUID? = UUID.randomUUID(),
     @Column(name = "event_time") var eventTime: OffsetDateTime? = OffsetDateTime.now(),
     @Column(name = "user_id") var userId: String? = null,
+    @Enumerated(EnumType.STRING) @Column(name = "user_role") var userRole: UserRole = UserRole.USER,
     @Column(name = "ip_near") var ipNear: String? = null,
     @Column(name = "ip_far") var ipFar: String? = null,
     @Enumerated(EnumType.STRING) var action: Action? = null,
     @Enumerated(EnumType.STRING) var status: Status? = null,
     @Column(name = "failure_description") var failureDescription: String? = null,
     @Enumerated(EnumType.STRING) @Column(name = "object_type") var objectType: ObjectType? = null,
-    @Column(name = "object_id") var objectId: Int? = null,
+    @Column(name = "object_id") var objectId: String? = null,
     @Column(name = "object_before") var objectBefore: String? = null,
     @Column(name = "object_after") var objectAfter: String? = null
 )

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/YhteystietoLoggingEntryHolder.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/YhteystietoLoggingEntryHolder.kt
@@ -80,11 +80,12 @@ class YhteystietoLoggingEntryHolder {
         val auditLogEntry =
             AuditLogEntry(
                 userId = userId,
+                userRole = UserRole.USER,
                 action = action,
                 status = if (failed) Status.FAILED else Status.SUCCESS,
                 failureDescription = failureDescription,
                 objectType = ObjectType.YHTEYSTIETO,
-                objectId = yhteystietoId,
+                objectId = yhteystietoId?.toString(),
                 objectBefore = oldEntity?.toChangeLogJsonString(),
                 objectAfter = newEntity?.toChangeLogJsonString(),
             )

--- a/services/hanke-service/src/main/resources/db/changelog/changesets/012-add-user-role-to-audit-log.yml
+++ b/services/hanke-service/src/main/resources/db/changelog/changesets/012-add-user-role-to-audit-log.yml
@@ -1,0 +1,21 @@
+databaseChangeLog:
+  - changeSet:
+      id: 012-add-user-role-to-audit-log
+      comment: Change audit log user id to string
+      author: Topias Heinonen
+      changes:
+        - addColumn:
+            tableName: audit_log
+            columns:
+              - column:
+                  name: user_role
+                  type: varchar(250) # enum
+                  remarks: "The role of the actor (USER / SERVICE)"
+        - addNotNullConstraint:
+            tableName: audit_log
+            columnName: user_role
+            defaultNullValue: "USER"
+        - modifyDataType:
+            tableName: audit_log
+            columnName: object_id
+            newDataType: varchar

--- a/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -51,3 +51,5 @@ databaseChangeLog:
       file: db/changelog/changesets/010-create-table-for-database-logging.yml
   - include:
       file: db/changelog/changesets/011-drop-old-personal-data-log-tables.yml
+  - include:
+      file: db/changelog/changesets/012-add-user-role-to-audit-log.yml

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/HankeControllerTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/HankeControllerTest.kt
@@ -10,7 +10,6 @@ import fi.hel.haitaton.hanke.permissions.PermissionProfiles
 import fi.hel.haitaton.hanke.permissions.PermissionService
 import io.mockk.Called
 import io.mockk.clearAllMocks
-import io.mockk.justRun
 import io.mockk.mockk
 import io.mockk.verify
 import java.time.ZonedDateTime
@@ -18,7 +17,7 @@ import java.time.temporal.ChronoUnit
 import javax.validation.ConstraintViolationException
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
-import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mockito
@@ -49,7 +48,7 @@ class HankeControllerTest {
         @Bean
         fun permissionService(): PermissionService = Mockito.mock(PermissionService::class.java)
 
-        @Bean fun yhteystietoLoggingService(): DisclosureLogService = mockk()
+        @Bean fun yhteystietoLoggingService(): DisclosureLogService = mockk(relaxUnitFun = true)
 
         @Bean
         fun hankeController(
@@ -76,8 +75,8 @@ class HankeControllerTest {
 
     @Autowired private lateinit var disclosureLogService: DisclosureLogService
 
-    @BeforeEach
-    fun resetMockks() {
+    @AfterEach
+    fun cleanUp() {
         clearAllMocks()
     }
 
@@ -108,7 +107,6 @@ class HankeControllerTest {
                     SaveType.DRAFT
                 )
             )
-        justRun { disclosureLogService.saveDisclosureLogsForHanke(any(), "user") }
 
         val response = hankeController.getHankeByTunnus(mockedHankeTunnus)
 
@@ -164,7 +162,6 @@ class HankeControllerTest {
             )
         Mockito.`when`(permissionService.getPermissionsByUserId("user")).thenReturn(permissions)
         Mockito.`when`(hankeService.loadHankkeetByIds(listOf(1234, 50))).thenReturn(listOfHanke)
-        justRun { disclosureLogService.saveDisclosureLogsForHankkeet(any(), "user") }
 
         val hankeList = hankeController.getHankeList(false)
 
@@ -202,7 +199,6 @@ class HankeControllerTest {
         // mock HankeService response
         Mockito.`when`(hankeService.updateHanke(partialHanke))
             .thenReturn(partialHanke.copy(modifiedBy = "user", modifiedAt = getCurrentTimeUTC()))
-        justRun { disclosureLogService.saveDisclosureLogsForHanke(any(), "user") }
 
         // Actual call
         val response: Hanke = hankeController.updateHanke(partialHanke, "id123")
@@ -291,7 +287,6 @@ class HankeControllerTest {
 
         // mock HankeService response
         Mockito.`when`(hankeService.createHanke(hanke)).thenReturn(mockedHanke)
-        justRun { disclosureLogService.saveDisclosureLogsForHanke(any(), "Tiina") }
 
         // Actual call
         val response: Hanke = hankeController.createHanke(hanke)
@@ -365,7 +360,6 @@ class HankeControllerTest {
         mockedHanke.hankeTunnus = "JOKU12"
 
         Mockito.`when`(hankeService.createHanke(hanke)).thenReturn(mockedHanke)
-        justRun { disclosureLogService.saveDisclosureLogsForHanke(any(), "Tiina") }
 
         val response: Hanke = hankeController.createHanke(hanke)
 

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/allu/ApplicationControllerTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/allu/ApplicationControllerTest.kt
@@ -5,11 +5,9 @@ import fi.hel.haitaton.hanke.logging.DisclosureLogService
 import io.mockk.clearAllMocks
 import io.mockk.confirmVerified
 import io.mockk.every
-import io.mockk.justRun
 import io.mockk.mockk
 import io.mockk.verify
 import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.security.test.context.support.WithMockUser
@@ -21,21 +19,17 @@ class ApplicationControllerTest {
     private val username = "testUser"
 
     private val applicationService: ApplicationService = mockk()
-    private val disclosureLogService: DisclosureLogService = mockk()
+    private val disclosureLogService: DisclosureLogService = mockk(relaxUnitFun = true)
 
     private val applicationController =
         ApplicationController(applicationService, disclosureLogService)
 
-    @BeforeEach
-    fun clearMockks() {
-        clearAllMocks()
-    }
-
     @AfterEach
-    fun checkStubs() {
+    fun cleanUp() {
         // TODO: Needs newer MockK, which needs newer Spring test dependencies
         // checkUnnecessaryStub()
         confirmVerified()
+        clearAllMocks()
     }
 
     @Test
@@ -50,7 +44,6 @@ class ApplicationControllerTest {
                 ),
             )
         every { applicationService.getAllApplicationsForCurrentUser() } returns applications
-        justRun { disclosureLogService.saveDisclosureLogsForApplications(applications, username) }
 
         applicationController.getAll()
 
@@ -61,7 +54,6 @@ class ApplicationControllerTest {
     fun `getById saves disclosure logs`() {
         val application = AlluDataFactory.createApplicationDto()
         every { applicationService.getApplicationById(1) } returns application
-        justRun { disclosureLogService.saveDisclosureLogsForApplication(application, username) }
 
         applicationController.getById(1)
 
@@ -73,9 +65,6 @@ class ApplicationControllerTest {
         val requestApplication = AlluDataFactory.createApplicationDto(id = null)
         val createdApplication = requestApplication.copy(id = 1)
         every { applicationService.create(requestApplication) } returns createdApplication
-        justRun {
-            disclosureLogService.saveDisclosureLogsForApplication(createdApplication, username)
-        }
 
         applicationController.create(requestApplication)
 
@@ -89,7 +78,6 @@ class ApplicationControllerTest {
         val application = AlluDataFactory.createApplicationDto(id = 1)
         every { applicationService.updateApplicationData(1, application.applicationData) } returns
             application
-        justRun { disclosureLogService.saveDisclosureLogsForApplication(application, username) }
 
         applicationController.update(1, application)
 

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/allu/ApplicationServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/allu/ApplicationServiceTest.kt
@@ -5,7 +5,6 @@ import assertk.assertions.isEqualTo
 import com.fasterxml.jackson.module.kotlin.treeToValue
 import fi.hel.haitaton.hanke.OBJECT_MAPPER
 import fi.hel.haitaton.hanke.asJsonNode
-import fi.hel.haitaton.hanke.logging.ALLU_AUDIT_LOG_USERID
 import fi.hel.haitaton.hanke.logging.DisclosureLogService
 import fi.hel.haitaton.hanke.logging.Status
 import io.mockk.called
@@ -73,11 +72,7 @@ class ApplicationServiceTest {
         val expectedApplication =
             OBJECT_MAPPER.treeToValue<CableReportApplication>(applicationData)!!
         verify {
-            disclosureLogService.saveDisclosureLogsForCableReportApplication(
-                expectedApplication,
-                ALLU_AUDIT_LOG_USERID,
-                Status.SUCCESS
-            )
+            disclosureLogService.saveDisclosureLogsForAllu(expectedApplication, Status.SUCCESS)
         }
     }
 
@@ -102,11 +97,7 @@ class ApplicationServiceTest {
         val expectedApplication =
             OBJECT_MAPPER.treeToValue<CableReportApplication>(applicationData)!!
         verify {
-            disclosureLogService.saveDisclosureLogsForCableReportApplication(
-                expectedApplication,
-                ALLU_AUDIT_LOG_USERID,
-                Status.SUCCESS
-            )
+            disclosureLogService.saveDisclosureLogsForAllu(expectedApplication, Status.SUCCESS)
         }
     }
 
@@ -132,11 +123,7 @@ class ApplicationServiceTest {
                 pendingOnClient = false
             }
         verify {
-            disclosureLogService.saveDisclosureLogsForCableReportApplication(
-                expectedApplication,
-                ALLU_AUDIT_LOG_USERID,
-                Status.SUCCESS
-            )
+            disclosureLogService.saveDisclosureLogsForAllu(expectedApplication, Status.SUCCESS)
         }
     }
 
@@ -161,11 +148,7 @@ class ApplicationServiceTest {
                 pendingOnClient = false
             }
         verify {
-            disclosureLogService.saveDisclosureLogsForCableReportApplication(
-                expectedApplication,
-                ALLU_AUDIT_LOG_USERID,
-                Status.FAILED
-            )
+            disclosureLogService.saveDisclosureLogsForAllu(expectedApplication, Status.FAILED)
         }
     }
 

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/allu/ApplicationServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/allu/ApplicationServiceTest.kt
@@ -2,143 +2,50 @@ package fi.hel.haitaton.hanke.allu
 
 import assertk.assertThat
 import assertk.assertions.isEqualTo
-import com.ninjasquad.springmockk.MockkBean
+import com.fasterxml.jackson.module.kotlin.treeToValue
 import fi.hel.haitaton.hanke.OBJECT_MAPPER
+import fi.hel.haitaton.hanke.asJsonNode
+import fi.hel.haitaton.hanke.logging.ALLU_AUDIT_LOG_USERID
+import fi.hel.haitaton.hanke.logging.DisclosureLogService
+import fi.hel.haitaton.hanke.logging.Status
+import io.mockk.called
+import io.mockk.clearAllMocks
+import io.mockk.confirmVerified
 import io.mockk.every
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.verify
+import java.lang.RuntimeException
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.security.test.context.support.WithMockUser
 import org.springframework.test.context.junit.jupiter.SpringExtension
 
+const val username = "test"
+
 @ExtendWith(SpringExtension::class)
-@WithMockUser
+@WithMockUser(username)
 class ApplicationServiceTest {
+    private val applicationRepo: ApplicationRepository = mockk()
+    private val cableReportService: CableReportService = mockk()
+    private val disclosureLogService: DisclosureLogService = mockk(relaxUnitFun = true)
 
-    @MockkBean private lateinit var applicationRepo: ApplicationRepository
+    private val service: ApplicationService =
+        ApplicationService(applicationRepo, cableReportService, disclosureLogService)
 
-    @MockkBean private lateinit var cableReportService: CableReportService
+    @AfterEach
+    fun cleanup() {
+        // TODO: Needs newer MockK, which needs newer Spring test dependencies
+        // checkUnnecessaryStub()
+        confirmVerified()
+        clearAllMocks()
+    }
 
     @Test
-    fun test() {
-        val service = ApplicationService(applicationRepo, cableReportService)
-
-        val json =
-            """
-        {
-            "name":"test",
-            "customerWithContacts":{
-                "customer":{
-                    "type":"PERSON",
-                    "name":"Testi Testinen",
-                    "country":"FI",
-                    "postalAddress":{
-                        "streetAddress":{
-                            "streetName":"Mannerheimintie 1 2 3"
-                        },
-                        "postalCode":"00900",
-                        "city":"Helsinki"
-                    },
-                    "email":"test@haitaton.fi",
-                    "phone":"0123456789",
-                    "registryKey":null,
-                    "ovt":null,
-                    "invoicingOperator":null,
-                    "sapCustomerNumber":null
-                },
-                "contacts":[
-                    {
-                        "email":"test@haitaton.fi",
-                        "name":"Testi Testinen",
-                        "orderer":true,
-                        "phone":"0123456789",
-                        "postalAddress":{
-                            "city":"Helsinki",
-                            "postalCode":"00900",
-                            "streetAddress":{
-                                "streetName":"Mannerheimintie 1 2 3"
-                            }
-                        }
-                    }
-                ]
-            },
-            "geometry":{
-                "type":"GeometryCollection",
-                "crs":{
-                    "type":"name",
-                    "properties":{
-                        "name":"EPSG:3879"
-                    }
-                },
-                "geometries":[
-                    {
-                        "type":"Polygon",
-                        "coordinates":[
-                            [
-                                [ 25497314.94, 6672065.27 ],
-                                [ 25497232.87, 6672189.43 ],
-                                [ 25497108.71, 6672107.36 ],
-                                [ 25497190.78, 6671983.2 ],
-                                [ 25497314.94, 6672065.27 ]
-                            ]
-                        ]
-                    }
-                ]
-            },
-            "startTime":"2022-06-01T00:00:00Z",
-            "endTime":"2022-07-01T00:00:00Z",
-            "pendingOnClient":true,
-            "identificationNumber":"HAI-123",
-            "clientApplicationKind":"Testi",
-            "workDescription":"anything goes",
-            "contractorWithContacts":{
-                "customer":{
-                    "type":"COMPANY",
-                    "name":"Haitaton Oy",
-                    "country":"FI",
-                    "postalAddress":{
-                        "streetAddress":{
-                            "streetName":"Mannerheimintie 1 2 3"
-                        },
-                        "postalCode":"00900",
-                        "city":"Helsinki"
-                    },
-                    "email":"test@haitaton.fi",
-                    "phone":"0123456789",
-                    "registryKey":null,
-                    "ovt":null,
-                    "invoicingOperator":null,
-                    "sapCustomerNumber":null
-                },
-                "contacts":[
-                    {
-                        "name":"Testi Testinen",
-                        "postalAddress":{
-                            "streetAddress":{
-                                "streetName":"Mannerheimintie 1 2 3"
-                            },
-                            "postalCode":"00900",
-                            "city":"Helsinki"
-                        },
-                        "email":"test@haitaton.fi",
-                        "phone":"0123456789",
-                        "orderer":false
-                    }
-                ]
-            },
-            "postalAddress":null,
-            "representativeWithContacts":null,
-            "invoicingCustomer":null,
-            "customerReference":null,
-            "area":null,
-            "propertyDeveloperWithContacts":null,
-            "constructionWork":false,
-            "maintenanceWork":false,
-            "emergencyWork":true,
-            "propertyConnectivity":false
-        }
-        """.trimIndent()
-
-        val applicationData = OBJECT_MAPPER.readTree(json)
+    fun create() {
+        val applicationData = "/fi/hel/haitaton/hanke/application/applicationData.json".asJsonNode()
         val dto =
             ApplicationDto(
                 id = null,
@@ -146,7 +53,6 @@ class ApplicationServiceTest {
                 applicationType = ApplicationType.CABLE_REPORT,
                 applicationData = applicationData
             )
-
         every { cableReportService.create(any()) } returns 42
         every { applicationRepo.save(any()) } answers
             {
@@ -161,7 +67,127 @@ class ApplicationServiceTest {
             }
 
         val created = service.create(dto)
+
         assertThat(created.id).isEqualTo(1)
         assertThat(created.alluid).isEqualTo(42)
+        val expectedApplication =
+            OBJECT_MAPPER.treeToValue<CableReportApplication>(applicationData)!!
+        verify {
+            disclosureLogService.saveDisclosureLogsForCableReportApplication(
+                expectedApplication,
+                ALLU_AUDIT_LOG_USERID,
+                Status.SUCCESS
+            )
+        }
+    }
+
+    @Test
+    fun `updateApplicationData saves disclosure logs when updating Allu data`() {
+        val applicationData = "/fi/hel/haitaton/hanke/application/applicationData.json".asJsonNode()
+        val applicationEntity =
+            AlluApplication(
+                id = 3,
+                alluid = 42,
+                userId = username,
+                applicationType = ApplicationType.CABLE_REPORT,
+                applicationData = applicationData
+            )
+        every { applicationRepo.findOneByIdAndUserId(3, username) } returns applicationEntity
+        every { applicationRepo.save(applicationEntity) } returns applicationEntity
+        justRun { cableReportService.update(42, any()) }
+        every { cableReportService.getCurrentStatus(42) } returns null
+
+        service.updateApplicationData(3, applicationData)
+
+        val expectedApplication =
+            OBJECT_MAPPER.treeToValue<CableReportApplication>(applicationData)!!
+        verify {
+            disclosureLogService.saveDisclosureLogsForCableReportApplication(
+                expectedApplication,
+                ALLU_AUDIT_LOG_USERID,
+                Status.SUCCESS
+            )
+        }
+    }
+
+    @Test
+    fun `sendApplication saves disclosure logs for successful attempts`() {
+        val applicationData = "/fi/hel/haitaton/hanke/application/applicationData.json".asJsonNode()
+        val applicationEntity =
+            AlluApplication(
+                id = 3,
+                alluid = null,
+                userId = username,
+                applicationType = ApplicationType.CABLE_REPORT,
+                applicationData = applicationData
+            )
+        every { applicationRepo.findOneByIdAndUserId(3, username) } returns applicationEntity
+        every { applicationRepo.save(any()) } answers { firstArg() }
+        every { cableReportService.create(any()) } returns 42
+
+        service.sendApplication(3)
+
+        val expectedApplication =
+            OBJECT_MAPPER.treeToValue<CableReportApplication>(applicationData)!!.apply {
+                pendingOnClient = false
+            }
+        verify {
+            disclosureLogService.saveDisclosureLogsForCableReportApplication(
+                expectedApplication,
+                ALLU_AUDIT_LOG_USERID,
+                Status.SUCCESS
+            )
+        }
+    }
+
+    @Test
+    fun `sendApplication saves disclosure logs for failed attempts`() {
+        val applicationData = "/fi/hel/haitaton/hanke/application/applicationData.json".asJsonNode()
+        val applicationEntity =
+            AlluApplication(
+                id = 3,
+                alluid = null,
+                userId = username,
+                applicationType = ApplicationType.CABLE_REPORT,
+                applicationData = applicationData
+            )
+        every { applicationRepo.findOneByIdAndUserId(3, username) } returns applicationEntity
+        every { cableReportService.create(any()) } throws RuntimeException()
+
+        assertThrows<RuntimeException> { service.sendApplication(3) }
+
+        val expectedApplication =
+            OBJECT_MAPPER.treeToValue<CableReportApplication>(applicationData)!!.apply {
+                pendingOnClient = false
+            }
+        verify {
+            disclosureLogService.saveDisclosureLogsForCableReportApplication(
+                expectedApplication,
+                ALLU_AUDIT_LOG_USERID,
+                Status.FAILED
+            )
+        }
+    }
+
+    @Test
+    fun `sendApplication doesn't save disclosure logs for login errors`() {
+        val applicationData = "/fi/hel/haitaton/hanke/application/applicationData.json".asJsonNode()
+        val applicationEntity =
+            AlluApplication(
+                id = 3,
+                alluid = null,
+                userId = username,
+                applicationType = ApplicationType.CABLE_REPORT,
+                applicationData = applicationData
+            )
+        every { applicationRepo.findOneByIdAndUserId(3, username) } returns applicationEntity
+        every { cableReportService.create(any()) } throws AlluLoginException(RuntimeException())
+        OBJECT_MAPPER.treeToValue<CableReportApplication>(applicationData)!!.apply {
+            pendingOnClient = false
+        }
+
+        assertThrows<AlluLoginException> { service.sendApplication(3) }
+
+        verify { disclosureLogService wasNot called }
     }
 }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/AuditLogEntryFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/AuditLogEntryFactory.kt
@@ -7,12 +7,14 @@ import fi.hel.haitaton.hanke.logging.Action
 import fi.hel.haitaton.hanke.logging.AuditLogEntry
 import fi.hel.haitaton.hanke.logging.ObjectType
 import fi.hel.haitaton.hanke.logging.Status
+import fi.hel.haitaton.hanke.logging.UserRole
 import fi.hel.haitaton.hanke.toJsonString
 
 object AuditLogEntryFactory : Factory<AuditLogEntry>() {
 
     fun createReadEntry(
         userId: String? = "test",
+        userRole: UserRole = UserRole.USER,
         action: Action = Action.READ,
         status: Status = Status.SUCCESS,
         objectType: ObjectType = ObjectType.YHTEYSTIETO,
@@ -23,10 +25,11 @@ object AuditLogEntryFactory : Factory<AuditLogEntry>() {
     ) =
         AuditLogEntry(
             userId = userId,
+            userRole = userRole,
             action = action,
             status = status,
             objectType = objectType,
-            objectId = objectId,
+            objectId = objectId?.toString(),
             objectBefore = objectBefore,
             ipNear = ipNear,
             ipFar = ipFar,
@@ -43,6 +46,7 @@ object AuditLogEntryFactory : Factory<AuditLogEntry>() {
             objectType = ObjectType.ALLU_CONTACT,
             objectBefore = contact.toJsonString()
         )
+
     fun createReadEntryForCustomer(customer: Customer): AuditLogEntry =
         createReadEntry(
             objectId = null,

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/logging/DisclosureLogServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/logging/DisclosureLogServiceTest.kt
@@ -250,23 +250,19 @@ internal class DisclosureLogServiceTest {
 
     @ParameterizedTest(name = "{displayName}({arguments})")
     @EnumSource(Status::class)
-    fun `saveDisclosureLogsForCableReportApplication saves logs with the given status`(
-        expectedStatus: Status
-    ) {
+    fun `saveDisclosureLogsForAllu saves logs with the given status`(expectedStatus: Status) {
         val cableReportApplication = AlluDataFactory.createCableReportApplication()
         val contact = cableReportApplication.customerWithContacts.contacts[0]
         val expectedLogs =
             listOf(
                 AuditLogEntryFactory.createReadEntryForContact(contact).apply {
                     status = expectedStatus
+                    userId = ALLU_AUDIT_LOG_USERID
+                    userRole = UserRole.SERVICE
                 }
             )
 
-        disclosureLogService.saveDisclosureLogsForCableReportApplication(
-            cableReportApplication,
-            userId,
-            expectedStatus
-        )
+        disclosureLogService.saveDisclosureLogsForAllu(cableReportApplication, expectedStatus)
 
         verify {
             auditLogRepository.saveAll(match(containsAllWithoutGeneratedFields(expectedLogs)))

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/logging/DisclosureLogServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/logging/DisclosureLogServiceTest.kt
@@ -23,31 +23,27 @@ import fi.hel.haitaton.hanke.toJsonString
 import io.mockk.Called
 import io.mockk.clearAllMocks
 import io.mockk.confirmVerified
-import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
 
 internal class DisclosureLogServiceTest {
 
     private val userId = "test"
 
-    private val auditLogRepository: AuditLogRepository = mockk()
+    private val auditLogRepository: AuditLogRepository = mockk(relaxed = true)
     private val disclosureLogService = DisclosureLogService(auditLogRepository)
 
-    @BeforeEach
-    fun clearMockks() {
-        clearAllMocks()
-    }
-
     @AfterEach
-    fun checkStubs() {
+    fun cleanUp() {
         // TODO: Needs newer MockK, which needs newer Spring test dependencies
         // checkUnnecessaryStub()
         confirmVerified()
+        clearAllMocks()
     }
 
     @Test
@@ -63,9 +59,6 @@ internal class DisclosureLogServiceTest {
     fun `saveDisclosureLogsForHanke saves audit logs for all yhteystiedot`() {
         val hanke = HankeFactory.create().withYhteystiedot()
         val expectedLogs = AuditLogEntryFactory.createReadEntriesForHanke(hanke)
-        every {
-            auditLogRepository.saveAll(match(containsAllWithoutGeneratedFields(expectedLogs)))
-        } returns expectedLogs
 
         disclosureLogService.saveDisclosureLogsForHanke(hanke, userId)
 
@@ -85,9 +78,6 @@ internal class DisclosureLogServiceTest {
             }
         val expectedLogs =
             listOf(AuditLogEntryFactory.createReadEntry(objectBefore = yhteystieto.toJsonString()))
-        every {
-            auditLogRepository.saveAll(match(containsAllWithoutGeneratedFields(expectedLogs)))
-        } returns expectedLogs
 
         disclosureLogService.saveDisclosureLogsForHanke(hanke, userId)
 
@@ -123,9 +113,6 @@ internal class DisclosureLogServiceTest {
                     .withGeneratedToteuttaja(6)
             )
         val expectedLogs = hankkeet.flatMap { AuditLogEntryFactory.createReadEntriesForHanke(it) }
-        every {
-            auditLogRepository.saveAll(match(containsAllWithoutGeneratedFields(expectedLogs)))
-        } returns expectedLogs
 
         disclosureLogService.saveDisclosureLogsForHankkeet(hankkeet, userId)
 
@@ -142,9 +129,6 @@ internal class DisclosureLogServiceTest {
                 HankeFactory.create().withYhteystiedot()
             )
         val expectedLogs = AuditLogEntryFactory.createReadEntriesForHanke(hankkeet[0])
-        every {
-            auditLogRepository.saveAll(match(containsAllWithoutGeneratedFields(expectedLogs)))
-        } returns expectedLogs
 
         disclosureLogService.saveDisclosureLogsForHankkeet(hankkeet, userId)
 
@@ -242,9 +226,6 @@ internal class DisclosureLogServiceTest {
             listOf(
                 AuditLogEntryFactory.createReadEntryForCustomer(customerWithoutContacts.customer)
             )
-        every {
-            auditLogRepository.saveAll(match(containsAllWithoutGeneratedFields(expectedLogs)))
-        } returns expectedLogs
 
         disclosureLogService.saveDisclosureLogsForApplication(application, userId)
 
@@ -258,12 +239,34 @@ internal class DisclosureLogServiceTest {
         val cableReportApplication = AlluDataFactory.createCableReportApplication()
         val contact = cableReportApplication.customerWithContacts.contacts[0]
         val expectedLogs = listOf(AuditLogEntryFactory.createReadEntryForContact(contact))
-        every {
-            auditLogRepository.saveAll(match(containsAllWithoutGeneratedFields(expectedLogs)))
-        } returns expectedLogs
         val application = applicationDto(applicationData = cableReportApplication)
 
         disclosureLogService.saveDisclosureLogsForApplication(application, userId)
+
+        verify {
+            auditLogRepository.saveAll(match(containsAllWithoutGeneratedFields(expectedLogs)))
+        }
+    }
+
+    @ParameterizedTest(name = "{displayName}({arguments})")
+    @EnumSource(Status::class)
+    fun `saveDisclosureLogsForCableReportApplication saves logs with the given status`(
+        expectedStatus: Status
+    ) {
+        val cableReportApplication = AlluDataFactory.createCableReportApplication()
+        val contact = cableReportApplication.customerWithContacts.contacts[0]
+        val expectedLogs =
+            listOf(
+                AuditLogEntryFactory.createReadEntryForContact(contact).apply {
+                    status = expectedStatus
+                }
+            )
+
+        disclosureLogService.saveDisclosureLogsForCableReportApplication(
+            cableReportApplication,
+            userId,
+            expectedStatus
+        )
 
         verify {
             auditLogRepository.saveAll(match(containsAllWithoutGeneratedFields(expectedLogs)))
@@ -278,9 +281,6 @@ internal class DisclosureLogServiceTest {
             (contacts.map { AuditLogEntryFactory.createReadEntryForContact(it) } +
                 customers.map { AuditLogEntryFactory.createReadEntryForCustomer(it) })
         assertEquals(12, expectedLogs.size)
-        every {
-            auditLogRepository.saveAll(match(containsAllWithoutGeneratedFields(expectedLogs)))
-        } returns expectedLogs
         val customersWithContacts =
             (0..3).map { i ->
                 CustomerWithContacts(


### PR DESCRIPTION
# Description

Add entries to audit logs whenever users read customers and contacts from Allu applications. This is done because we need to know who has accessed personal information and what that information was.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1076

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [X] Other

# Instructions for testing
Allu test environment is down at the moment, so this has only been tested with unit tests.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 