### PR TITLE
HAI-1076 Create audit log when responsing to GDPR requests

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/IntegrationTestConfiguration.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/IntegrationTestConfiguration.kt
@@ -62,7 +62,7 @@ class IntegrationTestConfiguration {
 
     @Bean fun tormaystarkasteluLaskentaService(): TormaystarkasteluLaskentaService = mockk()
 
-    @Bean fun yhteystietoLoggingService(): DisclosureLogService = mockk()
+    @Bean fun disclosureLogService(): DisclosureLogService = mockk(relaxUnitFun = true)
 
     @EventListener
     fun onApplicationEvent(event: ContextRefreshedEvent) {

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/gdpr/GdprController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/gdpr/GdprController.kt
@@ -2,6 +2,7 @@ package fi.hel.haitaton.hanke.gdpr
 
 import fi.hel.haitaton.hanke.HankeService
 import fi.hel.haitaton.hanke.allu.ApplicationService
+import fi.hel.haitaton.hanke.logging.DisclosureLogService
 import fi.hel.haitaton.hanke.profiili.ProfiiliClient
 import io.sentry.Sentry
 import io.swagger.v3.oas.annotations.Operation
@@ -10,7 +11,6 @@ import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import mu.KotlinLogging
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpStatus
 import org.springframework.validation.annotation.Validated
@@ -27,10 +27,11 @@ private val logger = KotlinLogging.logger {}
 @RequestMapping("/gdpr-api")
 @Validated
 class GdprController(
-    @Autowired private val applicationService: ApplicationService,
-    @Autowired private val hankeService: HankeService,
-    @Autowired private val profiiliClient: ProfiiliClient,
-    @Autowired private val gdprJsonConverter: GdprJsonConverter,
+    private val applicationService: ApplicationService,
+    private val hankeService: HankeService,
+    private val profiiliClient: ProfiiliClient,
+    private val gdprJsonConverter: GdprJsonConverter,
+    private val disclosureLogService: DisclosureLogService,
 ) {
 
     @Value("\${haitaton.gdpr.disabled}") var gdprDisabled: Boolean = true
@@ -90,6 +91,7 @@ class GdprController(
             throw UserNotFoundException(userId)
         }
 
+        disclosureLogService.saveDisclosureLogsForProfiili(userId, gdprInfo)
         logger.info { "Returning GDPR information for user $userId" }
         return gdprInfo
     }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/DisclosureLogService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/DisclosureLogService.kt
@@ -9,6 +9,7 @@ import fi.hel.haitaton.hanke.allu.Customer
 import fi.hel.haitaton.hanke.allu.CustomerType
 import fi.hel.haitaton.hanke.domain.Hanke
 import fi.hel.haitaton.hanke.domain.HankeYhteystieto
+import fi.hel.haitaton.hanke.gdpr.CollectionNode
 import fi.hel.haitaton.hanke.toJsonString
 import java.time.OffsetDateTime
 import org.springframework.stereotype.Service
@@ -16,9 +17,21 @@ import org.springframework.stereotype.Service
 /** Special username for Allu service. */
 const val ALLU_AUDIT_LOG_USERID = "Allu"
 
+/** Special username for Helsinki Profiili. */
+const val PROFIILI_AUDIT_LOG_USERID = "Helsinki Profiili"
+
 /** Luovutusloki */
 @Service
 class DisclosureLogService(private val auditLogRepository: AuditLogRepository) {
+
+    /**
+     * Save disclosure log for when we are responding to a GDPR information request from Profiili.
+     * Write a single disclosure log entry with the response data.
+     */
+    fun saveDisclosureLogsForProfiili(userId: String, gdprInfo: CollectionNode) {
+        val entry = disclosureLogEntry(ObjectType.GDPR_RESPONSE, userId, gdprInfo)
+        saveDisclosureLogs(PROFIILI_AUDIT_LOG_USERID, UserRole.SERVICE, listOf(entry))
+    }
 
     /**
      * Save disclosure logs for when we are sending a cable report application to Allu. Write

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/Persistence.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/Persistence.kt
@@ -53,6 +53,7 @@ enum class ObjectType {
     YHTEYSTIETO,
     ALLU_CUSTOMER,
     ALLU_CONTACT,
+    GDPR_RESPONSE,
 }
 
 enum class UserRole {

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/AuditLogEntryFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/AuditLogEntryFactory.kt
@@ -18,7 +18,7 @@ object AuditLogEntryFactory : Factory<AuditLogEntry>() {
         action: Action = Action.READ,
         status: Status = Status.SUCCESS,
         objectType: ObjectType = ObjectType.YHTEYSTIETO,
-        objectId: Int? = 1,
+        objectId: Any? = 1,
         objectBefore: String? = null,
         ipNear: String? = null,
         ipFar: String? = null,


### PR DESCRIPTION
# Description
Add entries to audit logs whenever we respond to GDPR requests with personal information. This is done because we need to know who has accessed personal information and what that information was.

### Jira Issue:
https://helsinkisolutionoffice.atlassian.net/browse/HAI-1076

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [X] Other

# Instructions for testing
Please describe tests how this change or new feature can be tested.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 

# Other relevant info
Please describe here if there is e.g. some requirements for this change or
 other info that the tester/user needs to know.