### PR TITLE
HAI-1323 Make audit log table compatible with transfer component

### DIFF
--- a/haitaton_audit_log_mapping.yml
+++ b/haitaton_audit_log_mapping.yml
@@ -1,0 +1,41 @@
+# The mapping used to create the Elasticsearch index for audit logging.
+# Saved here as a reference and as a base for later modifications.
+components:
+  - name: haitaton-hanke
+    description: Haitaton hanke-service audit logging
+    mapping_properties:
+      '@timestamp':
+        type: date # Time of the event.
+      audit_event:
+        type: object
+        properties:
+          date_time: # Time of the event.
+            type: date # time event in format “yyyy-MM-ddThh:mm.ss.SSSZ”
+          operation: # What operation was made (CREATE / UPDATE / READ / DELETE / LOCK / UNLOCK).
+            type: keyword
+          status: # Whether the operation was successful or not (SUCCESS / FAILURE).
+            type: keyword
+          failure_description: # Description of the failure, if one is available. No stack dumps.
+            type: text
+          app_version:
+            type: text # Version of the audit log schema used.
+          actor:
+            type: object
+            properties:
+              ip_address: # A useful IP nearest to the server.
+                type: keyword
+              user_id: # ID of the user who performed the operation.
+                type: keyword
+              role: # Role of the user, currently either USER or SERVICE, affects the interpretation of user_id.
+                type: keyword
+          target:
+            type: object
+            properties:
+              id: # ID of the target object.
+                type: keyword
+              type: # What type of object the target is, e.g. YHTEYSTIETO.
+                type: keyword
+              object_before: # JSON representation of the object before it was changed, null for new objects.
+                type: text
+              object_after: # JSON representation of the object after it was changed, null for reads and deletes. If the operation fails, this shows how the object would have been if it had succeeded.
+                type: text

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Configuration.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Configuration.kt
@@ -8,7 +8,7 @@ import fi.hel.haitaton.hanke.geometria.HankeGeometriatDao
 import fi.hel.haitaton.hanke.geometria.HankeGeometriatDaoImpl
 import fi.hel.haitaton.hanke.geometria.HankeGeometriatService
 import fi.hel.haitaton.hanke.geometria.HankeGeometriatServiceImpl
-import fi.hel.haitaton.hanke.logging.AuditLogRepository
+import fi.hel.haitaton.hanke.logging.AuditLogService
 import fi.hel.haitaton.hanke.logging.DisclosureLogService
 import fi.hel.haitaton.hanke.organisaatio.OrganisaatioRepository
 import fi.hel.haitaton.hanke.organisaatio.OrganisaatioService
@@ -73,14 +73,14 @@ class Configuration {
         hankeRepository: HankeRepository,
         tormaystarkasteluLaskentaService: TormaystarkasteluLaskentaService,
         hanketunnusService: HanketunnusService,
-        auditLogRepository: AuditLogRepository,
+        auditLogService: AuditLogService,
         permissionService: PermissionService
     ): HankeService =
         HankeServiceImpl(
             hankeRepository,
             tormaystarkasteluLaskentaService,
             hanketunnusService,
-            auditLogRepository
+            auditLogService
         )
 
     @Bean

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/ApplicationService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/ApplicationService.kt
@@ -9,6 +9,8 @@ import fi.hel.haitaton.hanke.logging.Status
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 
+const val ALLU_APPLICATION_ERROR_MSG = "Error sending application to Allu"
+
 class ApplicationService(
     private val repo: ApplicationRepository,
     private val cableReportService: CableReportService,
@@ -130,7 +132,11 @@ class ApplicationService(
             // There was an exception outside logging, so there was at least an attempt to send the
             // application to Allu. Allu might have read it and rejected it, so we should log this
             // as a disclosure event.
-            disclosureLogService.saveDisclosureLogsForAllu(cableReportApplication, Status.FAILED)
+            disclosureLogService.saveDisclosureLogsForAllu(
+                cableReportApplication,
+                Status.FAILED,
+                ALLU_APPLICATION_ERROR_MSG
+            )
             throw e
         }
         // There were no exceptions, so log this as a successful disclosure.

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/AuditLogEntry.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/AuditLogEntry.kt
@@ -1,0 +1,86 @@
+package fi.hel.haitaton.hanke.logging
+
+import java.time.OffsetDateTime
+
+/**
+ * Type of operation/event.
+ *
+ * @param isChange tells whether the operation can change the business data
+ */
+enum class Operation(val isChange: Boolean) {
+    /** When some new "business data" object is created. */
+    CREATE(true),
+
+    /** When some (sensitive) "business data" is read. */
+    READ(false),
+
+    /** When some "business data" is changed. */
+    UPDATE(true),
+
+    /**
+     * When some "business data" object is deleted. (Note, the whole object, not just one or more
+     * fields in it.)
+     */
+    DELETE(true),
+
+    /**
+     * To record a change of the data locked -field to "true". Not done by Haitaton itself (for
+     * now), so add a row with this operation when manually setting that restriction flag.
+     */
+    LOCK(false),
+
+    /**
+     * To record a change of the data locked -field from "true" to "false". Not done by Haitaton
+     * itself (for now), so add a row with this operation when manually setting that restriction
+     * flag.
+     */
+    UNLOCK(false)
+}
+
+enum class Status {
+    SUCCESS,
+    FAILED
+}
+
+enum class ObjectType {
+    YHTEYSTIETO,
+    ALLU_CUSTOMER,
+    ALLU_CONTACT,
+    GDPR_RESPONSE,
+}
+
+enum class UserRole {
+    USER,
+    SERVICE,
+}
+
+/** Flat [AuditLogMessage] for better ergonomics. */
+data class AuditLogEntry(
+    val dateTime: OffsetDateTime? = OffsetDateTime.now(),
+    val operation: Operation,
+    val status: Status,
+    val failureDescription: String? = null,
+    val userId: String? = null,
+    val userRole: UserRole = UserRole.USER,
+    val ipAddress: String? = null,
+    val objectId: String? = null,
+    val objectType: ObjectType,
+    val objectBefore: String? = null,
+    val objectAfter: String? = null,
+) {
+    // TODO: There will be a centralized place for object mappers. This should be moved there.
+    fun toEntity(): AuditLogEntryEntity =
+        AuditLogEntryEntity(
+            message =
+                AuditLogMessage(
+                    AuditLogEvent(
+                        dateTime = dateTime!!,
+                        operation = operation,
+                        status = status,
+                        failureDescription = failureDescription,
+                        actor = AuditLogActor(userId, userRole, ipAddress),
+                        target = AuditLogTarget(objectId, objectType, objectBefore, objectAfter),
+                    )
+                )
+        )
+}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/AuditLogService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/AuditLogService.kt
@@ -1,0 +1,13 @@
+package fi.hel.haitaton.hanke.logging
+
+import org.springframework.stereotype.Service
+
+/** Service for methods common to all types of audit logs. */
+@Service
+class AuditLogService(private val auditLogRepository: AuditLogRepository) {
+
+    /** Save audit log entries. Converts them to entities and saves them. */
+    fun saveAll(auditLogEntries: Collection<AuditLogEntry>): MutableList<AuditLogEntryEntity> {
+        return auditLogRepository.saveAll(auditLogEntries.map { it.toEntity() })
+    }
+}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/Persistence.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/Persistence.kt
@@ -1,84 +1,133 @@
 package fi.hel.haitaton.hanke.logging
 
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.core.JsonGenerator
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.SerializerProvider
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import com.fasterxml.jackson.databind.annotation.JsonSerialize
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer
+import com.fasterxml.jackson.databind.ser.std.StdSerializer
+import com.vladmihalcea.hibernate.type.json.JsonBinaryType
+import java.time.LocalDateTime
 import java.time.OffsetDateTime
-import java.util.*
+import java.time.format.DateTimeFormatter
+import java.util.UUID
 import javax.persistence.Column
 import javax.persistence.Entity
-import javax.persistence.EnumType
-import javax.persistence.Enumerated
+import javax.persistence.GeneratedValue
+import javax.persistence.GenerationType
 import javax.persistence.Id
 import javax.persistence.Table
+import org.hibernate.annotations.Generated
+import org.hibernate.annotations.GenerationTime
+import org.hibernate.annotations.Type
+import org.hibernate.annotations.TypeDef
 import org.springframework.data.jpa.repository.JpaRepository
 
 /**
- * Type of action/event.
- *
- * @param isChange tells whether the action can change the business data
+ * Version for the schema of the audit log message schema. Change when making changes to the
+ * [AuditLogEvent] object tree. The changes need to be also done to the Elasticsearch schema, and
+ * they should be somehow synchronized.
  */
-enum class Action(val isChange: Boolean) {
-    /** When some new "business data" object is created. */
-    CREATE(true),
+const val AUDIT_LOG_SCHEMA_VERSION = "1"
 
-    /** When some (sensitive) "business data" is read. */
-    READ(false),
-
-    /** When some "business data" is changed. */
-    UPDATE(true),
-
-    /**
-     * When some "business data" object is deleted. (Note, the whole object, not just one or more
-     * fields in it.)
-     */
-    DELETE(true),
-
-    /**
-     * To record a change of the data locked -field to "true". Not done by Haitaton itself (for
-     * now), so add a row with this action when manually setting that restriction flag.
-     */
-    LOCK(false),
-
-    /**
-     * To record a change of the data locked -field from "true" to "false". Not done by Haitaton
-     * itself (for now), so add a row with this action when manually setting that restriction flag.
-     */
-    UNLOCK(false)
-}
-
-enum class Status {
-    SUCCESS,
-    FAILED
-}
-
-enum class ObjectType {
-    YHTEYSTIETO,
-    ALLU_CUSTOMER,
-    ALLU_CONTACT,
-    GDPR_RESPONSE,
-}
-
-enum class UserRole {
-    USER,
-    SERVICE,
-}
-
+/**
+ * This needs to match
+ * https://helsinkisolutionoffice.atlassian.net/wiki/spaces/HELFI/pages/8033697816/Logging+Transferring+log+entries+to+elastic+using+reusable+component?NO_SSR=1#Schema
+ */
 @Entity
-@Table(name = "audit_log")
-data class AuditLogEntry(
-    @Id var id: UUID? = UUID.randomUUID(),
-    @Column(name = "event_time") var eventTime: OffsetDateTime? = OffsetDateTime.now(),
-    @Column(name = "user_id") var userId: String? = null,
-    @Enumerated(EnumType.STRING) @Column(name = "user_role") var userRole: UserRole = UserRole.USER,
-    @Column(name = "ip_near") var ipNear: String? = null,
-    @Column(name = "ip_far") var ipFar: String? = null,
-    @Enumerated(EnumType.STRING) var action: Action? = null,
-    @Enumerated(EnumType.STRING) var status: Status? = null,
-    @Column(name = "failure_description") var failureDescription: String? = null,
-    @Enumerated(EnumType.STRING) @Column(name = "object_type") var objectType: ObjectType? = null,
-    @Column(name = "object_id") var objectId: String? = null,
-    @Column(name = "object_before") var objectBefore: String? = null,
-    @Column(name = "object_after") var objectAfter: String? = null
+@Table(name = "audit_logs")
+@TypeDef(name = "json", typeClass = JsonBinaryType::class)
+data class AuditLogEntryEntity(
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY) val id: Long? = null,
+
+    /**
+     * This will always be false in hanke-service. The log transfer component will set this to true
+     * after the logs are sent successfully.
+     */
+    @Column(name = "is_sent") val isSent: Boolean = false,
+
+    /** The message in JSON as a jsonb column. */
+    @Column(columnDefinition = "json") @Type(type = "json") val message: AuditLogMessage,
+
+    /** This will be set by the database. */
+    @Column(name = "created_at")
+    @Generated(GenerationTime.INSERT)
+    val createdAt: LocalDateTime? = null,
 )
 
-interface AuditLogRepository : JpaRepository<AuditLogEntry, UUID> {
+data class AuditLogMessage(@JsonProperty("audit_event") val auditEvent: AuditLogEvent)
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+data class AuditLogEvent(
+    @JsonProperty("date_time")
+    @JsonSerialize(using = CustomOffsetDateTimeSerializer::class)
+    @JsonDeserialize(using = CustomOffsetDateTimeDeserializer::class)
+    val dateTime: OffsetDateTime,
+    val operation: Operation,
+    val status: Status,
+    @JsonProperty("failure_description") val failureDescription: String?,
+    @JsonProperty("app_version") val appVersion: String = AUDIT_LOG_SCHEMA_VERSION,
+    val actor: AuditLogActor,
+    val target: AuditLogTarget,
+)
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+data class AuditLogActor(
+    @JsonProperty("user_id") val userId: String?,
+    val role: UserRole,
+    @JsonProperty("ip_address") val ipAddress: String?,
+)
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+data class AuditLogTarget(
+    val id: String?,
+    val type: ObjectType,
+    @JsonProperty("object_before") val objectBefore: String?,
+    @JsonProperty("object_after") val objectAfter: String?,
+)
+
+interface AuditLogRepository : JpaRepository<AuditLogEntryEntity, UUID> {
     // No need for additional functions. Only adding entries from Haitaton app.
+}
+
+/**
+ * A custom serializer to make sure the date_time field is in the right format (ISO 8601). We can't
+ * directly specify which [com.fasterxml.jackson.databind.ObjectMapper] Hibernate uses when
+ * serializing the message as JSON, so we can't just tell it to use
+ * [com.fasterxml.jackson.datatype.jsr310.JavaTimeModule]. We could add configuration that forces
+ * the object mapper everywhere, but that might have implications elsewhere, which could lead to
+ * really hard bugs. Specifying custom serializers and deserializers is not the prettiest solution,
+ * but still cleaner than changing project-wide configurations.
+ *
+ * Based on https://www.baeldung.com/jackson-serialize-dates#java-8-no-dependency
+ */
+class CustomOffsetDateTimeSerializer @JvmOverloads constructor(t: Class<OffsetDateTime?>? = null) :
+    StdSerializer<OffsetDateTime?>(t) {
+
+    override fun serialize(
+        value: OffsetDateTime?,
+        gen: JsonGenerator,
+        arg2: SerializerProvider?,
+    ) {
+        gen.writeString(value?.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME))
+    }
+}
+
+/**
+ * See [CustomOffsetDateTimeSerializer] for rationale.
+ *
+ * Based on: https://www.baeldung.com/jackson-serialize-dates#java-8-no-dependency
+ */
+class CustomOffsetDateTimeDeserializer
+@JvmOverloads
+constructor(t: Class<OffsetDateTime?>? = null) : StdDeserializer<OffsetDateTime?>(t) {
+    override fun deserialize(
+        jsonparser: JsonParser,
+        context: DeserializationContext?
+    ): OffsetDateTime? =
+        OffsetDateTime.parse(jsonparser.text, DateTimeFormatter.ISO_OFFSET_DATE_TIME)
 }

--- a/services/hanke-service/src/main/resources/db/changelog/changesets/013-recreate-audit-logs-table.yml
+++ b/services/hanke-service/src/main/resources/db/changelog/changesets/013-recreate-audit-logs-table.yml
@@ -1,0 +1,48 @@
+databaseChangeLog:
+  - changeSet:
+      id: 013-drop-old-audit-log-table
+      comment: Audit logs are not in production yet, so the table is safe to drop.
+      author: Topias Heinonen
+      changes:
+        - dropTable:
+            tableName: audit_log
+  - changeSet:
+      id: 013-create-new-audit-logs-table
+      comment: Create audit log table compatible with the generic log transfer component
+      author: Topias Heinonen
+      changes:
+        - createTable:
+            tableName: audit_logs # Database name mandated by the log transfer component
+            remarks: "Table for caching audit logs before log transfer component sends them to a centralized logging service"
+            columns:
+              - column:
+                  name: id
+                  type: bigint
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+                  remarks: "Unique ID for this log row"
+              - column:
+                  name: is_sent
+                  type: boolean
+                  constraints:
+                    nullable: false
+                  remarks: "Whether this row has been sent. Used by the log transfer component."
+              - column:
+                  name: message
+                  type: jsonb
+                  constraints:
+                    nullable: false
+                  remarks: "The actual log object in JSON"
+              - column:
+                  name: created_at
+                  type: timestamp
+                  defaultValueComputed: CURRENT_TIMESTAMP
+                  constraints:
+                    nullable: false
+                  remarks: "Auto-generated timestamp on when the log row was written to the database"
+        - addAutoIncrement:
+            tableName: audit_logs
+            columnName: id
+            columnDataType: bigint
+            generationType: ALWAYS

--- a/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -53,3 +53,5 @@ databaseChangeLog:
       file: db/changelog/changesets/011-drop-old-personal-data-log-tables.yml
   - include:
       file: db/changelog/changesets/012-add-user-role-to-audit-log.yml
+  - include:
+      file: db/changelog/changesets/013-recreate-audit-logs-table.yml

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/allu/ApplicationServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/allu/ApplicationServiceTest.kt
@@ -14,7 +14,6 @@ import io.mockk.every
 import io.mockk.justRun
 import io.mockk.mockk
 import io.mockk.verify
-import java.lang.RuntimeException
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -148,7 +147,11 @@ class ApplicationServiceTest {
                 pendingOnClient = false
             }
         verify {
-            disclosureLogService.saveDisclosureLogsForAllu(expectedApplication, Status.FAILED)
+            disclosureLogService.saveDisclosureLogsForAllu(
+                expectedApplication,
+                Status.FAILED,
+                ALLU_APPLICATION_ERROR_MSG
+            )
         }
     }
 

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/AuditLogEntryFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/AuditLogEntryFactory.kt
@@ -3,9 +3,9 @@ package fi.hel.haitaton.hanke.factory
 import fi.hel.haitaton.hanke.allu.Contact
 import fi.hel.haitaton.hanke.allu.Customer
 import fi.hel.haitaton.hanke.domain.Hanke
-import fi.hel.haitaton.hanke.logging.Action
 import fi.hel.haitaton.hanke.logging.AuditLogEntry
 import fi.hel.haitaton.hanke.logging.ObjectType
+import fi.hel.haitaton.hanke.logging.Operation
 import fi.hel.haitaton.hanke.logging.Status
 import fi.hel.haitaton.hanke.logging.UserRole
 import fi.hel.haitaton.hanke.toJsonString
@@ -15,24 +15,22 @@ object AuditLogEntryFactory : Factory<AuditLogEntry>() {
     fun createReadEntry(
         userId: String? = "test",
         userRole: UserRole = UserRole.USER,
-        action: Action = Action.READ,
+        operation: Operation = Operation.READ,
         status: Status = Status.SUCCESS,
         objectType: ObjectType = ObjectType.YHTEYSTIETO,
         objectId: Any? = 1,
         objectBefore: String? = null,
-        ipNear: String? = null,
-        ipFar: String? = null,
+        ipAddress: String? = null,
     ) =
         AuditLogEntry(
             userId = userId,
             userRole = userRole,
-            action = action,
+            operation = operation,
             status = status,
             objectType = objectType,
             objectId = objectId?.toString(),
             objectBefore = objectBefore,
-            ipNear = ipNear,
-            ipFar = ipFar,
+            ipAddress = ipAddress,
         )
 
     fun createReadEntriesForHanke(hanke: Hanke): List<AuditLogEntry> =

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/logging/DisclosureLogServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/logging/DisclosureLogServiceTest.kt
@@ -38,8 +38,8 @@ internal class DisclosureLogServiceTest {
 
     private val userId = "test"
 
-    private val auditLogRepository: AuditLogRepository = mockk(relaxed = true)
-    private val disclosureLogService = DisclosureLogService(auditLogRepository)
+    private val auditLogService: AuditLogService = mockk(relaxed = true)
+    private val disclosureLogService = DisclosureLogService(auditLogService)
 
     @AfterEach
     fun cleanUp() {
@@ -87,7 +87,7 @@ internal class DisclosureLogServiceTest {
                 )
             )
         verify {
-            auditLogRepository.saveAll(match(containsAllWithoutGeneratedFields(expectedEntries)))
+            auditLogService.saveAll(match(containsAllWithoutGeneratedFields(expectedEntries)))
         }
     }
 
@@ -97,7 +97,7 @@ internal class DisclosureLogServiceTest {
 
         disclosureLogService.saveDisclosureLogsForHanke(hanke, userId)
 
-        verify { auditLogRepository wasNot Called }
+        verify { auditLogService wasNot Called }
     }
 
     @Test
@@ -107,9 +107,7 @@ internal class DisclosureLogServiceTest {
 
         disclosureLogService.saveDisclosureLogsForHanke(hanke, userId)
 
-        verify {
-            auditLogRepository.saveAll(match(containsAllWithoutGeneratedFields(expectedLogs)))
-        }
+        verify { auditLogService.saveAll(match(containsAllWithoutGeneratedFields(expectedLogs))) }
     }
 
     @Test
@@ -126,16 +124,14 @@ internal class DisclosureLogServiceTest {
 
         disclosureLogService.saveDisclosureLogsForHanke(hanke, userId)
 
-        verify {
-            auditLogRepository.saveAll(match(containsAllWithoutGeneratedFields(expectedLogs)))
-        }
+        verify { auditLogService.saveAll(match(containsAllWithoutGeneratedFields(expectedLogs))) }
     }
 
     @Test
     fun `saveDisclosureLogsForHankkeet without hankkeet does nothing`() {
         disclosureLogService.saveDisclosureLogsForHankkeet(listOf(), userId)
 
-        verify { auditLogRepository wasNot Called }
+        verify { auditLogService wasNot Called }
     }
 
     @Test
@@ -144,7 +140,7 @@ internal class DisclosureLogServiceTest {
 
         disclosureLogService.saveDisclosureLogsForHankkeet(hankkeet, userId)
 
-        verify { auditLogRepository wasNot Called }
+        verify { auditLogService wasNot Called }
     }
 
     @Test
@@ -161,9 +157,7 @@ internal class DisclosureLogServiceTest {
 
         disclosureLogService.saveDisclosureLogsForHankkeet(hankkeet, userId)
 
-        verify {
-            auditLogRepository.saveAll(match(containsAllWithoutGeneratedFields(expectedLogs)))
-        }
+        verify { auditLogService.saveAll(match(containsAllWithoutGeneratedFields(expectedLogs))) }
     }
 
     @Test
@@ -177,16 +171,14 @@ internal class DisclosureLogServiceTest {
 
         disclosureLogService.saveDisclosureLogsForHankkeet(hankkeet, userId)
 
-        verify {
-            auditLogRepository.saveAll(match(containsAllWithoutGeneratedFields(expectedLogs)))
-        }
+        verify { auditLogService.saveAll(match(containsAllWithoutGeneratedFields(expectedLogs))) }
     }
 
     @Test
     fun `saveDisclosureLogsForApplication with null application does nothing`() {
         disclosureLogService.saveDisclosureLogsForApplication(null, userId)
 
-        verify { auditLogRepository wasNot Called }
+        verify { auditLogService wasNot Called }
     }
 
     @Test
@@ -206,7 +198,7 @@ internal class DisclosureLogServiceTest {
 
         disclosureLogService.saveDisclosureLogsForApplication(application, userId)
 
-        verify { auditLogRepository wasNot Called }
+        verify { auditLogService wasNot Called }
     }
 
     @Test
@@ -229,7 +221,7 @@ internal class DisclosureLogServiceTest {
 
         disclosureLogService.saveDisclosureLogsForApplication(application, userId)
 
-        verify { auditLogRepository wasNot Called }
+        verify { auditLogService wasNot Called }
     }
 
     @Test
@@ -251,7 +243,7 @@ internal class DisclosureLogServiceTest {
 
         disclosureLogService.saveDisclosureLogsForApplication(application, userId)
 
-        verify { auditLogRepository wasNot Called }
+        verify { auditLogService wasNot Called }
     }
 
     @Test
@@ -274,9 +266,7 @@ internal class DisclosureLogServiceTest {
 
         disclosureLogService.saveDisclosureLogsForApplication(application, userId)
 
-        verify {
-            auditLogRepository.saveAll(match(containsAllWithoutGeneratedFields(expectedLogs)))
-        }
+        verify { auditLogService.saveAll(match(containsAllWithoutGeneratedFields(expectedLogs))) }
     }
 
     @Test
@@ -288,9 +278,7 @@ internal class DisclosureLogServiceTest {
 
         disclosureLogService.saveDisclosureLogsForApplication(application, userId)
 
-        verify {
-            auditLogRepository.saveAll(match(containsAllWithoutGeneratedFields(expectedLogs)))
-        }
+        verify { auditLogService.saveAll(match(containsAllWithoutGeneratedFields(expectedLogs))) }
     }
 
     @ParameterizedTest(name = "{displayName}({arguments})")
@@ -300,18 +288,17 @@ internal class DisclosureLogServiceTest {
         val contact = cableReportApplication.customerWithContacts.contacts[0]
         val expectedLogs =
             listOf(
-                AuditLogEntryFactory.createReadEntryForContact(contact).apply {
-                    status = expectedStatus
-                    userId = ALLU_AUDIT_LOG_USERID
-                    userRole = UserRole.SERVICE
-                }
+                AuditLogEntryFactory.createReadEntryForContact(contact)
+                    .copy(
+                        status = expectedStatus,
+                        userId = ALLU_AUDIT_LOG_USERID,
+                        userRole = UserRole.SERVICE,
+                    )
             )
 
         disclosureLogService.saveDisclosureLogsForAllu(cableReportApplication, expectedStatus)
 
-        verify {
-            auditLogRepository.saveAll(match(containsAllWithoutGeneratedFields(expectedLogs)))
-        }
+        verify { auditLogService.saveAll(match(containsAllWithoutGeneratedFields(expectedLogs))) }
     }
 
     @Test
@@ -344,16 +331,14 @@ internal class DisclosureLogServiceTest {
 
         disclosureLogService.saveDisclosureLogsForApplications(applications, userId)
 
-        verify {
-            auditLogRepository.saveAll(match(containsAllWithoutGeneratedFields(expectedLogs)))
-        }
+        verify { auditLogService.saveAll(match(containsAllWithoutGeneratedFields(expectedLogs))) }
     }
 
     @Test
     fun `saveDisclosureLogsForApplications with company customers and no contacts does nothing`() {
         disclosureLogService.saveDisclosureLogsForApplications(listOf(), userId)
 
-        verify { auditLogRepository wasNot Called }
+        verify { auditLogService wasNot Called }
     }
 
     private fun containsAllWithoutGeneratedFields(
@@ -366,7 +351,7 @@ internal class DisclosureLogServiceTest {
         this.size == other.size && this.toSet() == other.toSet()
 
     private fun withoutGeneratedFields(entries: List<AuditLogEntry>): List<AuditLogEntry> =
-        entries.map { it.copy(eventTime = null, id = null) }
+        entries.map { it.copy(dateTime = null) }
 
     private fun applicationDto(applicationData: CableReportApplication): ApplicationDto =
         ApplicationDto(


### PR DESCRIPTION
# Description

Drop the earlier audit_log table and recreate it as audit_logs with the schema the transfer component uses. The audit logging was never in production, so it's safe to drop the table with it's content.

Transferring audit logs from the local haitaton database to the centralized logging storage will be handled by the reusable log transfer component. The transfer component needs the audit logs to be in a specific database table with a specific schema. These are documented on its [confluence page](https://helsinkisolutionoffice.atlassian.net/wiki/spaces/HELFI/pages/8033697816/Logging+Transferring+log+entries+to+elastic+using+reusable+component).

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1323

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [X] Other

# Instructions for testing
Opening the "Omat Hankkeet" page should write to the audit_logs table if there are any hankkeet with any contact persons.

Adding or modifying the contact persons of a hanke should add CREATE or UPDATE events to the audit_logs table.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [X] I have made necessary changes to the documentation, link to confluence
 or other location: https://helsinkisolutionoffice.atlassian.net/wiki/spaces/HAI/pages/7990181897/Lokituksista