### PR TITLE
HAI-1323 Refactor db containers in tests

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/DatabaseTest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/DatabaseTest.kt
@@ -1,0 +1,51 @@
+package fi.hel.haitaton.hanke
+
+import org.springframework.jdbc.core.RowMapper
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.springframework.test.context.jdbc.Sql
+import org.springframework.test.context.jdbc.SqlMergeMode
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.utility.MountableFile
+
+val countMapper = RowMapper { rs, _ -> rs.getInt(1) }
+
+/**
+ * Start a Docker container running PostgreSQL with the PostGIS extension. Tests extending this
+ * class can call the database through Autowired repositories. The database is reused for all tests
+ * during one run. After the run, the container is removed.
+ *
+ * The database is cleaned before each test. Entity tables are emptied, but the `tormays_*` tables
+ * are kept. Sequences are also not reset, including the `idcounter` table.
+ *
+ * The various tormays_* tables are populated when the database is first started.
+ */
+@Sql("/clear-db.sql")
+@SqlMergeMode(SqlMergeMode.MergeMode.MERGE)
+abstract class DatabaseTest {
+    companion object {
+        @Container
+        private val container: HaitatonPostgreSQLContainer =
+            HaitatonPostgreSQLContainer()
+                .withExposedPorts(5433) // use non-default port
+                .withPassword("test")
+                .withUsername("test")
+                .withCopyFileToContainer(
+                    MountableFile.forClasspathResource(
+                        "/fi/hel/haitaton/hanke/tormaystarkastelu/HEL-GIS-data-test.sql"
+                    ),
+                    "/docker-entrypoint-initdb.d/HEL-GIS-data-test.sql"
+                )
+
+        @JvmStatic
+        @DynamicPropertySource
+        fun postgresqlProperties(registry: DynamicPropertyRegistry) {
+            registry.add("spring.datasource.url", container::getJdbcUrl)
+            registry.add("spring.datasource.username", container::getUsername)
+            registry.add("spring.datasource.password", container::getPassword)
+            registry.add("spring.liquibase.url", container::getJdbcUrl)
+            registry.add("spring.liquibase.user", container::getUsername)
+            registry.add("spring.liquibase.password", container::getPassword)
+        }
+    }
+}

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
@@ -22,10 +22,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.security.test.context.support.WithMockUser
 import org.springframework.test.context.ActiveProfiles
-import org.springframework.test.context.DynamicPropertyRegistry
-import org.springframework.test.context.DynamicPropertySource
 import org.springframework.transaction.annotation.Transactional
-import org.testcontainers.junit.jupiter.Container
 import org.testcontainers.junit.jupiter.Testcontainers
 
 @Testcontainers
@@ -33,30 +30,10 @@ import org.testcontainers.junit.jupiter.Testcontainers
 @ActiveProfiles("default")
 @Transactional
 @WithMockUser(username = "test7358", roles = ["haitaton-user"])
-class HankeServiceITests {
+class HankeServiceITests : DatabaseTest() {
 
     // Must match the username of the mock user above
     private val USER_NAME = "test7358"
-
-    companion object {
-        @Container
-        var container: HaitatonPostgreSQLContainer =
-            HaitatonPostgreSQLContainer()
-                .withExposedPorts(5433) // use non-default port
-                .withPassword("test")
-                .withUsername("test")
-
-        @JvmStatic
-        @DynamicPropertySource
-        fun postgresqlProperties(registry: DynamicPropertyRegistry) {
-            registry.add("spring.datasource.url", container::getJdbcUrl)
-            registry.add("spring.datasource.username", container::getUsername)
-            registry.add("spring.datasource.password", container::getPassword)
-            registry.add("spring.liquibase.url", container::getJdbcUrl)
-            registry.add("spring.liquibase.user", container::getUsername)
-            registry.add("spring.liquibase.password", container::getPassword)
-        }
-    }
 
     @Autowired private lateinit var hankeService: HankeService
 

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HanketunnusServiceImplITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HanketunnusServiceImplITest.kt
@@ -6,38 +6,15 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
-import org.springframework.test.context.DynamicPropertyRegistry
-import org.springframework.test.context.DynamicPropertySource
 import org.springframework.transaction.annotation.Transactional
-import org.testcontainers.junit.jupiter.Container
 import org.testcontainers.junit.jupiter.Testcontainers
 
 @Testcontainers
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("default")
-internal class HanketunnusServiceImplITest {
+internal class HanketunnusServiceImplITest : DatabaseTest() {
 
-    companion object {
-        @Container
-        var container: HaitatonPostgreSQLContainer = HaitatonPostgreSQLContainer()
-            .withExposedPorts(5433) // use non-default port
-            .withPassword("test")
-            .withUsername("test")
-
-        @JvmStatic
-        @DynamicPropertySource
-        fun postgresqlProperties(registry: DynamicPropertyRegistry) {
-            registry.add("spring.datasource.url", container::getJdbcUrl)
-            registry.add("spring.datasource.username", container::getUsername)
-            registry.add("spring.datasource.password", container::getPassword)
-            registry.add("spring.liquibase.url", container::getJdbcUrl)
-            registry.add("spring.liquibase.user", container::getUsername)
-            registry.add("spring.liquibase.password", container::getPassword)
-        }
-    }
-
-    @Autowired
-    lateinit var hanketunnusService: HanketunnusService
+    @Autowired lateinit var hanketunnusService: HanketunnusService
 
     @Test
     @Transactional

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/geometria/HankeGeometriatDaoImplITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/geometria/HankeGeometriatDaoImplITest.kt
@@ -4,64 +4,33 @@ import assertk.assertAll
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNotNull
-import assertk.assertions.isNull
-import fi.hel.haitaton.hanke.HaitatonPostgreSQLContainer
+import fi.hel.haitaton.hanke.DatabaseTest
 import fi.hel.haitaton.hanke.asJsonResource
+import fi.hel.haitaton.hanke.countMapper
+import java.time.ZonedDateTime
+import javax.transaction.Transactional
 import org.geojson.Point
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.test.context.ActiveProfiles
-import org.springframework.test.context.DynamicPropertyRegistry
-import org.springframework.test.context.DynamicPropertySource
-import org.testcontainers.junit.jupiter.Container
 import org.testcontainers.junit.jupiter.Testcontainers
-import java.time.ZonedDateTime
-import javax.transaction.Transactional
 
 @Testcontainers
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("default")
 @Transactional
-internal class HankeGeometriatDaoImplITest {
+internal class HankeGeometriatDaoImplITest : DatabaseTest() {
 
-    companion object {
-        @Container
-        var container: HaitatonPostgreSQLContainer = HaitatonPostgreSQLContainer()
-            .withExposedPorts(5433) // use non-default port
-            .withPassword("test")
-            .withUsername("test")
+    @Autowired private lateinit var hankeGeometriatDao: HankeGeometriatDao
 
-        @JvmStatic
-        @DynamicPropertySource
-        fun postgresqlProperties(registry: DynamicPropertyRegistry) {
-            registry.add("spring.datasource.url", container::getJdbcUrl)
-            registry.add("spring.datasource.username", container::getUsername)
-            registry.add("spring.datasource.password", container::getPassword)
-            registry.add("spring.liquibase.url", container::getJdbcUrl)
-            registry.add("spring.liquibase.user", container::getUsername)
-            registry.add("spring.liquibase.password", container::getPassword)
-        }
-    }
-
-    @Autowired
-    private lateinit var hankeGeometriatDao: HankeGeometriatDao
-
-    @Autowired
-    private lateinit var jdbcTemplate: JdbcTemplate
-
-    @BeforeEach
-    fun setUp() {
-        // delete existing data from database
-        jdbcTemplate.execute("DELETE FROM HankeGeometriat")
-    }
+    @Autowired private lateinit var jdbcTemplate: JdbcTemplate
 
     @Test
     fun `CRUD testing`() {
-        val hankeGeometriat = "/fi/hel/haitaton/hanke/geometria/hankeGeometriat.json"
-            .asJsonResource(HankeGeometriat::class.java)
+        val hankeGeometriat: HankeGeometriat =
+            "/fi/hel/haitaton/hanke/geometria/hankeGeometriat.json".asJsonResource()
         hankeGeometriat.createdByUserId = "1111"
         hankeGeometriat.modifiedByUserId = "2222"
         // For FK constraints we need a Hanke in database
@@ -70,37 +39,47 @@ internal class HankeGeometriatDaoImplITest {
         // Create
         hankeGeometriatDao.createHankeGeometriat(hankeGeometriat)
         // Retrieve
-        var loadedHankeGeometriat = hankeGeometriatDao.retrieveHankeGeometriat(hankeGeometriat.hankeId!!)
+        var loadedHankeGeometriat =
+            hankeGeometriatDao.retrieveHankeGeometriat(hankeGeometriat.hankeId!!)
         assertAll {
             assertThat(loadedHankeGeometriat!!.hankeId).isEqualTo(hankeGeometriat.hankeId)
             assertThat(loadedHankeGeometriat!!.version).isEqualTo(hankeGeometriat.version)
-            assertThat(loadedHankeGeometriat!!.createdByUserId).isEqualTo(hankeGeometriat.createdByUserId)
+            assertThat(loadedHankeGeometriat!!.createdByUserId)
+                .isEqualTo(hankeGeometriat.createdByUserId)
             assertThat(loadedHankeGeometriat!!.createdAt).isEqualTo(hankeGeometriat.createdAt)
-            assertThat(loadedHankeGeometriat!!.modifiedByUserId).isEqualTo(hankeGeometriat.modifiedByUserId)
+            assertThat(loadedHankeGeometriat!!.modifiedByUserId)
+                .isEqualTo(hankeGeometriat.modifiedByUserId)
             assertThat(loadedHankeGeometriat!!.modifiedAt).isEqualTo(hankeGeometriat.modifiedAt)
             assertThat(loadedHankeGeometriat!!.featureCollection!!.features.size).isEqualTo(2)
             assertThat(loadedHankeGeometriat!!.featureCollection!!.features[0].geometry is Point)
-            val loadedPoint = loadedHankeGeometriat!!.featureCollection!!.features[0].geometry as Point
+            val loadedPoint =
+                loadedHankeGeometriat!!.featureCollection!!.features[0].geometry as Point
             val point = hankeGeometriat.featureCollection!!.features[0].geometry as Point
             assertThat(loadedPoint.coordinates).isEqualTo(point.coordinates)
         }
         // Update
-        hankeGeometriat.featureCollection!!.features
+        hankeGeometriat.featureCollection!!
+            .features
             .add(hankeGeometriat.featureCollection!!.features[0]) // add one more geometry
         hankeGeometriat.version = hankeGeometriat.version!! + 1
         hankeGeometriat.modifiedAt = ZonedDateTime.now()
         hankeGeometriatDao.updateHankeGeometriat(hankeGeometriat)
-        loadedHankeGeometriat = hankeGeometriatDao.retrieveHankeGeometriat(hankeGeometriat.hankeId!!)
+        loadedHankeGeometriat =
+            hankeGeometriatDao.retrieveHankeGeometriat(hankeGeometriat.hankeId!!)
         assertAll {
             assertThat(loadedHankeGeometriat!!.hankeId).isEqualTo(hankeGeometriat.hankeId)
             assertThat(loadedHankeGeometriat.version).isEqualTo(hankeGeometriat.version)
-            assertThat(loadedHankeGeometriat.createdByUserId).isEqualTo(hankeGeometriat.createdByUserId)
+            assertThat(loadedHankeGeometriat.createdByUserId)
+                .isEqualTo(hankeGeometriat.createdByUserId)
             assertThat(loadedHankeGeometriat.createdAt).isEqualTo(hankeGeometriat.createdAt)
-            assertThat(loadedHankeGeometriat.modifiedByUserId).isEqualTo(hankeGeometriat.modifiedByUserId)
+            assertThat(loadedHankeGeometriat.modifiedByUserId)
+                .isEqualTo(hankeGeometriat.modifiedByUserId)
             assertThat(loadedHankeGeometriat.modifiedAt!!.isAfter(hankeGeometriat.modifiedAt!!))
-            assertThat(loadedHankeGeometriat.featureCollection!!.features.size).isEqualTo(3) // this has increased
+            assertThat(loadedHankeGeometriat.featureCollection!!.features.size)
+                .isEqualTo(3) // this has increased
             assertThat(loadedHankeGeometriat.featureCollection!!.features[0].geometry is Point)
-            val loadedPoint = loadedHankeGeometriat.featureCollection!!.features[0].geometry as Point
+            val loadedPoint =
+                loadedHankeGeometriat.featureCollection!!.features[0].geometry as Point
             val point = hankeGeometriat.featureCollection!!.features[0].geometry as Point
             assertThat(loadedPoint.coordinates).isEqualTo(point.coordinates)
         }
@@ -108,10 +87,11 @@ internal class HankeGeometriatDaoImplITest {
         // Delete
         hankeGeometriatDao.deleteHankeGeometriat(hankeGeometriat)
         // check that all was deleted correctly
-        assertThat(hankeGeometriatDao.retrieveHankeGeometriat(hankeGeometriat.hankeId!!)).isNotNull()
-        assertThat(jdbcTemplate.queryForObject("SELECT COUNT(*) FROM HankeGeometriat") { rs, _ -> rs.getInt(1) })
+        assertThat(hankeGeometriatDao.retrieveHankeGeometriat(hankeGeometriat.hankeId!!))
+            .isNotNull()
+        assertThat(jdbcTemplate.queryForObject("SELECT COUNT(*) FROM HankeGeometriat", countMapper))
             .isEqualTo(1)
-        assertThat(jdbcTemplate.queryForObject("SELECT COUNT(*) FROM HankeGeometria") { rs, _ -> rs.getInt(1) })
+        assertThat(jdbcTemplate.queryForObject("SELECT COUNT(*) FROM HankeGeometria", countMapper))
             .isEqualTo(0)
     }
 }

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/geometria/HankeGeometriatServiceImplITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/geometria/HankeGeometriatServiceImplITest.kt
@@ -3,17 +3,15 @@ package fi.hel.haitaton.hanke.geometria
 import assertk.assertAll
 import assertk.assertThat
 import assertk.assertions.isEqualTo
-import assertk.assertions.isFalse
 import assertk.assertions.isNotNull
 import assertk.assertions.isNull
-import assertk.assertions.isTrue
 import fi.hel.haitaton.hanke.DATABASE_TIMESTAMP_FORMAT
-import fi.hel.haitaton.hanke.HaitatonPostgreSQLContainer
+import fi.hel.haitaton.hanke.DatabaseTest
 import fi.hel.haitaton.hanke.HankeService
 import fi.hel.haitaton.hanke.asJsonResource
+import fi.hel.haitaton.hanke.countMapper
 import fi.hel.haitaton.hanke.domain.Hanke
 import org.geojson.Point
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
@@ -21,10 +19,7 @@ import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.security.test.context.support.WithMockUser
 import org.springframework.test.context.ActiveProfiles
-import org.springframework.test.context.DynamicPropertyRegistry
-import org.springframework.test.context.DynamicPropertySource
 import org.springframework.transaction.annotation.Transactional
-import org.testcontainers.junit.jupiter.Container
 import org.testcontainers.junit.jupiter.Testcontainers
 
 @Testcontainers
@@ -32,46 +27,16 @@ import org.testcontainers.junit.jupiter.Testcontainers
 @ActiveProfiles("default")
 @Transactional
 @WithMockUser(username = "test", roles = ["haitaton-user"])
-internal class HankeGeometriatServiceImplITest {
+internal class HankeGeometriatServiceImplITest : DatabaseTest() {
 
-    companion object {
-        @Container
-        var container: HaitatonPostgreSQLContainer = HaitatonPostgreSQLContainer()
-            .withExposedPorts(5433) // use non-default port
-            .withPassword("test")
-            .withUsername("test")
-
-        @JvmStatic
-        @DynamicPropertySource
-        fun postgresqlProperties(registry: DynamicPropertyRegistry) {
-            registry.add("spring.datasource.url", container::getJdbcUrl)
-            registry.add("spring.datasource.username", container::getUsername)
-            registry.add("spring.datasource.password", container::getPassword)
-            registry.add("spring.liquibase.url", container::getJdbcUrl)
-            registry.add("spring.liquibase.user", container::getUsername)
-            registry.add("spring.liquibase.password", container::getPassword)
-        }
-    }
-
-    @Autowired
-    private lateinit var hankeService: HankeService
-
-    @Autowired
-    private lateinit var hankeGeometriatService: HankeGeometriatService
-
-    @Autowired
-    private lateinit var jdbcTemplate: JdbcTemplate
-
-    @BeforeEach
-    fun setUp() {
-        // delete existing data from database
-        jdbcTemplate.execute("DELETE FROM HankeGeometriat")
-    }
+    @Autowired private lateinit var hankeService: HankeService
+    @Autowired private lateinit var hankeGeometriatService: HankeGeometriatService
+    @Autowired private lateinit var jdbcTemplate: JdbcTemplate
 
     @Test
     fun `save and load and update`() {
-        val hankeGeometriat = "/fi/hel/haitaton/hanke/geometria/hankeGeometriat.json"
-            .asJsonResource(HankeGeometriat::class.java)
+        val hankeGeometriat: HankeGeometriat =
+            "/fi/hel/haitaton/hanke/geometria/hankeGeometriat.json".asJsonResource()
         val username = SecurityContextHolder.getContext().authentication.name
 
         // For FK constraints we need a Hanke in database
@@ -101,15 +66,19 @@ internal class HankeGeometriatServiceImplITest {
             assertThat(loadedHankeGeometriat!!.modifiedByUserId).isNull()
             assertThat(loadedHankeGeometriat!!.featureCollection!!.features.size).isEqualTo(2)
             assertThat(loadedHankeGeometriat!!.featureCollection!!.features[0].geometry is Point)
-            val loadedPoint = loadedHankeGeometriat!!.featureCollection!!.features[0].geometry as Point
+            val loadedPoint =
+                loadedHankeGeometriat!!.featureCollection!!.features[0].geometry as Point
             val point = hankeGeometriat.featureCollection!!.features[0].geometry as Point
             assertThat(loadedPoint.coordinates).isEqualTo(point.coordinates)
-            assertThat(loadedHankeGeometriat!!.featureCollection!!.features[0].properties["hankeTunnus"])
+            assertThat(
+                    loadedHankeGeometriat?.featureCollection!!.features[0].properties["hankeTunnus"]
+                )
                 .isEqualTo(hankeTunnus)
         }
 
         // update
-        loadedHankeGeometriat.featureCollection!!.features.add(loadedHankeGeometriat.featureCollection!!.features[0])
+        val first = loadedHankeGeometriat.featureCollection!!.features[0]
+        loadedHankeGeometriat.featureCollection!!.features.add(first)
         loadedHankeGeometriat.id = null
         loadedHankeGeometriat.version = null
         loadedHankeGeometriat.modifiedAt = null
@@ -127,22 +96,29 @@ internal class HankeGeometriatServiceImplITest {
                 .isEqualTo(createdAt.format(DATABASE_TIMESTAMP_FORMAT))
             assertThat(loadedHankeGeometriat.modifiedAt!!.isAfter(modifiedAt)) // this has changed
             assertThat(loadedHankeGeometriat.modifiedByUserId).isEqualTo(username)
-            assertThat(loadedHankeGeometriat.featureCollection!!.features.size).isEqualTo(3) // this has increased
+            assertThat(loadedHankeGeometriat.featureCollection!!.features.size)
+                .isEqualTo(3) // this has increased
             assertThat(loadedHankeGeometriat.featureCollection!!.features[0].geometry is Point)
-            val loadedPoint = loadedHankeGeometriat.featureCollection!!.features[0].geometry as Point
+            val loadedPoint =
+                loadedHankeGeometriat.featureCollection!!.features[0].geometry as Point
             val point = hankeGeometriat.featureCollection!!.features[0].geometry as Point
             assertThat(loadedPoint.coordinates).isEqualTo(point.coordinates)
-            assertThat(loadedHankeGeometriat.featureCollection!!.features[0].properties["hankeTunnus"])
+            assertThat(
+                    loadedHankeGeometriat.featureCollection!!.features[0].properties["hankeTunnus"]
+                )
                 .isEqualTo(hankeTunnus)
         }
 
         // check database too to make sure there is everything correctly
         assertAll {
-            assertThat(jdbcTemplate.queryForObject("SELECT COUNT(*) FROM HankeGeometriat") { rs, _ -> rs.getInt(1) })
+            assertThat(
+                    jdbcTemplate.queryForObject("SELECT COUNT(*) FROM HankeGeometriat", countMapper)
+                )
                 .isEqualTo(1)
-            val ids = jdbcTemplate.query("SELECT id, hankegeometriatid FROM HankeGeometria") { rs, _ ->
-                Pair(rs.getInt(1), rs.getInt(2))
-            }
+            val ids =
+                jdbcTemplate.query("SELECT id, hankegeometriatid FROM HankeGeometria") { rs, _ ->
+                    Pair(rs.getInt(1), rs.getInt(2))
+                }
             assertThat(ids.size).isEqualTo(3)
             ids.forEach { idPair ->
                 assertThat(idPair.first).isNotNull()

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/logging/AuditLogServiceITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/logging/AuditLogServiceITests.kt
@@ -8,7 +8,7 @@ import assertk.assertions.isNotNull
 import assertk.assertions.isNull
 import assertk.assertions.support.expected
 import assertk.assertions.support.show
-import fi.hel.haitaton.hanke.HaitatonPostgreSQLContainer
+import fi.hel.haitaton.hanke.DatabaseTest
 import java.time.Duration
 import java.time.LocalDateTime
 import java.time.OffsetDateTime
@@ -18,10 +18,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
-import org.springframework.test.context.DynamicPropertyRegistry
-import org.springframework.test.context.DynamicPropertySource
 import org.springframework.transaction.annotation.Transactional
-import org.testcontainers.junit.jupiter.Container
 import org.testcontainers.junit.jupiter.Testcontainers
 
 /**
@@ -36,32 +33,10 @@ import org.testcontainers.junit.jupiter.Testcontainers
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("default")
 @Transactional
-class AuditLogServiceITests
-@Autowired
-constructor(
-    val entityManager: EntityManager,
-    val auditLogService: AuditLogService,
-) {
+class AuditLogServiceITests : DatabaseTest() {
 
-    companion object {
-        @Container
-        var container: HaitatonPostgreSQLContainer =
-            HaitatonPostgreSQLContainer()
-                .withExposedPorts(5433) // use non-default port
-                .withPassword("test")
-                .withUsername("test")
-
-        @JvmStatic
-        @DynamicPropertySource
-        fun postgresqlProperties(registry: DynamicPropertyRegistry) {
-            registry.add("spring.datasource.url", container::getJdbcUrl)
-            registry.add("spring.datasource.username", container::getUsername)
-            registry.add("spring.datasource.password", container::getPassword)
-            registry.add("spring.liquibase.url", container::getJdbcUrl)
-            registry.add("spring.liquibase.user", container::getUsername)
-            registry.add("spring.liquibase.password", container::getPassword)
-        }
-    }
+    @Autowired private lateinit var entityManager: EntityManager
+    @Autowired private lateinit var auditLogService: AuditLogService
 
     fun Assert<OffsetDateTime?>.isRecent(offset: TemporalAmount) = given { actual ->
         if (actual == null) return

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluLaskentaServiceImplITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluLaskentaServiceImplITest.kt
@@ -4,7 +4,7 @@ import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNotNull
 import com.ninjasquad.springmockk.MockkBean
-import fi.hel.haitaton.hanke.HaitatonPostgreSQLContainer
+import fi.hel.haitaton.hanke.DatabaseTest
 import fi.hel.haitaton.hanke.HankeService
 import fi.hel.haitaton.hanke.KaistajarjestelynPituus
 import fi.hel.haitaton.hanke.TZ_UTC
@@ -19,10 +19,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.security.test.context.support.WithMockUser
 import org.springframework.test.context.ActiveProfiles
-import org.springframework.test.context.DynamicPropertyRegistry
-import org.springframework.test.context.DynamicPropertySource
 import org.springframework.transaction.annotation.Transactional
-import org.testcontainers.junit.jupiter.Container
 import org.testcontainers.junit.jupiter.Testcontainers
 
 @Testcontainers
@@ -30,35 +27,12 @@ import org.testcontainers.junit.jupiter.Testcontainers
 @ActiveProfiles("default")
 @Transactional
 @WithMockUser(username = "test", roles = ["haitaton-user"])
-internal class TormaystarkasteluLaskentaServiceImplITest {
+internal class TormaystarkasteluLaskentaServiceImplITest : DatabaseTest() {
 
-    companion object {
-        @Container
-        var container: HaitatonPostgreSQLContainer = HaitatonPostgreSQLContainer()
-            .withExposedPorts(5433) // use non-default port
-            .withPassword("test")
-            .withUsername("test")
+    @MockkBean private lateinit var hankeGeometriatDao: HankeGeometriatDao
+    @MockkBean private lateinit var tormaystarkasteluDao: TormaystarkasteluTormaysService
 
-        @JvmStatic
-        @DynamicPropertySource
-        fun postgresqlProperties(registry: DynamicPropertyRegistry) {
-            registry.add("spring.datasource.url", container::getJdbcUrl)
-            registry.add("spring.datasource.username", container::getUsername)
-            registry.add("spring.datasource.password", container::getPassword)
-            registry.add("spring.liquibase.url", container::getJdbcUrl)
-            registry.add("spring.liquibase.user", container::getUsername)
-            registry.add("spring.liquibase.password", container::getPassword)
-        }
-    }
-
-    @MockkBean
-    private lateinit var hankeGeometriatDao: HankeGeometriatDao
-
-    @MockkBean
-    private lateinit var tormaystarkasteluDao: TormaystarkasteluTormaysService
-
-    @Autowired
-    private lateinit var hankeService: HankeService
+    @Autowired private lateinit var hankeService: HankeService
 
     @Autowired
     private lateinit var tormaystarkasteluLaskentaService: TormaystarkasteluLaskentaService
@@ -71,8 +45,8 @@ internal class TormaystarkasteluLaskentaServiceImplITest {
         val tulos = tormaystarkasteluLaskentaService.calculateTormaystarkastelu(hanke)
         assertThat(tulos).isNotNull()
         assertThat(tulos!!.liikennehaittaIndeksi).isNotNull()
-        assertThat(tulos.liikennehaittaIndeksi!!.indeksi).isNotNull()
-        assertThat(tulos.liikennehaittaIndeksi!!.indeksi).isEqualTo(4.0f)
+        assertThat(tulos.liikennehaittaIndeksi.indeksi).isNotNull()
+        assertThat(tulos.liikennehaittaIndeksi.indeksi).isEqualTo(4.0f)
     }
 
     private fun setupHappyCase(): Hanke {
@@ -89,17 +63,12 @@ internal class TormaystarkasteluLaskentaServiceImplITest {
 
         val hankeId = hanke.id!!
         val hankeGeometriatId = 1
-        val hankeGeometriaId = 1
         val hankeGeometriat = HankeGeometriat(hankeGeometriatId, hankeId)
         hankeService.updateHanke(hanke)
         hanke.geometriat = hankeGeometriat
 
-        every {
-            hankeGeometriatDao.retrieveHankeGeometriat(hankeId)
-        } returns hankeGeometriat
-        every {
-            tormaystarkasteluDao.anyIntersectsYleinenKatuosa(hankeGeometriat)
-        } returns true
+        every { hankeGeometriatDao.retrieveHankeGeometriat(hankeId) } returns hankeGeometriat
+        every { tormaystarkasteluDao.anyIntersectsYleinenKatuosa(hankeGeometriat) } returns true
         every {
             tormaystarkasteluDao.maxIntersectingYleinenkatualueKatuluokka(hankeGeometriat)
         } returns TormaystarkasteluKatuluokka.ALUEELLINEN_KOKOOJAKATU.value
@@ -107,23 +76,18 @@ internal class TormaystarkasteluLaskentaServiceImplITest {
             tormaystarkasteluDao.maxIntersectingLiikenteellinenKatuluokka(hankeGeometriat)
         } returns TormaystarkasteluKatuluokka.ALUEELLINEN_KOKOOJAKATU.value
         every {
-            tormaystarkasteluDao.maxLiikennemaara(hankeGeometriat, TormaystarkasteluLiikennemaaranEtaisyys.RADIUS_30)
+            tormaystarkasteluDao.maxLiikennemaara(
+                hankeGeometriat,
+                TormaystarkasteluLiikennemaaranEtaisyys.RADIUS_30
+            )
         } returns 1000
-        every {
-            tormaystarkasteluDao.anyIntersectsWithCyclewaysPriority(hankeGeometriat)
-        } returns false
-        every {
-            tormaystarkasteluDao.anyIntersectsWithCyclewaysMain(hankeGeometriat)
-        } returns true
-        every {
-            tormaystarkasteluDao.maxIntersectingTramByLaneType(hankeGeometriat)
-        } returns TormaystarkasteluRaitiotiekaistatyyppi.JAETTU.value
-        every {
-            tormaystarkasteluDao.anyIntersectsCriticalBusRoutes(hankeGeometriat)
-        } returns true
+        every { tormaystarkasteluDao.anyIntersectsWithCyclewaysPriority(hankeGeometriat) } returns
+            false
+        every { tormaystarkasteluDao.anyIntersectsWithCyclewaysMain(hankeGeometriat) } returns true
+        every { tormaystarkasteluDao.maxIntersectingTramByLaneType(hankeGeometriat) } returns
+            TormaystarkasteluRaitiotiekaistatyyppi.JAETTU.value
+        every { tormaystarkasteluDao.anyIntersectsCriticalBusRoutes(hankeGeometriat) } returns true
 
         return hanke
     }
-
-
 }

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluTormaysServicePGITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluTormaysServicePGITest.kt
@@ -5,69 +5,41 @@ import assertk.assertions.containsOnly
 import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
 import assertk.assertions.isTrue
-import fi.hel.haitaton.hanke.HaitatonPostgreSQLContainer
+import fi.hel.haitaton.hanke.DatabaseTest
 import fi.hel.haitaton.hanke.HankeEntity
 import fi.hel.haitaton.hanke.HankeRepository
 import fi.hel.haitaton.hanke.asJsonResource
 import fi.hel.haitaton.hanke.geometria.HankeGeometriat
 import fi.hel.haitaton.hanke.geometria.HankeGeometriatDao
 import javax.transaction.Transactional
-import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
-import org.springframework.test.context.DynamicPropertyRegistry
-import org.springframework.test.context.DynamicPropertySource
-import org.testcontainers.junit.jupiter.Container
 import org.testcontainers.junit.jupiter.Testcontainers
-import org.testcontainers.utility.MountableFile
 
 @Testcontainers
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("default")
 @Transactional
-internal class TormaystarkasteluTormaysServicePGITest {
+internal class TormaystarkasteluTormaysServicePGITest : DatabaseTest() {
 
-    companion object {
-        @Container
-        var container: HaitatonPostgreSQLContainer = HaitatonPostgreSQLContainer()
-            .withExposedPorts(5433) // use non-default port
-            .withPassword("test")
-            .withUsername("test")
-            .withCopyFileToContainer(
-                MountableFile.forClasspathResource(
-                    "/fi/hel/haitaton/hanke/tormaystarkastelu/HEL-GIS-data-test.sql"
-                ),
-                "/docker-entrypoint-initdb.d/HEL-GIS-data-test.sql"
-            )
+    @Autowired private lateinit var hankeRepository: HankeRepository
+    @Autowired private lateinit var hankeGeometriatDao: HankeGeometriatDao
 
-        @JvmStatic
-        @DynamicPropertySource
-        fun postgresqlProperties(registry: DynamicPropertyRegistry) {
-            registry.add("spring.datasource.url", container::getJdbcUrl)
-            registry.add("spring.datasource.username", container::getUsername)
-            registry.add("spring.datasource.password", container::getPassword)
-            registry.add("spring.liquibase.url", container::getJdbcUrl)
-            registry.add("spring.liquibase.user", container::getUsername)
-            registry.add("spring.liquibase.password", container::getPassword)
-        }
-
-        @JvmStatic
-        @BeforeAll
-        fun setUp(@Autowired hankeRepository: HankeRepository, @Autowired hankeGeometriatDao: HankeGeometriatDao) {
-            val entity = hankeRepository.save(HankeEntity(hankeTunnus = "HAI21-1-testi"))
-            hankeGeometriat = "/fi/hel/haitaton/hanke/tormaystarkastelu/hankeGeometriat.json"
-                .asJsonResource(HankeGeometriat::class.java)
-            hankeGeometriat.hankeId = entity.id
-            hankeGeometriatDao.createHankeGeometriat(hankeGeometriat)
-        }
-
-        private var hankeGeometriat: HankeGeometriat = HankeGeometriat()
+    @BeforeEach
+    fun setUp() {
+        val entity = hankeRepository.save(HankeEntity(hankeTunnus = "HAI21-1-testi"))
+        hankeGeometriat =
+            "/fi/hel/haitaton/hanke/tormaystarkastelu/hankeGeometriat.json".asJsonResource()
+        hankeGeometriat.hankeId = entity.id
+        hankeGeometriatDao.createHankeGeometriat(hankeGeometriat)
     }
 
-    @Autowired
-    private lateinit var tormaysService: TormaystarkasteluTormaysService
+    private var hankeGeometriat: HankeGeometriat = HankeGeometriat()
+
+    @Autowired private lateinit var tormaysService: TormaystarkasteluTormaysService
 
     /*
     Test manually whether Hanke geometries are located on general street area ("yleinen katuosa", ylre_parts)
@@ -109,8 +81,12 @@ internal class TormaystarkasteluTormaysServicePGITest {
     @Test
     fun liikennemaarat15() {
         assertThat(
-                tormaysService.maxLiikennemaara(hankeGeometriat, TormaystarkasteluLiikennemaaranEtaisyys.RADIUS_15)
-        ).isEqualTo(17566)
+                tormaysService.maxLiikennemaara(
+                    hankeGeometriat,
+                    TormaystarkasteluLiikennemaaranEtaisyys.RADIUS_15
+                )
+            )
+            .isEqualTo(17566)
     }
 
     /*
@@ -119,8 +95,12 @@ internal class TormaystarkasteluTormaysServicePGITest {
     @Test
     fun liikennemaarat30() {
         assertThat(
-            tormaysService.maxLiikennemaara(hankeGeometriat, TormaystarkasteluLiikennemaaranEtaisyys.RADIUS_30)
-        ).isEqualTo(17566)
+                tormaysService.maxLiikennemaara(
+                    hankeGeometriat,
+                    TormaystarkasteluLiikennemaaranEtaisyys.RADIUS_30
+                )
+            )
+            .isEqualTo(17566)
     }
 
     /*
@@ -147,7 +127,7 @@ internal class TormaystarkasteluTormaysServicePGITest {
     @Test
     fun raitiotiet() {
         assertThat(tormaysService.maxIntersectingTramByLaneType(hankeGeometriat))
-                .isEqualTo(TormaystarkasteluRaitiotiekaistatyyppi.JAETTU.value)
+            .isEqualTo(TormaystarkasteluRaitiotiekaistatyyppi.JAETTU.value)
     }
 
     /*

--- a/services/hanke-service/src/integrationTest/resources/clear-db.sql
+++ b/services/hanke-service/src/integrationTest/resources/clear-db.sql
@@ -1,0 +1,11 @@
+TRUNCATE TABLE
+    applications,
+    audit_logs,
+    hanke,
+    hankegeometria,
+    hankegeometriat,
+    hanketyomaatyyppi,
+    hankeyhteystieto,
+    organisaatio,
+    permissions,
+    tormaystarkastelutulos;

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/TestExtensions.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/TestExtensions.kt
@@ -1,9 +1,13 @@
 package fi.hel.haitaton.hanke
 
 import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.module.kotlin.readValue
 
 fun <T> String.asJsonResource(type: Class<T>): T =
     OBJECT_MAPPER.readValue(getResourceAsText(this), type)
+
+inline fun <reified T : Any> String.asJsonResource(): T =
+    OBJECT_MAPPER.readValue(getResourceAsText(this))
 
 fun String.asJsonNode(): JsonNode = OBJECT_MAPPER.readTree(getResourceAsText(this))
 


### PR DESCRIPTION
# Description

Move the PostgreSQL container definitions to an abstract class so that they are not repeated in every test class that needs to use the database.

This has the added benefit of reusing the database container for all tests. Even after adding a script to clean the database between each test, this sped up running the integration tests from 2.5 minutes to 50 seconds on my machine. That's 1/3 of the time they used to take.

Some other, smaller, refactoring was done while touching the classes anyway, e.g. fixing the compilation warnings from
`TormaystarkasteluLaskentaServiceImplITest`.

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [X] Other

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 