### PR TITLE
HAI-1292 Prepare traffic volumes GIS material

### DIFF
--- a/scripts/gis-material-update/README.md
+++ b/scripts/gis-material-update/README.md
@@ -36,6 +36,8 @@ Local development database is set up with PostGIS spatial support.
 
 Local directory `haitaton-downloads` is mapped to fetch and processing containers.
 
+Local directory `haitaton-gis-output` is mapped to processing container.
+
 External volume `haitaton_gis_prepare` contains scripts for processing.
 
 External volume `haitaton_gis_db` is dedicated for database.
@@ -114,7 +116,7 @@ Where `<source>` is currently one of:
 - `osm`
 - `ylre_katualue`
 - `ylre_katuosat`
-- `maka_autoliikennemaarat`
+- `maka_autoliikennemaarat` - Traffic volumes (car traffic)
 
 Data files are downloaded to `./haitaton-downloads` -directory.
 
@@ -147,6 +149,25 @@ haitaton-gis-output
 
 - buses_lines.gpkg
 - tormays_buses_polys.gpkg
+
+### `maka_autoliikennemaarat`
+
+Docker example run (ensure that image build and file copying is
+already performed as instructed above):
+
+```sh
+docker-compose up -d gis-db
+docker-compose run --rm gis-fetch maka_autoliikennemaarat
+docker-compose run --rm gis-process maka_autoliikennemaarat
+docker-compose stop gis-db
+```
+
+Processed GIS material is available in:
+haitaton-gis-output
+
+- volume_lines.gpkg
+- tormays_volumes15_polys.gpkg
+- tormays_volumes30_polys.gpkg
 
 # Run tests
 

--- a/scripts/gis-material-update/config.yaml
+++ b/scripts/gis-material-update/config.yaml
@@ -9,6 +9,11 @@ maka_autoliikennemaarat:
   addr: "https://kartta.hel.fi/ws/geoserver/avoindata/wfs"
   layer: "avoindata:Ajoneuvoliikenne_liikennemaarat_viiva"
   local_file: "maka_autoliikennemaarat.gpkg"
+  target_file: "volume_lines.gpkg"
+  target_buffer_file: "tormays_volume_{}.gpkg"
+  buffer:
+    - 15
+    - 30
 ylre_katualue:
   addr: "https://kartta.hel.fi/ws/geoserver/avoindata/wfs"
   layer: "avoindata:YLRE_Katualue_alue"

--- a/scripts/gis-material-update/config.yaml
+++ b/scripts/gis-material-update/config.yaml
@@ -10,7 +10,7 @@ maka_autoliikennemaarat:
   layer: "avoindata:Ajoneuvoliikenne_liikennemaarat_viiva"
   local_file: "maka_autoliikennemaarat.gpkg"
   target_file: "volume_lines.gpkg"
-  target_buffer_file: "tormays_volume_{}.gpkg"
+  target_buffer_file: "tormays_volumes{}_polys.gpkg"
   buffer:
     - 15
     - 30

--- a/scripts/gis-material-update/inspect-disk.sh
+++ b/scripts/gis-material-update/inspect-disk.sh
@@ -2,6 +2,7 @@
 
 docker container create --name dummy \
     -v haitaton_gis_prepare:/haitaton-gis \
+    -v $(pwd)/haitaton-gis-output:/gis-output \
     -v $(pwd)/haitaton-downloads:/downloads \
     ubuntu
 

--- a/scripts/gis-material-update/process/modules/autoliikennemaarat.py
+++ b/scripts/gis-material-update/process/modules/autoliikennemaarat.py
@@ -6,7 +6,7 @@ from modules.config import Config
 
 
 class MakaAutoliikennemaarat:
-    """ "Process traffic (car) volumes."""
+    """Process traffic (car) volumes."""
 
     def __init__(self, cfg: Config):
         self._cfg = cfg
@@ -36,7 +36,7 @@ class MakaAutoliikennemaarat:
     def persist_to_database(self) -> None:
         connection = create_engine(self._cfg.pg_conn_uri())
 
-        # persist route lines to database
+        # persist traffic volume lines to database
         self._df.to_postgis(
             "volume_lines",
             connection,
@@ -46,7 +46,7 @@ class MakaAutoliikennemaarat:
             index_label="fid",
         )
 
-        # persist polygons to database
+        # persist traffic volume polygons to database
         for buffer_size, polygon_data in self._process_result.items():
             polygon_data.to_postgis(
                 "volume_{}".format(buffer_size),

--- a/scripts/gis-material-update/process/modules/autoliikennemaarat.py
+++ b/scripts/gis-material-update/process/modules/autoliikennemaarat.py
@@ -1,0 +1,68 @@
+import geopandas as gpd
+from sqlalchemy import create_engine
+
+
+from modules.config import Config
+
+
+class MakaAutoliikennemaarat:
+    """ "Process traffic (car) volumes."""
+
+    def __init__(self, cfg: Config):
+        self._cfg = cfg
+        self._module = "maka_autoliikennemaarat"
+
+        filename = cfg.local_file(self._module)
+        layer = cfg.layer(self._module)
+        df = gpd.read_file(filename, layer=layer)
+        self._df = (
+            df.loc[:, ["autot", "geometry"]]
+            .rename(columns={"autot": "volume"})
+            .explode(index_parts=False)
+        )
+        self._df["fid"] = self._df.reset_index().index
+        self._df = self._df.set_index("fid")
+
+    def process(self) -> None:
+        buffers = self._cfg.buffer(self._module)
+
+        result = {}
+        for buffer in buffers:
+            target_volume_polys = self._df.copy()
+            target_volume_polys["geometry"] = target_volume_polys.buffer(buffer)
+            result[buffer] = target_volume_polys
+        self._process_result = result
+
+    def persist_to_database(self) -> None:
+        connection = create_engine(self._cfg.pg_conn_uri())
+
+        # persist route lines to database
+        self._df.to_postgis(
+            "volume_lines",
+            connection,
+            "public",
+            if_exists="replace",
+            index=True,
+            index_label="fid",
+        )
+
+        # persist polygons to database
+        for buffer_size, polygon_data in self._process_result.items():
+            polygon_data.to_postgis(
+                "volume_{}".format(buffer_size),
+                connection,
+                "public",
+                if_exists="replace",
+                index=True,
+                index_label="fid",
+            )
+
+    def save_to_file(self):
+        target_lines_file_name = self._cfg.target_file(self._module)
+        self._df.to_file(target_lines_file_name, driver="GPKG")
+
+        target_buffer_file_template = self._cfg.target_buffer_file(self._module)
+
+        for buffer_size, polygon_data in self._process_result.items():
+            file_name = target_buffer_file_template.format(buffer_size)
+            polygon_data.to_file(file_name, driver="GPKG")

--- a/scripts/gis-material-update/process/process_data.py
+++ b/scripts/gis-material-update/process/process_data.py
@@ -5,6 +5,8 @@ import sys
 
 from modules.config import Config
 from modules.gis_processing import GisProcessor
+
+from modules.autoliikennemaarat import MakaAutoliikennemaarat
 from modules.hsl import HslBuses
 
 
@@ -21,6 +23,8 @@ def instantiate_processor(item: str, cfg: Config) -> GisProcessor:
     """Instantiate correct class for processing data."""
     if item == "hsl":
         return HslBuses(cfg, validate_gtfs=False)
+    elif item == "maka_autoliikennemaarat":
+        return MakaAutoliikennemaarat(cfg)
     else:
         try:
             raise RuntimeError("Configuration not recognized: {}".format(item))

--- a/scripts/gis-material-update/process/test/test_autoliikennemaarat.py
+++ b/scripts/gis-material-update/process/test/test_autoliikennemaarat.py
@@ -1,0 +1,45 @@
+import geopandas as gpd
+import pandas as pd
+import unittest
+
+
+from modules.config import Config
+from modules.autoliikennemaarat import MakaAutoliikennemaarat
+
+
+class TestMakaAutoliikennemaarat(unittest.TestCase):
+    """Test MAKA Autoliikennemäärät -processing"""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.cfg = Config()
+        cls._module_name = "maka_autoliikennemaarat"
+        filename_template = cls.cfg.target_buffer_file(cls._module_name)
+        buffers = cls.cfg.buffer(cls._module_name)
+
+        results = {}
+        for buffer in buffers:
+            results[buffer] = gpd.read_file(filename_template.format(buffer))
+
+        cls._polygon_results = results
+
+        cls._line_results = gpd.read_file(cls.cfg.target_file(cls._module_name))
+
+    def test_line_geometry_is_linestring(self):
+        geom_names = self._line_results.geometry.geom_type.unique().tolist()
+
+        self.assertEqual(len(geom_names), 1)
+
+        self.assertEqual(geom_names[0].lower(), "linestring")
+
+    def test_buffer_geometry_is_polygon(self):
+        for _, geom_data in self._polygon_results.items():
+            geom_names = geom_data.geometry.geom_type.unique().tolist()
+
+            self.assertEqual(len(geom_names), 1)
+
+            self.assertEqual(geom_names[0].lower(), "polygon")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/gis-material-update/process/test/test_autoliikennemaarat.py
+++ b/scripts/gis-material-update/process/test/test_autoliikennemaarat.py
@@ -12,9 +12,9 @@ class TestMakaAutoliikennemaarat(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls) -> None:
-        cfg = Config()
+        cls.cfg = Config()
 
-        volumes = MakaAutoliikennemaarat(cfg)
+        volumes = MakaAutoliikennemaarat(cls.cfg)
         volumes.process()
 
         cls._line_results = volumes._df
@@ -27,8 +27,8 @@ class TestMakaAutoliikennemaarat(unittest.TestCase):
 
         self.assertEqual(geom_names[0].lower(), "linestring")
 
-    def test_line_geometry_has_crs_epsg_3879(self):
-        self.assertEqual(self._line_results.crs, "EPSG:3879")
+    def test_line_geometry_has_configured_crs(self):
+        self.assertEqual(self._line_results.crs, self.cfg.crs())
 
     def test_buffered_geometry_is_polygon(self):
         for _, geom_data in self._polygon_results.items():
@@ -38,9 +38,9 @@ class TestMakaAutoliikennemaarat(unittest.TestCase):
 
             self.assertEqual(geom_names[0].lower(), "polygon")
 
-    def test_buffered_geometry_has_crs_epsg_3879(self):
+    def test_buffered_geometry_has_configured_crs(self):
         for _, geom_data in self._polygon_results.items():
-            self.assertEqual(geom_data.crs, "EPSG:3879")
+            self.assertEqual(geom_data.crs, self.cfg.crs())
 
     def test_tormays_attributes(self):
         attributes = set(["volume", "geometry"])

--- a/scripts/gis-material-update/process/test/test_configuration.py
+++ b/scripts/gis-material-update/process/test/test_configuration.py
@@ -1,0 +1,22 @@
+"""Test for configuration YAML contents."""
+import unittest
+
+
+from modules.config import Config
+
+
+class TestConfiguration(unittest.TestCase):
+    """Test configuration"""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls._cfg = Config()
+
+    def test_crs_is_epsg_3879(self):
+        crs = self._cfg.crs()
+
+        self.assertEqual("EPSG:3879", crs)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/gis-material-update/process/test/test_hsl.py
+++ b/scripts/gis-material-update/process/test/test_hsl.py
@@ -36,6 +36,11 @@ class TestHslLines(unittest.TestCase):
         # Geometry is Polygon
         self.assertEqual(geom_names[0].lower(), "polygon")
 
+    def test_tormays_geometry_has_configured_crs(self):
+        polygons = self._target_buffer_dataframe
+
+        self.assertEqual(polygons.geometry.crs, self.cfg.crs())
+
     def test_tormays_attributes(self):
         tormays = self._target_buffer_dataframe
         attributes = set(["direction_id", "route_id", "rush_hour", "trunk", "geometry"])


### PR DESCRIPTION
# Description

Implemented processing of traffic volume polygons.

### Jira Issue: 

https://helsinkisolutionoffice.atlassian.net/browse/HAI-1292

## Type of change

- [ ] Bug fix 
- [x] New feature 
- [ ] Other

# Instructions for testing
Prerequisite: fetch `maka_autoliikennemaarat` source materials, as per instructions in the README

Go to directory: haitaton-backend/scripts/gis-material-update/process

(create and) activate Python virtual environment
run `python -m unittest discover -v`

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [] I have made necessary changes to the documentation, link to confluence
 or other location: 

# Other relevant info

-