### PR TITLE
HAI-1323 Add timestamp to created_at in audit_logs

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/logging/AuditLogServiceITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/logging/AuditLogServiceITests.kt
@@ -10,7 +10,6 @@ import assertk.assertions.support.expected
 import assertk.assertions.support.show
 import fi.hel.haitaton.hanke.HaitatonPostgreSQLContainer
 import java.time.Duration
-import java.time.LocalDateTime
 import java.time.OffsetDateTime
 import java.time.temporal.TemporalAmount
 import javax.persistence.EntityManager
@@ -70,13 +69,6 @@ constructor(
         expected("after:${show(now.minus(offset))} but was:${show(actual)}")
     }
 
-    fun Assert<LocalDateTime?>.isRecentLocal(offset: TemporalAmount) = given { actual ->
-        if (actual == null) return
-        val now = LocalDateTime.now()
-        if (actual.isBefore(now) && actual.isAfter(now.minus(offset))) return
-        expected("after:${show(now.minus(offset))} but was:${show(actual)}")
-    }
-
     @Test
     fun `saving audit log entry works`() {
         // Create a log entry, save it, flush, clear caches:
@@ -104,7 +96,7 @@ constructor(
         assertThat(foundAuditLogEntry).isNotNull()
         assertThat(foundAuditLogEntry.id).isNotNull()
         assertThat(foundAuditLogEntry.isSent).isFalse()
-        assertThat(foundAuditLogEntry.createdAt).isRecentLocal(Duration.ofMinutes(1))
+        assertThat(foundAuditLogEntry.createdAt).isRecent(Duration.ofMinutes(1))
         val auditLogEvent = foundAuditLogEntry.message.auditEvent
         assertThat(auditLogEvent.dateTime).isRecent(Duration.ofMinutes(1))
         assertThat(auditLogEvent.appVersion).isEqualTo("1")

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/Persistence.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/Persistence.kt
@@ -11,7 +11,6 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer
 import com.fasterxml.jackson.databind.ser.std.StdSerializer
 import com.vladmihalcea.hibernate.type.json.JsonBinaryType
-import java.time.LocalDateTime
 import java.time.OffsetDateTime
 import java.time.format.DateTimeFormatter
 import java.util.UUID
@@ -56,7 +55,7 @@ data class AuditLogEntryEntity(
     /** This will be set by the database. */
     @Column(name = "created_at")
     @Generated(GenerationTime.INSERT)
-    val createdAt: LocalDateTime? = null,
+    val createdAt: OffsetDateTime? = null,
 )
 
 data class AuditLogMessage(@JsonProperty("audit_event") val auditEvent: AuditLogEvent)

--- a/services/hanke-service/src/main/resources/db/changelog/changesets/014-add-timezone-to-audit-logs-created-at.sql
+++ b/services/hanke-service/src/main/resources/db/changelog/changesets/014-add-timezone-to-audit-logs-created-at.sql
@@ -1,0 +1,7 @@
+--liquibase formatted sql
+--changeset Topias Heinonen:014-add-timezone-to-audit-logs-created-at
+--comment: Add timezone to audit_logs created_at
+
+ALTER TABLE audit_logs
+    ALTER created_at TYPE timestamp with time zone USING created_at AT TIME ZONE 'UTC',
+    ALTER created_at SET DEFAULT now();

--- a/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -55,3 +55,5 @@ databaseChangeLog:
       file: db/changelog/changesets/012-add-user-role-to-audit-log.yml
   - include:
       file: db/changelog/changesets/013-recreate-audit-logs-table.yml
+  - include:
+      file: db/changelog/changesets/014-add-timezone-to-audit-logs-created-at.sql


### PR DESCRIPTION
# Description

Modify the created_at column in audit_logs table to use timestamp with timezone instead of timezoneless timestamp.

The reusable log transfer component has been giving out warnings when transferring audit logs. It complains that created_at doesn't have timezone information, even though timezones would be supported. The documentation was ambiguous on whether the timestamp should have timezone information or not. The documentation has since been improved.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1323

## Type of change

- [X] Bug fix 
- [ ] New feature 
- [ ] Other

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [X] I have made necessary changes to the documentation, link to confluence
 or other location:
 
  - https://helsinkisolutionoffice.atlassian.net/wiki/spaces/HELFI/pages/8033697816/Logging+Transferring+log+entries+to+elastic+using+reusable+component?NO_SSR=1#Schema
  - https://github.com/City-of-Helsinki/structured-log-transfer#postgresql-create-minimal-table-and-insert-test-data-into-it

# Other relevant info
I checked that the created_at times of the rows in the audit_logs table didn't change over the migration.