### PR TITLE
HAI-1075 Add modify log for deleting hankkeet

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/domain/PublicHankeControllerITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/domain/PublicHankeControllerITests.kt
@@ -5,7 +5,7 @@ import fi.hel.haitaton.hanke.IntegrationTestConfiguration
 import fi.hel.haitaton.hanke.IntegrationTestResourceServerConfig
 import fi.hel.haitaton.hanke.factory.HankeFactory
 import fi.hel.haitaton.hanke.factory.HankeFactory.mutate
-import fi.hel.haitaton.hanke.factory.HankeFactory.withHaitta
+import fi.hel.haitaton.hanke.factory.HankeFactory.withHankealue
 import fi.hel.haitaton.hanke.factory.HankeFactory.withYhteystiedot
 import fi.hel.haitaton.hanke.geometria.GeometriatService
 import fi.hel.haitaton.hanke.tormaystarkastelu.TormaystarkasteluTulos
@@ -51,10 +51,10 @@ class PublicHankeControllerITests(@Autowired val mockMvc: MockMvc) {
     fun `only returns hankkeet with tormaystarkasteluTulos`() {
         performGetHankkeet(
                 listOf(
-                    HankeFactory.create().withHaitta().mutate {
+                    HankeFactory.create().withHankealue().mutate {
                         it.tormaystarkasteluTulos = TormaystarkasteluTulos(1f, 1f, 1f)
                     },
-                    HankeFactory.create(id = 444, hankeTunnus = "HAI-TEST-2").withHaitta()
+                    HankeFactory.create(id = 444, hankeTunnus = "HAI-TEST-2").withHankealue()
                 )
             )
             .andExpect(MockMvcResultMatchers.status().isOk)
@@ -68,7 +68,7 @@ class PublicHankeControllerITests(@Autowired val mockMvc: MockMvc) {
     fun `doesn't return personal information from yhteystiedot`() {
         performGetHankkeet(
                 listOf(
-                    HankeFactory.create().withHaitta().withYhteystiedot().mutate {
+                    HankeFactory.create().withHankealue().withYhteystiedot().mutate {
                         it.tormaystarkasteluTulos = TormaystarkasteluTulos(1f, 1f, 1f)
                     }
                 )

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/geometria/GeometriatServiceImplITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/geometria/GeometriatServiceImplITest.kt
@@ -51,7 +51,7 @@ internal class GeometriatServiceImplITest : DatabaseTest() {
         // they must be picked from the created hanke-instance.
         val hankeId = 1
         val hankeInit = HankeFactory.create(id = hankeId)
-        hankeInit.alueet.add(HankealueFactory.create(null, null, geometriat = geometriat))
+        hankeInit.alueet.add(HankealueFactory.createMinimal(geometriat = geometriat))
         val hanke = hankeService.createHanke(hankeInit)
         val hankeTunnus = hanke.hankeTunnus!!
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Configuration.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Configuration.kt
@@ -10,6 +10,7 @@ import fi.hel.haitaton.hanke.geometria.GeometriatService
 import fi.hel.haitaton.hanke.geometria.GeometriatServiceImpl
 import fi.hel.haitaton.hanke.logging.AuditLogService
 import fi.hel.haitaton.hanke.logging.DisclosureLogService
+import fi.hel.haitaton.hanke.logging.HankeLoggingService
 import fi.hel.haitaton.hanke.organisaatio.OrganisaatioRepository
 import fi.hel.haitaton.hanke.organisaatio.OrganisaatioService
 import fi.hel.haitaton.hanke.permissions.PermissionService
@@ -75,14 +76,16 @@ class Configuration {
         geometriatService: GeometriatService,
         hanketunnusService: HanketunnusService,
         auditLogService: AuditLogService,
-        permissionService: PermissionService
+        permissionService: PermissionService,
+        hankeLoggingService: HankeLoggingService,
     ): HankeService =
         HankeServiceImpl(
             hankeRepository,
             tormaystarkasteluLaskentaService,
             hanketunnusService,
             geometriatService,
-            auditLogService
+            auditLogService,
+            hankeLoggingService,
         )
 
     @Bean

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Constants.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Constants.kt
@@ -1,5 +1,6 @@
 package fi.hel.haitaton.hanke
 
+import com.fasterxml.jackson.databind.MapperFeature
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
@@ -11,14 +12,17 @@ const val SRID = 3879
 
 const val COORDINATE_SYSTEM_URN = "urn:ogc:def:crs:EPSG::$SRID"
 
-val OBJECT_MAPPER = jacksonObjectMapper().apply {
-    this.registerModule(JavaTimeModule())
-    this.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
-}
+val OBJECT_MAPPER =
+    jacksonObjectMapper().apply {
+        this.disable(MapperFeature.DEFAULT_VIEW_INCLUSION)
+        this.registerModule(JavaTimeModule())
+        this.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+    }
 
 val TZ_UTC: ZoneId = ZoneId.of("UTC")
 
-val DATABASE_TIMESTAMP_FORMAT: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS")
+val DATABASE_TIMESTAMP_FORMAT: DateTimeFormatter =
+    DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS")
 
 // Note: database definition has no limit, so this is sort of important; must be quite long,
 // but not excessive (considering database size etc.)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Extensions.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Extensions.kt
@@ -9,6 +9,18 @@ fun Any?.toJsonString(): String = OBJECT_MAPPER.writeValueAsString(this)
 fun Any?.toJsonPrettyString(): String =
     OBJECT_MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(this)
 
+/**
+ * Serializes only the main data fields; no audit fields or other irrelevant fields.
+ *
+ * The fields to serialize are marked with as [com.fasterxml.jackson.annotation.JsonView] with
+ * [ChangeLogView] view.
+ */
+fun Any?.toChangeLogJsonString(): String =
+    OBJECT_MAPPER.writerWithView(ChangeLogView::class.java).writeValueAsString(this)
+
+// These marker classes are used to get a limited set of info for logging.
+open class ChangeLogView
+
 /** Rounds a Float to one decimal. */
 fun Float.roundToOneDecimal(): Float {
     return BigDecimal(this.toDouble()).setScale(1, RoundingMode.HALF_UP).toFloat()

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeController.kt
@@ -122,13 +122,13 @@ class HankeController(
         val hanke = hankeService.loadHanke(hankeTunnus) ?: throw HankeNotFoundException(hankeTunnus)
         val hankeId = hanke.id!!
 
-        val permissions =
-            permissionService.getPermissionByHankeIdAndUserId(hankeId, currentUserId())
+        val userId = currentUserId()
+        val permissions = permissionService.getPermissionByHankeIdAndUserId(hankeId, userId)
         if (permissions == null || !permissions.permissions.contains(PermissionCode.DELETE)) {
             throw HankeNotFoundException(hankeTunnus)
         }
 
-        hankeService.deleteHanke(hankeId)
+        hankeService.deleteHanke(hanke, userId)
 
         logger.info { "Deleted Hanke: ${hanke.toLogString()}" }
     }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeService.kt
@@ -1,6 +1,7 @@
 package fi.hel.haitaton.hanke
 
 import fi.hel.haitaton.hanke.domain.Hanke
+import org.springframework.transaction.annotation.Transactional
 
 interface HankeService {
 
@@ -11,7 +12,7 @@ interface HankeService {
 
     fun updateHanke(hanke: Hanke): Hanke
 
-    fun deleteHanke(id: Int)
+    @Transactional fun deleteHanke(hanke: Hanke, userId: String)
 
     fun loadAllHanke(): List<Hanke>
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeYhteystietoEntity.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeYhteystietoEntity.kt
@@ -2,69 +2,61 @@ package fi.hel.haitaton.hanke
 
 import com.fasterxml.jackson.annotation.JsonView
 import java.time.LocalDateTime
-import javax.persistence.*
+import javax.persistence.Entity
+import javax.persistence.EnumType
+import javax.persistence.Enumerated
+import javax.persistence.FetchType
+import javax.persistence.GeneratedValue
+import javax.persistence.GenerationType
+import javax.persistence.Id
+import javax.persistence.JoinColumn
+import javax.persistence.ManyToOne
+import javax.persistence.Table
 
 enum class ContactType {
-    OMISTAJA, //owner
-    ARVIOIJA, //planner or person to do the planning of hanke
+    OMISTAJA, // owner
+    ARVIOIJA, // planner or person to do the planning of hanke
     TOTEUTTAJA // implementor or builder
 }
 
 @Entity
 @Table(name = "hankeyhteystieto")
-class HankeYhteystietoEntity (
-        @JsonView(ChangeLogView::class)
-        @Enumerated(EnumType.STRING)
-        var contactType: ContactType,
+class HankeYhteystietoEntity(
+    @JsonView(ChangeLogView::class) @Enumerated(EnumType.STRING) var contactType: ContactType,
 
-        // must have contact information
-        @JsonView(ChangeLogView::class)
-        var sukunimi: String,
-        @JsonView(ChangeLogView::class)
-        var etunimi: String,
-        @JsonView(ChangeLogView::class)
-        var email: String,
-        @JsonView(ChangeLogView::class)
-        var puhelinnumero: String,
+    // must have contact information
+    @JsonView(ChangeLogView::class) var sukunimi: String,
+    @JsonView(ChangeLogView::class) var etunimi: String,
+    @JsonView(ChangeLogView::class) var email: String,
+    @JsonView(ChangeLogView::class) var puhelinnumero: String,
+    @JsonView(ChangeLogView::class) var organisaatioId: Int? = 0,
+    @JsonView(ChangeLogView::class) var organisaatioNimi: String? = null,
+    @JsonView(ChangeLogView::class) var osasto: String? = null,
 
-        @JsonView(ChangeLogView::class)
-        var organisaatioId: Int? = 0,
-        @JsonView(ChangeLogView::class)
-        var organisaatioNimi: String? = null,
-        @JsonView(ChangeLogView::class)
-        var osasto: String? = null,
+    // Personal data processing restriction (or other needs to prevent changes)
+    var dataLocked: Boolean? = false,
+    var dataLockInfo: String? = null,
 
-        // Personal data processing restriction (or other needs to prevent changes)
-        @JsonView(NotInChangeLogView::class)
-        var dataLocked: Boolean? = false,
-        @JsonView(NotInChangeLogView::class)
-        var dataLockInfo: String? = null,
-
-        // NOTE: createdByUserId must be non-null for valid data, but to allow creating instances with
-        // no-arg constructor and programming convenience, this class allows it to be null (temporarily).
-        @JsonView(NotInChangeLogView::class)
-        var createdByUserId: String? = null,
-        @JsonView(NotInChangeLogView::class)
-        var createdAt: LocalDateTime? = null,
-        @JsonView(NotInChangeLogView::class)
-        var modifiedByUserId: String? = null,
-        @JsonView(NotInChangeLogView::class)
-        var modifiedAt: LocalDateTime? = null,
-        // NOTE: using IDENTITY (i.e. db does auto-increments, Hibernate reads the result back)
-        // can be a performance problem if there is a need to do bulk inserts.
-        // Using SEQUENCE would allow getting multiple ids more efficiently.
-        @JsonView(NotInChangeLogView::class)
-        @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-        var id: Int? = null,
-
-        @JsonView(NotInChangeLogView::class)
-        @ManyToOne(fetch = FetchType.EAGER)
-        @JoinColumn(name="hankeid")
-        var hanke: HankeEntity? = null
+    // NOTE: createdByUserId must be non-null for valid data, but to allow creating instances with
+    // no-arg constructor and programming convenience, this class allows it to be null
+    // (temporarily).
+    var createdByUserId: String? = null,
+    var createdAt: LocalDateTime? = null,
+    var modifiedByUserId: String? = null,
+    var modifiedAt: LocalDateTime? = null,
+    // NOTE: using IDENTITY (i.e. db does auto-increments, Hibernate reads the result back)
+    // can be a performance problem if there is a need to do bulk inserts.
+    // Using SEQUENCE would allow getting multiple ids more efficiently.
+    @JsonView(ChangeLogView::class)
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Int? = null,
+    @ManyToOne(fetch = FetchType.EAGER) @JoinColumn(name = "hankeid") var hanke: HankeEntity? = null
 ) {
 
     // Must consider both id and all non-audit fields for correct operations in certain collections
-    // Id can not be used as the only comparison, as one can have entities with null id (before they get saved).
+    // Id can not be used as the only comparison, as one can have entities with null id (before they
+    // get saved).
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other !is HankeYhteystietoEntity) return false
@@ -97,22 +89,18 @@ class HankeYhteystietoEntity (
     }
 
     /**
-     * Returns a new instance with the main fields copied.
-     * Main fields being the contact type, name, email, phone, organisation info.
+     * Returns a new instance with the main fields copied. Main fields being the contact type, name,
+     * email, phone, organisation info.
      */
     fun cloneWithMainFields(): HankeYhteystietoEntity =
         HankeYhteystietoEntity(
-            contactType, sukunimi, etunimi, email, puhelinnumero, organisaatioId, organisaatioNimi, osasto)
-
-    /**
-     * Serializes only the main personal data fields; not audit fields or the reference
-     * to the parent hanke.
-     */
-    fun toChangeLogJsonString(): String =
-        OBJECT_MAPPER.writerWithView(ChangeLogView::class.java).writeValueAsString(this)
+            contactType,
+            sukunimi,
+            etunimi,
+            email,
+            puhelinnumero,
+            organisaatioId,
+            organisaatioNimi,
+            osasto
+        )
 }
-
-// These marker classes are used to get a limited set of info for logging.
-open class ChangeLogView {}
-
-class NotInChangeLogView : ChangeLogView() {}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankealueEntity.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankealueEntity.kt
@@ -1,6 +1,5 @@
 package fi.hel.haitaton.hanke
 
-import com.fasterxml.jackson.annotation.JsonView
 import java.time.LocalDate
 import javax.persistence.Entity
 import javax.persistence.FetchType
@@ -16,10 +15,7 @@ import javax.persistence.Table
 class HankealueEntity {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY) var id: Int? = null
 
-    @JsonView(NotInChangeLogView::class)
-    @ManyToOne(fetch = FetchType.EAGER)
-    @JoinColumn(name = "hankeid")
-    var hanke: HankeEntity? = null
+    @ManyToOne(fetch = FetchType.EAGER) @JoinColumn(name = "hankeid") var hanke: HankeEntity? = null
 
     // NOTE: This should be changed to an entity
     // Refers to HankeGeometria.

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/Hanke.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/Hanke.kt
@@ -1,6 +1,8 @@
 package fi.hel.haitaton.hanke.domain
 
 import com.fasterxml.jackson.annotation.JsonIgnore
+import com.fasterxml.jackson.annotation.JsonView
+import fi.hel.haitaton.hanke.ChangeLogView
 import fi.hel.haitaton.hanke.Haitta13
 import fi.hel.haitaton.hanke.KaistajarjestelynPituus
 import fi.hel.haitaton.hanke.SaveType
@@ -20,16 +22,16 @@ data class Hanke(
     /**
      * Can be used for e.g. autosaving before hankeTunnus has been given (optional future stuff).
      */
-    var id: Int?,
-    var hankeTunnus: String?,
-    var onYKTHanke: Boolean?,
-    var nimi: String?,
-    var kuvaus: String?,
-    var alkuPvm: ZonedDateTime?,
-    var loppuPvm: ZonedDateTime?,
-    var vaihe: Vaihe?,
-    var suunnitteluVaihe: SuunnitteluVaihe?,
-    var version: Int?,
+    @JsonView(ChangeLogView::class) override var id: Int?,
+    @JsonView(ChangeLogView::class) var hankeTunnus: String?,
+    @JsonView(ChangeLogView::class) var onYKTHanke: Boolean?,
+    @JsonView(ChangeLogView::class) var nimi: String?,
+    @JsonView(ChangeLogView::class) var kuvaus: String?,
+    @JsonView(ChangeLogView::class) var alkuPvm: ZonedDateTime?,
+    @JsonView(ChangeLogView::class) var loppuPvm: ZonedDateTime?,
+    @JsonView(ChangeLogView::class) var vaihe: Vaihe?,
+    @JsonView(ChangeLogView::class) var suunnitteluVaihe: SuunnitteluVaihe?,
+    @JsonView(ChangeLogView::class) var version: Int?,
     val createdBy: String?,
     val createdAt: ZonedDateTime?,
     var modifiedBy: String?,
@@ -37,7 +39,7 @@ data class Hanke(
 
     /** Default for machine API's. UI should always give the save type. */
     var saveType: SaveType? = SaveType.SUBMIT
-) {
+) : HasId<Int> {
 
     // --------------- Yhteystiedot -----------------
     var omistajat = mutableListOf<HankeYhteystieto>()
@@ -45,9 +47,9 @@ data class Hanke(
     var toteuttajat = mutableListOf<HankeYhteystieto>()
 
     // --------------- Hankkeen lisätiedot / Työmaan tiedot -------------------
-    var tyomaaKatuosoite: String? = null
-    var tyomaaTyyppi = mutableSetOf<TyomaaTyyppi>()
-    var tyomaaKoko: TyomaaKoko? = null
+    @JsonView(ChangeLogView::class) var tyomaaKatuosoite: String? = null
+    @JsonView(ChangeLogView::class) var tyomaaTyyppi = mutableSetOf<TyomaaTyyppi>()
+    @JsonView(ChangeLogView::class) var tyomaaKoko: TyomaaKoko? = null
 
     // --------------- Hankkeen haitat -------------------
     fun kaistaHaitat(): Set<TodennakoinenHaittaPaaAjoRatojenKaistajarjestelyihin> {
@@ -70,7 +72,7 @@ data class Hanke(
         return alueet.map { it.tarinaHaitta }.filterNotNull().toSet()
     }
 
-    var alueet = mutableListOf<Hankealue>()
+    @JsonView(ChangeLogView::class) var alueet = mutableListOf<Hankealue>()
 
     var permissions: List<PermissionCode>? = null
 
@@ -88,7 +90,7 @@ data class Hanke(
         tormaystarkasteluTulos?.liikennehaittaIndeksi
     }
 
-    var tormaystarkasteluTulos: TormaystarkasteluTulos? = null
+    @JsonView(ChangeLogView::class) var tormaystarkasteluTulos: TormaystarkasteluTulos? = null
 
     fun getHaittaAlkuPvm(): ZonedDateTime? {
         return alueet.map { it.haittaAlkuPvm }.filterNotNull().minOfOrNull { it }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/HankeYhteystieto.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/HankeYhteystieto.kt
@@ -1,43 +1,51 @@
 package fi.hel.haitaton.hanke.domain
 
 import com.fasterxml.jackson.annotation.JsonIgnore
+import com.fasterxml.jackson.annotation.JsonView
+import fi.hel.haitaton.hanke.ChangeLogView
 import java.time.ZonedDateTime
 
 // e.g. omistaja, arvioija, toteuttaja
 data class HankeYhteystieto(
-    var id: Int?,
+    @JsonView(ChangeLogView::class) override var id: Int?,
 
     // must have contact information fields:
-    var sukunimi: String,
-    var etunimi: String,
-    var email: String,
-    var puhelinnumero: String,
+    @JsonView(ChangeLogView::class) var sukunimi: String,
+    @JsonView(ChangeLogView::class) var etunimi: String,
+    @JsonView(ChangeLogView::class) var email: String,
+    @JsonView(ChangeLogView::class) var puhelinnumero: String,
 
     // organisaatio (optional)
-    var organisaatioId: Int?,
-    var organisaatioNimi: String?,
-    var osasto: String?,
-
+    @JsonView(ChangeLogView::class) var organisaatioId: Int?,
+    @JsonView(ChangeLogView::class) var organisaatioNimi: String?,
+    @JsonView(ChangeLogView::class) var osasto: String?,
     var createdBy: String? = null,
     var createdAt: ZonedDateTime? = null,
     var modifiedBy: String? = null,
     var modifiedAt: ZonedDateTime? = null
-) {
+) : HasId<Int> {
 
     /**
-     * Returns true if at least one Yhteystieto-field is non-null, non-empty and non-whitespace-only.
+     * Returns true if at least one Yhteystieto-field is non-null, non-empty and
+     * non-whitespace-only.
      */
     @JsonIgnore
     fun isAnyFieldSet(): Boolean {
-        return isAnyMandatoryFieldSet() || !organisaatioNimi.isNullOrBlank() || !osasto.isNullOrBlank()
+        return isAnyMandatoryFieldSet() ||
+            !organisaatioNimi.isNullOrBlank() ||
+            !osasto.isNullOrBlank()
     }
 
     /**
-     * Returns true if at least one mandatory Yhteystieto-field is non-null, non-empty and non-whitespace-only.
+     * Returns true if at least one mandatory Yhteystieto-field is non-null, non-empty and
+     * non-whitespace-only.
      */
     @JsonIgnore
     fun isAnyMandatoryFieldSet(): Boolean {
-        return sukunimi.isNotBlank() || etunimi.isNotBlank() || email.isNotBlank() || puhelinnumero.isNotBlank()
+        return sukunimi.isNotBlank() ||
+            etunimi.isNotBlank() ||
+            email.isNotBlank() ||
+            puhelinnumero.isNotBlank()
     }
 
     /**
@@ -45,6 +53,9 @@ data class HankeYhteystieto(
      */
     @JsonIgnore
     fun isValid(): Boolean {
-        return sukunimi.isNotBlank() && etunimi.isNotBlank() && email.isNotBlank() && puhelinnumero.isNotBlank()
+        return sukunimi.isNotBlank() &&
+            etunimi.isNotBlank() &&
+            email.isNotBlank() &&
+            puhelinnumero.isNotBlank()
     }
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/Hankealue.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/Hankealue.kt
@@ -1,5 +1,7 @@
 package fi.hel.haitaton.hanke.domain
 
+import com.fasterxml.jackson.annotation.JsonView
+import fi.hel.haitaton.hanke.ChangeLogView
 import fi.hel.haitaton.hanke.Haitta13
 import fi.hel.haitaton.hanke.KaistajarjestelynPituus
 import fi.hel.haitaton.hanke.TodennakoinenHaittaPaaAjoRatojenKaistajarjestelyihin
@@ -11,14 +13,15 @@ import java.time.ZonedDateTime
  * NOTE Remember to update PublicHankealue after changes
  */
 data class Hankealue(
-    var id: Int? = null,
-    var hankeId: Int? = null,
-    var haittaAlkuPvm: ZonedDateTime? = null,
-    var haittaLoppuPvm: ZonedDateTime? = null,
+    @JsonView(ChangeLogView::class) var id: Int? = null,
+    @JsonView(ChangeLogView::class) var hankeId: Int? = null,
+    @JsonView(ChangeLogView::class) var haittaAlkuPvm: ZonedDateTime? = null,
+    @JsonView(ChangeLogView::class) var haittaLoppuPvm: ZonedDateTime? = null,
     var geometriat: Geometriat? = null,
+    @JsonView(ChangeLogView::class)
     var kaistaHaitta: TodennakoinenHaittaPaaAjoRatojenKaistajarjestelyihin? = null,
-    var kaistaPituusHaitta: KaistajarjestelynPituus? = null,
-    var meluHaitta: Haitta13? = null,
-    var polyHaitta: Haitta13? = null,
-    var tarinaHaitta: Haitta13? = null,
+    @JsonView(ChangeLogView::class) var kaistaPituusHaitta: KaistajarjestelynPituus? = null,
+    @JsonView(ChangeLogView::class) var meluHaitta: Haitta13? = null,
+    @JsonView(ChangeLogView::class) var polyHaitta: Haitta13? = null,
+    @JsonView(ChangeLogView::class) var tarinaHaitta: Haitta13? = null,
 )

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/HasId.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/HasId.kt
@@ -1,0 +1,9 @@
+package fi.hel.haitaton.hanke.domain
+
+/**
+ * Marker interface for classes that have an id-field of type [ID]. Useful for generic functions
+ * that need access to the id-field.
+ */
+interface HasId<ID> {
+    var id: ID?
+}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/AuditLogEntry.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/AuditLogEntry.kt
@@ -47,6 +47,7 @@ enum class ObjectType {
     ALLU_CUSTOMER,
     ALLU_CONTACT,
     GDPR_RESPONSE,
+    HANKE,
 }
 
 enum class UserRole {
@@ -56,25 +57,23 @@ enum class UserRole {
 
 /** Flat [AuditLogMessage] for better ergonomics. */
 data class AuditLogEntry(
-    val dateTime: OffsetDateTime? = OffsetDateTime.now(),
     val operation: Operation,
     val status: Status,
     val failureDescription: String? = null,
     val userId: String? = null,
     val userRole: UserRole = UserRole.USER,
-    val ipAddress: String? = null,
     val objectId: String? = null,
     val objectType: ObjectType,
     val objectBefore: String? = null,
     val objectAfter: String? = null,
 ) {
     // TODO: There will be a centralized place for object mappers. This should be moved there.
-    fun toEntity(): AuditLogEntryEntity =
+    fun toEntity(dateTime: OffsetDateTime, ipAddress: String?): AuditLogEntryEntity =
         AuditLogEntryEntity(
             message =
                 AuditLogMessage(
                     AuditLogEvent(
-                        dateTime = dateTime!!,
+                        dateTime = dateTime,
                         operation = operation,
                         status = status,
                         failureDescription = failureDescription,

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/AuditLogService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/AuditLogService.kt
@@ -1,13 +1,67 @@
 package fi.hel.haitaton.hanke.logging
 
+import fi.hel.haitaton.hanke.domain.HasId
+import fi.hel.haitaton.hanke.toChangeLogJsonString
+import java.time.OffsetDateTime
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.web.context.request.RequestContextHolder
+import org.springframework.web.context.request.ServletRequestAttributes
 
 /** Service for methods common to all types of audit logs. */
 @Service
 class AuditLogService(private val auditLogRepository: AuditLogRepository) {
 
-    /** Save audit log entries. Converts them to entities and saves them. */
-    fun saveAll(auditLogEntries: Collection<AuditLogEntry>): MutableList<AuditLogEntryEntity> {
-        return auditLogRepository.saveAll(auditLogEntries.map { it.toEntity() })
+    /**
+     * Save new audit log entries. Converts them to entities and saves them.
+     *
+     * Sets the date_time and ip_address fields for every entry.
+     */
+    @Transactional(propagation = Propagation.SUPPORTS)
+    fun createAll(auditLogEntries: Collection<AuditLogEntry>): MutableList<AuditLogEntryEntity> {
+        // Make sure all related logs have the same time
+        val now = OffsetDateTime.now()
+        return auditLogRepository.saveAll(auditLogEntries.map { it.toEntity(now, getIpAddress()) })
+    }
+
+    companion object {
+        /**
+         * If request context (attributes) exists, returns the IP from it.
+         *
+         * TODO: very very very simplified implementation. Needs a lot of improvement.
+         */
+        fun getIpAddress(): String? {
+            val attribs =
+                (RequestContextHolder.getRequestAttributes() as ServletRequestAttributes?)
+                    ?: return null
+            val request = attribs.request
+            // Very simplified version for now.
+            // For starters, see e.g.
+            // https://stackoverflow.com/questions/22877350/how-to-extract-ip-address-in-spring-mvc-controller-get-call
+            // Combine all the various ideas into one, and note that even then it is not even
+            // half-way to a proper solution. Hopefully one can find a ready-made fully thought out
+            // implementation.
+            var ip: String =
+                request.getHeader("X-FORWARDED-FOR") ?: request.remoteAddr ?: return null
+            // Just to make sure it won't break the db if someone put something silly long in the
+            // header:
+            if (ip.length > PERSONAL_DATA_LOGGING_MAX_IP_LENGTH)
+                ip = ip.substring(0, PERSONAL_DATA_LOGGING_MAX_IP_LENGTH)
+
+            return ip
+        }
+
+        fun <ID, T : HasId<ID>> deleteEntry(userId: String, type: ObjectType, objectBefore: T) =
+            AuditLogEntry(
+                operation = Operation.DELETE,
+                status = Status.SUCCESS,
+                userId = userId,
+                userRole = UserRole.USER,
+                objectId = objectBefore.id?.toString(),
+                objectType = type,
+                objectBefore = objectBefore.toChangeLogJsonString(),
+                objectAfter = null,
+            )
     }
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/DisclosureLogService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/DisclosureLogService.kt
@@ -11,7 +11,6 @@ import fi.hel.haitaton.hanke.domain.Hanke
 import fi.hel.haitaton.hanke.domain.HankeYhteystieto
 import fi.hel.haitaton.hanke.gdpr.CollectionNode
 import fi.hel.haitaton.hanke.toJsonString
-import java.time.OffsetDateTime
 import org.springframework.stereotype.Service
 
 /** Special username for Allu service. */
@@ -163,7 +162,6 @@ class DisclosureLogService(private val auditLogService: AuditLogService) {
         failureDescription: String? = null,
     ): AuditLogEntry =
         AuditLogEntry(
-            dateTime = null,
             operation = Operation.READ,
             status = status,
             failureDescription = failureDescription,
@@ -181,12 +179,8 @@ class DisclosureLogService(private val auditLogService: AuditLogService) {
             return
         }
 
-        val eventTime = OffsetDateTime.now()
-        val entities =
-            YhteystietoLoggingEntryHolder.applyIpAddresses(entries).map {
-                it.copy(userId = userId, userRole = userRole, dateTime = eventTime)
-            }
+        val entities = entries.map { it.copy(userId = userId, userRole = userRole) }
 
-        auditLogService.saveAll(entities)
+        auditLogService.createAll(entities)
     }
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/HankeLoggingService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/HankeLoggingService.kt
@@ -1,0 +1,29 @@
+package fi.hel.haitaton.hanke.logging
+
+import fi.hel.haitaton.hanke.domain.Hanke
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class HankeLoggingService(private val auditLogService: AuditLogService) {
+
+    /**
+     * Create audit log entry for a deleted hanke.
+     *
+     * This also creates entries for sub-entities (yhteystiedot and geometries), since they will be
+     * deleted with the hanke, and they are not handled anywhere else.
+     */
+    @Transactional(propagation = Propagation.MANDATORY)
+    fun logDelete(hanke: Hanke, userId: String) {
+        // TODO: Add geometries in auditLogEntry or as separate log entries.
+        //   Waits for the changes in HAI-1273 before implementing.
+        val auditLogEntry = AuditLogService.deleteEntry(userId, ObjectType.HANKE, hanke)
+        val yhteystietoEntries =
+            (hanke.arvioijat + hanke.toteuttajat + hanke.omistajat).map {
+                AuditLogService.deleteEntry(userId, ObjectType.YHTEYSTIETO, it)
+            }
+
+        auditLogService.createAll(yhteystietoEntries + auditLogEntry)
+    }
+}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluTulos.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluTulos.kt
@@ -1,5 +1,7 @@
 package fi.hel.haitaton.hanke.tormaystarkastelu
 
+import com.fasterxml.jackson.annotation.JsonView
+import fi.hel.haitaton.hanke.ChangeLogView
 import fi.hel.haitaton.hanke.HankeEntity
 import javax.persistence.Entity
 import javax.persistence.FetchType
@@ -11,11 +13,12 @@ import javax.persistence.ManyToOne
 import javax.persistence.Table
 
 data class TormaystarkasteluTulos(
-    val perusIndeksi: Float,
-    val pyorailyIndeksi: Float,
-    val joukkoliikenneIndeksi: Float
+    @JsonView(ChangeLogView::class) val perusIndeksi: Float,
+    @JsonView(ChangeLogView::class) val pyorailyIndeksi: Float,
+    @JsonView(ChangeLogView::class) val joukkoliikenneIndeksi: Float
 ) {
 
+    @get:JsonView(ChangeLogView::class)
     val liikennehaittaIndeksi: LiikennehaittaIndeksiType by lazy {
         when (maxOf(perusIndeksi, pyorailyIndeksi, joukkoliikenneIndeksi)) {
             joukkoliikenneIndeksi ->
@@ -26,7 +29,10 @@ data class TormaystarkasteluTulos(
     }
 }
 
-data class LiikennehaittaIndeksiType(val indeksi: Float, val tyyppi: IndeksiType)
+data class LiikennehaittaIndeksiType(
+    @JsonView(ChangeLogView::class) val indeksi: Float,
+    @JsonView(ChangeLogView::class) val tyyppi: IndeksiType
+)
 
 enum class IndeksiType {
     PERUSINDEKSI,
@@ -36,7 +42,7 @@ enum class IndeksiType {
 
 @Entity
 @Table(name = "tormaystarkastelutulos")
-data class TormaystarkasteluTulosEntity(
+class TormaystarkasteluTulosEntity(
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY) val id: Int = 0,
     val perus: Float,
     val pyoraily: Float,
@@ -44,4 +50,30 @@ data class TormaystarkasteluTulosEntity(
     @ManyToOne(optional = false, fetch = FetchType.LAZY)
     @JoinColumn(name = "hankeid")
     val hanke: HankeEntity,
-)
+) {
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is TormaystarkasteluTulosEntity) return false
+
+        // For persisted entities, checking id match is enough
+        if (id != other.id) return false
+
+        // For non-persisted, have to compare almost everything
+        if (hanke != other.hanke) return false
+        if (perus != other.perus) return false
+        if (pyoraily != other.pyoraily) return false
+        if (joukkoliikenne != other.joukkoliikenne) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = id.hashCode()
+        result = 31 * result + (hanke.hashCode())
+        result = 31 * result + (perus.hashCode())
+        result = 31 * result + (pyoraily.hashCode())
+        result = 31 * result + (joukkoliikenne.hashCode())
+        return result
+    }
+}

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/AuditLogEntryFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/AuditLogEntryFactory.kt
@@ -20,7 +20,6 @@ object AuditLogEntryFactory : Factory<AuditLogEntry>() {
         objectType: ObjectType = ObjectType.YHTEYSTIETO,
         objectId: Any? = 1,
         objectBefore: String? = null,
-        ipAddress: String? = null,
     ) =
         AuditLogEntry(
             userId = userId,
@@ -30,7 +29,6 @@ object AuditLogEntryFactory : Factory<AuditLogEntry>() {
             objectType = objectType,
             objectId = objectId?.toString(),
             objectBefore = objectBefore,
-            ipAddress = ipAddress,
         )
 
     fun createReadEntriesForHanke(hanke: Hanke): List<AuditLogEntry> =

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeFactory.kt
@@ -1,10 +1,7 @@
 package fi.hel.haitaton.hanke.factory
 
-import fi.hel.haitaton.hanke.Haitta13
-import fi.hel.haitaton.hanke.KaistajarjestelynPituus
 import fi.hel.haitaton.hanke.SaveType
 import fi.hel.haitaton.hanke.SuunnitteluVaihe
-import fi.hel.haitaton.hanke.TodennakoinenHaittaPaaAjoRatojenKaistajarjestelyihin
 import fi.hel.haitaton.hanke.TyomaaKoko
 import fi.hel.haitaton.hanke.TyomaaTyyppi
 import fi.hel.haitaton.hanke.Vaihe
@@ -61,27 +58,26 @@ object HankeFactory : Factory<Hanke>() {
         )
 
     /**
-     * Add a haitta to a test Hanke.
+     * Add a hankealue with haitat to a test Hanke.
      *
      * Example:
      * ```
-     * HankeFactory.create().withHaitta()
+     * HankeFactory.create().withHankealue()
      * ```
      */
-    fun Hanke.withHaitta(): Hanke {
+    fun Hanke.withHankealue(
+        alue: Hankealue =
+            HankealueFactory.create(
+                hankeId = this.id,
+                haittaAlkuPvm = this.alkuPvm,
+                haittaLoppuPvm = this.loppuPvm
+            )
+    ): Hanke {
         this.tyomaaKatuosoite = "Testikatu 1"
         this.tyomaaTyyppi.add(TyomaaTyyppi.VESI)
         this.tyomaaTyyppi.add(TyomaaTyyppi.MUU)
         this.tyomaaKoko = TyomaaKoko.LAAJA_TAI_USEA_KORTTELI
 
-        val alue = Hankealue()
-        alue.haittaAlkuPvm = DateFactory.getStartDatetime()
-        alue.haittaLoppuPvm = DateFactory.getEndDatetime()
-        alue.kaistaHaitta = TodennakoinenHaittaPaaAjoRatojenKaistajarjestelyihin.KAKSI
-        alue.kaistaPituusHaitta = KaistajarjestelynPituus.NELJA
-        alue.meluHaitta = Haitta13.YKSI
-        alue.polyHaitta = Haitta13.KAKSI
-        alue.tarinaHaitta = Haitta13.KOLME
         this.alueet.add(alue)
 
         return this

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankealueFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankealueFactory.kt
@@ -3,6 +3,7 @@ package fi.hel.haitaton.hanke.factory
 import fi.hel.haitaton.hanke.Haitta13
 import fi.hel.haitaton.hanke.KaistajarjestelynPituus
 import fi.hel.haitaton.hanke.TodennakoinenHaittaPaaAjoRatojenKaistajarjestelyihin
+import fi.hel.haitaton.hanke.asJsonResource
 import fi.hel.haitaton.hanke.domain.Hankealue
 import fi.hel.haitaton.hanke.geometria.Geometriat
 import java.time.ZonedDateTime
@@ -12,6 +13,34 @@ object HankealueFactory {
     fun create(
         id: Int? = 1,
         hankeId: Int? = 2,
+        haittaAlkuPvm: ZonedDateTime? = DateFactory.getStartDatetime(),
+        haittaLoppuPvm: ZonedDateTime? = DateFactory.getEndDatetime(),
+        geometriat: Geometriat? =
+            "/fi/hel/haitaton/hanke/geometria/hankeGeometriat.json".asJsonResource(),
+        kaistaHaitta: TodennakoinenHaittaPaaAjoRatojenKaistajarjestelyihin? =
+            TodennakoinenHaittaPaaAjoRatojenKaistajarjestelyihin.KAKSI,
+        kaistaPituusHaitta: KaistajarjestelynPituus? = KaistajarjestelynPituus.NELJA,
+        meluHaitta: Haitta13? = Haitta13.YKSI,
+        polyHaitta: Haitta13? = Haitta13.KAKSI,
+        tarinaHaitta: Haitta13? = Haitta13.KOLME,
+    ): Hankealue {
+        return Hankealue(
+            id,
+            hankeId,
+            haittaAlkuPvm,
+            haittaLoppuPvm,
+            geometriat,
+            kaistaHaitta,
+            kaistaPituusHaitta,
+            meluHaitta,
+            polyHaitta,
+            tarinaHaitta,
+        )
+    }
+
+    fun createMinimal(
+        id: Int? = null,
+        hankeId: Int? = null,
         haittaAlkuPvm: ZonedDateTime? = DateFactory.getStartDatetime(),
         haittaLoppuPvm: ZonedDateTime? = DateFactory.getEndDatetime(),
         geometriat: Geometriat? = null,

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/logging/DisclosureLogServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/logging/DisclosureLogServiceTest.kt
@@ -86,9 +86,7 @@ internal class DisclosureLogServiceTest {
                     objectBefore = expectedObject
                 )
             )
-        verify {
-            auditLogService.saveAll(match(containsAllWithoutGeneratedFields(expectedEntries)))
-        }
+        verify { auditLogService.createAll(match(containsAll(expectedEntries))) }
     }
 
     @Test
@@ -107,7 +105,7 @@ internal class DisclosureLogServiceTest {
 
         disclosureLogService.saveDisclosureLogsForHanke(hanke, userId)
 
-        verify { auditLogService.saveAll(match(containsAllWithoutGeneratedFields(expectedLogs))) }
+        verify { auditLogService.createAll(match(containsAll(expectedLogs))) }
     }
 
     @Test
@@ -125,7 +123,7 @@ internal class DisclosureLogServiceTest {
 
         disclosureLogService.saveDisclosureLogsForHanke(hanke, userId)
 
-        verify { auditLogService.saveAll(match(containsAllWithoutGeneratedFields(expectedLogs))) }
+        verify { auditLogService.createAll(match(containsAll(expectedLogs))) }
     }
 
     @Test
@@ -158,7 +156,7 @@ internal class DisclosureLogServiceTest {
 
         disclosureLogService.saveDisclosureLogsForHankkeet(hankkeet, userId)
 
-        verify { auditLogService.saveAll(match(containsAllWithoutGeneratedFields(expectedLogs))) }
+        verify { auditLogService.createAll(match(containsAll(expectedLogs))) }
     }
 
     @Test
@@ -172,7 +170,7 @@ internal class DisclosureLogServiceTest {
 
         disclosureLogService.saveDisclosureLogsForHankkeet(hankkeet, userId)
 
-        verify { auditLogService.saveAll(match(containsAllWithoutGeneratedFields(expectedLogs))) }
+        verify { auditLogService.createAll(match(containsAll(expectedLogs))) }
     }
 
     @Test
@@ -267,7 +265,7 @@ internal class DisclosureLogServiceTest {
 
         disclosureLogService.saveDisclosureLogsForApplication(application, userId)
 
-        verify { auditLogService.saveAll(match(containsAllWithoutGeneratedFields(expectedLogs))) }
+        verify { auditLogService.createAll(match(containsAll(expectedLogs))) }
     }
 
     @Test
@@ -279,7 +277,7 @@ internal class DisclosureLogServiceTest {
 
         disclosureLogService.saveDisclosureLogsForApplication(application, userId)
 
-        verify { auditLogService.saveAll(match(containsAllWithoutGeneratedFields(expectedLogs))) }
+        verify { auditLogService.createAll(match(containsAll(expectedLogs))) }
     }
 
     @ParameterizedTest(name = "{displayName}({arguments})")
@@ -299,7 +297,7 @@ internal class DisclosureLogServiceTest {
 
         disclosureLogService.saveDisclosureLogsForAllu(cableReportApplication, expectedStatus)
 
-        verify { auditLogService.saveAll(match(containsAllWithoutGeneratedFields(expectedLogs))) }
+        verify { auditLogService.createAll(match(containsAll(expectedLogs))) }
     }
 
     @Test
@@ -332,7 +330,7 @@ internal class DisclosureLogServiceTest {
 
         disclosureLogService.saveDisclosureLogsForApplications(applications, userId)
 
-        verify { auditLogService.saveAll(match(containsAllWithoutGeneratedFields(expectedLogs))) }
+        verify { auditLogService.createAll(match(containsAll(expectedLogs))) }
     }
 
     @Test
@@ -342,17 +340,12 @@ internal class DisclosureLogServiceTest {
         verify { auditLogService wasNot Called }
     }
 
-    private fun containsAllWithoutGeneratedFields(
+    private fun containsAll(
         expectedLogs: List<AuditLogEntry>,
-    ): (List<AuditLogEntry>) -> Boolean = { entries ->
-        withoutGeneratedFields(entries) equalsIgnoreOrder withoutGeneratedFields(expectedLogs)
-    }
+    ): (List<AuditLogEntry>) -> Boolean = { entries -> entries equalsIgnoreOrder expectedLogs }
 
-    private infix fun <T> List<T>.equalsIgnoreOrder(other: List<T>) =
+    private infix fun <T> List<T>.equalsIgnoreOrder(other: List<T>): Boolean =
         this.size == other.size && this.toSet() == other.toSet()
-
-    private fun withoutGeneratedFields(entries: List<AuditLogEntry>): List<AuditLogEntry> =
-        entries.map { it.copy(dateTime = null) }
 
     private fun applicationDto(applicationData: CableReportApplication): ApplicationDto =
         ApplicationDto(

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/logging/HankeLoggingServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/logging/HankeLoggingServiceTest.kt
@@ -1,0 +1,85 @@
+package fi.hel.haitaton.hanke.logging
+
+import fi.hel.haitaton.hanke.factory.HankeFactory
+import fi.hel.haitaton.hanke.factory.HankeFactory.withYhteystiedot
+import io.mockk.clearAllMocks
+import io.mockk.confirmVerified
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions
+import org.assertj.core.api.Condition
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+internal class HankeLoggingServiceTest {
+    private val userId = "test"
+
+    private val auditLogService: AuditLogService = mockk(relaxed = true)
+    private val hankeLoggingService = HankeLoggingService(auditLogService)
+
+    @AfterEach
+    fun cleanUp() {
+        // TODO: Needs newer MockK, which needs newer Spring test dependencies
+        // checkUnnecessaryStub()
+        confirmVerified()
+        clearAllMocks()
+    }
+
+    @Test
+    fun `logDelete creates audit log entry for deleted hanke`() {
+        val hanke = HankeFactory.create()
+
+        hankeLoggingService.logDelete(hanke, userId)
+
+        verify {
+            auditLogService.createAll(
+                withArg { entries ->
+                    assertEquals(1, entries.size)
+                    val entry = entries.first()
+                    assertEquals(Operation.DELETE, entry.operation)
+                    assertEquals(Status.SUCCESS, entry.status)
+                    assertNull(entry.failureDescription)
+                    assertEquals(userId, entry.userId)
+                    assertEquals(UserRole.USER, entry.userRole)
+                    assertEquals(HankeFactory.defaultId.toString(), entry.objectId)
+                    assertEquals(ObjectType.HANKE, entry.objectType)
+                    assertNull(entry.objectAfter)
+                    assertNotNull(entry.objectBefore)
+                }
+            )
+        }
+    }
+
+    @Test
+    fun `logDelete creates audit log entries for deleted yhteystiedot`() {
+        val hanke = HankeFactory.create().withYhteystiedot()
+
+        hankeLoggingService.logDelete(hanke, userId)
+
+        verify {
+            auditLogService.createAll(
+                withArg { entries ->
+                    Assertions.assertThat(entries)
+                        .hasSize(4)
+                        .allSatisfy { entry ->
+                            assertEquals(Operation.DELETE, entry.operation)
+                            assertEquals(Status.SUCCESS, entry.status)
+                            assertNull(entry.failureDescription)
+                            assertEquals(userId, entry.userId)
+                            assertEquals(UserRole.USER, entry.userRole)
+                            assertNull(entry.objectAfter)
+                            assertNotNull(entry.objectBefore)
+                        }
+                        .areExactly(
+                            3,
+                            Condition({ it.objectType == ObjectType.YHTEYSTIETO }, "Yhteystieto")
+                        )
+                        .areExactly(1, Condition({ it.objectType == ObjectType.HANKE }, "Hanke"))
+                }
+            )
+        }
+    }
+}

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/test/TestUtils.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/test/TestUtils.kt
@@ -1,0 +1,13 @@
+package fi.hel.haitaton.hanke.test
+
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.web.context.request.RequestContextHolder
+import org.springframework.web.context.request.ServletRequestAttributes
+
+object TestUtils {
+    fun addMockedRequestIp(ip: String = "127.0.0.1") {
+        val request = MockHttpServletRequest()
+        request.remoteAddr = ip
+        RequestContextHolder.setRequestAttributes(ServletRequestAttributes(request))
+    }
+}


### PR DESCRIPTION
# Description

Add entries to audit logs whenever users delete a hanke. Log seperate entries for the hanke itself and the yhteystiedot of those.

Refactor some logging code to make adding the rest of the audit logs easier.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1075

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
1. Create a hanke. Add some yhteystiedot for it.
2. Delete the hanke.
3. Check database audit_logs table for results.
    - You can query the DELETE type log messages with:
      ```select * from audit_logs where message->'audit_event'->>'operation' = 'DELETE';```  

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 