### PR TITLE
HAI-1213/OSM download and limit to Helsinki area

### DIFF
--- a/scripts/gis-material-update/README.md
+++ b/scripts/gis-material-update/README.md
@@ -113,12 +113,32 @@ Where `<source>` is currently one of:
 
 - `hsl` - HSL bus schedules
 - `hki` - Helsinki area GIS material, polygon, scale 1:1000000
-- `osm`
-- `ylre_katualue`
+- `osm` - OpenStreetMap export of Finland
+- `helsinki_osm_lines` - line geometry export from `osm`, covering area of city of Helsinki
+- `ylre_katualue` - Helsinki YLRE street areas, polygons.
 - `ylre_katuosat` - Helsinki YLRE parts, polygons.
 - `maka_autoliikennemaarat` - Traffic volumes (car traffic)
 
 Data files are downloaded to `./haitaton-downloads` -directory.
+
+Primary function in data download is to download from remote location (and possibly convert) file during download.
+
+Exceptions are listed below.
+
+### `helsinki_osm_lines`
+
+Prerequisites:
+
+- `osm` material fetched
+- `hki` material fetched
+
+  Helsinki OSM line geometries are obtained by intersecting city of Helsinki area
+  and OSM GIS material from whole Finland.
+
+Materials are expected to be previously fetched to local directory.
+
+Intersection is computed using OGR VRT driver in actual fetch operation. Due to
+large area in OSM material, computation takes tens of minutes to complete.
 
 ## Run processing
 

--- a/scripts/gis-material-update/config.yaml
+++ b/scripts/gis-material-update/config.yaml
@@ -35,7 +35,7 @@ osm:
   extra_args: "-oo INTERLEAVED_READING=YES"
 helsinki_osm_lines:
   addr: "/haitaton-gis/osm_vrt_clip.vrt"
-  local_file: "helsinki-osm.gpkg"
+  local_file: "helsinki-osm-lines.gpkg"
   extra_args: "-dialect sqlite -nln lines -sql"
   extra_quoted_args: "SELECT lines.* FROM lines, area WHERE ST_Intersects(lines.geom, area.geom)"
 hki:

--- a/scripts/gis-material-update/config.yaml
+++ b/scripts/gis-material-update/config.yaml
@@ -6,7 +6,7 @@ hsl:
   buffer:
     - 15
 maka_autoliikennemaarat:
-  addr: "https://kartta.hel.fi/ws/geoserver/avoindata/wfs"
+  addr: "WFS:https://kartta.hel.fi/ws/geoserver/avoindata/wfs"
   layer: "avoindata:Ajoneuvoliikenne_liikennemaarat_viiva"
   local_file: "maka_autoliikennemaarat.gpkg"
   target_file: "volume_lines.gpkg"
@@ -15,13 +15,13 @@ maka_autoliikennemaarat:
     - 15
     - 30
 ylre_katualueet:
-  addr: "https://kartta.hel.fi/ws/geoserver/avoindata/wfs"
+  addr: "WFS:https://kartta.hel.fi/ws/geoserver/avoindata/wfs"
   layer: "avoindata:YLRE_Katualue_alue"
   local_file: "ylre_katualue_alue.gpkg"
   target_file: "ylre_classes_orig_polys.gpkg"
   target_buffer_file: "tormays_ylre_classes_polys.gpkg"
 ylre_katuosat:
-  addr: "https://kartta.hel.fi/ws/geoserver/avoindata/wfs"
+  addr: "WFS:https://kartta.hel.fi/ws/geoserver/avoindata/wfs"
   layer: "avoindata:YLRE_Katuosat_alue"
   local_file: "ylre_katuosat_alue.gpkg"
   target_file: "ylre_parts_orig_polys.gpkg"
@@ -29,10 +29,12 @@ ylre_katuosat:
   buffer:
     - 5
 osm:
-  addr: "https://download.geofabrik.de/europe/finland-latest.osm.pbf"
-  local_file: "finland-latest.osm.pbf"
+  addr: "/vsicurl/https://download.geofabrik.de/europe/finland-latest.osm.pbf"
+  layer: "lines"
+  local_file: "finland-latest.gpkg"
+  extra_args: "-oo INTERLEAVED_READING=YES"
 hki:
-  addr: "https://geo.stat.fi/geoserver/tilastointialueet/wfs"
+  addr: "WFS:https://geo.stat.fi/geoserver/tilastointialueet/wfs"
   layer: "tilastointialueet:kunta1000k"
   local_file: "helsinki_alue.gpkg"
   extra_args: "-nln alue -where kunta='091'"

--- a/scripts/gis-material-update/config.yaml
+++ b/scripts/gis-material-update/config.yaml
@@ -33,6 +33,11 @@ osm:
   layer: "lines"
   local_file: "finland-latest.gpkg"
   extra_args: "-oo INTERLEAVED_READING=YES"
+helsinki_osm_lines:
+  addr: "/haitaton-gis/osm_vrt_clip.vrt"
+  local_file: "helsinki-osm.gpkg"
+  extra_args: "-dialect sqlite -nln lines -sql"
+  extra_quoted_args: "SELECT lines.* FROM lines, area WHERE ST_Intersects(lines.geom, area.geom)"
 hki:
   addr: "WFS:https://geo.stat.fi/geoserver/tilastointialueet/wfs"
   layer: "tilastointialueet:kunta1000k"

--- a/scripts/gis-material-update/copy-files.sh
+++ b/scripts/gis-material-update/copy-files.sh
@@ -14,5 +14,6 @@ do
 done
 
 docker cp config.yaml dummy://haitaton-gis
+docker cp osm_vrt_clip.vrt dummy://haitaton-gis
 
 docker rm dummy

--- a/scripts/gis-material-update/fetch/fetch_data.sh
+++ b/scripts/gis-material-update/fetch/fetch_data.sh
@@ -38,8 +38,15 @@ cfg_dest_layer () {
     echo "${data_object}.dest_layer"
 }
 
+# default extra args
 cfg_extra_args () {
     echo "${data_object}.extra_args"
+}
+
+# extra args when quoting is needed
+# e.g. parameter with -sql
+cfg_extra_quoted_args () {
+    echo "${data_object}.extra_quoted_args"
 }
 
 # download path
@@ -51,14 +58,15 @@ layer=$(parse_config $(cfg_layer $data_object))
 local_file=${download_dir}/$(parse_config $(cfg_local_file $data_object))
 dest_layer=$(parse_config $(cfg_dest_layer $data_object))
 extra_args=$(parse_config $(cfg_extra_args $data_object))
+extra_quoted_args=$(parse_config $(cfg_extra_quoted_args $data_object))
 
 case $data_object in
 hsl)
     wget -O "$local_file" "$addr"
     ;;
 # plain WFS fetch
-hki|ylre_katualueet|ylre_katuosat|maka_autoliikennemaarat|osm)
-    ogr2ogr -progress -f GPKG "$local_file" ${extra_args:+$extra_args} "$addr" "$layer"
+hki|ylre_katualueet|ylre_katuosat|maka_autoliikennemaarat|osm|helsinki_osm_lines)
+    ogr2ogr -progress -f GPKG "$local_file" ${extra_args:+$extra_args} ${extra_quoted_args:+"$extra_quoted_args"} "$addr" "$layer"
     ;;
 *)
     echo "Not supported"

--- a/scripts/gis-material-update/fetch/fetch_data.sh
+++ b/scripts/gis-material-update/fetch/fetch_data.sh
@@ -53,12 +53,12 @@ dest_layer=$(parse_config $(cfg_dest_layer $data_object))
 extra_args=$(parse_config $(cfg_extra_args $data_object))
 
 case $data_object in
-hsl|osm)
+hsl)
     wget -O "$local_file" "$addr"
     ;;
 # plain WFS fetch
-hki|ylre_katualueet|ylre_katuosat|maka_autoliikennemaarat)
-    ogr2ogr -progress -f GPKG "$local_file" ${extra_args:+$extra_args} WFS:"$addr" "$layer"
+hki|ylre_katualueet|ylre_katuosat|maka_autoliikennemaarat|osm)
+    ogr2ogr -progress -f GPKG "$local_file" ${extra_args:+$extra_args} "$addr" "$layer"
     ;;
 *)
     echo "Not supported"

--- a/scripts/gis-material-update/osm_vrt_clip.vrt
+++ b/scripts/gis-material-update/osm_vrt_clip.vrt
@@ -1,0 +1,16 @@
+<OGRVRTDataSource>
+<OGRVRTWarpedLayer>
+    <OGRVRTLayer name="lines">
+        <SrcDataSource>/downloads/finland-latest.gpkg</SrcDataSource>
+        <SrcLayer>lines</SrcLayer>
+    </OGRVRTLayer>
+    <TargetSRS>EPSG:3879</TargetSRS>
+</OGRVRTWarpedLayer>
+<OGRVRTWarpedLayer>
+    <OGRVRTLayer name="area">
+        <SrcDataSource>/downloads/helsinki_alue.gpkg</SrcDataSource>
+        <SrcLayer>alue</SrcLayer>
+    </OGRVRTLayer>
+    <TargetSRS>EPSG:3879</TargetSRS>
+</OGRVRTWarpedLayer>
+</OGRVRTDataSource>


### PR DESCRIPTION
# Description

OSM material download. Limit downloaded line geometries to Helsinki area.

Changed address description in configuration file (`addr`) to contain also method (i.e. `WFS`, `/vsicurl`, ...)

Implemented reprojection and intersection computation with OGR VRT driver.

Implemented SQL quoting in configuration file with separate label, which is delivered as quoted string in fetch shell script: `extra_quoted_args`

### Jira Issues: 

https://helsinkisolutionoffice.atlassian.net/browse/HAI-1312
https://helsinkisolutionoffice.atlassian.net/browse/HAI-1313

## Type of change

- [ ] Bug fix 
- [x] New feature 
- [ ] Other

# Instructions for testing

Prerequisite: fetch `hki` and `osm` source materials, as per instructions in the README

* build containers and copy files, as instructed in README
* Run fetch (processing time around 30 minutes or a bit less): `docker-compose run --rm gis-fetch helsinki_osm_lines`
* check that output file can be read, and contains attributes: `ogrinfo haitaton-downloads/helsinki-osm-lines.gpkg lines -so`

Attributes: 
```
FID Column = fid
Geometry Column = geom
osm_id: String (0.0)
name: String (0.0)
highway: String (0.0)
waterway: String (0.0)
aerialway: String (0.0)
barrier: String (0.0)
man_made: String (0.0)
z_order: Integer (0.0)
other_tags: String (0.0)
```

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 

# Other relevant info
-