### PR TITLE
HAI-1075 Add modify log for creating hankkeet

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
@@ -35,15 +35,14 @@ import org.springframework.test.context.ActiveProfiles
 import org.springframework.transaction.annotation.Transactional
 import org.testcontainers.junit.jupiter.Testcontainers
 
+private const val USER_NAME = "test7358"
+
 @Testcontainers
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("default")
 @Transactional
-@WithMockUser(username = "test7358", roles = ["haitaton-user"])
+@WithMockUser(USER_NAME)
 class HankeServiceITests : DatabaseTest() {
-
-    // Must match the username of the mock user above
-    private val USER_NAME = "test7358"
 
     @Autowired private lateinit var hankeService: HankeService
     @Autowired private lateinit var auditLogRepository: AuditLogRepository
@@ -514,14 +513,15 @@ class HankeServiceITests : DatabaseTest() {
         val yhteystietoId2 = createdHanke.omistajat[1].id!!
         assertThat(createdHanke.omistajat[1].sukunimi).isEqualTo("suku2")
 
-        var auditLogEvents = auditLogRepository.findAll().map { it.message.auditEvent }
+        var auditLogEvents =
+            auditLogRepository.findByType(ObjectType.YHTEYSTIETO).map { it.message.auditEvent }
         // The log must have 2 entries since two yhteystietos were created.
         assertThat(auditLogEvents.count()).isEqualTo(2)
         // Check that each yhteystieto has single entry in log:
         var auditLogEvents1 = auditLogEvents.filter { it.target.id == yhteystietoId1.toString() }
         var auditLogEvents2 = auditLogEvents.filter { it.target.id == yhteystietoId2.toString() }
-        assertThat(auditLogEvents1.size).isEqualTo(1)
-        assertThat(auditLogEvents2.size).isEqualTo(1)
+        assertThat(auditLogEvents1).hasSize(1)
+        assertThat(auditLogEvents2).hasSize(1)
 
         // Check that each entry has correct data.
         assertThat(auditLogEvents1[0].operation).isEqualTo(Operation.CREATE)
@@ -559,14 +559,15 @@ class HankeServiceITests : DatabaseTest() {
         assertThat(hankeAfterUpdate.omistajat[0].sukunimi).isEqualTo("suku1")
         assertThat(hankeAfterUpdate.omistajat[1].sukunimi).isEqualTo("Som Et Hing")
 
-        auditLogEvents = auditLogRepository.findAll().map { it.message.auditEvent }
+        auditLogEvents =
+            auditLogRepository.findByType(ObjectType.YHTEYSTIETO).map { it.message.auditEvent }
         // Check that only 1 entry was added to log, about the updated yhteystieto.
-        assertThat(auditLogEvents.size).isEqualTo(3)
+        assertThat(auditLogEvents).hasSize(3)
         // Check that the second yhteystieto got a single entry in log and the other didn't.
         auditLogEvents1 = auditLogEvents.filter { it.target.id == yhteystietoId1.toString() }
         auditLogEvents2 = auditLogEvents.filter { it.target.id == yhteystietoId2.toString() }
-        assertThat(auditLogEvents1.size).isEqualTo(1)
-        assertThat(auditLogEvents2.size).isEqualTo(2)
+        assertThat(auditLogEvents1).hasSize(1)
+        assertThat(auditLogEvents2).hasSize(2)
         // Check that the new entry has correct data.
         assertThat(auditLogEvents2[1].operation).isEqualTo(Operation.UPDATE)
         assertThat(auditLogEvents2[1].actor.userId).isEqualTo(USER_NAME)
@@ -594,14 +595,15 @@ class HankeServiceITests : DatabaseTest() {
         assertThat(hankeAfterDelete.omistajat[0].id).isEqualTo(yhteystietoId1)
         assertThat(hankeAfterDelete.omistajat[0].sukunimi).isEqualTo("suku1")
 
-        auditLogEvents = auditLogRepository.findAll().map { it.message.auditEvent }
+        auditLogEvents =
+            auditLogRepository.findByType(ObjectType.YHTEYSTIETO).map { it.message.auditEvent }
         // Check that only 1 entry was added to log, about the deleted yhteystieto.
-        assertThat(auditLogEvents.size).isEqualTo(4)
+        assertThat(auditLogEvents).hasSize(4)
         // Check that the second yhteystieto got a single entry in log and the other didn't.
         auditLogEvents1 = auditLogEvents.filter { it.target.id == yhteystietoId1.toString() }
         auditLogEvents2 = auditLogEvents.filter { it.target.id == yhteystietoId2.toString() }
-        assertThat(auditLogEvents1.size).isEqualTo(1)
-        assertThat(auditLogEvents2.size).isEqualTo(3)
+        assertThat(auditLogEvents1).hasSize(1)
+        assertThat(auditLogEvents2).hasSize(3)
         // Check that the new entry has correct data.
         assertThat(auditLogEvents2[2].operation).isEqualTo(Operation.DELETE)
         assertThat(auditLogEvents2[2].actor.userId).isEqualTo(USER_NAME)
@@ -624,7 +626,7 @@ class HankeServiceITests : DatabaseTest() {
         // Call create, get the return object:
         val returnedHanke = hankeService.createHanke(hanke)
         // Logs must have 2 entries (two yhteystietos were created):
-        assertThat(auditLogRepository.count()).isEqualTo(2)
+        assertThat(auditLogRepository.countByType(ObjectType.YHTEYSTIETO)).isEqualTo(2)
 
         // Get the non-owner yhteystieto, and set the processing restriction (i.e. locked) -flag
         // (must be done via entities):
@@ -649,15 +651,15 @@ class HankeServiceITests : DatabaseTest() {
             .isThrownBy { hankeService.updateHanke(hankeWithLockedYT) }
         // The initial create has created two entries to the log, and now the failed update should
         // have added one more.
-        assertThat(auditLogRepository.count()).isEqualTo(3)
+        assertThat(auditLogRepository.countByType(ObjectType.YHTEYSTIETO)).isEqualTo(3)
         var auditLogEvents =
             auditLogRepository
-                .findAll()
+                .findByType(ObjectType.YHTEYSTIETO)
                 .map { it.message.auditEvent }
                 .filter { it.target.id == arvioijaId }
         // For the second yhteystieto, there should be one entry for the earlier creation and
         // another for this failed update.
-        assertThat(auditLogEvents.size).isEqualTo(2)
+        assertThat(auditLogEvents).hasSize(2)
         assertThat(auditLogEvents[1].operation).isEqualTo(Operation.UPDATE)
         assertThat(auditLogEvents[1].actor.userId).isEqualTo(USER_NAME)
         assertThat(auditLogEvents[1].actor.role).isEqualTo(UserRole.USER)
@@ -680,15 +682,15 @@ class HankeServiceITests : DatabaseTest() {
         assertThatExceptionOfType(HankeYhteystietoProcessingRestrictedException::class.java)
             .isThrownBy { hankeService.updateHanke(hankeWithLockedYT) }
         // There should be one more entry in the audit log.
-        assertThat(auditLogRepository.count()).isEqualTo(4)
+        assertThat(auditLogRepository.countByType(ObjectType.YHTEYSTIETO)).isEqualTo(4)
         auditLogEvents =
             auditLogRepository
-                .findAll()
+                .findByType(ObjectType.YHTEYSTIETO)
                 .map { it.message.auditEvent }
                 .filter { it.target.id == arvioijaId }
         // For the second yhteystieto, there should be one more audit log entry for this failed
         // deletion:
-        assertThat(auditLogEvents.size).isEqualTo(3)
+        assertThat(auditLogEvents).hasSize(3)
         assertThat(auditLogEvents[2].operation).isEqualTo(Operation.DELETE)
         assertThat(auditLogEvents[2].actor.userId).isEqualTo(USER_NAME)
         assertThat(auditLogEvents[2].actor.role).isEqualTo(UserRole.USER)
@@ -720,14 +722,14 @@ class HankeServiceITests : DatabaseTest() {
         // Check that the change went through:
         assertThat(finalHanke.arvioijat[0].etunimi).isEqualTo("Hopefully-Not-Evil-Change")
         // There should be one more entry in the log.
-        assertThat(auditLogRepository.count()).isEqualTo(5)
+        assertThat(auditLogRepository.countByType(ObjectType.YHTEYSTIETO)).isEqualTo(5)
         auditLogEvents =
             auditLogRepository
-                .findAll()
+                .findByType(ObjectType.YHTEYSTIETO)
                 .map { it.message.auditEvent }
                 .filter { it.target.id == arvioijaId }
         // For the second yhteystieto, there should be one more entry in the log:
-        assertThat(auditLogEvents.size).isEqualTo(4)
+        assertThat(auditLogEvents).hasSize(4)
     }
 
     @Test
@@ -768,6 +770,7 @@ class HankeServiceITests : DatabaseTest() {
         // Update needed for generating TormaystarkasteluTulos
         hankeService.updateHanke(hanke)
         val hankeWithTulos = hankeService.loadHanke(hanke.hankeTunnus!!)!!
+        auditLogRepository.deleteAll()
         assertEquals(0, auditLogRepository.count())
         TestUtils.addMockedRequestIp()
 
@@ -791,38 +794,18 @@ class HankeServiceITests : DatabaseTest() {
         assertEquals(ObjectType.HANKE, event.target.type)
         assertNull(event.target.objectAfter)
         val expectedObject =
-            """{"id":${hankeWithTulos.id},
-               |"hankeTunnus":"${hankeWithTulos.hankeTunnus}",
-               |"onYKTHanke":true,
-               |"nimi":"Hämeentien perusparannus ja katuvalot",
-               |"kuvaus":"lorem ipsum dolor sit amet...",
-               |"alkuPvm":"2023-02-20T00:00:00Z",
-               |"loppuPvm":"2023-02-21T00:00:00Z",
-               |"vaihe":"OHJELMOINTI",
-               |"suunnitteluVaihe":null,
-               |"version":1,
-               |"tyomaaKatuosoite":"Testikatu 1",
-               |"tyomaaTyyppi":["VESI", "MUU"],
-               |"tyomaaKoko":"LAAJA_TAI_USEA_KORTTELI",
-               |"alueet": [
-               |  {
-               |     "id": ${hankeWithTulos.alueet[0].id},
-               |     "hankeId": ${hankeWithTulos.id},
-               |     "haittaAlkuPvm":"2023-02-20T00:00:00Z",
-               |     "haittaLoppuPvm":"2023-02-21T00:00:00Z",
-               |     "kaistaHaitta":"KAKSI",
-               |     "kaistaPituusHaitta":"NELJA",
-               |     "meluHaitta":"YKSI",
-               |     "polyHaitta":"KAKSI",
-               |     "tarinaHaitta":"KOLME"
-               |  }
-               |],
-               |"tormaystarkasteluTulos":{
+            expectedHankeLogObject(
+                hankeWithTulos.id,
+                hankeWithTulos.alueet[0].id,
+                hankeWithTulos.hankeTunnus,
+                1,
+                """{
                |"perusIndeksi":1.4,
                |"pyorailyIndeksi":1.0,
                |"joukkoliikenneIndeksi":1.0,
                |"liikennehaittaIndeksi":{"indeksi":1.4,"tyyppi":"PERUSINDEKSI"}
-               |}}""".trimMargin()
+               |}""".trimMargin()
+            )
         JSONAssert.assertEquals(
             expectedObject,
             event.target.objectBefore,
@@ -832,18 +815,18 @@ class HankeServiceITests : DatabaseTest() {
 
     @Test
     fun `deleteHanke creates audit log entries for deleted yhteystiedot`() {
-        assertEquals(0, auditLogRepository.count())
         val hanke =
             hankeService.createHanke(
                 HankeFactory.create(id = null, hankeTunnus = null).withYhteystiedot { it.id = null }
             )
-        assertEquals(3, auditLogRepository.count())
+        auditLogRepository.deleteAll()
+        assertEquals(0, auditLogRepository.count())
         TestUtils.addMockedRequestIp()
 
         hankeService.deleteHanke(hanke, "testUser")
 
         val logs = auditLogRepository.findByType(ObjectType.YHTEYSTIETO)
-        assertEquals(6, logs.size)
+        assertEquals(3, logs.size)
         val deleteLogs = logs.filter { it.message.auditEvent.operation == Operation.DELETE }
         assertThat(deleteLogs).hasSize(3).allSatisfy { log ->
             assertFalse(log.isSent)
@@ -878,6 +861,116 @@ class HankeServiceITests : DatabaseTest() {
             toteuttajaEvent.target.objectBefore,
             JSONCompareMode.NON_EXTENSIBLE
         )
+    }
+
+    @Test
+    fun `createHanke creates audit log entry for created hanke`() {
+        TestUtils.addMockedRequestIp()
+
+        val hanke = hankeService.createHanke(HankeFactory.create(id = null).withHankealue())
+
+        val hankeLogs = auditLogRepository.findByType(ObjectType.HANKE)
+        assertEquals(1, hankeLogs.size)
+        val hankeLog = hankeLogs[0]
+        assertFalse(hankeLog.isSent)
+        assertThat(hankeLog.createdAt).isCloseToUtcNow(byLessThan(1, ChronoUnit.MINUTES))
+        val event = hankeLog.message.auditEvent
+        assertThat(event.dateTime).isCloseToUtcNow(byLessThan(1, ChronoUnit.MINUTES))
+        assertEquals(Operation.CREATE, event.operation)
+        assertEquals(Status.SUCCESS, event.status)
+        assertNull(event.failureDescription)
+        assertEquals("1", event.appVersion)
+        assertEquals("test7358", event.actor.userId)
+        assertEquals(UserRole.USER, event.actor.role)
+        assertEquals("127.0.0.1", event.actor.ipAddress)
+        assertEquals(hanke.id?.toString(), event.target.id)
+        assertEquals(ObjectType.HANKE, event.target.type)
+        assertNull(event.target.objectBefore)
+        val expectedObject =
+            expectedHankeLogObject(hanke.id, hanke.alueet[0].id, hanke.hankeTunnus, 0, null)
+        JSONAssert.assertEquals(
+            expectedObject,
+            event.target.objectAfter,
+            JSONCompareMode.NON_EXTENSIBLE
+        )
+    }
+
+    @Test
+    fun `createHanke without a hankealue creates audit log entry for created hanke`() {
+        TestUtils.addMockedRequestIp()
+        val hankeBefore = HankeFactory.create(id = null)
+        hankeBefore.tyomaaKatuosoite = "Testikatu 1"
+        hankeBefore.tyomaaKoko = TyomaaKoko.LAAJA_TAI_USEA_KORTTELI
+        hankeBefore.tyomaaTyyppi = mutableSetOf(TyomaaTyyppi.VESI, TyomaaTyyppi.MUU)
+
+        val hanke = hankeService.createHanke(hankeBefore)
+
+        val hankeLogs = auditLogRepository.findByType(ObjectType.HANKE)
+        assertEquals(1, hankeLogs.size)
+        val hankeLog = hankeLogs[0]
+        assertFalse(hankeLog.isSent)
+        assertThat(hankeLog.createdAt).isCloseToUtcNow(byLessThan(1, ChronoUnit.MINUTES))
+        val event = hankeLog.message.auditEvent
+        assertThat(event.dateTime).isCloseToUtcNow(byLessThan(1, ChronoUnit.MINUTES))
+        assertEquals(Operation.CREATE, event.operation)
+        assertEquals(Status.SUCCESS, event.status)
+        assertNull(event.failureDescription)
+        assertEquals("1", event.appVersion)
+        assertEquals("test7358", event.actor.userId)
+        assertEquals(UserRole.USER, event.actor.role)
+        assertEquals("127.0.0.1", event.actor.ipAddress)
+        assertEquals(hanke.id?.toString(), event.target.id)
+        assertEquals(ObjectType.HANKE, event.target.type)
+        assertNull(event.target.objectBefore)
+        val expectedObject = expectedHankeLogObject(hanke.id, null, hanke.hankeTunnus, 0, null)
+        JSONAssert.assertEquals(
+            expectedObject,
+            event.target.objectAfter,
+            JSONCompareMode.NON_EXTENSIBLE
+        )
+    }
+
+    private fun expectedHankeLogObject(
+        id: Int?,
+        alueId: Int?,
+        hankeTunnus: String?,
+        version: Int,
+        tormaystarkasteluTulos: String?
+    ): String {
+        val alue =
+            alueId?.let {
+                """
+               {
+                  "id": ${alueId},
+                  "hankeId": ${id},
+                  "haittaAlkuPvm":"2023-02-20T00:00:00Z",
+                  "haittaLoppuPvm":"2023-02-21T00:00:00Z",
+                  "kaistaHaitta":"KAKSI",
+                  "kaistaPituusHaitta":"NELJA",
+                  "meluHaitta":"YKSI",
+                  "polyHaitta":"KAKSI",
+                  "tarinaHaitta":"KOLME"
+               }
+        """.trimIndent()
+            }
+                ?: ""
+
+        return """{"id":$id,
+               |"hankeTunnus":"$hankeTunnus",
+               |"onYKTHanke":true,
+               |"nimi":"Hämeentien perusparannus ja katuvalot",
+               |"kuvaus":"lorem ipsum dolor sit amet...",
+               |"alkuPvm":"2023-02-20T00:00:00Z",
+               |"loppuPvm":"2023-02-21T00:00:00Z",
+               |"vaihe":"OHJELMOINTI",
+               |"suunnitteluVaihe":null,
+               |"version":$version,
+               |"tyomaaKatuosoite":"Testikatu 1",
+               |"tyomaaTyyppi":["VESI", "MUU"],
+               |"tyomaaKoko":"LAAJA_TAI_USEA_KORTTELI",
+               |"alueet": [$alue],
+               |"tormaystarkasteluTulos":$tormaystarkasteluTulos
+               |}""".trimMargin()
     }
 
     private fun List<AuditLogEntryEntity>.findByTargetId(id: Int): AuditLogEntryEntity =
@@ -926,4 +1019,6 @@ class HankeServiceITests : DatabaseTest() {
      */
     fun AuditLogRepository.findByType(type: ObjectType) =
         this.findAll().filter { it.message.auditEvent.target.type == type }
+
+    fun AuditLogRepository.countByType(type: ObjectType) = this.findByType(type).count()
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeService.kt
@@ -8,7 +8,7 @@ interface HankeService {
     /** Fetch hanke with hankeTunnus. Returns null if there is no hanke with the given tunnus. */
     fun loadHanke(hankeTunnus: String): Hanke?
 
-    fun createHanke(hanke: Hanke): Hanke
+    @Transactional fun createHanke(hanke: Hanke): Hanke
 
     fun updateHanke(hanke: Hanke): Hanke
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeServiceImpl.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeServiceImpl.kt
@@ -89,6 +89,7 @@ open class HankeServiceImpl(
         }
 
     /** @return a new Hanke instance with the added and possibly modified values. */
+    @Transactional
     override fun createHanke(hanke: Hanke): Hanke {
         // TODO: Only create that hanke-tunnus if a specific set of fields are non-empty/set.
 
@@ -127,7 +128,9 @@ open class HankeServiceImpl(
         // Creating a new domain object for the return value; it will have the updated values from
         // the database, e.g. the main date values truncated to midnight, and the added id and
         // hanketunnus.
-        return createHankeDomainObjectFromEntity(entity)
+        val savedHanke = createHankeDomainObjectFromEntity(entity)
+        hankeLoggingService.logCreate(savedHanke, userId)
+        return savedHanke
     }
 
     // WITH THIS ONE CAN AUTHORIZE ONLY THE OWNER TO UPDATE A HANKE:
@@ -357,24 +360,15 @@ open class HankeServiceImpl(
         // A temporary copy, so that we can remove handled entries from it, leaving
         // certain deleted entries as remainder:
         val tempLockedExistingYts = lockedExistingYTs.toMutableMap()
-        findAndLogAffectedBlockedYhteystietos(
-            incomingHanke.omistajat,
-            tempLockedExistingYts,
-            loggingEntryHolderForRestrictedActions,
-            userid
-        )
-        findAndLogAffectedBlockedYhteystietos(
-            incomingHanke.arvioijat,
-            tempLockedExistingYts,
-            loggingEntryHolderForRestrictedActions,
-            userid
-        )
-        findAndLogAffectedBlockedYhteystietos(
-            incomingHanke.toteuttajat,
-            tempLockedExistingYts,
-            loggingEntryHolderForRestrictedActions,
-            userid
-        )
+        listOf(incomingHanke.omistajat, incomingHanke.arvioijat, incomingHanke.toteuttajat)
+            .forEach { yhteystiedot ->
+                findAndLogAffectedBlockedYhteystietos(
+                    yhteystiedot,
+                    tempLockedExistingYts,
+                    loggingEntryHolderForRestrictedActions,
+                    userid
+                )
+            }
 
         // If no entries were blocked, and there is nothing left in the tempLockedExistingYts, all
         // clear to proceed:
@@ -566,30 +560,21 @@ open class HankeServiceImpl(
 
         // Check each incoming yhteystieto (from three lists) for being new or an update to existing
         // one, and add to the main entity's single list if necessary:
-        processIncomingHankeYhteystietosOfSpecificTypeToEntity(
-            hanke.omistajat,
-            entity,
-            ContactType.OMISTAJA,
-            userid,
-            existingYTs,
-            loggingEntryHolder
-        )
-        processIncomingHankeYhteystietosOfSpecificTypeToEntity(
-            hanke.arvioijat,
-            entity,
-            ContactType.ARVIOIJA,
-            userid,
-            existingYTs,
-            loggingEntryHolder
-        )
-        processIncomingHankeYhteystietosOfSpecificTypeToEntity(
-            hanke.toteuttajat,
-            entity,
-            ContactType.TOTEUTTAJA,
-            userid,
-            existingYTs,
-            loggingEntryHolder
-        )
+        listOf(
+                ContactType.OMISTAJA to hanke.omistajat,
+                ContactType.ARVIOIJA to hanke.arvioijat,
+                ContactType.TOTEUTTAJA to hanke.toteuttajat,
+            )
+            .forEach { (type, yhteystiedot) ->
+                processIncomingHankeYhteystietosOfSpecificTypeToEntity(
+                    yhteystiedot,
+                    entity,
+                    type,
+                    userid,
+                    existingYTs,
+                    loggingEntryHolder
+                )
+            }
 
         // TODO: this method of removing entries if they are missing in the incoming data is
         //  different to behavior of the other simpler fields, where missing or null field is

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/HankeLoggingService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/HankeLoggingService.kt
@@ -26,4 +26,16 @@ class HankeLoggingService(private val auditLogService: AuditLogService) {
 
         auditLogService.createAll(yhteystietoEntries + auditLogEntry)
     }
+
+    /**
+     * Create audit log entry for a created hanke.
+     *
+     * Don't process sub-entities, they are handled elsewhere. Log entries for yhteystiedot are
+     * added in [fi.hel.haitaton.hanke.HankeServiceImpl]. Geometries are added in their own
+     * controller, so they are logged there.
+     */
+    @Transactional(propagation = Propagation.MANDATORY)
+    fun logCreate(hanke: Hanke, userId: String) {
+        auditLogService.create(AuditLogService.createEntry(userId, ObjectType.HANKE, hanke))
+    }
 }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/logging/HankeLoggingServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/logging/HankeLoggingServiceTest.kt
@@ -82,4 +82,27 @@ internal class HankeLoggingServiceTest {
             )
         }
     }
+
+    @Test
+    fun `logCreate creates audit log entry for created hanke`() {
+        val hanke = HankeFactory.create()
+
+        hankeLoggingService.logCreate(hanke, userId)
+
+        verify {
+            auditLogService.create(
+                withArg { entry ->
+                    assertEquals(Operation.CREATE, entry.operation)
+                    assertEquals(Status.SUCCESS, entry.status)
+                    assertNull(entry.failureDescription)
+                    assertEquals(userId, entry.userId)
+                    assertEquals(UserRole.USER, entry.userRole)
+                    assertEquals(HankeFactory.defaultId.toString(), entry.objectId)
+                    assertEquals(ObjectType.HANKE, entry.objectType)
+                    assertNotNull(entry.objectAfter)
+                    assertNull(entry.objectBefore)
+                }
+            )
+        }
+    }
 }


### PR DESCRIPTION
# Description

Add an entry to audit logs whenever users create a new hanke. Yhteystiedot were already logged, and I didn't mess with those.

It was tempting to refactor the yhteystieto logging, so it wouldn't be quite so entwined with creating the data, and also updating the hanke. But this would've meant rewriting most of the create and update code, so I didn't.

### Jira Issue: 

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
- Create a new hanke.
- Check database audit_logs table has a new entry for the created hanke.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 
