### PR TITLE
HAI-1075 Add modify log for updating hankkeet

### DIFF
--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeService.kt
@@ -10,7 +10,7 @@ interface HankeService {
 
     @Transactional fun createHanke(hanke: Hanke): Hanke
 
-    fun updateHanke(hanke: Hanke): Hanke
+    @Transactional fun updateHanke(hanke: Hanke): Hanke
 
     @Transactional fun deleteHanke(hanke: Hanke, userId: String)
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankealueEntity.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankealueEntity.kt
@@ -1,5 +1,6 @@
 package fi.hel.haitaton.hanke
 
+import fi.hel.haitaton.hanke.domain.HasId
 import java.time.LocalDate
 import javax.persistence.Entity
 import javax.persistence.FetchType
@@ -12,8 +13,8 @@ import javax.persistence.Table
 
 @Entity
 @Table(name = "hankealue")
-class HankealueEntity {
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY) var id: Int? = null
+class HankealueEntity : HasId<Int> {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY) override var id: Int? = null
 
     @ManyToOne(fetch = FetchType.EAGER) @JoinColumn(name = "hankeid") var hanke: HankeEntity? = null
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/Hankealue.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/Hankealue.kt
@@ -13,7 +13,7 @@ import java.time.ZonedDateTime
  * NOTE Remember to update PublicHankealue after changes
  */
 data class Hankealue(
-    @JsonView(ChangeLogView::class) var id: Int? = null,
+    @JsonView(ChangeLogView::class) override var id: Int? = null,
     @JsonView(ChangeLogView::class) var hankeId: Int? = null,
     @JsonView(ChangeLogView::class) var haittaAlkuPvm: ZonedDateTime? = null,
     @JsonView(ChangeLogView::class) var haittaLoppuPvm: ZonedDateTime? = null,
@@ -24,4 +24,4 @@ data class Hankealue(
     @JsonView(ChangeLogView::class) var meluHaitta: Haitta13? = null,
     @JsonView(ChangeLogView::class) var polyHaitta: Haitta13? = null,
     @JsonView(ChangeLogView::class) var tarinaHaitta: Haitta13? = null,
-)
+) : HasId<Int>

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/AuditLogService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/AuditLogService.kt
@@ -84,5 +84,35 @@ class AuditLogService(private val auditLogRepository: AuditLogRepository) {
                 objectBefore = null,
                 objectAfter = createdObject.toChangeLogJsonString(),
             )
+
+        /**
+         * Create an audit log entry for the update if some logged data has changed.
+         *
+         * @return the audit log event if there are changes. null if there are not.
+         */
+        fun <ID, T : HasId<ID>> updateEntry(
+            userId: String,
+            type: ObjectType,
+            objectBefore: T,
+            objectAfter: T
+        ): AuditLogEntry? {
+            val jsonBefore = objectBefore.toChangeLogJsonString()
+            val jsonAfter = objectAfter.toChangeLogJsonString()
+
+            return if (jsonBefore == jsonAfter) {
+                null
+            } else {
+                AuditLogEntry(
+                    operation = Operation.UPDATE,
+                    status = Status.SUCCESS,
+                    userId = userId,
+                    userRole = UserRole.USER,
+                    objectId = objectAfter.id?.toString(),
+                    objectType = type,
+                    objectBefore = objectBefore.toChangeLogJsonString(),
+                    objectAfter = objectAfter.toChangeLogJsonString(),
+                )
+            }
+        }
     }
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/HankeLoggingService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/HankeLoggingService.kt
@@ -38,4 +38,23 @@ class HankeLoggingService(private val auditLogService: AuditLogService) {
     fun logCreate(hanke: Hanke, userId: String) {
         auditLogService.create(AuditLogService.createEntry(userId, ObjectType.HANKE, hanke))
     }
+
+    /**
+     * Create audit log entry for an updated hanke.
+     *
+     * Only create the entry if the logged content of the hanke has changed.
+     *
+     * Currently, the version field is updated even if there are no other changes, so the audit log
+     * entry is always created.
+     *
+     * Don't process sub-entities, they are handled elsewhere. Log entries for yhteystiedot are
+     * added in [fi.hel.haitaton.hanke.HankeServiceImpl]. Geometries are added in their own
+     * controller, so they are logged there.
+     */
+    @Transactional(propagation = Propagation.MANDATORY)
+    fun logUpdate(hankeBefore: Hanke, hankeAfter: Hanke, userId: String) {
+        AuditLogService.updateEntry(userId, ObjectType.HANKE, hankeBefore, hankeAfter)?.let {
+            auditLogService.create(it)
+        }
+    }
 }


### PR DESCRIPTION
# Description

Add an entry to audit logs whenever users update a new hanke.

Only add the entry, if the content of the hanke has been changed. Currently, the content always changes, since the version field is updated whether there are any other changes or not.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1075

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
- Make a change to a hanke.
- Check database audit_logs table has a new entry for the updated hanke.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 