### PR TITLE
HAI-1297 Refactor saving Allu ID

### DIFF
--- a/services/hanke-service/README.md
+++ b/services/hanke-service/README.md
@@ -39,6 +39,9 @@ setup can not currently support authentication, so can not test the actions with
 > http://localhost:8080/swagger-ui.html \
 > http://localhost:8080/v3/api-docs
 
+When running the services with Docker Compose, the Swagger UI can be accessed with
+[http://localhost:3000/swagger-ui/index.html](http://localhost:3000/swagger-ui/index.html).
+
 ### Spotless formatter
 
 The Spotless Gradle plugin checks during the build stage that all code is formatted with ktfmt. If

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/allu/ApplicationControllerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/allu/ApplicationControllerITest.kt
@@ -26,7 +26,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
-private const val userName = "testUser"
+private const val username = "testUser"
 
 @WebMvcTest(ApplicationController::class)
 @Import(IntegrationTestConfiguration::class)
@@ -55,19 +55,19 @@ class ApplicationControllerITest(@Autowired override val mockMvc: MockMvc) : Con
     }
 
     @Test
-    @WithMockUser(userName)
+    @WithMockUser(username)
     fun `getAll with no accessible applications returns empty list`() {
-        every { applicationService.getAllApplicationsForUser(userName) } returns listOf()
+        every { applicationService.getAllApplicationsForUser(username) } returns listOf()
 
         get("/hakemukset").andExpect(status().isOk).andExpect(content().json("[]"))
 
-        verify { applicationService.getAllApplicationsForUser(userName) }
+        verify { applicationService.getAllApplicationsForUser(username) }
     }
 
     @Test
-    @WithMockUser(userName)
+    @WithMockUser(username)
     fun `getAll returns applications for the current user`() {
-        every { applicationService.getAllApplicationsForUser(userName) } returns
+        every { applicationService.getAllApplicationsForUser(username) } returns
             AlluDataFactory.createApplications(3)
 
         get("/hakemukset")
@@ -75,7 +75,7 @@ class ApplicationControllerITest(@Autowired override val mockMvc: MockMvc) : Con
             .andExpect(jsonPath("$").isArray)
             .andExpect(jsonPath("$.length()").value(3))
 
-        verify { applicationService.getAllApplicationsForUser(userName) }
+        verify { applicationService.getAllApplicationsForUser(username) }
     }
 
     @Test
@@ -86,20 +86,20 @@ class ApplicationControllerITest(@Autowired override val mockMvc: MockMvc) : Con
     }
 
     @Test
-    @WithMockUser(userName)
+    @WithMockUser(username)
     fun `getById with unknown ID returns 404`() {
-        every { applicationService.getApplicationById(1234, userName) } throws
+        every { applicationService.getApplicationById(1234, username) } throws
             ApplicationNotFoundException(1234)
 
         get("/hakemukset/1234").andExpect(status().isNotFound)
 
-        verify { applicationService.getApplicationById(1234, userName) }
+        verify { applicationService.getApplicationById(1234, username) }
     }
 
     @Test
-    @WithMockUser(userName)
+    @WithMockUser(username)
     fun `getById with known ID returns application`() {
-        every { applicationService.getApplicationById(1234, userName) } returns
+        every { applicationService.getApplicationById(1234, username) } returns
             AlluDataFactory.createApplication(id = 1234)
 
         get("/hakemukset/1234")
@@ -107,7 +107,7 @@ class ApplicationControllerITest(@Autowired override val mockMvc: MockMvc) : Con
             .andExpect(jsonPath("$.applicationType").value("CABLE_REPORT"))
             .andExpect(jsonPath("$.applicationData.applicationType").value("CABLE_REPORT"))
 
-        verify { applicationService.getApplicationById(1234, userName) }
+        verify { applicationService.getApplicationById(1234, username) }
     }
 
     @Test
@@ -119,7 +119,7 @@ class ApplicationControllerITest(@Autowired override val mockMvc: MockMvc) : Con
     }
 
     @Test
-    @WithMockUser(userName)
+    @WithMockUser(username)
     fun `create without body returns 400`() {
         post("/hakemukset").andExpect(status().isBadRequest)
 
@@ -127,21 +127,21 @@ class ApplicationControllerITest(@Autowired override val mockMvc: MockMvc) : Con
     }
 
     @Test
-    @WithMockUser(userName)
+    @WithMockUser(username)
     fun `create with proper application creates application`() {
         val newApplication = AlluDataFactory.createApplication(id = null)
         val createdApplication = newApplication.copy(id = 1234)
-        every { applicationService.create(newApplication, userName) } returns createdApplication
+        every { applicationService.create(newApplication, username) } returns createdApplication
 
         val response: Application =
             post("/hakemukset", newApplication).andExpect(status().isOk).andReturnBody()
 
         assertEquals(createdApplication, response)
-        verify { applicationService.create(newApplication, userName) }
+        verify { applicationService.create(newApplication, username) }
     }
 
     @Test
-    @WithMockUser(userName)
+    @WithMockUser(username)
     fun `create with missing application data type returns 400`() {
         val application = AlluDataFactory.createApplication(id = null)
         val content: ObjectNode = OBJECT_MAPPER.valueToTree(application)
@@ -153,7 +153,7 @@ class ApplicationControllerITest(@Autowired override val mockMvc: MockMvc) : Con
     }
 
     @Test
-    @WithMockUser(userName)
+    @WithMockUser(username)
     fun `create with missing application type returns 400`() {
         val application = AlluDataFactory.createApplication(id = null)
         val content: ObjectNode = OBJECT_MAPPER.valueToTree(application)
@@ -175,7 +175,7 @@ class ApplicationControllerITest(@Autowired override val mockMvc: MockMvc) : Con
     }
 
     @Test
-    @WithMockUser(userName)
+    @WithMockUser(username)
     fun `update without body returns 400`() {
         put("/hakemukset/1234").andExpect(status().isBadRequest)
 
@@ -183,11 +183,11 @@ class ApplicationControllerITest(@Autowired override val mockMvc: MockMvc) : Con
     }
 
     @Test
-    @WithMockUser(userName)
+    @WithMockUser(username)
     fun `update with known id returns ok`() {
         val application = AlluDataFactory.createApplication()
         every {
-            applicationService.updateApplicationData(1234, application.applicationData, userName)
+            applicationService.updateApplicationData(1234, application.applicationData, username)
         } returns application
 
         val response: Application =
@@ -195,12 +195,12 @@ class ApplicationControllerITest(@Autowired override val mockMvc: MockMvc) : Con
 
         assertEquals(application, response)
         verify {
-            applicationService.updateApplicationData(1234, application.applicationData, userName)
+            applicationService.updateApplicationData(1234, application.applicationData, username)
         }
     }
 
     @Test
-    @WithMockUser(userName)
+    @WithMockUser(username)
     fun `update with missing application data type returns 400`() {
         val application = AlluDataFactory.createApplication()
         val content: ObjectNode = OBJECT_MAPPER.valueToTree(application)
@@ -212,7 +212,7 @@ class ApplicationControllerITest(@Autowired override val mockMvc: MockMvc) : Con
     }
 
     @Test
-    @WithMockUser(userName)
+    @WithMockUser(username)
     fun `update with missing application type returns 400`() {
         val application = AlluDataFactory.createApplication()
         val content: ObjectNode = OBJECT_MAPPER.valueToTree(application)
@@ -226,17 +226,32 @@ class ApplicationControllerITest(@Autowired override val mockMvc: MockMvc) : Con
     }
 
     @Test
-    @WithMockUser(userName)
+    @WithMockUser(username)
     fun `update with unknown id returns 404`() {
         val application = AlluDataFactory.createApplication()
         every {
-            applicationService.updateApplicationData(1234, application.applicationData, userName)
+            applicationService.updateApplicationData(1234, application.applicationData, username)
         } throws ApplicationNotFoundException(1234)
 
         put("/hakemukset/1234", application).andExpect(status().isNotFound)
 
         verify {
-            applicationService.updateApplicationData(1234, application.applicationData, userName)
+            applicationService.updateApplicationData(1234, application.applicationData, username)
+        }
+    }
+
+    @Test
+    @WithMockUser(username)
+    fun `update with application that's no longer pending returns 409`() {
+        val application = AlluDataFactory.createApplication()
+        every {
+            applicationService.updateApplicationData(1234, application.applicationData, username)
+        } throws ApplicationAlreadyProcessingException(1234, 21)
+
+        put("/hakemukset/1234", application).andExpect(status().isConflict)
+
+        verify {
+            applicationService.updateApplicationData(1234, application.applicationData, username)
         }
     }
 
@@ -249,65 +264,71 @@ class ApplicationControllerITest(@Autowired override val mockMvc: MockMvc) : Con
     }
 
     @Test
-    @WithMockUser(userName)
-    fun `sendApplication without body returns 400`() {
-        post("/hakemukset").andExpect(status().isBadRequest)
-
-        verify { applicationService wasNot Called }
-    }
-
-    @Test
-    @WithMockUser(userName)
-    fun `sendApplication with proper application creates application`() {
-        val newApplication = AlluDataFactory.createApplication(id = null)
-        val createdApplication = newApplication.copy(id = 1234)
-        every { applicationService.create(newApplication, userName) } returns createdApplication
+    @WithMockUser(username)
+    fun `sendApplication without body sends application to Allu and returns the result`() {
+        val application = AlluDataFactory.createApplication()
+        every { applicationService.sendApplication(1234, username) } returns application
 
         val response: Application =
-            post("/hakemukset", newApplication).andExpect(status().isOk).andReturnBody()
+            post("/hakemukset/1234/send-application").andExpect(status().isOk).andReturnBody()
 
-        assertEquals(createdApplication, response)
-        verify { applicationService.create(newApplication, userName) }
+        assertEquals(application, response)
+        verify { applicationService.sendApplication(1234, username) }
     }
 
     @Test
-    @WithMockUser(userName)
-    fun `sendApplication with missing application data type returns 400`() {
-        val application = AlluDataFactory.createApplication(id = null)
+    @WithMockUser(username)
+    fun `sendApplication ignores request body`() {
+        val application = AlluDataFactory.createApplication(alluid = 21)
+        every { applicationService.sendApplication(1234, username) } returns application
+
+        val response: Application =
+            post("/hakemukset/1234/send-application", application.copy(alluid = 9999))
+                .andExpect(status().isOk)
+                .andReturnBody()
+
+        assertEquals(application, response)
+        verify { applicationService.sendApplication(1234, username) }
+    }
+
+    @Test
+    @WithMockUser(username)
+    fun `sendApplication ignores even broken request body`() {
+        val application = AlluDataFactory.createApplication()
         val content: ObjectNode = OBJECT_MAPPER.valueToTree(application)
         (content.get("applicationData") as ObjectNode).remove("applicationType")
+        every { applicationService.sendApplication(1234, username) } returns application
 
-        postRaw("/hakemukset", content.toJsonString()).andExpect(status().isBadRequest)
+        val response: Application =
+            postRaw("/hakemukset/1234/send-application", content.toJsonString())
+                .andExpect(status().isOk)
+                .andReturnBody()
 
-        verify { applicationService wasNot Called }
+        assertEquals(application, response)
+        verify { applicationService.sendApplication(1234, username) }
     }
 
     @Test
-    @WithMockUser(userName)
-    fun `sendApplication with missing application type returns 400`() {
-        val application = AlluDataFactory.createApplication(id = null)
-        val content: ObjectNode = OBJECT_MAPPER.valueToTree(application)
-        content.remove("applicationType")
-
-        postRaw("/hakemukset", content.toJsonString())
-            .andDo { print(it) }
-            .andExpect(status().isBadRequest)
-
-        verify { applicationService wasNot Called }
-    }
-
-    @Test
-    @WithMockUser(userName)
+    @WithMockUser(username)
     fun `sendApplication with unknown id returns 404`() {
         val application = AlluDataFactory.createApplication()
-        every {
-            applicationService.updateApplicationData(1234, application.applicationData, userName)
-        } throws ApplicationNotFoundException(1234)
+        every { applicationService.sendApplication(1234, username) } throws
+            ApplicationNotFoundException(1234)
 
-        put("/hakemukset/1234", application).andExpect(status().isNotFound)
+        post("/hakemukset/1234/send-application", application).andExpect(status().isNotFound)
 
-        verify {
-            applicationService.updateApplicationData(1234, application.applicationData, userName)
-        }
+        verify { applicationService.sendApplication(1234, username) }
+    }
+
+    @Test
+    @WithMockUser(username)
+    fun `sendApplication with application that's no longer pending returns 409`() {
+        val application = AlluDataFactory.createApplication()
+        every { applicationService.sendApplication(1234, username) } throws
+            ApplicationAlreadyProcessingException(1234, 21)
+
+        post("/hakemukset/1234/send-application", application).andExpect(status().isConflict)
+
+        verify { applicationService.sendApplication(1234, username) }
     }
 }

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/allu/CableReportServiceAlluITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/allu/CableReportServiceAlluITests.kt
@@ -161,22 +161,19 @@ class CableReportServiceAlluITests {
 
         val now = ZonedDateTime.now()
 
-        val application =
-            CableReportApplicationData(
-                applicationType = ApplicationType.CABLE_REPORT,
-                name = "Haitaton hankkeen nimi",
-                customerWithContacts = customerWContacts,
-                geometry = geometry,
-                startTime = now.plusDays(1L),
-                endTime = now.plusDays(22L),
-                pendingOnClient = false,
-                identificationNumber = "HAI-123",
-                clientApplicationKind = "Telekaapelin laittoa",
-                workDescription = "Kaivuhommiahan nää tietty",
-                contractorWithContacts = contractorWContacts
-            )
-        application.constructionWork = true
-
-        return application
+        return CableReportApplicationData(
+            applicationType = ApplicationType.CABLE_REPORT,
+            name = "Haitaton hankkeen nimi",
+            customerWithContacts = customerWContacts,
+            geometry = geometry,
+            startTime = now.plusDays(1L),
+            endTime = now.plusDays(22L),
+            pendingOnClient = false,
+            identificationNumber = "HAI-123",
+            clientApplicationKind = "Telekaapelin laittoa",
+            workDescription = "Kaivuhommiahan nää tietty",
+            contractorWithContacts = contractorWContacts,
+            constructionWork = true,
+        )
     }
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeError.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeError.kt
@@ -26,7 +26,9 @@ enum class HankeError(val errorMessage: String) {
     HAI1030("Problem with classification of geometries"),
     HAI1031("Invalid state: Missing needed data"),
     HAI2001("Application not found"),
-    HAI2002("Incompatible application data type");
+    HAI2002("Incompatible application data type"),
+    HAI2003("Application is already processing in Allu and can no longer be updated."),
+    ;
 
     val errorCode: String
         get() = name

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/ApplicationData.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/ApplicationData.kt
@@ -22,6 +22,9 @@ import org.geojson.GeometryCollection
 sealed interface ApplicationData {
     val applicationType: ApplicationType
     val name: String
+    val pendingOnClient: Boolean
+
+    fun copy(pendingOnClient: Boolean): ApplicationData
 }
 
 @JsonView(ChangeLogView::class)
@@ -34,7 +37,7 @@ data class CableReportApplicationData(
     val geometry: GeometryCollection,
     val startTime: ZonedDateTime,
     val endTime: ZonedDateTime,
-    var pendingOnClient: Boolean,
+    override val pendingOnClient: Boolean,
     val identificationNumber: String,
 
     // CableReport specific, required
@@ -43,19 +46,22 @@ data class CableReportApplicationData(
     val contractorWithContacts: CustomerWithContacts, // työn suorittaja
 
     // Common, not required
-    var postalAddress: PostalAddress? = null,
-    var representativeWithContacts: CustomerWithContacts? = null,
-    var invoicingCustomer: Customer? = null,
-    var customerReference: String? = null,
-    var area: Double? = null,
+    val postalAddress: PostalAddress? = null,
+    val representativeWithContacts: CustomerWithContacts? = null,
+    val invoicingCustomer: Customer? = null,
+    val customerReference: String? = null,
+    val area: Double? = null,
 
     // CableReport specific, not required
-    var propertyDeveloperWithContacts: CustomerWithContacts? = null, // rakennuttaja
-    var constructionWork: Boolean = false,
-    var maintenanceWork: Boolean = false,
-    var emergencyWork: Boolean = false,
-    var propertyConnectivity: Boolean = false, // tontti-/kiinteistöliitos
-) : ApplicationData
+    val propertyDeveloperWithContacts: CustomerWithContacts? = null, // rakennuttaja
+    val constructionWork: Boolean = false,
+    val maintenanceWork: Boolean = false,
+    val emergencyWork: Boolean = false,
+    val propertyConnectivity: Boolean = false, // tontti-/kiinteistöliitos
+) : ApplicationData {
+    override fun copy(pendingOnClient: Boolean): CableReportApplicationData =
+        copy(applicationType = applicationType, pendingOnClient = pendingOnClient)
+}
 
 data class CableReportInformationRequestResponse(
     val applicationData: CableReportApplicationData,


### PR DESCRIPTION
# Description

Make saving the Allu ID more evident. Changing the value on the entity was buried deep in the call-stack. Instead, use Allu ID was the return value of the methods and set it at the main service methods.

There was a bug with pendingOnClient. When an application was sent to Allu and it was still in PENDING status in Allu, doing any change to the application would set the pendingOnClient parameter to true. This would make Allu set the status to PENDING_CLIENT, stopping any processing of the application in Allu.

This is fixed by stopping application update API from changing the pendingOnClient value at all. There's a separate send application API which sets the pendingOnClient to false, allowing it's processing in Allu. In Haitaton lingo, we would say the application transitions from a draft to a proper application. Since there's a separate API endpoint for this transition, it seemed silly to have update do it on the side without logging it separately, etc.

There's currently no way to transition back to a draft, i.e. set the pendingOnClient back to true. The Allu people weren't really sure why anyone would like to do this. This might have to be revisited when implementing the full application functionality.

Handling the pendingOnClient was also done deep within the call stack like setting the Allu ID. This was refactored to set the correct pendingOnClient before processing the send.

To discourage surprising side-effects on function parameters, ApplicationData was made immutable. Personally, I would be happier if our database entities would also be immutable, but that's not quite as straightforward, and would mean really big changes to the codebase.

While doing refactoring, other changes are introduced:
- Add some basic "technical" logging for creating, updating and sending applications.
- Add a new exception for trying to update an application that's already processing. I.e. it's no longer pending. Make the backend return 409 Conflict instead of 400 Bad Request for this case.
- Separate the create and update flows from each other. There's was a strange covergent-divergent flow that made these harder to understand. The current solution might not be optimal though.
- Add OpenAPI descriptions to ApplicationController.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1297

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [X] Other