### PR TITLE
HAI-1331/update split to download and database update

### DIFF
--- a/scripts/hel-gis-data-download.sh
+++ b/scripts/hel-gis-data-download.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 # Script to download tormays polygons GIS material from project fileshare
+# Maintenance VPN is needed to access the fileshare.
 
 set -e
 
@@ -21,7 +22,6 @@ if ! [ -d "$POLYS_DIR" ]; then
     mkdir "$POLYS_DIR"
 fi
 
-# Needs maintenance VPN to access the fileshare.
 start=`date +%s`
 
 counter=0

--- a/scripts/hel-gis-data-download.sh
+++ b/scripts/hel-gis-data-download.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# Script to download tormays polygons GIS material from project fileshare
+
+set -e
+
+# Kudos: https://stackoverflow.com/questions/2683279/how-to-detect-if-a-script-is-being-sourced
+(return 0 2>/dev/null) && sourced=1 || sourced=0
+
+if [ "$sourced" -eq "1" ] || ! test -z "$(type -p)" ; then
+    echo "Use bash to run script."
+    return 0
+fi
+
+# Common variables are fetched from separate file
+. ./hel-gis-data-variables.sh
+
+FILESHARE_ADDR="http://haitaton-fileshare-dev.internal.apps.arodevtest.hel.fi"
+
+if ! [ -d "$POLYS_DIR" ]; then
+    mkdir "$POLYS_DIR"
+fi
+
+# Needs maintenance VPN to access the fileshare.
+start=`date +%s`
+
+counter=0
+for file in ${FILES[@]}; do
+    counter=$((counter + 1))
+    echo "[$counter/${#FILES[@]}] Downloading ${file} to $POLYS_DIR"
+    wget --show-progress "${FILESHARE_ADDR}/${file}" -O "${POLYS_DIR}/${file}"
+    echo "Downloaded ${file}"
+done
+
+end=`date +%s`
+runtime=$((end-start))
+rt=$(echo "scale=2; $runtime / 60" | bc -l)
+echo "Download took $rt minutes"
+echo "Files are downloaded to directory: ${POLYS_DIR}"

--- a/scripts/hel-gis-data-import-to-db.sh
+++ b/scripts/hel-gis-data-import-to-db.sh
@@ -26,11 +26,15 @@ start=`date +%s`
 counter=0
 for file in ${FILES[@]}; do
     counter=$((counter + 1))
-    echo "[$counter/${#FILES[@]}] Importing ${file}"
-    docker run --rm --network=haitaton-backend_backbone -v $(pwd)/tormays_polys:/tormays_polys osgeo/gdal:alpine-small-latest \
-        ogr2ogr -overwrite -f PostgreSQL PG:"dbname='$DB_NAME' host='$DB_HOST' port='$DB_PORT' user='$DB_USER' password='$DB_PASS'" \
-        ${POLYS_DIR}/${file}
-    echo "Imported ${file}"
+    if [ -f "${POLYS_DIR}/${file}" ]; then
+        echo "[$counter/${#FILES[@]}] Importing '${file}'"
+        docker run --rm --network=haitaton-backend_backbone -v $(pwd)/tormays_polys:/tormays_polys osgeo/gdal:alpine-small-latest \
+            ogr2ogr -overwrite -f PostgreSQL PG:"dbname='$DB_NAME' host='$DB_HOST' port='$DB_PORT' user='$DB_USER' password='$DB_PASS'" \
+            ${POLYS_DIR}/${file}
+        echo "Imported '${file}'"
+    else
+        echo "[$counter/${#FILES[@]}] Skipping, '${file}' does not exist."
+    fi
 done
 
 end=`date +%s`

--- a/scripts/hel-gis-data-import-to-db.sh
+++ b/scripts/hel-gis-data-import-to-db.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# Script to import downloaded GIS material to local development database
+
+set -e
+
+# Kudos: https://stackoverflow.com/questions/2683279/how-to-detect-if-a-script-is-being-sourced
+(return 0 2>/dev/null) && sourced=1 || sourced=0
+
+if [ "$sourced" -eq "1" ] || ! test -z "$(type -p)" ; then
+    echo "Use bash to run script."
+    return 0
+fi
+
+# Common variables are fetched from dedicated file
+. ./hel-gis-data-variables.sh
+
+DB_NAME="haitaton"
+DB_USER="haitaton_user"
+DB_PASS="haitaton"
+DB_HOST="db"
+DB_PORT="5432"
+
+start=`date +%s`
+
+counter=0
+for file in ${FILES[@]}; do
+    counter=$((counter + 1))
+    echo "[$counter/${#FILES[@]}] Importing ${file}"
+    docker run --rm --network=haitaton-backend_backbone -v $(pwd)/tormays_polys:/tormays_polys osgeo/gdal:alpine-small-latest \
+        ogr2ogr -overwrite -f PostgreSQL PG:"dbname='$DB_NAME' host='$DB_HOST' port='$DB_PORT' user='$DB_USER' password='$DB_PASS'" \
+        ${POLYS_DIR}/${file}
+    echo "Imported ${file}"
+done
+
+end=`date +%s`
+runtime=$((end-start))
+rt=$(echo "scale=2; $runtime / 60" | bc -l)
+echo "Import took $rt minutes"

--- a/scripts/hel-gis-data-import-to-db.sh
+++ b/scripts/hel-gis-data-import-to-db.sh
@@ -12,7 +12,7 @@ if [ "$sourced" -eq "1" ] || ! test -z "$(type -p)" ; then
     return 0
 fi
 
-# Common variables are fetched from dedicated file
+# Common variables are fetched from separate file
 . ./hel-gis-data-variables.sh
 
 DB_NAME="haitaton"

--- a/scripts/hel-gis-data-variables.sh
+++ b/scripts/hel-gis-data-variables.sh
@@ -1,0 +1,17 @@
+# common variables for tormays GIS material download and update scripts
+POLYS_DIR="tormays_polys"
+
+FILES=(\
+    "tormays_buses_polys.gpkg" \
+    "tormays_central_business_area_polys.gpkg" \
+    "tormays_critical_area_polys.gpkg" \
+    "tormays_cycleways_basic_polys.gpkg" \
+    "tormays_cycleways_main_polys.gpkg" \
+    "tormays_cycleways_priority_polys.gpkg" \
+    "tormays_street_classes_polys.gpkg" \
+    "tormays_trams_polys.gpkg" \
+    "tormays_volumes15_polys.gpkg" \
+    "tormays_volumes30_polys.gpkg" \
+    "tormays_ylre_classes_polys.gpkg" \
+    "tormays_ylre_parts_polys.gpkg" \
+    )


### PR DESCRIPTION
# Description

Tormays GIS material update to local dev script is split to two: download and update.

### Jira Issue: 

https://helsinkisolutionoffice.atlassian.net/browse/HAI-1331

## Type of change

- [ ] Bug fix 
- [x] New feature 
- [ ] Other

# Instructions for testing

* start VPN
* ensure local development database is up and running
* run download script in `scripts` -directory: `bash hel-gis-data-download.sh`
  * data is downloaded from haitaton fileshare to separate directory (tormays_polys)
* (you might need to stop VPN at this point)
* run import script: `bash hel-gis-data-import-to-db.sh`
  * Geopackage files from `tormays_polys` are imported to local database

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 

# Other relevant info

With this setup, user is able to download tormays -gis materials to dedicated directory and import materials to local database. Next steps will focus on, how the material is updated to staging environments.