### PR TITLE
HAI Emergency fix for Hanke dates

### DIFF
--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/PublicHanke.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/PublicHanke.kt
@@ -1,6 +1,9 @@
 package fi.hel.haitaton.hanke.domain
 
-import fi.hel.haitaton.hanke.*
+import fi.hel.haitaton.hanke.HankeService
+import fi.hel.haitaton.hanke.SuunnitteluVaihe
+import fi.hel.haitaton.hanke.TyomaaTyyppi
+import fi.hel.haitaton.hanke.Vaihe
 import fi.hel.haitaton.hanke.geometria.HankeGeometriat
 import fi.hel.haitaton.hanke.geometria.HankeGeometriatService
 import fi.hel.haitaton.hanke.tormaystarkastelu.LiikennehaittaIndeksiType
@@ -49,8 +52,8 @@ data class PublicHanke(
     val hankeTunnus: String,
     val nimi: String,
     val kuvaus: String,
-    val alkuPvm: ZonedDateTime,
-    val loppuPvm: ZonedDateTime,
+    val alkuPvm: ZonedDateTime?,
+    val loppuPvm: ZonedDateTime?,
     val haittaAlkuPvm: ZonedDateTime,
     val haittaLoppuPvm: ZonedDateTime,
     val vaihe: Vaihe,
@@ -76,8 +79,8 @@ fun hankeToPublic(hanke: Hanke): PublicHanke {
         hanke.hankeTunnus!!,
         hanke.nimi!!,
         hanke.kuvaus!!,
-        hanke.alkuPvm!!,
-        hanke.loppuPvm!!,
+        hanke.alkuPvm,
+        hanke.loppuPvm,
         hanke.haittaAlkuPvm!!,
         hanke.haittaLoppuPvm!!,
         hanke.vaihe!!,

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluLaskentaService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluLaskentaService.kt
@@ -6,9 +6,9 @@ import fi.hel.haitaton.hanke.roundToOneDecimal
 import org.springframework.beans.factory.annotation.Autowired
 
 open class TormaystarkasteluLaskentaService(
-        @Autowired private val luokitteluRajaArvotService: LuokitteluRajaArvotService,
-        @Autowired private val perusIndeksiPainotService: PerusIndeksiPainotService,
-        @Autowired private val tormaysService: TormaystarkasteluTormaysService
+    @Autowired private val luokitteluRajaArvotService: LuokitteluRajaArvotService,
+    @Autowired private val perusIndeksiPainotService: PerusIndeksiPainotService,
+    @Autowired private val tormaysService: TormaystarkasteluTormaysService
 ) {
 
     fun calculateTormaystarkastelu(hanke: Hanke): TormaystarkasteluTulos? {
@@ -33,71 +33,81 @@ open class TormaystarkasteluLaskentaService(
     }
 
     private fun hasAllRequiredInformation(hanke: Hanke): Boolean {
-        return (hanke.hankeTunnus != null
-                && hanke.alkuPvm != null
-                && hanke.loppuPvm != null
-                && hanke.kaistaHaitta != null
-                && hanke.kaistaPituusHaitta != null
-                && hanke.geometriat != null
-                && hanke.geometriat?.id != null)
+        return (hanke.hankeTunnus != null &&
+            hanke.haittaAlkuPvm != null &&
+            hanke.haittaLoppuPvm != null &&
+            hanke.kaistaHaitta != null &&
+            hanke.kaistaPituusHaitta != null &&
+            hanke.geometriat != null &&
+            hanke.geometriat?.id != null)
     }
 
     private fun calculatePerusIndeksi(hanke: Hanke): Float {
         val luokittelu = mutableMapOf<LuokitteluType, Int>()
 
-        luokittelu[LuokitteluType.HAITTA_AJAN_KESTO] = haittaAjanKestoLuokittelu(hanke.haittaAjanKestoDays!!)
-        luokittelu[LuokitteluType.TODENNAKOINEN_HAITTA_PAAAJORATOJEN_KAISTAJARJESTELYIHIN] = hanke.kaistaHaitta!!.value
+        luokittelu[LuokitteluType.HAITTA_AJAN_KESTO] =
+            haittaAjanKestoLuokittelu(hanke.haittaAjanKestoDays!!)
+        luokittelu[LuokitteluType.TODENNAKOINEN_HAITTA_PAAAJORATOJEN_KAISTAJARJESTELYIHIN] =
+            hanke.kaistaHaitta!!.value
         luokittelu[LuokitteluType.KAISTAJARJESTELYN_PITUUS] = hanke.kaistaPituusHaitta!!.value
 
         val katuluokkaLuokittelu = katuluokkaLuokittelu(hanke.geometriat!!)
         luokittelu[LuokitteluType.KATULUOKKA] = katuluokkaLuokittelu
-        luokittelu[LuokitteluType.LIIKENNEMAARA] = liikennemaaraLuokittelu(hanke.geometriat!!, katuluokkaLuokittelu)
+        luokittelu[LuokitteluType.LIIKENNEMAARA] =
+            liikennemaaraLuokittelu(hanke.geometriat!!, katuluokkaLuokittelu)
 
         return calculatePerusIndeksiFromLuokittelu(luokittelu)
     }
 
     fun haittaAjanKestoLuokittelu(haittaAjanKestoDays: Int) =
-            luokitteluRajaArvotService.getHaittaAjanKestoLuokka(haittaAjanKestoDays)
+        luokitteluRajaArvotService.getHaittaAjanKestoLuokka(haittaAjanKestoDays)
 
     private fun katuluokkaLuokittelu(hankeGeometriat: HankeGeometriat): Int {
         if (tormaysService.anyIntersectsYleinenKatuosa(hankeGeometriat)) {
             // ON ylre_parts => street_classes?
             return tormaysService.maxIntersectingLiikenteellinenKatuluokka(hankeGeometriat)
-                    // EI street_classes => ylre_classes?
-                    ?: tormaysService.maxIntersectingYleinenkatualueKatuluokka(hankeGeometriat)
-                    // EI ylre_classes
-                    ?: 0
+            // EI street_classes => ylre_classes?
+            ?: tormaysService.maxIntersectingYleinenkatualueKatuluokka(hankeGeometriat)
+                // EI ylre_classes
+                ?: 0
         } else {
             // EI ylre_parts => ylre_classes?
-            val max = tormaysService.maxIntersectingYleinenkatualueKatuluokka(hankeGeometriat)
-                    // EI ylre_classes
-                    ?: return 0
+            val max =
+                tormaysService.maxIntersectingYleinenkatualueKatuluokka(hankeGeometriat)
+                // EI ylre_classes
+                ?: return 0
             // ON ylre_classes => street_classes?
             return tormaysService.maxIntersectingLiikenteellinenKatuluokka(hankeGeometriat)
-                    // JOS EI LÖYDY => Valitse ylre_classes
-                    ?: max
+            // JOS EI LÖYDY => Valitse ylre_classes
+            ?: max
         }
     }
 
-    private fun liikennemaaraLuokittelu(hankeGeometriat: HankeGeometriat, katuluokkaLuokittelu: Int): Int {
+    private fun liikennemaaraLuokittelu(
+        hankeGeometriat: HankeGeometriat,
+        katuluokkaLuokittelu: Int
+    ): Int {
         if (katuluokkaLuokittelu == 0) {
             return 0
         }
-        // type of street (=street class) decides which volume data we use for trafic (buffering of street width varies)
-        val radius = if (katuluokkaLuokittelu >= 4) {
-            TormaystarkasteluLiikennemaaranEtaisyys.RADIUS_30
-        } else {
-            TormaystarkasteluLiikennemaaranEtaisyys.RADIUS_15
-        }
+        // type of street (=street class) decides which volume data we use for trafic (buffering of
+        // street width varies)
+        val radius =
+            if (katuluokkaLuokittelu >= 4) {
+                TormaystarkasteluLiikennemaaranEtaisyys.RADIUS_30
+            } else {
+                TormaystarkasteluLiikennemaaranEtaisyys.RADIUS_15
+            }
         val maxVolume = tormaysService.maxLiikennemaara(hankeGeometriat, radius) ?: 0
         return luokitteluRajaArvotService.getLiikennemaaraLuokka(maxVolume)
     }
 
     fun calculatePerusIndeksiFromLuokittelu(luokitteluByType: Map<LuokitteluType, Int>): Float =
-            perusIndeksiPainotService.getAll()
-                    .map { (type, weight) -> luokitteluByType[type]!! * weight }
-                    .sum()
-                    .roundToOneDecimal()
+        perusIndeksiPainotService
+            .getAll()
+            .map { (type, weight) -> luokitteluByType[type]!! * weight }
+            .sum()
+            .roundToOneDecimal()
 
     private fun pyorailyLuokittelu(hankeGeometriat: HankeGeometriat): Int {
         return when {
@@ -105,8 +115,7 @@ open class TormaystarkasteluLaskentaService(
                 PyorailyTormaysLuokittelu.PRIORISOITU_REITTI
             tormaysService.anyIntersectsWithCyclewaysMain(hankeGeometriat) ->
                 PyorailyTormaysLuokittelu.PAAREITTI
-            else ->
-                PyorailyTormaysLuokittelu.EI_PYORAILUREITTI
+            else -> PyorailyTormaysLuokittelu.EI_PYORAILUREITTI
         }.value
     }
 
@@ -122,21 +131,22 @@ open class TormaystarkasteluLaskentaService(
         }
 
         val countOfRushHourBuses = bussesTormaystulos.sumOf { it.vuoromaaraRuuhkatunnissa }
-        val valueByRajaArvo = luokitteluRajaArvotService.getBussiLiikenneRuuhkaLuokka(countOfRushHourBuses)
+        val valueByRajaArvo =
+            luokitteluRajaArvotService.getBussiLiikenneRuuhkaLuokka(countOfRushHourBuses)
 
-        val valueByRunkolinja = when {
-            bussesTormaystulos.any { it.runkolinja == TormaystarkasteluBussiRunkolinja.ON } ->
-                BussiLiikenneLuokittelu.RUNKOLINJA
-            bussesTormaystulos.any { it.runkolinja == TormaystarkasteluBussiRunkolinja.LAHES } ->
-                BussiLiikenneLuokittelu.RUNKOLINJAMAINEN
-            else ->
-                BussiLiikenneLuokittelu.PERUS
-        }.value
+        val valueByRunkolinja =
+            when {
+                bussesTormaystulos.any { it.runkolinja == TormaystarkasteluBussiRunkolinja.ON } ->
+                    BussiLiikenneLuokittelu.RUNKOLINJA
+                bussesTormaystulos.any {
+                    it.runkolinja == TormaystarkasteluBussiRunkolinja.LAHES
+                } -> BussiLiikenneLuokittelu.RUNKOLINJAMAINEN
+                else -> BussiLiikenneLuokittelu.PERUS
+            }.value
 
         return maxOf(valueByRajaArvo, valueByRunkolinja)
     }
 
     private fun raitiovaunuLuokittelu(hankeGeometriat: HankeGeometriat) =
-            tormaysService.maxIntersectingTramByLaneType(hankeGeometriat) ?: 0
-
+        tormaysService.maxIntersectingTramByLaneType(hankeGeometriat) ?: 0
 }


### PR DESCRIPTION
# Description

Make hanke start and end dates optional.

The UI no longer sends start and end dates for a hanke. The dates will be a part of the new HankeAlue objects when hankkeet get those.

For now, resolve this by making them optional, so creating hankkeet doesn't crash.

### Jira Issue: None

## Type of change

- [X] Bug fix 
- [ ] New feature 
- [ ] Other