### PR TITLE
HAI-1384/traffic volume data type fix

### DIFF
--- a/scripts/gis-material-update/process/modules/autoliikennemaarat.py
+++ b/scripts/gis-material-update/process/modules/autoliikennemaarat.py
@@ -22,6 +22,7 @@ class MakaAutoliikennemaarat:
         )
         self._df["fid"] = self._df.reset_index().index
         self._df = self._df.set_index("fid")
+        self._df = self._df.astype({"volume": "int32"})
 
     def process(self) -> None:
         buffers = self._cfg.buffer(self._module)
@@ -65,4 +66,8 @@ class MakaAutoliikennemaarat:
 
         for buffer_size, polygon_data in self._process_result.items():
             file_name = target_buffer_file_template.format(buffer_size)
-            polygon_data.to_file(file_name, driver="GPKG")
+            polygons = polygon_data.reset_index()
+
+            schema = gpd.io.file.infer_schema(polygons)
+            schema["properties"]["volume"] = "int32"
+            polygons.to_file(file_name, schema=schema, driver="GPKG")


### PR DESCRIPTION
# Description

Data type was changed to int32 for `volume` -attribute.


### Jira Issue: 

https://helsinkisolutionoffice.atlassian.net/browse/HAI-1384

## Type of change

- [x] Bug fix 
- [ ] New feature 
- [ ] Other

# Instructions for testing

Run data fetch and data process as instructed here: https://github.com/City-of-Helsinki/haitaton-backend/blob/dev/scripts/gis-material-update/README.md

```
docker-compose up -d gis-db
docker-compose run --rm gis-fetch maka_autoliikennemaarat
docker-compose run --rm gis-process maka_autoliikennemaarat
docker-compose stop gis-db
```
Verify by checking output result (at directory gis-material-update):

First, 15m buffered material:

```
ogrinfo haitaton-gis-output/tormays_volumes15_polys.gpkg tormays_volumes15_polys -so | tail -3
FID Column = fid
Geometry Column = geom
volume: Integer (0.0)
```

And same check for 30m buffered material:
```
ogrinfo haitaton-gis-output/tormays_volumes30_polys.gpkg tormays_volumes30_polys -so | tail -3
FID Column = fid
Geometry Column = geom
volume: Integer (0.0)
```
# Checklist:

- [ ] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 

# Other relevant info

-