### PR TITLE
HAI-1385 YLRE parts data type change

### DIFF
--- a/scripts/gis-material-update/process/modules/ylre_katuosat.py
+++ b/scripts/gis-material-update/process/modules/ylre_katuosat.py
@@ -29,6 +29,7 @@ class YlreKatuosat:
         df["ylre_street_area"] = 1
         df["fid"] = df.reset_index().index
         self._df = df.set_index("fid")
+        self._df = self._df.astype({"ylre_street_area": "int32"})
 
     def process(self):
         buffers = self._cfg.buffer(self._module)
@@ -65,4 +66,9 @@ class YlreKatuosat:
         self._df.to_file(file_name, driver="GPKG")
 
         file_name = self._cfg.target_buffer_file(self._module)
-        self._process_result.to_file(file_name, driver="GPKG")
+
+        polygons = self._process_result.reset_index()
+        schema = gpd.io.file.infer_schema(polygons)
+        schema["properties"]["ylre_street_area"] = "int32"
+
+        polygons.to_file(file_name, schema=schema, driver="GPKG")


### PR DESCRIPTION
Old datatype for ylre_street_area was int64, new int32

# Description

Data type was changed to int32 for `ylre_-street_area` -attribute.

### Jira Issue: 

https://helsinkisolutionoffice.atlassian.net/browse/HAI-1385

## Type of change

- [x] Bug fix 
- [ ] New feature 
- [ ] Other

# Instructions for testing

Run data fetch and data process as instructed here: https://github.com/City-of-Helsinki/haitaton-backend/blob/dev/scripts/gis-material-update/README.md

```
docker-compose up -d gis-db
docker-compose run --rm gis-fetch ylre_katuosat
docker-compose run --rm gis-process ylre_katuosat
docker-compose stop gis-db
```

Verify by checking output result (at directory gis-material-update):

```
ogrinfo haitaton-gis-output/tormays_ylre_parts_polys.gpkg tormays_ylre_parts_polys -so | tail -3
FID Column = fid
Geometry Column = geom
ylre_street_area: Integer (0.0)
```

# Checklist:

- [ ] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 

# Other relevant info

-