### PR TITLE
HAI-1342 Add geometries to modify logs for hankkeet

### DIFF
--- a/services/hanke-service/build.gradle.kts
+++ b/services/hanke-service/build.gradle.kts
@@ -93,6 +93,7 @@ dependencies {
 	testImplementation("org.testcontainers:postgresql:1.15.2")
 	testImplementation("com.squareup.okhttp3:okhttp:4.9.3")
 	testImplementation("com.squareup.okhttp3:mockwebserver:4.9.3")
+	testImplementation("net.pwall.mustache:kotlin-mustache:0.10")
 
 	// Spring Boot Management
 	implementation("org.springframework.boot:spring-boot-starter-actuator")

--- a/services/hanke-service/src/integrationTest/resources/fi/hel/haitaton/hanke/logging/expectedHankeWithPoints.json.mustache
+++ b/services/hanke-service/src/integrationTest/resources/fi/hel/haitaton/hanke/logging/expectedHankeWithPoints.json.mustache
@@ -1,0 +1,101 @@
+{
+  "id": {{hankeId}},
+  "hankeTunnus": "{{hankeTunnus}}",
+  "onYKTHanke": true,
+  "nimi": "Hämeentien perusparannus ja katuvalot",
+  "kuvaus": "lorem ipsum dolor sit amet...",
+  "alkuPvm": "{{nextYear}}-02-20T00:00:00Z",
+  "loppuPvm": "{{nextYear}}-02-21T00:00:00Z",
+  "vaihe": "OHJELMOINTI",
+  "suunnitteluVaihe": null,
+  "version": {{hankeVersion}},
+  "tyomaaKatuosoite": "Testikatu 1",
+  "tyomaaTyyppi": [
+    "MUU",
+    "VESI"
+  ],
+  "tyomaaKoko": "LAAJA_TAI_USEA_KORTTELI",
+  "alueet": [
+{{#alueId}}
+    {
+      "id": {{alueId}},
+      "hankeId": {{hankeId}},
+      "haittaAlkuPvm": "{{nextYear}}-02-20T00:00:00Z",
+      "haittaLoppuPvm": "{{nextYear}}-02-21T00:00:00Z",
+      "geometriat": {
+        "id": {{geometriaId}},
+        "featureCollection": {
+          "type": "FeatureCollection",
+          "crs": {
+            "type": "name",
+            "properties": {
+              "name": "urn:ogc:def:crs:EPSG::3879"
+            }
+          },
+          "features": [
+            {
+              "type": "Feature",
+              "properties": {
+                "hankeTunnus": "{{hankeTunnus}}"
+              },
+              "geometry": {
+                "type": "Point",
+                "crs": {
+                  "type": "name",
+                  "properties": {
+                    "name": "EPSG:3879"
+                  }
+                },
+                "coordinates": [
+                  2.474785643E7,
+                  6562789.70
+                ]
+              }
+            },
+            {
+              "type": "Feature",
+              "geometry": {
+                "type": "Point",
+                "crs": {
+                  "type": "name",
+                  "properties": {
+                    "name": "EPSG:3879"
+                  }
+                },
+                "coordinates": [
+                  2.474785643E7,
+                  6562789.70
+                ]
+              },
+              "properties": {
+                "hankeTunnus": "{{hankeTunnus}}",
+                "geometryType": "KUOPPA"
+              }
+            }
+          ]
+        },
+        "version": {{geometriaVersion}}
+      },
+      "kaistaHaitta": "KAKSI",
+      "kaistaPituusHaitta": "NELJA",
+      "meluHaitta": "YKSI",
+      "polyHaitta": "KAKSI",
+      "tarinaHaitta": "KOLME"
+    }
+{{/alueId}}
+  ],
+{{#tormaystarkasteluTulos}}
+  "tormaystarkasteluTulos": {
+    "perusIndeksi": 1.4,
+    "pyorailyIndeksi": 1.0,
+    "joukkoliikenneIndeksi": 1.0,
+    "liikennehaittaIndeksi": {
+      "indeksi": 1.4,
+      "tyyppi": "PERUSINDEKSI"
+    }
+  }
+{{/tormaystarkasteluTulos}}
+{{^tormaystarkasteluTulos}}
+  "tormaystarkasteluTulos": null
+{{/tormaystarkasteluTulos}}
+}

--- a/services/hanke-service/src/integrationTest/resources/fi/hel/haitaton/hanke/logging/expectedHankeWithPolygon.json.mustache
+++ b/services/hanke-service/src/integrationTest/resources/fi/hel/haitaton/hanke/logging/expectedHankeWithPolygon.json.mustache
@@ -1,0 +1,97 @@
+{
+  "id": {{hankeId}},
+  "hankeTunnus": "{{hankeTunnus}}",
+  "onYKTHanke": true,
+  "nimi": "Hämeentien perusparannus ja katuvalot",
+  "kuvaus": "lorem ipsum dolor sit amet...",
+  "alkuPvm": "{{nextYear}}-02-20T00:00:00Z",
+  "loppuPvm": "{{nextYear}}-02-21T00:00:00Z",
+  "vaihe": "OHJELMOINTI",
+  "suunnitteluVaihe": null,
+  "version": {{hankeVersion}},
+  "tyomaaKatuosoite": "Testikatu 1",
+  "tyomaaTyyppi": [
+    "MUU",
+    "VESI"
+  ],
+  "tyomaaKoko": "LAAJA_TAI_USEA_KORTTELI",
+  "alueet": [
+{{#alueId}}
+    {
+      "id": {{alueId}},
+      "hankeId": {{hankeId}},
+      "haittaAlkuPvm": "{{nextYear}}-02-20T00:00:00Z",
+      "haittaLoppuPvm": "{{nextYear}}-02-21T00:00:00Z",
+      "geometriat": {
+        "id": {{geometriaId}},
+        "featureCollection": {
+          "type": "FeatureCollection",
+          "crs": {
+            "type": "name",
+            "properties": {
+              "name": "urn:ogc:def:crs:EPSG::3879"
+            }
+          },
+          "features": [
+            {
+              "type": "Feature",
+              "properties": {
+                "hankeTunnus": "{{hankeTunnus}}"
+              },
+              "geometry": {
+                "type": "Polygon",
+                "crs": {
+                  "type": "name",
+                  "properties": {
+                    "name": "EPSG:3879"
+                  }
+                },
+                "coordinates": [
+                  [
+                    [
+                      2.474785643E7,
+                      6562789.7
+                    ],
+                    [
+                      2.474785543E7,
+                      6562789.7
+                    ],
+                    [
+                      2.474785543E7,
+                      6562788.7
+                    ],
+                    [
+                      2.474785643E7,
+                      6562789.7
+                    ]
+                  ]
+                ]
+              }
+            }
+          ]
+        },
+        "version": {{geometriaVersion}}
+      },
+      "kaistaHaitta": "KAKSI",
+      "kaistaPituusHaitta": "NELJA",
+      "meluHaitta": "YKSI",
+      "polyHaitta": "KAKSI",
+      "tarinaHaitta": "KOLME"
+    }
+{{/alueId}}
+  ],
+{{#tormaystarkasteluTulos}}
+  "tormaystarkasteluTulos": {
+    "perusIndeksi": 1.4,
+    "pyorailyIndeksi": 1.0,
+    "joukkoliikenneIndeksi": 1.0,
+    "liikennehaittaIndeksi": {
+      "indeksi": 1.4,
+      "tyyppi": "PERUSINDEKSI"
+    }
+  }
+{{/tormaystarkasteluTulos}}
+{{^tormaystarkasteluTulos}}
+  "tormaystarkasteluTulos": null
+{{/tormaystarkasteluTulos}}
+}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/Hankealue.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/Hankealue.kt
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonView
 import fi.hel.haitaton.hanke.ChangeLogView
 import fi.hel.haitaton.hanke.Haitta13
 import fi.hel.haitaton.hanke.KaistajarjestelynPituus
-import fi.hel.haitaton.hanke.NotInChangeLogView
 import fi.hel.haitaton.hanke.TodennakoinenHaittaPaaAjoRatojenKaistajarjestelyihin
 import fi.hel.haitaton.hanke.geometria.Geometriat
 import java.time.ZonedDateTime
@@ -13,16 +12,16 @@ import java.time.ZonedDateTime
  *
  * NOTE Remember to update PublicHankealue after changes
  */
+@JsonView(ChangeLogView::class)
 data class Hankealue(
-    @JsonView(ChangeLogView::class) override var id: Int? = null,
-    @JsonView(ChangeLogView::class) var hankeId: Int? = null,
-    @JsonView(ChangeLogView::class) var haittaAlkuPvm: ZonedDateTime? = null,
-    @JsonView(ChangeLogView::class) var haittaLoppuPvm: ZonedDateTime? = null,
-    @JsonView(NotInChangeLogView::class) var geometriat: Geometriat? = null,
-    @JsonView(ChangeLogView::class)
+    override var id: Int? = null,
+    var hankeId: Int? = null,
+    var haittaAlkuPvm: ZonedDateTime? = null,
+    var haittaLoppuPvm: ZonedDateTime? = null,
+    var geometriat: Geometriat? = null,
     var kaistaHaitta: TodennakoinenHaittaPaaAjoRatojenKaistajarjestelyihin? = null,
-    @JsonView(ChangeLogView::class) var kaistaPituusHaitta: KaistajarjestelynPituus? = null,
-    @JsonView(ChangeLogView::class) var meluHaitta: Haitta13? = null,
-    @JsonView(ChangeLogView::class) var polyHaitta: Haitta13? = null,
-    @JsonView(ChangeLogView::class) var tarinaHaitta: Haitta13? = null,
+    var kaistaPituusHaitta: KaistajarjestelynPituus? = null,
+    var meluHaitta: Haitta13? = null,
+    var polyHaitta: Haitta13? = null,
+    var tarinaHaitta: Haitta13? = null,
 ) : HasId<Int>

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/geometria/Geometriat.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/geometria/Geometriat.kt
@@ -1,18 +1,22 @@
 package fi.hel.haitaton.hanke.geometria
 
+import com.fasterxml.jackson.annotation.JsonView
+import fi.hel.haitaton.hanke.ChangeLogView
+import fi.hel.haitaton.hanke.NotInChangeLogView
 import fi.hel.haitaton.hanke.domain.Hanke
+import fi.hel.haitaton.hanke.domain.HasId
 import java.time.ZonedDateTime
 import org.geojson.FeatureCollection
 
 data class Geometriat(
-    var id: Int? = null,
-    var featureCollection: FeatureCollection? = null,
-    var version: Int? = null,
-    var createdByUserId: String? = null,
-    var createdAt: ZonedDateTime? = null,
-    var modifiedByUserId: String? = null,
-    var modifiedAt: ZonedDateTime? = null
-) {
+    @JsonView(ChangeLogView::class) override var id: Int? = null,
+    @JsonView(ChangeLogView::class) var featureCollection: FeatureCollection? = null,
+    @JsonView(ChangeLogView::class) var version: Int? = null,
+    @JsonView(NotInChangeLogView::class) var createdByUserId: String? = null,
+    @JsonView(NotInChangeLogView::class) var createdAt: ZonedDateTime? = null,
+    @JsonView(NotInChangeLogView::class) var modifiedByUserId: String? = null,
+    @JsonView(NotInChangeLogView::class) var modifiedAt: ZonedDateTime? = null
+) : HasId<Int> {
     fun withFeatureCollection(featureCollection: FeatureCollection): Geometriat {
         this.featureCollection = featureCollection
         return this
@@ -30,6 +34,7 @@ data class Geometriat(
         }
     }
 
+    @JsonView(NotInChangeLogView::class)
     fun hasFeatures(): Boolean {
         return !featureCollection?.features.isNullOrEmpty()
     }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/HankeLoggingService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/HankeLoggingService.kt
@@ -16,8 +16,6 @@ class HankeLoggingService(private val auditLogService: AuditLogService) {
      */
     @Transactional(propagation = Propagation.MANDATORY)
     fun logDelete(hanke: Hanke, userId: String) {
-        // TODO: Add geometries in auditLogEntry or as separate log entries.
-        //   Waits for the changes in HAI-1273 before implementing.
         val auditLogEntry = AuditLogService.deleteEntry(userId, ObjectType.HANKE, hanke)
         val yhteystietoEntries =
             (hanke.arvioijat + hanke.toteuttajat + hanke.omistajat).map {

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/TestExtensions.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/TestExtensions.kt
@@ -8,22 +8,20 @@ import java.nio.charset.StandardCharsets
 import org.springframework.test.web.servlet.ResultActions
 
 fun <T> String.asJsonResource(type: Class<T>): T =
-    OBJECT_MAPPER.readValue(getResourceAsText(this), type)
+    OBJECT_MAPPER.readValue(this.getResourceAsText(), type)
 
 inline fun <reified T : Any> String.asJsonResource(): T =
-    OBJECT_MAPPER.readValue(getResourceAsText(this))
+    OBJECT_MAPPER.readValue(this.getResourceAsText())
 
 /** Read the response body from a MockMvc result and deserialize from JSON. */
 inline fun <reified T> ResultActions.andReturnBody(): T =
     OBJECT_MAPPER.readValue(andReturn().response.getContentAsString(StandardCharsets.UTF_8))
 
-fun String.asJsonNode(): JsonNode = OBJECT_MAPPER.readTree(getResourceAsText(this))
-
-fun getResourceAsText(path: String): String =
+fun String.getResourceAsText(): String =
     // The class here is arbitrary, could be any class.
     // Using ClassLoader might be cleaner, but it would require changing every resource file
     // path anywhere in the test files.
-    JsonNode::class.java.getResource(path)!!.readText(Charsets.UTF_8)
+    JsonNode::class.java.getResource(this)!!.readText(Charsets.UTF_8)
 
 /**
  * Find all audit logs for a specific object type. Getting all and filtering would obviously not be
@@ -34,6 +32,3 @@ fun getResourceAsText(path: String): String =
  */
 fun AuditLogRepository.findByType(type: ObjectType) =
     this.findAll().filter { it.message.auditEvent.target.type == type }
-
-fun AuditLogRepository.countByType(type: ObjectType) =
-    this.findAll().count { it.message.auditEvent.target.type == type }


### PR DESCRIPTION
# Description

When the modify logging for hankkeet was implemented, hankealue and the related geometries were under heavy development. It was decided to leave logging the geometries for later, with the thought it might be smart to log them separately from the main hanke object changes.

However, implementing separate logging for geometries or the hankealueet added a lot of complexity, so I deemed it better to just add them to the log objects of the main hanke object. There are no endpoints to modify the alueet or geometries separately and there no plans to add any. So logically, the hanke is a single resource from the API viewpoint.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1342

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 

[HAI-1342]: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1342?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ