### PR TITLE
HAI Make OpenAPI documentation accessible from behind reverse proxy

### DIFF
--- a/services/hanke-service/README.md
+++ b/services/hanke-service/README.md
@@ -34,13 +34,26 @@ for full API description) (and other sub-URLs similarly):
 > http://localhost:8080/hankkeet/<id> \
 > http://localhost:8080/hankkeet/<id>/geometriat
 
+### Swagger UI
+
 Swagger UI (see https://springdoc.org/) and OpenAPI v3 description (JSON). Note though that the swagger
 setup can not currently support authentication, so can not test the actions with it.
-> http://localhost:8080/swagger-ui.html \
-> http://localhost:8080/v3/api-docs
 
-When running the services with Docker Compose, the Swagger UI can be accessed with
-[http://localhost:3000/swagger-ui/index.html](http://localhost:3000/swagger-ui/index.html).
+Locally without Docker:
+- [http://localhost:8080/swagger-ui.html](http://localhost:8080/swagger-ui.html)
+- [http://localhost:8080/v3/api-docs](http://localhost:8080/v3/api-docs)
+
+When running the services with Docker Compose:
+- [http://localhost:3001/api/swagger-ui/index.html](http://localhost:3001/api/swagger-ui/index.html)
+- [http://localhost:3001/api/v3/api-docs](http://localhost:3001/api/v3/api-docs)
+
+On dev:
+- [https://haitaton-dev.agw.arodevtest.hel.fi/api/swagger-ui/index.html](https://haitaton-dev.agw.arodevtest.hel.fi/api/swagger-ui/index.html)
+- [https://haitaton-dev.agw.arodevtest.hel.fi/api/v3/api-docs](https://haitaton-dev.agw.arodevtest.hel.fi/api/v3/api-docs)
+
+On test:
+- [https://haitaton-test.agw.arodevtest.hel.fi/api/swagger-ui/index.html](https://haitaton-test.agw.arodevtest.hel.fi/api/swagger-ui/index.html)
+- [https://haitaton-test.agw.arodevtest.hel.fi/api/v3/api-docs](https://haitaton-test.agw.arodevtest.hel.fi/api/v3/api-docs)
 
 ### Spotless formatter
 

--- a/services/hanke-service/build.gradle.kts
+++ b/services/hanke-service/build.gradle.kts
@@ -1,5 +1,6 @@
 import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import org.springframework.boot.gradle.tasks.run.BootRun
 
 group = "fi.hel.haitaton"
 version = "0.0.1-SNAPSHOT"
@@ -37,6 +38,10 @@ idea {
 
 springBoot {
 	buildInfo()
+}
+
+tasks.getByName<BootRun>("bootRun") {
+	environment("HAITATON_SWAGGER_PATH_PREFIX", "/v3")
 }
 
 spotless {

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/configuration/Configuration.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/configuration/Configuration.kt
@@ -1,5 +1,11 @@
-package fi.hel.haitaton.hanke
+package fi.hel.haitaton.hanke.configuration
 
+import fi.hel.haitaton.hanke.HankeRepository
+import fi.hel.haitaton.hanke.HankeService
+import fi.hel.haitaton.hanke.HankeServiceImpl
+import fi.hel.haitaton.hanke.HanketunnusService
+import fi.hel.haitaton.hanke.HanketunnusServiceImpl
+import fi.hel.haitaton.hanke.IdCounterRepository
 import fi.hel.haitaton.hanke.allu.AlluProperties
 import fi.hel.haitaton.hanke.allu.ApplicationRepository
 import fi.hel.haitaton.hanke.allu.ApplicationService

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/configuration/OpenApiConfiguration.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/configuration/OpenApiConfiguration.kt
@@ -1,0 +1,16 @@
+package fi.hel.haitaton.hanke
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition
+import io.swagger.v3.oas.annotations.info.Info
+import io.swagger.v3.oas.annotations.servers.Server
+
+@OpenAPIDefinition(
+    info =
+        Info(
+            title = "Haitaton Internal API",
+            description = "API for Haitaton internal use. Can change without warning.",
+            version = "1"
+        ),
+    servers = [Server(url = "/")]
+)
+internal class OpenAPIConfiguration

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/configuration/ResourceServerConfig.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/configuration/ResourceServerConfig.kt
@@ -1,4 +1,4 @@
-package fi.hel.haitaton.hanke
+package fi.hel.haitaton.hanke.configuration
 
 import fi.hel.haitaton.hanke.security.AccessRules
 import org.springframework.boot.autoconfigure.security.oauth2.resource.PrincipalExtractor
@@ -18,7 +18,5 @@ class ResourceServerConfig : ResourceServerConfigurerAdapter() {
         AccessRules.configureHttpAccessRules(http)
     }
 
-    @Bean
-    fun principalExtractor(): PrincipalExtractor = PrincipalExtractor { it["sub"] }
-
+    @Bean fun principalExtractor(): PrincipalExtractor = PrincipalExtractor { it["sub"] }
 }

--- a/services/hanke-service/src/main/resources/application.properties
+++ b/services/hanke-service/src/main/resources/application.properties
@@ -62,3 +62,8 @@ sentry.logging.minimum-event-level=error
 sentry.logging.minimum-breadcrumb-level=info
 # as default Sentry logging is disabled
 sentry.logging.enabled=${HAITATON_SENTRY_LOGGING_ENABLED:false}
+
+# Configuration for Swagger UI & OpenAPI documentation.
+# Default is access from behind reverse proxy.
+springdoc.swagger-ui.url=${HAITATON_SWAGGER_PATH_PREFIX:/api/v3}/api-docs
+springdoc.swagger-ui.config-url=${HAITATON_SWAGGER_PATH_PREFIX:/api/v3}/api-docs/swagger-config


### PR DESCRIPTION
# Description

Both the UI code and the OpenAPI Json documentation are already accessible from anywhere in the world, but they don't work together, because the UI doesn't know to add `/api` in front of the URLs for Swagger configuration and the OpenAPI documentation.

Fix this by adding the `/api` in front of the URLs by default. This should work both locally with docker compose and on the cloud. Add an environment variable to `bootRun` to drop the `/api` prefix when running the service locally without docker.

### Jira Issue: -

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [X] Other
