### PR TITLE
HAI-1300 Add enpoint for reverting an application to draft

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/allu/ApplicationServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/allu/ApplicationServiceITest.kt
@@ -1,16 +1,21 @@
 package fi.hel.haitaton.hanke.allu
 
 import assertk.assertThat
+import assertk.assertions.containsExactlyInAnyOrder
 import assertk.assertions.each
 import assertk.assertions.extracting
 import assertk.assertions.hasSize
 import assertk.assertions.isEmpty
 import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
+import assertk.assertions.isNotNull
 import assertk.assertions.isNull
+import assertk.assertions.prop
 import com.ninjasquad.springmockk.MockkBean
 import fi.hel.haitaton.hanke.DatabaseTest
+import fi.hel.haitaton.hanke.asUtc
 import fi.hel.haitaton.hanke.factory.AlluDataFactory
+import fi.hel.haitaton.hanke.factory.ApplicationHistoryFactory
 import fi.hel.haitaton.hanke.findByType
 import fi.hel.haitaton.hanke.logging.AuditLogRepository
 import fi.hel.haitaton.hanke.logging.ObjectType
@@ -26,6 +31,8 @@ import io.mockk.confirmVerified
 import io.mockk.every
 import io.mockk.justRun
 import io.mockk.verify
+import java.time.OffsetDateTime
+import java.time.ZonedDateTime
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
@@ -51,10 +58,11 @@ private const val username = "test7358"
 @ActiveProfiles("default")
 @WithMockUser(username)
 class ApplicationServiceITest : DatabaseTest() {
-    @MockkBean private lateinit var cableReportServiceAllu: CableReportServiceAllu
+    @MockkBean private lateinit var cableReportServiceAllu: CableReportService
     @Autowired private lateinit var applicationService: ApplicationService
 
     @Autowired private lateinit var applicationRepository: ApplicationRepository
+    @Autowired private lateinit var alluStatusRepository: AlluStatusRepository
     @Autowired private lateinit var auditLogRepository: AuditLogRepository
     @Autowired private lateinit var alluDataFactory: AlluDataFactory
 
@@ -194,15 +202,11 @@ class ApplicationServiceITest : DatabaseTest() {
         val otherUser = "otherUser"
         alluDataFactory.saveApplicationEntities(6, "otherUser") { i, application ->
             if (i % 2 == 0) {
-                application.apply {
-                    this.userId = username
-                    this.applicationData =
-                        AlluDataFactory.createCableReportApplicationData(
-                            name = "Application data for $username"
-                        )
-                }
-            } else {
-                application
+                application.userId = username
+                application.applicationData =
+                    AlluDataFactory.createCableReportApplicationData(
+                        name = "Application data for $username"
+                    )
             }
         }
         assertThat(applicationRepository.findAll()).hasSize(6)
@@ -362,8 +366,7 @@ class ApplicationServiceITest : DatabaseTest() {
 
     @Test
     fun `updateApplicationData with application that's already saved to Allu is updated in Allu`() {
-        val application =
-            alluDataFactory.saveApplicationEntity(username) { it.apply { alluid = 21 } }
+        val application = alluDataFactory.saveApplicationEntity(username) { it.alluid = 21 }
         val newApplicationData =
             AlluDataFactory.createCableReportApplicationData(name = "Uudistettu johtoselvitys")
         every { cableReportServiceAllu.getCurrentStatus(21) } returns null
@@ -388,8 +391,7 @@ class ApplicationServiceITest : DatabaseTest() {
 
     @Test
     fun `updateApplicationData updates local database even if Allu update fails`() {
-        val application =
-            alluDataFactory.saveApplicationEntity(username) { it.apply { alluid = 21 } }
+        val application = alluDataFactory.saveApplicationEntity(username) { it.alluid = 21 }
         val newApplicationData =
             AlluDataFactory.createCableReportApplicationData(name = "Uudistettu johtoselvitys")
         every { cableReportServiceAllu.getCurrentStatus(21) } returns null
@@ -418,10 +420,8 @@ class ApplicationServiceITest : DatabaseTest() {
     fun `updateApplicationData with application that's pending on Allu is updated in Allu`() {
         val application =
             alluDataFactory.saveApplicationEntity(username) {
-                it.apply {
-                    alluid = 21
-                    applicationData = applicationData.copy(pendingOnClient = false)
-                }
+                it.alluid = 21
+                it.applicationData = it.applicationData.copy(pendingOnClient = false)
             }
         val newApplicationData =
             AlluDataFactory.createCableReportApplicationData(
@@ -453,10 +453,8 @@ class ApplicationServiceITest : DatabaseTest() {
     fun `updateApplicationData doesn't update pendingOnClient`() {
         val application =
             alluDataFactory.saveApplicationEntity(username) {
-                it.apply {
-                    alluid = 21
-                    applicationData = applicationData.copy(pendingOnClient = false)
-                }
+                it.alluid = 21
+                it.applicationData = it.applicationData.copy(pendingOnClient = false)
             }
         val newApplicationData =
             AlluDataFactory.createCableReportApplicationData(
@@ -481,8 +479,7 @@ class ApplicationServiceITest : DatabaseTest() {
 
     @Test
     fun `updateApplicationData with application that's already beyond pending in Allu is not updated`() {
-        val application =
-            alluDataFactory.saveApplicationEntity(username) { it.apply { alluid = 21 } }
+        val application = alluDataFactory.saveApplicationEntity(username) { it.alluid = 21 }
         val newApplicationData =
             AlluDataFactory.createCableReportApplicationData(name = "Uudistettu johtoselvitys")
         every { cableReportServiceAllu.getCurrentStatus(21) } returns ApplicationStatus.HANDLING
@@ -515,10 +512,8 @@ class ApplicationServiceITest : DatabaseTest() {
     fun `sendApplication sends pending application to Allu`() {
         val application =
             alluDataFactory.saveApplicationEntity(username) {
-                it.apply {
-                    alluid = 21
-                    applicationData = applicationData.copy(pendingOnClient = false)
-                }
+                it.alluid = 21
+                it.applicationData = it.applicationData.copy(pendingOnClient = false)
             }
         val applicationData = application.applicationData as CableReportApplicationData
         every { cableReportServiceAllu.getCurrentStatus(21) } returns ApplicationStatus.PENDING
@@ -536,10 +531,8 @@ class ApplicationServiceITest : DatabaseTest() {
     fun `sendApplication sets pendingOnClient to false`() {
         val application =
             alluDataFactory.saveApplicationEntity(username) {
-                it.apply {
-                    alluid = 21
-                    applicationData = applicationData.copy(pendingOnClient = false)
-                }
+                it.alluid = 21
+                it.applicationData = it.applicationData.copy(pendingOnClient = false)
             }
         val applicationData = application.applicationData as CableReportApplicationData
         val pendingApplicationData = applicationData.copy(pendingOnClient = false)
@@ -563,8 +556,7 @@ class ApplicationServiceITest : DatabaseTest() {
 
     @Test
     fun `sendApplication creates new application to Allu and saves ID to database`() {
-        val application =
-            alluDataFactory.saveApplicationEntity(username) { it.apply { alluid = null } }
+        val application = alluDataFactory.saveApplicationEntity(username) { it.alluid = null }
         val applicationData = application.applicationData as CableReportApplicationData
         val pendingApplicationData = applicationData.copy(pendingOnClient = false)
         every { cableReportServiceAllu.create(pendingApplicationData) } returns 26
@@ -585,10 +577,8 @@ class ApplicationServiceITest : DatabaseTest() {
     fun `sendApplication with application that's already beyond pending in Allu is not sent`() {
         val application =
             alluDataFactory.saveApplicationEntity(username) {
-                it.apply {
-                    alluid = 21
-                    applicationData = applicationData.copy(pendingOnClient = false)
-                }
+                it.alluid = 21
+                it.applicationData = it.applicationData.copy(pendingOnClient = false)
             }
         every { cableReportServiceAllu.getCurrentStatus(21) } throws
             ApplicationAlreadyProcessingException(application.id, 21)
@@ -599,6 +589,87 @@ class ApplicationServiceITest : DatabaseTest() {
 
         verify { cableReportServiceAllu.getCurrentStatus(21) }
     }
+
+    // TODO: Needs Spring 5.3, which comes with Spring Boot 2.4.
+    //  Inner test classes won't inherit properties from the enclosing class until then.
+    // @Nested class HandleApplicationUpdates {
+
+    /** The timestamp used in the initial DB migration. */
+    private val placeholderUpdateTime = OffsetDateTime.parse("2017-01-01T00:00:00Z")
+    private val updateTime = OffsetDateTime.parse("2022-10-09T06:36:51Z")
+
+    @Test
+    fun `handleApplicationUpdates with empty histories updates the last updated time`() {
+        assertThat(applicationRepository.findAll()).isEmpty()
+        assertEquals(placeholderUpdateTime, alluStatusRepository.getLastUpdateTime().asUtc())
+        applicationService.handleApplicationUpdates(listOf(), updateTime)
+
+        assertEquals(updateTime, alluStatusRepository.getLastUpdateTime().asUtc())
+    }
+
+    @Test
+    fun `handleApplicationUpdates updates the application statuses in the correct order`() {
+        val alluid = 42
+        assertThat(applicationRepository.findAll()).isEmpty()
+        assertEquals(placeholderUpdateTime, alluStatusRepository.getLastUpdateTime().asUtc())
+        alluDataFactory.saveApplicationEntity(username) { it.alluid = alluid }
+        val firstEventTime = ZonedDateTime.parse("2022-09-05T14:15:16Z")
+        val history =
+            ApplicationHistoryFactory.create(applicationId = alluid)
+                .copy(
+                    events =
+                        listOf(
+                            ApplicationHistoryFactory.createEvent(
+                                firstEventTime.plusDays(5),
+                                ApplicationStatus.PENDING
+                            ),
+                            ApplicationHistoryFactory.createEvent(
+                                firstEventTime.plusDays(10),
+                                ApplicationStatus.HANDLING
+                            ),
+                            ApplicationHistoryFactory.createEvent(
+                                firstEventTime,
+                                ApplicationStatus.PENDING
+                            ),
+                        )
+                )
+
+        applicationService.handleApplicationUpdates(listOf(history), updateTime)
+
+        assertEquals(updateTime, alluStatusRepository.getLastUpdateTime().asUtc())
+        val application = applicationRepository.getOneByAlluid(alluid)
+        assertThat(application)
+            .isNotNull()
+            .prop("alluStatus", ApplicationEntity::alluStatus)
+            .isEqualTo(ApplicationStatus.HANDLING)
+    }
+
+    @Test
+    fun `handleApplicationUpdates ignores missing application`() {
+        assertThat(applicationRepository.findAll()).isEmpty()
+        val alluid = 42
+        assertEquals(placeholderUpdateTime, alluStatusRepository.getLastUpdateTime().asUtc())
+        alluDataFactory.saveApplicationEntity(username) { it.alluid = alluid }
+        alluDataFactory.saveApplicationEntity(username) { it.alluid = alluid + 2 }
+        val histories =
+            listOf(
+                ApplicationHistoryFactory.create(applicationId = alluid),
+                ApplicationHistoryFactory.create(applicationId = alluid + 1),
+                ApplicationHistoryFactory.create(applicationId = alluid + 2),
+            )
+
+        applicationService.handleApplicationUpdates(histories, updateTime)
+        assertEquals(updateTime, alluStatusRepository.getLastUpdateTime().asUtc())
+        val applications = applicationRepository.findAll()
+        assertThat(applications).hasSize(2)
+        assertThat(applications.map { it.alluid }).containsExactlyInAnyOrder(alluid, alluid + 2)
+        assertThat(applications.map { it.alluStatus })
+            .containsExactlyInAnyOrder(
+                ApplicationStatus.PENDING_CLIENT,
+                ApplicationStatus.PENDING_CLIENT
+            )
+    }
+    // }
 
     val customerWithContactsJson =
         """
@@ -646,6 +717,8 @@ class ApplicationServiceITest : DatabaseTest() {
             {
               "id": $id,
               "alluid": $alluId,
+              "alluStatus": null,
+              "applicationIdentifier": null,
               "applicationType": "CABLE_REPORT",
               "applicationData": {
                 "name": "$name",

--- a/services/hanke-service/src/integrationTest/resources/clear-db.sql
+++ b/services/hanke-service/src/integrationTest/resources/clear-db.sql
@@ -10,3 +10,4 @@ TRUNCATE TABLE
     organisaatio,
     permissions,
     tormaystarkastelutulos;
+UPDATE allu_status SET history_last_updated = '2017-01-01T00:00:00Z';

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/AlluStatus.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/AlluStatus.kt
@@ -1,0 +1,22 @@
+package fi.hel.haitaton.hanke.allu
+
+import java.time.OffsetDateTime
+import javax.persistence.Column
+import javax.persistence.Entity
+import javax.persistence.Id
+import javax.persistence.Table
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.stereotype.Repository
+
+@Entity
+@Table(name = "allu_status")
+class AlluStatus(
+    @Id val id: Long,
+    @Column(name = "history_last_updated") var historyLastUpdated: OffsetDateTime,
+)
+
+@Repository
+interface AlluStatusRepository : JpaRepository<AlluStatus, Long> {
+    @Query("select historyLastUpdated from AlluStatus") fun getLastUpdateTime(): OffsetDateTime
+}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/AlluUpdateService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/AlluUpdateService.kt
@@ -1,0 +1,37 @@
+package fi.hel.haitaton.hanke.allu
+
+import java.time.OffsetDateTime
+import mu.KotlinLogging
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Service
+
+private val logger = KotlinLogging.logger {}
+
+@Service
+class AlluUpdateService(
+    private val applicationRepository: ApplicationRepository,
+    private val alluStatusRepository: AlluStatusRepository,
+    private val cableReportService: CableReportService,
+    private val applicationService: ApplicationService,
+) {
+
+    @Scheduled(fixedDelay = 1000 * 60, initialDelay = 1000 * 60)
+    fun checkApplicationStatuses() {
+        val ids = applicationRepository.getAllAlluIds()
+        if (ids.isEmpty()) {
+            // Exit if there are no alluids. Allu handles an empty list as "all", which we don't
+            // want.
+            return
+        }
+        val lastUpdate = alluStatusRepository.getLastUpdateTime()
+        val currentUpdate = OffsetDateTime.now()
+
+        logger.info {
+            "Updating application histories with date $lastUpdate and ${ids.size} Allu IDs"
+        }
+        val applicationHistories =
+            cableReportService.getApplicationStatusHistories(ids, lastUpdate.toZonedDateTime())
+
+        applicationService.handleApplicationUpdates(applicationHistories, currentUpdate)
+    }
+}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/Application.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/Application.kt
@@ -9,6 +9,8 @@ enum class ApplicationType {
 data class Application(
     override val id: Long?,
     val alluid: Int?,
+    val alluStatus: ApplicationStatus?,
+    val applicationIdentifier: String?,
     val applicationType: ApplicationType,
     val applicationData: ApplicationData
 ) : HasId<Long>

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/ApplicationController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/ApplicationController.kt
@@ -221,6 +221,10 @@ class ApplicationController(
     fun sendApplication(@PathVariable(name = "id") id: Long): Application =
         service.sendApplication(id, currentUserId())
 
+    @PostMapping("/{id}/make-draft")
+    fun makeDraft(@PathVariable(name = "id") id: Long): Application =
+        service.makeDraft(id, currentUserId())
+
     @ExceptionHandler(ApplicationNotFoundException::class)
     @ResponseStatus(HttpStatus.NOT_FOUND)
     fun missingApplication(ex: ApplicationNotFoundException): HankeError {

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/ApplicationEntity.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/ApplicationEntity.kt
@@ -18,9 +18,12 @@ import org.hibernate.annotations.TypeDef
 data class ApplicationEntity(
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY) val id: Long?,
     var alluid: Int?,
+    @Enumerated(EnumType.STRING) var alluStatus: ApplicationStatus?,
+    var applicationIdentifier: String?,
     var userId: String?,
     @Enumerated(EnumType.STRING) val applicationType: ApplicationType,
     @Type(type = "json") @Column(columnDefinition = "jsonb") var applicationData: ApplicationData,
 ) {
-    fun toApplication() = Application(id, alluid, applicationType, applicationData)
+    fun toApplication() =
+        Application(id, alluid, alluStatus, applicationIdentifier, applicationType, applicationData)
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/ApplicationService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/ApplicationService.kt
@@ -109,7 +109,7 @@ open class ApplicationService(
     ) {
         applicationHistories.forEach { handleApplicationUpdate(it) }
         val status = alluStatusRepository.getOne(1)
-        status.historyLastUpdated = updateTime // .minusDays(1) // TODO Remove minusDays
+        status.historyLastUpdated = updateTime
         alluStatusRepository.save(status)
     }
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/ApplicationService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/ApplicationService.kt
@@ -3,9 +3,11 @@ package fi.hel.haitaton.hanke.allu
 import fi.hel.haitaton.hanke.logging.ApplicationLoggingService
 import fi.hel.haitaton.hanke.logging.DisclosureLogService
 import fi.hel.haitaton.hanke.logging.Status
+import java.time.OffsetDateTime
 import kotlin.reflect.KClass
 import mu.KotlinLogging
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import org.springframework.transaction.annotation.Transactional
 
@@ -15,6 +17,7 @@ const val ALLU_APPLICATION_ERROR_MSG = "Error sending application to Allu"
 
 open class ApplicationService(
     private val repo: ApplicationRepository,
+    private val alluStatusRepository: AlluStatusRepository,
     private val cableReportService: CableReportService,
     private val disclosureLogService: DisclosureLogService,
     private val applicationLoggingService: ApplicationLoggingService,
@@ -33,6 +36,8 @@ open class ApplicationService(
             ApplicationEntity(
                 id = null,
                 alluid = null,
+                alluStatus = null,
+                applicationIdentifier = null,
                 userId = userId,
                 applicationType = application.applicationType,
                 // The application is still a draft in Haitaton until the customer explicitly sends
@@ -51,7 +56,7 @@ open class ApplicationService(
     open fun updateApplicationData(
         id: Long,
         newApplicationData: ApplicationData,
-        userId: String
+        userId: String,
     ): Application {
         val application = getById(id, userId)
         val applicationBefore = application.toApplication()
@@ -95,6 +100,42 @@ open class ApplicationService(
         logger.info("Sent application id=$id, alluid=${application.alluid}")
         // Save only if sendApplicationToAllu didn't throw an exception
         return repo.save(application).toApplication()
+    }
+
+    @Transactional
+    open fun handleApplicationUpdates(
+        applicationHistories: List<ApplicationHistory>,
+        updateTime: OffsetDateTime
+    ) {
+        applicationHistories.forEach { handleApplicationUpdate(it) }
+        val status = alluStatusRepository.getOne(1)
+        status.historyLastUpdated = updateTime // .minusDays(1) // TODO Remove minusDays
+        alluStatusRepository.save(status)
+    }
+
+    private fun handleApplicationUpdate(applicationHistory: ApplicationHistory) {
+        val application = repo.getOneByAlluid(applicationHistory.applicationId)
+        if (application == null) {
+            logger.error {
+                "Allu had events for an application we don't have anymore. alluid=${applicationHistory.applicationId}"
+            }
+            return
+        }
+        applicationHistory.events
+            .sortedBy { it.eventTime }
+            .forEach { event ->
+                application.alluStatus = event.newStatus
+                application.applicationIdentifier = event.applicationIdentifier
+                logger.info {
+                    "Updating application with new status, " +
+                        "id=${application.id}, " +
+                        "alluid=${application.alluid}, " +
+                        "application identifier=${application.applicationIdentifier}, " +
+                        "new status=${application.alluStatus}, " +
+                        "event time=${event.eventTime}"
+                }
+            }
+        repo.save(application)
     }
 
     private fun getById(id: Long, userId: String): ApplicationEntity {
@@ -211,5 +252,11 @@ class ApplicationAlreadyProcessingException(id: Long?, alluid: Int?) :
 @Repository
 interface ApplicationRepository : JpaRepository<ApplicationEntity, Long> {
     fun findOneByIdAndUserId(id: Long, userId: String): ApplicationEntity?
+
     fun getAllByUserId(userId: String): List<ApplicationEntity>
+
+    @Query("select alluid from ApplicationEntity where alluid is not null")
+    fun getAllAlluIds(): List<Int>
+
+    fun getOneByAlluid(alluid: Int): ApplicationEntity?
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/CableReportService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/CableReportService.kt
@@ -10,6 +10,11 @@ interface CableReportService {
         eventsAfter: ZonedDateTime
     ): List<ApplicationStatusEvent>
 
+    fun getApplicationStatusHistories(
+        applicationIds: List<Int>,
+        eventsAfter: ZonedDateTime
+    ): List<ApplicationHistory>
+
     fun create(cableReport: CableReportApplicationData): Int
     fun update(applicationId: Int, cableReport: CableReportApplicationData)
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/configuration/Configuration.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/configuration/Configuration.kt
@@ -7,8 +7,10 @@ import fi.hel.haitaton.hanke.HanketunnusService
 import fi.hel.haitaton.hanke.HanketunnusServiceImpl
 import fi.hel.haitaton.hanke.IdCounterRepository
 import fi.hel.haitaton.hanke.allu.AlluProperties
+import fi.hel.haitaton.hanke.allu.AlluStatusRepository
 import fi.hel.haitaton.hanke.allu.ApplicationRepository
 import fi.hel.haitaton.hanke.allu.ApplicationService
+import fi.hel.haitaton.hanke.allu.CableReportService
 import fi.hel.haitaton.hanke.allu.CableReportServiceAllu
 import fi.hel.haitaton.hanke.geometria.GeometriatDao
 import fi.hel.haitaton.hanke.geometria.GeometriatDaoImpl
@@ -49,7 +51,7 @@ class Configuration {
     @Value("\${haitaton.allu.insecure}") var alluTrustInsecure: Boolean = false
 
     @Bean
-    fun cableReportServiceAllu(): CableReportServiceAllu {
+    fun cableReportService(): CableReportService {
         val webClient =
             if (alluTrustInsecure) createInsecureTrustingWebClient() else WebClient.create()
         val alluProps =
@@ -67,13 +69,15 @@ class Configuration {
     @Bean
     fun applicationService(
         applicationRepository: ApplicationRepository,
-        cableReportServiceAllu: CableReportServiceAllu,
+        alluStatusRepository: AlluStatusRepository,
+        cableReportService: CableReportService,
         disclosureLogService: DisclosureLogService,
         applicationLoggingService: ApplicationLoggingService,
     ): ApplicationService =
         ApplicationService(
             applicationRepository,
-            cableReportServiceAllu,
+            alluStatusRepository,
+            cableReportService,
             disclosureLogService,
             applicationLoggingService,
         )

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/configuration/SchedulingConfig.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/configuration/SchedulingConfig.kt
@@ -1,0 +1,6 @@
+package fi.hel.haitaton.hanke.configuration
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.scheduling.annotation.EnableScheduling
+
+@Configuration @EnableScheduling class SchedulingConfig {}

--- a/services/hanke-service/src/main/resources/db/changelog/changesets/018-add-status-and-indentifier-for-applications.yml
+++ b/services/hanke-service/src/main/resources/db/changelog/changesets/018-add-status-and-indentifier-for-applications.yml
@@ -1,0 +1,17 @@
+databaseChangeLog:
+  - changeSet:
+      id: 018-add-status-and-indentifier-for-applications
+      comment: Add alluStatus and applicationIdentifier for applications
+      author: Topias Heinonen
+      changes:
+        - addColumn:
+            tableName: applications
+            columns:
+              - column:
+                  name: allustatus
+                  type: varchar
+                  remarks: "Status of this application in Allu. Can be null, if application not sent to Allu or Allu has no history available yet."
+              - column:
+                  name: applicationidentifier
+                  type: varchar
+                  remarks: "The official identifier of this application. Null until we get the correct value from Allu."

--- a/services/hanke-service/src/main/resources/db/changelog/changesets/019-create-allustatus-table.yml
+++ b/services/hanke-service/src/main/resources/db/changelog/changesets/019-create-allustatus-table.yml
@@ -1,0 +1,34 @@
+databaseChangeLog:
+  - changeSet:
+      id: 019-create-allustatus-table
+      comment: Create table for storing the last time application statuses were updated.
+      author: Topias Heinonen
+      changes:
+        - createTable:
+            tableName: allu_status
+            remarks: "Table for storing status information related Allu integration. Should only have one row."
+            columns:
+              - column:
+                  name: id
+                  type: bigint
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+                  remarks: "Id column for the table. Checked to be always 1, so that there is only one row in the table."
+              - column:
+                  name: history_last_updated
+                  type: timestamp with timezone
+                  constraints:
+                    nullable: false
+                  remarks: "The last time we successfully updated applications from Allu history endpoint."
+        - sql:
+            sql: "ALTER TABLE allu_status ADD CONSTRAINT allu_status_id_check CHECK (id = 1);"
+        - insert:
+            tableName: allu_status
+            columns:
+              - column:
+                  name: id
+                  value: 1
+              - column:
+                  name: history_last_updated
+                  value: "2017-01-01T00:00:00Z"

--- a/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -63,3 +63,7 @@ databaseChangeLog:
       file: db/changelog/changesets/016-rename-hankegeometriat.yml
   - include:
       file: db/changelog/changesets/017-create-role-table.yml
+  - include:
+      file: db/changelog/changesets/018-add-status-and-indentifier-for-applications.yml
+  - include:
+      file: db/changelog/changesets/019-create-allustatus-table.yml

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/TestExtensions.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/TestExtensions.kt
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import fi.hel.haitaton.hanke.logging.AuditLogRepository
 import fi.hel.haitaton.hanke.logging.ObjectType
 import java.nio.charset.StandardCharsets
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
 import org.springframework.test.web.servlet.ResultActions
 
 fun <T> String.asJsonResource(type: Class<T>): T =
@@ -32,3 +34,5 @@ fun String.getResourceAsText(): String =
  */
 fun AuditLogRepository.findByType(type: ObjectType) =
     this.findAll().filter { it.message.auditEvent.target.type == type }
+
+fun OffsetDateTime.asUtc(): OffsetDateTime = this.withOffsetSameInstant(ZoneOffset.UTC)

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/allu/AlluUpdateServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/allu/AlluUpdateServiceTest.kt
@@ -1,0 +1,138 @@
+package fi.hel.haitaton.hanke.allu
+
+import assertk.assertThat
+import fi.hel.haitaton.hanke.factory.ApplicationHistoryFactory
+import fi.hel.haitaton.hanke.test.Asserts.isRecent
+import io.mockk.Called
+import io.mockk.clearAllMocks
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.verify
+import java.time.OffsetDateTime
+import java.time.ZonedDateTime
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.test.context.junit.jupiter.SpringExtension
+
+@ExtendWith(SpringExtension::class)
+class AlluUpdateServiceTest {
+    private val applicationRepository: ApplicationRepository = mockk()
+    private val alluStatusRepository: AlluStatusRepository = mockk()
+    private val cableReportService: CableReportService = mockk()
+    private val applicationService: ApplicationService = mockk()
+
+    private val alluUpdateService =
+        AlluUpdateService(
+            applicationRepository,
+            alluStatusRepository,
+            cableReportService,
+            applicationService
+        )
+
+    @BeforeEach
+    fun clearMocks() {
+        clearAllMocks()
+    }
+
+    @AfterEach
+    fun confirmMocks() {
+        confirmVerified(
+            alluStatusRepository,
+            applicationRepository,
+            cableReportService,
+            applicationService
+        )
+    }
+
+    @Nested
+    inner class CheckApplicationStatuses {
+        @Test
+        fun `does nothing with no alluids`() {
+            every { applicationRepository.getAllAlluIds() } returns listOf()
+
+            alluUpdateService.checkApplicationStatuses()
+
+            verify {
+                applicationRepository.getAllAlluIds()
+                alluStatusRepository wasNot Called
+                cableReportService wasNot Called
+                applicationService wasNot Called
+            }
+        }
+
+        @Test
+        fun `calls Allu with alluids and last update date`() {
+            val alluids = listOf(23, 24)
+            val lastUpdatedString = "2022-10-12T14:14:58.423521Z"
+            val lastUpdated = OffsetDateTime.parse(lastUpdatedString)
+            val eventsAfter = ZonedDateTime.parse(lastUpdatedString)
+            every { applicationRepository.getAllAlluIds() } returns alluids
+            every { alluStatusRepository.getLastUpdateTime() } returns lastUpdated
+            every { cableReportService.getApplicationStatusHistories(alluids, eventsAfter) } returns
+                listOf()
+            justRun { applicationService.handleApplicationUpdates(listOf(), any()) }
+
+            alluUpdateService.checkApplicationStatuses()
+
+            verify {
+                applicationRepository.getAllAlluIds()
+                alluStatusRepository.getLastUpdateTime()
+                cableReportService.getApplicationStatusHistories(alluids, eventsAfter)
+                applicationService.handleApplicationUpdates(listOf(), any())
+            }
+        }
+
+        @Test
+        fun `calls application service with the returned histories`() {
+            val alluids = listOf(23, 24)
+            val lastUpdatedString = "2022-10-12T14:14:58.423521Z"
+            val lastUpdated = OffsetDateTime.parse(lastUpdatedString)
+            val eventsAfter = ZonedDateTime.parse(lastUpdatedString)
+            val histories = listOf(ApplicationHistoryFactory.create(applicationId = 24))
+            every { applicationRepository.getAllAlluIds() } returns alluids
+            every { alluStatusRepository.getLastUpdateTime() } returns lastUpdated
+            every { cableReportService.getApplicationStatusHistories(alluids, eventsAfter) } returns
+                histories
+            justRun { applicationService.handleApplicationUpdates(histories, any()) }
+
+            alluUpdateService.checkApplicationStatuses()
+
+            verify {
+                applicationRepository.getAllAlluIds()
+                alluStatusRepository.getLastUpdateTime()
+                cableReportService.getApplicationStatusHistories(alluids, eventsAfter)
+                applicationService.handleApplicationUpdates(histories, any())
+            }
+        }
+
+        @Test
+        fun `calls application service with the current time`() {
+            val alluids = listOf(23, 24)
+            val lastUpdatedString = "2022-10-12T14:14:58.423521Z"
+            val lastUpdated = OffsetDateTime.parse(lastUpdatedString)
+            val eventsAfter = ZonedDateTime.parse(lastUpdatedString)
+            every { applicationRepository.getAllAlluIds() } returns alluids
+            every { alluStatusRepository.getLastUpdateTime() } returns lastUpdated
+            every { cableReportService.getApplicationStatusHistories(alluids, eventsAfter) } returns
+                listOf()
+            justRun { applicationService.handleApplicationUpdates(listOf(), any()) }
+
+            alluUpdateService.checkApplicationStatuses()
+
+            verify {
+                applicationRepository.getAllAlluIds()
+                alluStatusRepository.getLastUpdateTime()
+                cableReportService.getApplicationStatusHistories(alluids, eventsAfter)
+                applicationService.handleApplicationUpdates(
+                    listOf(),
+                    withArg { assertThat(it).isRecent() }
+                )
+            }
+        }
+    }
+}

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/allu/AlluUpdateServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/allu/AlluUpdateServiceTest.kt
@@ -51,6 +51,10 @@ class AlluUpdateServiceTest {
 
     @Nested
     inner class CheckApplicationStatuses {
+        private val lastUpdatedString = "2022-10-12T14:14:58.423521Z"
+        private val lastUpdated = OffsetDateTime.parse(lastUpdatedString)
+        private val eventsAfter = ZonedDateTime.parse(lastUpdatedString)
+
         @Test
         fun `does nothing with no alluids`() {
             every { applicationRepository.getAllAlluIds() } returns listOf()
@@ -68,9 +72,6 @@ class AlluUpdateServiceTest {
         @Test
         fun `calls Allu with alluids and last update date`() {
             val alluids = listOf(23, 24)
-            val lastUpdatedString = "2022-10-12T14:14:58.423521Z"
-            val lastUpdated = OffsetDateTime.parse(lastUpdatedString)
-            val eventsAfter = ZonedDateTime.parse(lastUpdatedString)
             every { applicationRepository.getAllAlluIds() } returns alluids
             every { alluStatusRepository.getLastUpdateTime() } returns lastUpdated
             every { cableReportService.getApplicationStatusHistories(alluids, eventsAfter) } returns
@@ -90,9 +91,6 @@ class AlluUpdateServiceTest {
         @Test
         fun `calls application service with the returned histories`() {
             val alluids = listOf(23, 24)
-            val lastUpdatedString = "2022-10-12T14:14:58.423521Z"
-            val lastUpdated = OffsetDateTime.parse(lastUpdatedString)
-            val eventsAfter = ZonedDateTime.parse(lastUpdatedString)
             val histories = listOf(ApplicationHistoryFactory.create(applicationId = 24))
             every { applicationRepository.getAllAlluIds() } returns alluids
             every { alluStatusRepository.getLastUpdateTime() } returns lastUpdated
@@ -113,9 +111,6 @@ class AlluUpdateServiceTest {
         @Test
         fun `calls application service with the current time`() {
             val alluids = listOf(23, 24)
-            val lastUpdatedString = "2022-10-12T14:14:58.423521Z"
-            val lastUpdated = OffsetDateTime.parse(lastUpdatedString)
-            val eventsAfter = ZonedDateTime.parse(lastUpdatedString)
             every { applicationRepository.getAllAlluIds() } returns alluids
             every { alluStatusRepository.getLastUpdateTime() } returns lastUpdated
             every { cableReportService.getApplicationStatusHistories(alluids, eventsAfter) } returns

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/allu/ApplicationServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/allu/ApplicationServiceTest.kt
@@ -3,16 +3,19 @@ package fi.hel.haitaton.hanke.allu
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import fi.hel.haitaton.hanke.asJsonResource
+import fi.hel.haitaton.hanke.factory.AlluDataFactory
 import fi.hel.haitaton.hanke.logging.ApplicationLoggingService
 import fi.hel.haitaton.hanke.logging.DisclosureLogService
 import fi.hel.haitaton.hanke.logging.Status
 import io.mockk.called
 import io.mockk.clearAllMocks
+import io.mockk.confirmVerified
 import io.mockk.every
 import io.mockk.justRun
 import io.mockk.mockk
 import io.mockk.verify
 import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
@@ -23,6 +26,7 @@ private const val username = "test"
 @ExtendWith(SpringExtension::class)
 class ApplicationServiceTest {
     private val applicationRepo: ApplicationRepository = mockk()
+    private val statusRepo: AlluStatusRepository = mockk()
     private val cableReportService: CableReportService = mockk()
     private val disclosureLogService: DisclosureLogService = mockk(relaxUnitFun = true)
     private val applicationLoggingService: ApplicationLoggingService = mockk(relaxUnitFun = true)
@@ -30,60 +34,63 @@ class ApplicationServiceTest {
     private val service: ApplicationService =
         ApplicationService(
             applicationRepo,
+            statusRepo,
             cableReportService,
             disclosureLogService,
             applicationLoggingService,
         )
 
-    @AfterEach
+    @BeforeEach
     fun cleanup() {
         // TODO: Needs newer MockK, which needs newer Spring test dependencies
         // checkUnnecessaryStub()
         clearAllMocks()
     }
 
+    @AfterEach
+    fun verifyMocks() {
+        confirmVerified(
+            applicationRepo,
+            statusRepo,
+            cableReportService,
+            disclosureLogService,
+            applicationLoggingService
+        )
+    }
+
+    private val applicationData: CableReportApplicationData =
+        "/fi/hel/haitaton/hanke/application/applicationData.json".asJsonResource()
+
     @Test
     fun create() {
-        val applicationData: CableReportApplicationData =
-            "/fi/hel/haitaton/hanke/application/applicationData.json".asJsonResource()
-        val dto =
-            Application(
-                id = null,
-                alluid = null,
-                applicationType = ApplicationType.CABLE_REPORT,
-                applicationData = applicationData
-            )
+        val dto = AlluDataFactory.createApplication(id = null, applicationData = applicationData)
         every { cableReportService.create(any()) } returns 42
         every { applicationRepo.save(any()) } answers
             {
                 val application: ApplicationEntity = firstArg()
-                ApplicationEntity(
-                    id = 1,
-                    alluid = application.alluid,
-                    userId = application.userId,
-                    applicationType = application.applicationType,
-                    applicationData = application.applicationData
-                )
+                application.copy(id = 1)
             }
 
         val created = service.create(dto, username)
 
         assertThat(created.id).isEqualTo(1)
         assertThat(created.alluid).isEqualTo(42)
-        verify { disclosureLogService.saveDisclosureLogsForAllu(applicationData, Status.SUCCESS) }
+        verify {
+            disclosureLogService.saveDisclosureLogsForAllu(applicationData, Status.SUCCESS)
+            cableReportService.create(any())
+            applicationRepo.save(any())
+            applicationLoggingService.logCreate(any(), username)
+        }
     }
 
     @Test
     fun `updateApplicationData saves disclosure logs when updating Allu data`() {
-        val applicationData: CableReportApplicationData =
-            "/fi/hel/haitaton/hanke/application/applicationData.json".asJsonResource()
         val applicationEntity =
-            ApplicationEntity(
+            AlluDataFactory.createApplicationEntity(
                 id = 3,
                 alluid = 42,
                 userId = username,
-                applicationType = ApplicationType.CABLE_REPORT,
-                applicationData = applicationData
+                applicationData = applicationData,
             )
         every { applicationRepo.findOneByIdAndUserId(3, username) } returns applicationEntity
         every { applicationRepo.save(applicationEntity) } returns applicationEntity
@@ -92,19 +99,23 @@ class ApplicationServiceTest {
 
         service.updateApplicationData(3, applicationData, username)
 
-        verify { disclosureLogService.saveDisclosureLogsForAllu(applicationData, Status.SUCCESS) }
+        verify {
+            disclosureLogService.saveDisclosureLogsForAllu(applicationData, Status.SUCCESS)
+            applicationRepo.findOneByIdAndUserId(3, username)
+            applicationRepo.save(applicationEntity)
+            cableReportService.update(42, any())
+            cableReportService.getCurrentStatus(42)
+            applicationLoggingService.logUpdate(any(), any(), username)
+        }
     }
 
     @Test
     fun `sendApplication saves disclosure logs for successful attempts`() {
-        val applicationData: CableReportApplicationData =
-            "/fi/hel/haitaton/hanke/application/applicationData.json".asJsonResource()
         val applicationEntity =
-            ApplicationEntity(
+            AlluDataFactory.createApplicationEntity(
                 id = 3,
                 alluid = null,
                 userId = username,
-                applicationType = ApplicationType.CABLE_REPORT,
                 applicationData = applicationData
             )
         every { applicationRepo.findOneByIdAndUserId(3, username) } returns applicationEntity
@@ -116,19 +127,19 @@ class ApplicationServiceTest {
         val expectedApplication = applicationData.copy(pendingOnClient = false)
         verify {
             disclosureLogService.saveDisclosureLogsForAllu(expectedApplication, Status.SUCCESS)
+            applicationRepo.findOneByIdAndUserId(3, username)
+            applicationRepo.save(any())
+            cableReportService.create(any())
         }
     }
 
     @Test
     fun `sendApplication saves disclosure logs for failed attempts`() {
-        val applicationData: CableReportApplicationData =
-            "/fi/hel/haitaton/hanke/application/applicationData.json".asJsonResource()
         val applicationEntity =
-            ApplicationEntity(
+            AlluDataFactory.createApplicationEntity(
                 id = 3,
                 alluid = null,
                 userId = username,
-                applicationType = ApplicationType.CABLE_REPORT,
                 applicationData = applicationData
             )
         every { applicationRepo.findOneByIdAndUserId(3, username) } returns applicationEntity
@@ -143,19 +154,18 @@ class ApplicationServiceTest {
                 Status.FAILED,
                 ALLU_APPLICATION_ERROR_MSG
             )
+            applicationRepo.findOneByIdAndUserId(3, username)
+            cableReportService.create(any())
         }
     }
 
     @Test
     fun `sendApplication doesn't save disclosure logs for login errors`() {
-        val applicationData: CableReportApplicationData =
-            "/fi/hel/haitaton/hanke/application/applicationData.json".asJsonResource()
         val applicationEntity =
-            ApplicationEntity(
+            AlluDataFactory.createApplicationEntity(
                 id = 3,
                 alluid = null,
                 userId = username,
-                applicationType = ApplicationType.CABLE_REPORT,
                 applicationData = applicationData
             )
         every { applicationRepo.findOneByIdAndUserId(3, username) } returns applicationEntity
@@ -163,6 +173,10 @@ class ApplicationServiceTest {
 
         assertThrows<AlluLoginException> { service.sendApplication(3, username) }
 
-        verify { disclosureLogService wasNot called }
+        verify {
+            disclosureLogService wasNot called
+            applicationRepo.findOneByIdAndUserId(3, username)
+            cableReportService.create(any())
+        }
     }
 }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/ApplicationHistoryFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/ApplicationHistoryFactory.kt
@@ -1,0 +1,55 @@
+package fi.hel.haitaton.hanke.factory
+
+import fi.hel.haitaton.hanke.allu.ApplicationHistory
+import fi.hel.haitaton.hanke.allu.ApplicationStatus
+import fi.hel.haitaton.hanke.allu.ApplicationStatusEvent
+import java.time.ZonedDateTime
+
+object ApplicationHistoryFactory {
+
+    val defaultApplicationId = 1
+    val defaultApplicationIdentifier = "JS2300001"
+    val defaultEventTime = ZonedDateTime.parse("2022-10-12T15:25:34.981654Z")
+    val defaultStatus = ApplicationStatus.PENDING
+    val defaultTargetStatus: ApplicationStatus? = null
+
+    /**
+     * Create a history for an application with two events at different times. Supervision events
+     * are not included.
+     */
+    fun create(
+        applicationId: Int = defaultApplicationId,
+        applicationIdentifier: String = defaultApplicationIdentifier,
+    ): ApplicationHistory =
+        ApplicationHistory(
+            applicationId,
+            events =
+                listOf(
+                    createEvent(
+                        eventTime = ZonedDateTime.parse("2022-10-12T15:25:34.981654Z[UTC]"),
+                        newStatus = ApplicationStatus.PENDING,
+                        applicationIdentifier = applicationIdentifier,
+                    ),
+                    createEvent(
+                        eventTime = ZonedDateTime.parse("2023-01-09T14:37:09.135Z[UTC]"),
+                        newStatus = ApplicationStatus.PENDING_CLIENT,
+                        applicationIdentifier = applicationIdentifier,
+                    ),
+                ),
+            supervisionEvents = listOf()
+        )
+
+    /** Create a status event for an application. */
+    fun createEvent(
+        eventTime: ZonedDateTime = defaultEventTime,
+        newStatus: ApplicationStatus = defaultStatus,
+        applicationIdentifier: String = defaultApplicationIdentifier,
+        targetStatus: ApplicationStatus? = defaultTargetStatus,
+    ) =
+        ApplicationStatusEvent(
+            eventTime = eventTime,
+            newStatus = newStatus,
+            applicationIdentifier = applicationIdentifier,
+            targetStatus = targetStatus
+        )
+}

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/gdpr/GdprJsonConverterTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/gdpr/GdprJsonConverterTest.kt
@@ -6,8 +6,6 @@ import assertk.assertions.containsExactlyInAnyOrder
 import assertk.assertions.each
 import assertk.assertions.isEmpty
 import assertk.assertions.isEqualTo
-import fi.hel.haitaton.hanke.allu.Application
-import fi.hel.haitaton.hanke.allu.ApplicationType
 import fi.hel.haitaton.hanke.allu.CableReportApplicationData
 import fi.hel.haitaton.hanke.allu.CustomerType
 import fi.hel.haitaton.hanke.allu.CustomerWithContacts
@@ -43,7 +41,7 @@ internal class GdprJsonConverterTest {
     fun `createGdprJson returns null when no names match`() {
         val applicationData: CableReportApplicationData =
             "/fi/hel/haitaton/hanke/application/applicationData.json".asJsonResource()
-        val application = Application(null, null, ApplicationType.CABLE_REPORT, applicationData)
+        val application = AlluDataFactory.createApplication(applicationData = applicationData)
         val hanke =
             HankeFactory.create().withYhteystiedot(
                 omistajat = listOf(1, 2),
@@ -61,7 +59,7 @@ internal class GdprJsonConverterTest {
     fun `createGdprJson combines identical results when there are several infos`() {
         val applicationData: CableReportApplicationData =
             "/fi/hel/haitaton/hanke/application/applicationData.json".asJsonResource()
-        val application = Application(null, null, ApplicationType.CABLE_REPORT, applicationData)
+        val application = AlluDataFactory.createApplication(applicationData = applicationData)
         val hanke =
             HankeFactory.create().withYhteystiedot(
                 omistajat = listOf(1, 2),

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/logging/DisclosureLogServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/logging/DisclosureLogServiceTest.kt
@@ -1,8 +1,5 @@
 package fi.hel.haitaton.hanke.logging
 
-import fi.hel.haitaton.hanke.allu.Application
-import fi.hel.haitaton.hanke.allu.ApplicationType
-import fi.hel.haitaton.hanke.allu.CableReportApplicationData
 import fi.hel.haitaton.hanke.allu.Contact
 import fi.hel.haitaton.hanke.allu.Customer
 import fi.hel.haitaton.hanke.allu.CustomerType
@@ -185,7 +182,7 @@ internal class DisclosureLogServiceTest {
         val contractorWithoutContacts =
             CustomerWithContacts(AlluDataFactory.createCompanyCustomer(name = "Second"), listOf())
         val application =
-            applicationDto(
+            AlluDataFactory.createApplication(
                 applicationData =
                     AlluDataFactory.createCableReportApplicationData(
                         customerWithContacts = customerWithoutContacts,
@@ -208,7 +205,7 @@ internal class DisclosureLogServiceTest {
                 listOf(Contact("", PostalAddress(StreetAddress(""), "", ""), "", ""))
             )
         val application =
-            applicationDto(
+            AlluDataFactory.createApplication(
                 applicationData =
                     AlluDataFactory.createCableReportApplicationData(
                         customerWithContacts = customerWithoutContacts,
@@ -230,7 +227,7 @@ internal class DisclosureLogServiceTest {
         val customerWithoutContacts = CustomerWithContacts(blankCustomer, listOf())
         val contractorWithoutContacts = CustomerWithContacts(blankCustomerWithCountry, listOf())
         val application =
-            applicationDto(
+            AlluDataFactory.createApplication(
                 applicationData =
                     AlluDataFactory.createCableReportApplicationData(
                         customerWithContacts = customerWithoutContacts,
@@ -250,11 +247,12 @@ internal class DisclosureLogServiceTest {
         val contractorWithoutContacts =
             CustomerWithContacts(AlluDataFactory.createPersonCustomer(), listOf())
         val application =
-            applicationDto(
-                AlluDataFactory.createCableReportApplicationData(
-                    customerWithContacts = customerWithoutContacts,
-                    contractorWithContacts = contractorWithoutContacts
-                )
+            AlluDataFactory.createApplication(
+                applicationData =
+                    AlluDataFactory.createCableReportApplicationData(
+                        customerWithContacts = customerWithoutContacts,
+                        contractorWithContacts = contractorWithoutContacts
+                    )
             )
         val expectedLogs =
             listOf(
@@ -271,7 +269,8 @@ internal class DisclosureLogServiceTest {
         val cableReportApplication = AlluDataFactory.createCableReportApplicationData()
         val contact = cableReportApplication.customerWithContacts.contacts[0]
         val expectedLogs = listOf(AuditLogEntryFactory.createReadEntryForContact(contact))
-        val application = applicationDto(applicationData = cableReportApplication)
+        val application =
+            AlluDataFactory.createApplication(applicationData = cableReportApplication)
 
         disclosureLogService.saveDisclosureLogsForApplication(application, userId)
 
@@ -324,7 +323,7 @@ internal class DisclosureLogServiceTest {
                         contractorWithContacts = customersWithContacts[3],
                     )
                 )
-                .map { applicationDto(it) }
+                .map { AlluDataFactory.createApplication(applicationData = it) }
 
         disclosureLogService.saveDisclosureLogsForApplications(applications, userId)
 
@@ -344,12 +343,4 @@ internal class DisclosureLogServiceTest {
 
     private infix fun <T> List<T>.equalsIgnoreOrder(other: List<T>): Boolean =
         this.size == other.size && this.toSet() == other.toSet()
-
-    private fun applicationDto(applicationData: CableReportApplicationData): Application =
-        Application(
-            id = 1,
-            alluid = null,
-            applicationType = ApplicationType.CABLE_REPORT,
-            applicationData = applicationData
-        )
 }


### PR DESCRIPTION
# Description

Revert an application in Allu to a draft. Used to test the application status history feature, since this is the only status change we can influence directly from Haitaton.

Does the same as sending an application, but sets the pending on client value to true.

Not meant to be merged, but as a tool for testing #248 
