### PR TITLE
HAI-1300 Distributed mutex with database

### DIFF
--- a/services/hanke-service/build.gradle.kts
+++ b/services/hanke-service/build.gradle.kts
@@ -69,6 +69,7 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-web")
 	implementation("org.springframework.boot:spring-boot-starter-webflux")
 	implementation("org.springframework.boot:spring-boot-starter-validation")
+	implementation("org.springframework.integration:spring-integration-jdbc")
 	implementation("com.fasterxml.jackson.core:jackson-databind")
 	implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 	implementation("com.fasterxml.jackson.module:jackson-module-jaxb-annotations")

--- a/services/hanke-service/src/integrationTest/resources/clear-db.sql
+++ b/services/hanke-service/src/integrationTest/resources/clear-db.sql
@@ -1,12 +1,13 @@
 TRUNCATE TABLE
     applications,
     audit_logs,
+    geometriat,
     hanke,
     hankealue,
     hankegeometria,
-    geometriat,
     hanketyomaatyyppi,
     hankeyhteystieto,
+    int_lock,
     organisaatio,
     permissions,
     tormaystarkastelutulos;

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/configuration/LockService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/configuration/LockService.kt
@@ -1,0 +1,52 @@
+package fi.hel.haitaton.hanke.configuration
+
+import javax.sql.DataSource
+import mu.KotlinLogging
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.integration.jdbc.lock.DefaultLockRepository
+import org.springframework.integration.jdbc.lock.JdbcLockRegistry
+import org.springframework.integration.jdbc.lock.LockRepository
+import org.springframework.stereotype.Service
+
+private val logger = KotlinLogging.logger {}
+
+@Configuration
+class LockRepositories {
+    /** The time to hold on to dead locks. */
+    private val timeToLive = 15 * 60 * 1000 // 15 minutes in milliseconds
+
+    @Bean
+    fun defaultLockRepository(dataSource: DataSource?): DefaultLockRepository {
+        val repository = DefaultLockRepository(dataSource)
+        repository.setTimeToLive(timeToLive)
+        return repository
+    }
+
+    @Bean
+    fun jdbcLockRegistry(lockRepository: LockRepository?): JdbcLockRegistry {
+        return JdbcLockRegistry(lockRepository)
+    }
+}
+
+@Service
+class LockService(private val jdbcLockRegistry: JdbcLockRegistry) {
+
+    /** Run the given function if a lock is obtained. If the lock is not obtained, do nothing. */
+    fun doIfUnlocked(name: String, f: () -> Unit) {
+        val lock = jdbcLockRegistry.obtain(name)
+        if (lock.tryLock()) {
+            logger.info("Lock obtained, name = $name")
+            try {
+                f()
+            } catch (e: Exception) {
+                logger.error(e) { "Exception while holding lock, name = $name" }
+            } finally {
+                lock.unlock()
+                logger.info("Lock released, name = $name")
+            }
+        } else {
+            logger.info("Lock was already reserved, name = $name")
+        }
+    }
+}

--- a/services/hanke-service/src/main/resources/db/changelog/changesets/020-create-lock-table.yml
+++ b/services/hanke-service/src/main/resources/db/changelog/changesets/020-create-lock-table.yml
@@ -1,0 +1,33 @@
+# Based on https://github.com/spring-projects/spring-integration/blob/5.3.x/spring-integration-jdbc/src/main/resources/org/springframework/integration/jdbc/schema-postgresql.sql
+databaseChangeLog:
+  - changeSet:
+      id: 020-create-lock-table
+      comment: Create a table for spring-integration-jdbc locking.
+      author: Topias Heinonen
+      changes:
+        - createTable:
+            tableName: INT_LOCK
+            remarks: "Table for distributed locking between service instances/pods."
+            columns:
+              - column:
+                  name: LOCK_KEY
+                  type: CHAR(36)
+                  constraints:
+                    nullable: false
+                    primaryKey: true
+                    primaryKeyName: INT_LOCK_PK
+              - column:
+                  name: REGION
+                  type: VARCHAR(100)
+                  constraints:
+                    nullable: false
+                    primaryKey: true
+                    primaryKeyName: INT_LOCK_PK
+              - column:
+                  name: CLIENT_ID
+                  type: CHAR(36)
+              - column:
+                  name: CREATED_DATE
+                  type: timestamp
+                  constraints:
+                    nullable: false

--- a/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -67,3 +67,5 @@ databaseChangeLog:
       file: db/changelog/changesets/018-add-status-and-indentifier-for-applications.yml
   - include:
       file: db/changelog/changesets/019-create-allustatus-table.yml
+  - include:
+      file: db/changelog/changesets/020-create-lock-table.yml


### PR DESCRIPTION
# Description

Use Spring's distributed database lock to make sure only one instance / pod of hanke-service tries to update application statuses at any one time.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1300

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 