### PR TITLE
HAI-1397 Split internal and external application data representation

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/IntegrationTestConfiguration.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/IntegrationTestConfiguration.kt
@@ -1,6 +1,6 @@
 package fi.hel.haitaton.hanke
 
-import fi.hel.haitaton.hanke.allu.ApplicationService
+import fi.hel.haitaton.hanke.application.ApplicationService
 import fi.hel.haitaton.hanke.gdpr.GdprJsonConverter
 import fi.hel.haitaton.hanke.geometria.GeometriatDao
 import fi.hel.haitaton.hanke.geometria.GeometriatService

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/allu/CableReportServiceAlluITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/allu/CableReportServiceAlluITests.kt
@@ -166,7 +166,7 @@ class CableReportServiceAlluITests {
         return stubbedBearer
     }
 
-    private fun getTestApplication(): CableReportApplicationData {
+    private fun getTestApplication(): AlluCableReportApplicationData {
         val customer =
             Customer(
                 type = CustomerType.COMPANY,
@@ -230,8 +230,7 @@ class CableReportServiceAlluITests {
 
         val now = ZonedDateTime.now()
 
-        return CableReportApplicationData(
-            applicationType = ApplicationType.CABLE_REPORT,
+        return AlluCableReportApplicationData(
             name = "Haitaton hankkeen nimi",
             customerWithContacts = customerWContacts,
             geometry = geometry,

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/gdpr/GdprControllerITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/gdpr/GdprControllerITests.kt
@@ -2,7 +2,7 @@ package fi.hel.haitaton.hanke.gdpr
 
 import fi.hel.haitaton.hanke.HankeService
 import fi.hel.haitaton.hanke.IntegrationTestConfiguration
-import fi.hel.haitaton.hanke.allu.ApplicationService
+import fi.hel.haitaton.hanke.application.ApplicationService
 import fi.hel.haitaton.hanke.factory.HankeFactory
 import fi.hel.haitaton.hanke.factory.UserInfoFactory
 import fi.hel.haitaton.hanke.logging.DisclosureLogService

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeError.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeError.kt
@@ -28,6 +28,7 @@ enum class HankeError(val errorMessage: String) {
     HAI2001("Application not found"),
     HAI2002("Incompatible application data type"),
     HAI2003("Application is already processing in Allu and can no longer be updated."),
+    HAI2004("Application data missing information needed by Allu."),
     ;
 
     val errorCode: String

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/AlluApplicationData.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/AlluApplicationData.kt
@@ -1,36 +1,14 @@
 package fi.hel.haitaton.hanke.allu
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties
-import com.fasterxml.jackson.annotation.JsonSubTypes
-import com.fasterxml.jackson.annotation.JsonTypeInfo
-import com.fasterxml.jackson.annotation.JsonView
-import fi.hel.haitaton.hanke.ChangeLogView
-import fi.hel.haitaton.hanke.NotInChangeLogView
 import java.time.ZonedDateTime
 import org.geojson.GeometryCollection
 
-@JsonIgnoreProperties(ignoreUnknown = true)
-@JsonTypeInfo(
-    use = JsonTypeInfo.Id.NAME,
-    include = JsonTypeInfo.As.EXISTING_PROPERTY,
-    property = "applicationType",
-    visible = true
-)
-@JsonSubTypes(
-    JsonSubTypes.Type(value = CableReportApplicationData::class, name = "CABLE_REPORT"),
-)
-sealed interface ApplicationData {
-    val applicationType: ApplicationType
+sealed interface AlluApplicationData {
     val name: String
     val pendingOnClient: Boolean
-
-    fun copy(pendingOnClient: Boolean): ApplicationData
 }
 
-@JsonView(ChangeLogView::class)
-data class CableReportApplicationData(
-    @JsonView(NotInChangeLogView::class) override val applicationType: ApplicationType,
-
+data class AlluCableReportApplicationData(
     // Common, required
     override val name: String,
     val customerWithContacts: CustomerWithContacts,
@@ -58,12 +36,9 @@ data class CableReportApplicationData(
     val maintenanceWork: Boolean = false,
     val emergencyWork: Boolean = false,
     val propertyConnectivity: Boolean = false, // tontti-/kiinteistöliitos
-) : ApplicationData {
-    override fun copy(pendingOnClient: Boolean): CableReportApplicationData =
-        copy(applicationType = applicationType, pendingOnClient = pendingOnClient)
-}
+) : AlluApplicationData
 
 data class CableReportInformationRequestResponse(
-    val applicationData: CableReportApplicationData,
+    val applicationData: AlluCableReportApplicationData,
     val updatedFields: List<InformationRequestFieldKey>
 )

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/AlluCommonDomain.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/AlluCommonDomain.kt
@@ -1,6 +1,5 @@
 package fi.hel.haitaton.hanke.allu
 
-import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonView
 import fi.hel.haitaton.hanke.ChangeLogView
@@ -15,20 +14,10 @@ data class Contact(
     val email: String?,
     val phone: String?,
     val orderer: Boolean = false
-) {
-    /** Check if this contact is blank, i.e. it doesn't contain any actual contact information. */
-    @JsonIgnore
-    fun isBlank() =
-        name.isNullOrBlank() &&
-            email.isNullOrBlank() &&
-            phone.isNullOrBlank() &&
-            postalAddress.isNullOrBlank()
+)
 
-    fun hasInformation() = !isBlank()
-}
-
+/** Non-null fields are not mandatory in Allu. */
 @JsonIgnoreProperties(ignoreUnknown = true)
-@JsonView(ChangeLogView::class)
 data class Customer(
     val type: CustomerType,
     val name: String,
@@ -40,37 +29,14 @@ data class Customer(
     val ovt: String?, // e-invoice identifier (ovt-tunnus)
     val invoicingOperator: String?, // e-invoicing operator code
     val sapCustomerNumber: String? // customer's sap number
-) {
-    /** Check if this customer is blank, i.e. it doesn't contain any actual customer information. */
-    @JsonIgnore
-    fun isBlank() =
-        name.isBlank() &&
-            country.isBlank() &&
-            postalAddress.isNullOrBlank() &&
-            email.isNullOrBlank() &&
-            phone.isNullOrBlank() &&
-            registryKey.isNullOrBlank() &&
-            ovt.isNullOrBlank() &&
-            invoicingOperator.isNullOrBlank() &&
-            sapCustomerNumber.isNullOrBlank()
-
-    fun hasInformation() = !isBlank()
-}
+)
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class PostalAddress(
     val streetAddress: StreetAddress,
     val postalCode: String,
     val city: String
-) {
-    /** Check if this address is blank, i.e. none of fields have any information. */
-    @JsonIgnore
-    fun isBlank() =
-        streetAddress.streetName.isNullOrBlank() && postalCode.isBlank() && city.isBlank()
-}
-
-/** Check if this address is blank, i.e. none of fields have any information. */
-fun PostalAddress?.isNullOrBlank() = this?.isBlank() ?: true
+)
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonView(ChangeLogView::class)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/CableReportService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/CableReportService.kt
@@ -15,8 +15,8 @@ interface CableReportService {
         eventsAfter: ZonedDateTime
     ): List<ApplicationHistory>
 
-    fun create(cableReport: CableReportApplicationData): Int
-    fun update(applicationId: Int, cableReport: CableReportApplicationData)
+    fun create(cableReport: AlluCableReportApplicationData): Int
+    fun update(applicationId: Int, cableReport: AlluCableReportApplicationData)
 
     fun addAttachment(applicationId: Int, metadata: AttachmentInfo, file: ByteArray)
 
@@ -24,7 +24,7 @@ interface CableReportService {
     fun respondToInformationRequest(
         applicationId: Int,
         requestId: Int,
-        cableReport: CableReportApplicationData,
+        cableReport: AlluCableReportApplicationData,
         updatedFields: List<InformationRequestFieldKey>
     )
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/CableReportServiceAllu.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/CableReportServiceAllu.kt
@@ -126,7 +126,7 @@ class CableReportServiceAllu(
             .block()!!
     }
 
-    override fun create(cableReport: CableReportApplicationData): Int {
+    override fun create(cableReport: AlluCableReportApplicationData): Int {
         val token = login()!!
         return webClient
             .post()
@@ -144,7 +144,7 @@ class CableReportServiceAllu(
             .orElseThrow()
     }
 
-    override fun update(applicationId: Int, cableReport: CableReportApplicationData) {
+    override fun update(applicationId: Int, cableReport: AlluCableReportApplicationData) {
         val token = login()!!
         webClient
             .put()
@@ -205,7 +205,7 @@ class CableReportServiceAllu(
     override fun respondToInformationRequest(
         applicationId: Int,
         requestId: Int,
-        cableReport: CableReportApplicationData,
+        cableReport: AlluCableReportApplicationData,
         updatedFields: List<InformationRequestFieldKey>,
     ) {
         val token = login()!!

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/AlluUpdateService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/AlluUpdateService.kt
@@ -1,5 +1,7 @@
-package fi.hel.haitaton.hanke.allu
+package fi.hel.haitaton.hanke.application
 
+import fi.hel.haitaton.hanke.allu.AlluStatusRepository
+import fi.hel.haitaton.hanke.allu.CableReportService
 import fi.hel.haitaton.hanke.configuration.LockService
 import java.time.OffsetDateTime
 import mu.KotlinLogging

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/Application.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/Application.kt
@@ -1,5 +1,6 @@
-package fi.hel.haitaton.hanke.allu
+package fi.hel.haitaton.hanke.application
 
+import fi.hel.haitaton.hanke.allu.ApplicationStatus
 import fi.hel.haitaton.hanke.domain.HasId
 
 enum class ApplicationType {

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationController.kt
@@ -1,4 +1,4 @@
-package fi.hel.haitaton.hanke.allu
+package fi.hel.haitaton.hanke.application
 
 import fi.hel.haitaton.hanke.HankeError
 import fi.hel.haitaton.hanke.currentUserId
@@ -238,6 +238,13 @@ class ApplicationController(
     @ExceptionHandler(ApplicationAlreadyProcessingException::class)
     @ResponseStatus(HttpStatus.CONFLICT)
     fun applicationAlreadyProcessing(ex: ApplicationAlreadyProcessingException): HankeError {
+        logger.warn(ex) { ex.message }
+        return HankeError.HAI2003
+    }
+
+    @ExceptionHandler(AlluDataException::class)
+    @ResponseStatus(HttpStatus.CONFLICT)
+    fun alluDataError(ex: AlluDataException): HankeError {
         logger.warn(ex) { ex.message }
         return HankeError.HAI2003
     }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationData.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationData.kt
@@ -1,0 +1,95 @@
+package fi.hel.haitaton.hanke.application
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonSubTypes
+import com.fasterxml.jackson.annotation.JsonTypeInfo
+import com.fasterxml.jackson.annotation.JsonView
+import fi.hel.haitaton.hanke.ChangeLogView
+import fi.hel.haitaton.hanke.NotInChangeLogView
+import fi.hel.haitaton.hanke.allu.AlluApplicationData
+import fi.hel.haitaton.hanke.allu.AlluCableReportApplicationData
+import java.time.ZonedDateTime
+import org.geojson.GeometryCollection
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NAME,
+    include = JsonTypeInfo.As.EXISTING_PROPERTY,
+    property = "applicationType",
+    visible = true
+)
+@JsonSubTypes(
+    JsonSubTypes.Type(value = CableReportApplicationData::class, name = "CABLE_REPORT"),
+)
+sealed interface ApplicationData {
+    val applicationType: ApplicationType
+    val name: String
+    val pendingOnClient: Boolean
+
+    fun copy(pendingOnClient: Boolean): ApplicationData
+    fun toAlluData(): AlluApplicationData?
+}
+
+@JsonView(ChangeLogView::class)
+data class CableReportApplicationData(
+    @JsonView(NotInChangeLogView::class) override val applicationType: ApplicationType,
+
+    // Common, required
+    override val name: String,
+    val customerWithContacts: CustomerWithContacts,
+    val geometry: GeometryCollection,
+    val startTime: ZonedDateTime?,
+    val endTime: ZonedDateTime?,
+    override val pendingOnClient: Boolean,
+    val identificationNumber: String,
+
+    // CableReport specific, required
+    val clientApplicationKind: String,
+    val workDescription: String,
+    val contractorWithContacts: CustomerWithContacts, // työn suorittaja
+
+    // Common, not required
+    val postalAddress: PostalAddress? = null,
+    val representativeWithContacts: CustomerWithContacts? = null,
+    val invoicingCustomer: Customer? = null,
+    val customerReference: String? = null,
+    val area: Double? = null,
+
+    // CableReport specific, not required
+    val propertyDeveloperWithContacts: CustomerWithContacts? = null, // rakennuttaja
+    val constructionWork: Boolean = false,
+    val maintenanceWork: Boolean = false,
+    val emergencyWork: Boolean = false,
+    val propertyConnectivity: Boolean = false, // tontti-/kiinteistöliitos
+) : ApplicationData {
+    override fun copy(pendingOnClient: Boolean): CableReportApplicationData =
+        copy(applicationType = applicationType, pendingOnClient = pendingOnClient)
+
+    override fun toAlluData(): AlluCableReportApplicationData {
+        return AlluCableReportApplicationData(
+            name,
+            customerWithContacts.toAlluData("applicationData.customerWithContacts"),
+            geometry,
+            startTime ?: throw AlluDataException("applicationData.startTime", "Can't be null"),
+            endTime ?: throw AlluDataException("applicationData.endTime", "Can't be null"),
+            pendingOnClient,
+            identificationNumber,
+            clientApplicationKind,
+            workDescription,
+            contractorWithContacts.toAlluData("applicationData"),
+            postalAddress?.toAlluData(),
+            representativeWithContacts?.toAlluData("applicationData"),
+            invoicingCustomer?.toAlluData("applicationData"),
+            customerReference,
+            area,
+            propertyDeveloperWithContacts?.toAlluData("applicationData"),
+            constructionWork,
+            maintenanceWork,
+            emergencyWork,
+            propertyConnectivity
+        )
+    }
+}
+
+class AlluDataException(path: String, error: String) :
+    RuntimeException("Application data failed validation at $path: $error")

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationEntity.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationEntity.kt
@@ -1,6 +1,7 @@
-package fi.hel.haitaton.hanke.allu
+package fi.hel.haitaton.hanke.application
 
 import com.vladmihalcea.hibernate.type.json.JsonType
+import fi.hel.haitaton.hanke.allu.ApplicationStatus
 import javax.persistence.Column
 import javax.persistence.Entity
 import javax.persistence.EnumType

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/CustomerWithContacts.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/CustomerWithContacts.kt
@@ -1,0 +1,113 @@
+package fi.hel.haitaton.hanke.application
+
+import com.fasterxml.jackson.annotation.JsonIgnore
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonView
+import fi.hel.haitaton.hanke.ChangeLogView
+import fi.hel.haitaton.hanke.allu.Contact as AlluContact
+import fi.hel.haitaton.hanke.allu.Customer as AlluCustomer
+import fi.hel.haitaton.hanke.allu.CustomerType
+import fi.hel.haitaton.hanke.allu.CustomerWithContacts as AlluCustomerWithContacts
+import fi.hel.haitaton.hanke.allu.PostalAddress as AlluPostalAddress
+import fi.hel.haitaton.hanke.allu.StreetAddress as AlluStreetAddress
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class CustomerWithContacts(val customer: Customer, val contacts: List<Contact>) {
+    fun toAlluData(path: String): AlluCustomerWithContacts {
+        return AlluCustomerWithContacts(
+            customer.toAlluData("$path.customer"),
+            contacts.map { it.toAlluData() }
+        )
+    }
+}
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class Contact(
+    val name: String?,
+    val postalAddress: PostalAddress?,
+    val email: String?,
+    val phone: String?,
+    val orderer: Boolean = false,
+) {
+    /** Check if this contact is blank, i.e. it doesn't contain any actual contact information. */
+    @JsonIgnore
+    fun isBlank() =
+        name.isNullOrBlank() &&
+            email.isNullOrBlank() &&
+            phone.isNullOrBlank() &&
+            postalAddress.isNullOrBlank()
+
+    fun hasInformation() = !isBlank()
+
+    fun toAlluData(): AlluContact =
+        AlluContact(name, postalAddress?.toAlluData(), email, phone, orderer)
+}
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonView(ChangeLogView::class)
+data class Customer(
+    val type: CustomerType?, // Mandatory in Allu, but not in drafts.
+    val name: String,
+    val country: String, // ISO 3166-1 alpha-2 country code
+    val postalAddress: PostalAddress?,
+    val email: String?,
+    val phone: String?,
+    val registryKey: String?, // ssn or y-tunnus
+    val ovt: String?, // e-invoice identifier (ovt-tunnus)
+    val invoicingOperator: String?, // e-invoicing operator code
+    val sapCustomerNumber: String?, // customer's sap number
+) {
+    /** Check if this customer is blank, i.e. it doesn't contain any actual customer information. */
+    @JsonIgnore
+    fun isBlank() =
+        name.isBlank() &&
+            country.isBlank() &&
+            postalAddress.isNullOrBlank() &&
+            email.isNullOrBlank() &&
+            phone.isNullOrBlank() &&
+            registryKey.isNullOrBlank() &&
+            ovt.isNullOrBlank() &&
+            invoicingOperator.isNullOrBlank() &&
+            sapCustomerNumber.isNullOrBlank()
+
+    fun hasInformation() = !isBlank()
+
+    fun toAlluData(path: String): AlluCustomer =
+        AlluCustomer(
+            type ?: throw AlluDataException("$path.type", "Can't be null"),
+            name,
+            country,
+            postalAddress?.toAlluData(),
+            email,
+            phone,
+            registryKey,
+            ovt,
+            invoicingOperator,
+            sapCustomerNumber,
+        )
+}
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonView(ChangeLogView::class)
+data class PostalAddress(
+    val streetAddress: StreetAddress,
+    val postalCode: String,
+    val city: String,
+) {
+    /** Check if this address is blank, i.e. none of fields have any information. */
+    @JsonIgnore
+    fun isBlank() =
+        streetAddress.streetName.isNullOrBlank() && postalCode.isBlank() && city.isBlank()
+
+    fun toAlluData(): AlluPostalAddress =
+        AlluPostalAddress(streetAddress.toAlluData(), postalCode, city)
+}
+
+/** Check if this address is blank, i.e. none of fields have any information. */
+fun PostalAddress?.isNullOrBlank() = this?.isBlank() ?: true
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonView(ChangeLogView::class)
+data class StreetAddress(val streetName: String?) {
+    fun toAlluData(): AlluStreetAddress = AlluStreetAddress(streetName)
+}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/configuration/Configuration.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/configuration/Configuration.kt
@@ -8,10 +8,10 @@ import fi.hel.haitaton.hanke.HanketunnusServiceImpl
 import fi.hel.haitaton.hanke.IdCounterRepository
 import fi.hel.haitaton.hanke.allu.AlluProperties
 import fi.hel.haitaton.hanke.allu.AlluStatusRepository
-import fi.hel.haitaton.hanke.allu.ApplicationRepository
-import fi.hel.haitaton.hanke.allu.ApplicationService
 import fi.hel.haitaton.hanke.allu.CableReportService
 import fi.hel.haitaton.hanke.allu.CableReportServiceAllu
+import fi.hel.haitaton.hanke.application.ApplicationRepository
+import fi.hel.haitaton.hanke.application.ApplicationService
 import fi.hel.haitaton.hanke.geometria.GeometriatDao
 import fi.hel.haitaton.hanke.geometria.GeometriatDaoImpl
 import fi.hel.haitaton.hanke.geometria.GeometriatService

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/gdpr/GdprController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/gdpr/GdprController.kt
@@ -1,7 +1,7 @@
 package fi.hel.haitaton.hanke.gdpr
 
 import fi.hel.haitaton.hanke.HankeService
-import fi.hel.haitaton.hanke.allu.ApplicationService
+import fi.hel.haitaton.hanke.application.ApplicationService
 import fi.hel.haitaton.hanke.logging.DisclosureLogService
 import fi.hel.haitaton.hanke.profiili.ProfiiliClient
 import io.sentry.Sentry

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/gdpr/GdprJsonConverter.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/gdpr/GdprJsonConverter.kt
@@ -1,13 +1,13 @@
 package fi.hel.haitaton.hanke.gdpr
 
-import fi.hel.haitaton.hanke.allu.Application
-import fi.hel.haitaton.hanke.allu.ApplicationData
-import fi.hel.haitaton.hanke.allu.CableReportApplicationData
-import fi.hel.haitaton.hanke.allu.Contact
-import fi.hel.haitaton.hanke.allu.Customer
 import fi.hel.haitaton.hanke.allu.CustomerType
-import fi.hel.haitaton.hanke.allu.CustomerWithContacts
-import fi.hel.haitaton.hanke.allu.PostalAddress
+import fi.hel.haitaton.hanke.application.Application
+import fi.hel.haitaton.hanke.application.ApplicationData
+import fi.hel.haitaton.hanke.application.CableReportApplicationData
+import fi.hel.haitaton.hanke.application.Contact
+import fi.hel.haitaton.hanke.application.Customer
+import fi.hel.haitaton.hanke.application.CustomerWithContacts
+import fi.hel.haitaton.hanke.application.PostalAddress
 import fi.hel.haitaton.hanke.domain.Hanke
 import fi.hel.haitaton.hanke.domain.HankeYhteystieto
 import fi.hel.haitaton.hanke.organisaatio.OrganisaatioService
@@ -123,7 +123,10 @@ class GdprJsonConverter(private val organisaatioService: OrganisaatioService) {
     ): List<GdprInfo> {
         return when (applicationData) {
             is CableReportApplicationData ->
-                listOf(applicationData.customerWithContacts, applicationData.contractorWithContacts)
+                listOfNotNull(
+                        applicationData.customerWithContacts,
+                        applicationData.contractorWithContacts
+                    )
                     .flatMap { getGdprInfosFromCustomerWithContacts(it, userInfo) }
         }
     }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/ApplicationLoggingService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/ApplicationLoggingService.kt
@@ -1,6 +1,6 @@
 package fi.hel.haitaton.hanke.logging
 
-import fi.hel.haitaton.hanke.allu.Application
+import fi.hel.haitaton.hanke.application.Application
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/DisclosureLogService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/DisclosureLogService.kt
@@ -1,11 +1,11 @@
 package fi.hel.haitaton.hanke.logging
 
-import fi.hel.haitaton.hanke.allu.Application
-import fi.hel.haitaton.hanke.allu.ApplicationData
-import fi.hel.haitaton.hanke.allu.CableReportApplicationData
-import fi.hel.haitaton.hanke.allu.Contact
-import fi.hel.haitaton.hanke.allu.Customer
 import fi.hel.haitaton.hanke.allu.CustomerType
+import fi.hel.haitaton.hanke.application.Application
+import fi.hel.haitaton.hanke.application.ApplicationData
+import fi.hel.haitaton.hanke.application.CableReportApplicationData
+import fi.hel.haitaton.hanke.application.Contact
+import fi.hel.haitaton.hanke.application.Customer
 import fi.hel.haitaton.hanke.domain.Hanke
 import fi.hel.haitaton.hanke.domain.HankeYhteystieto
 import fi.hel.haitaton.hanke.gdpr.CollectionNode

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/application/AlluUpdateServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/application/AlluUpdateServiceTest.kt
@@ -1,6 +1,8 @@
-package fi.hel.haitaton.hanke.allu
+package fi.hel.haitaton.hanke.application
 
 import assertk.assertThat
+import fi.hel.haitaton.hanke.allu.AlluStatusRepository
+import fi.hel.haitaton.hanke.allu.CableReportService
 import fi.hel.haitaton.hanke.configuration.LockService
 import fi.hel.haitaton.hanke.factory.ApplicationHistoryFactory
 import fi.hel.haitaton.hanke.test.Asserts.isRecent

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/application/ApplicationControllerTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/application/ApplicationControllerTest.kt
@@ -1,4 +1,4 @@
-package fi.hel.haitaton.hanke.allu
+package fi.hel.haitaton.hanke.application
 
 import fi.hel.haitaton.hanke.factory.AlluDataFactory
 import fi.hel.haitaton.hanke.logging.DisclosureLogService

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/AlluDataFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/AlluDataFactory.kt
@@ -1,17 +1,18 @@
 package fi.hel.haitaton.hanke.factory
 
-import fi.hel.haitaton.hanke.allu.Application
-import fi.hel.haitaton.hanke.allu.ApplicationEntity
-import fi.hel.haitaton.hanke.allu.ApplicationRepository
 import fi.hel.haitaton.hanke.allu.ApplicationStatus
-import fi.hel.haitaton.hanke.allu.ApplicationType
-import fi.hel.haitaton.hanke.allu.CableReportApplicationData
-import fi.hel.haitaton.hanke.allu.Contact
-import fi.hel.haitaton.hanke.allu.Customer
 import fi.hel.haitaton.hanke.allu.CustomerType
-import fi.hel.haitaton.hanke.allu.CustomerWithContacts
-import fi.hel.haitaton.hanke.allu.PostalAddress
-import fi.hel.haitaton.hanke.allu.StreetAddress
+import fi.hel.haitaton.hanke.application.Application
+import fi.hel.haitaton.hanke.application.ApplicationData
+import fi.hel.haitaton.hanke.application.ApplicationEntity
+import fi.hel.haitaton.hanke.application.ApplicationRepository
+import fi.hel.haitaton.hanke.application.ApplicationType
+import fi.hel.haitaton.hanke.application.CableReportApplicationData
+import fi.hel.haitaton.hanke.application.Contact
+import fi.hel.haitaton.hanke.application.Customer
+import fi.hel.haitaton.hanke.application.CustomerWithContacts
+import fi.hel.haitaton.hanke.application.PostalAddress
+import fi.hel.haitaton.hanke.application.StreetAddress
 import java.time.ZonedDateTime
 import org.geojson.GeometryCollection
 import org.springframework.stereotype.Component
@@ -29,7 +30,7 @@ class AlluDataFactory(val applicationRepository: ApplicationRepository) {
         ) = PostalAddress(streetAddress, postalCode, city)
 
         fun createPersonCustomer(
-            type: CustomerType = CustomerType.PERSON,
+            type: CustomerType? = CustomerType.PERSON,
             name: String = "Teppo Testihenkilö",
             country: String = "FI",
             postalAddress: PostalAddress? = createPostalAddress(),
@@ -54,7 +55,7 @@ class AlluDataFactory(val applicationRepository: ApplicationRepository) {
             )
 
         fun createCompanyCustomer(
-            type: CustomerType = CustomerType.COMPANY,
+            type: CustomerType? = CustomerType.COMPANY,
             name: String = "DNA",
             country: String = "FI",
             postalAddress: PostalAddress? = createPostalAddress(),
@@ -90,8 +91,8 @@ class AlluDataFactory(val applicationRepository: ApplicationRepository) {
             customerWithContacts: CustomerWithContacts =
                 CustomerWithContacts(createCompanyCustomer(), listOf(createContact())),
             geometry: GeometryCollection = GeometryCollection(),
-            startTime: ZonedDateTime = DateFactory.getStartDatetime(),
-            endTime: ZonedDateTime = DateFactory.getEndDatetime(),
+            startTime: ZonedDateTime? = DateFactory.getStartDatetime(),
+            endTime: ZonedDateTime? = DateFactory.getEndDatetime(),
             pendingOnClient: Boolean = false,
             identificationNumber: String = "identification",
             clientApplicationKind: String = "applicationKind",
@@ -163,7 +164,7 @@ class AlluDataFactory(val applicationRepository: ApplicationRepository) {
             applicationIdentifier: String? = null,
             userId: String? = null,
             applicationType: ApplicationType = ApplicationType.CABLE_REPORT,
-            applicationData: CableReportApplicationData = createCableReportApplicationData(),
+            applicationData: ApplicationData = createCableReportApplicationData(),
         ): ApplicationEntity =
             ApplicationEntity(
                 id,

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/AuditLogEntryFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/AuditLogEntryFactory.kt
@@ -1,7 +1,7 @@
 package fi.hel.haitaton.hanke.factory
 
-import fi.hel.haitaton.hanke.allu.Contact
-import fi.hel.haitaton.hanke.allu.Customer
+import fi.hel.haitaton.hanke.application.Contact
+import fi.hel.haitaton.hanke.application.Customer
 import fi.hel.haitaton.hanke.domain.Hanke
 import fi.hel.haitaton.hanke.logging.AuditLogEntry
 import fi.hel.haitaton.hanke.logging.ObjectType

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/gdpr/GdprJsonConverterTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/gdpr/GdprJsonConverterTest.kt
@@ -6,9 +6,9 @@ import assertk.assertions.containsExactlyInAnyOrder
 import assertk.assertions.each
 import assertk.assertions.isEmpty
 import assertk.assertions.isEqualTo
-import fi.hel.haitaton.hanke.allu.CableReportApplicationData
 import fi.hel.haitaton.hanke.allu.CustomerType
-import fi.hel.haitaton.hanke.allu.CustomerWithContacts
+import fi.hel.haitaton.hanke.application.CableReportApplicationData
+import fi.hel.haitaton.hanke.application.CustomerWithContacts
 import fi.hel.haitaton.hanke.asJsonResource
 import fi.hel.haitaton.hanke.factory.AlluDataFactory
 import fi.hel.haitaton.hanke.factory.HankeFactory

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/logging/DisclosureLogServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/logging/DisclosureLogServiceTest.kt
@@ -1,11 +1,11 @@
 package fi.hel.haitaton.hanke.logging
 
-import fi.hel.haitaton.hanke.allu.Contact
-import fi.hel.haitaton.hanke.allu.Customer
 import fi.hel.haitaton.hanke.allu.CustomerType
-import fi.hel.haitaton.hanke.allu.CustomerWithContacts
-import fi.hel.haitaton.hanke.allu.PostalAddress
-import fi.hel.haitaton.hanke.allu.StreetAddress
+import fi.hel.haitaton.hanke.application.Contact
+import fi.hel.haitaton.hanke.application.Customer
+import fi.hel.haitaton.hanke.application.CustomerWithContacts
+import fi.hel.haitaton.hanke.application.PostalAddress
+import fi.hel.haitaton.hanke.application.StreetAddress
 import fi.hel.haitaton.hanke.factory.AlluDataFactory
 import fi.hel.haitaton.hanke.factory.AuditLogEntryFactory
 import fi.hel.haitaton.hanke.factory.HankeFactory


### PR DESCRIPTION
# Description

Split the representation for application data we use internally within Haitaton from the one we use to communicate with Allu. So far they've been the same, but we need to support hakemusalueet internally, which Allu doesn't support.

1. Split the purely Allu-related classes to their own package, move the rest to application-package.
2. Copy the Application Data and it's child classes to the application package.
3. Rename the Allu-version of ApplicationData as AlluApplicationData.
3. Remove unnecessary fields and methods from the classes in allu-package.

While doing that, change customer type and start / end dates to be optional internally. Add some simple validation while converting the values to Allu classes.

As a slightly unrelated change, stop updating an application in database if it should be sent to Allu, but sending it failed.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1397

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [X] Other

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 