### PR TITLE
HAI-1444 Fix public hanke list

### DIFF
--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/PublicHankeController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/PublicHankeController.kt
@@ -1,0 +1,22 @@
+package fi.hel.haitaton.hanke
+
+import fi.hel.haitaton.hanke.domain.PublicHanke
+import fi.hel.haitaton.hanke.domain.hankeToPublic
+import fi.hel.haitaton.hanke.validation.CompleteHankeValidator
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/public-hankkeet")
+class PublicHankeController(
+    @Autowired private val hankeService: HankeService,
+) {
+    @GetMapping
+    fun getAll(): List<PublicHanke> {
+        val hankkeet =
+            hankeService.loadAllHanke().filter { CompleteHankeValidator.isHankeComplete(it) }
+        return hankkeet.map { hankeToPublic(it) }
+    }
+}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/PublicHanke.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/PublicHanke.kt
@@ -1,7 +1,6 @@
 package fi.hel.haitaton.hanke.domain
 
 import fi.hel.haitaton.hanke.Haitta13
-import fi.hel.haitaton.hanke.HankeService
 import fi.hel.haitaton.hanke.KaistajarjestelynPituus
 import fi.hel.haitaton.hanke.SuunnitteluVaihe
 import fi.hel.haitaton.hanke.TodennakoinenHaittaPaaAjoRatojenKaistajarjestelyihin
@@ -12,10 +11,6 @@ import fi.hel.haitaton.hanke.tormaystarkastelu.LiikennehaittaIndeksiType
 import fi.hel.haitaton.hanke.tormaystarkastelu.TormaystarkasteluTulos
 import java.time.ZonedDateTime
 import org.geojson.FeatureCollection
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
 
 data class PublicHankeYhteystieto(
     val organisaatioId: Int?,
@@ -114,17 +109,4 @@ fun hankeToPublic(hanke: Hanke): PublicHanke {
         omistajat,
         alueet,
     )
-}
-
-@RestController
-@RequestMapping("/public-hankkeet")
-class PublicHankeController(
-    @Autowired private val hankeService: HankeService,
-) {
-
-    @GetMapping
-    fun getAll(): List<PublicHanke> {
-        val hankkeet = hankeService.loadAllHanke().filter { it.tormaystarkasteluTulos != null }
-        return hankkeet.map { hankeToPublic(it) }
-    }
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/validation/CompleteHankeValidator.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/validation/CompleteHankeValidator.kt
@@ -1,0 +1,58 @@
+package fi.hel.haitaton.hanke.validation
+
+import fi.hel.haitaton.hanke.Vaihe
+import fi.hel.haitaton.hanke.domain.Hanke
+import fi.hel.haitaton.hanke.domain.HankeYhteystieto
+import fi.hel.haitaton.hanke.domain.Hankealue
+
+/**
+ * Methods for checking whether a hanke is complete or a draft. A hanke is considered complete if
+ * all mandatory fields are filled.
+ */
+object CompleteHankeValidator {
+
+    fun isHankeComplete(hanke: Hanke): Boolean = !isHankeDraft(hanke)
+
+    private fun isHankeDraft(hanke: Hanke): Boolean {
+        return hanke.nimi.isNullOrBlank() ||
+            hanke.kuvaus.isNullOrBlank() ||
+            hanke.tyomaaKatuosoite.isNullOrBlank() ||
+            hanke.vaihe == null ||
+            (hanke.vaihe == Vaihe.SUUNNITTELU && hanke.suunnitteluVaihe == null) ||
+            hanke.alueet.size == 0 ||
+            hanke.alueet.any { incompleteAlue(it) } ||
+            hanke.omistajat.size == 0 ||
+            hanke.omistajat.any { incompleteYhteystieto(it) } ||
+            hanke.arvioijat.any { incompleteYhteystieto(it) } ||
+            hanke.toteuttajat.any { incompleteYhteystieto(it) } ||
+            hanke.tormaystarkasteluTulos == null
+    }
+
+    private fun incompleteAlue(alue: Hankealue): Boolean {
+        return alue.haittaAlkuPvm == null ||
+            alue.haittaLoppuPvm == null ||
+            alue.meluHaitta == null ||
+            alue.polyHaitta == null ||
+            alue.tarinaHaitta == null ||
+            alue.kaistaHaitta == null ||
+            alue.kaistaPituusHaitta == null ||
+            alue.geometriat?.featureCollection?.features?.isEmpty() != false
+    }
+
+    /**
+     * Mandatory fields after Yhteystiedot have been redone:
+     * - Tyyppi
+     * - Nimi
+     * - Y-tunnus tai henkilötunnus
+     * - Email
+     *
+     * For cantacs the mandatory fields are:
+     * - Nimi
+     * - Email
+     */
+    private fun incompleteYhteystieto(yhteystieto: HankeYhteystieto): Boolean {
+        return yhteystieto.etunimi.isBlank() ||
+            yhteystieto.sukunimi.isBlank() ||
+            yhteystieto.email.isBlank()
+    }
+}

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/TestExtensions.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/TestExtensions.kt
@@ -36,3 +36,10 @@ fun AuditLogRepository.findByType(type: ObjectType) =
     this.findAll().filter { it.message.auditEvent.target.type == type }
 
 fun OffsetDateTime.asUtc(): OffsetDateTime = this.withOffsetSameInstant(ZoneOffset.UTC)
+
+/**
+ * "Uses" a variable without doing anything with it. Used to avoid "Parameter is never used"
+ * warnings when compiling. Especially useful for ParameterizedTests if there are parameters meant
+ * to be used in the name of the test.
+ */
+fun Any?.touch() = Unit

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeFactory.kt
@@ -8,6 +8,7 @@ import fi.hel.haitaton.hanke.Vaihe
 import fi.hel.haitaton.hanke.domain.Hanke
 import fi.hel.haitaton.hanke.domain.HankeYhteystieto
 import fi.hel.haitaton.hanke.domain.Hankealue
+import fi.hel.haitaton.hanke.tormaystarkastelu.TormaystarkasteluTulos
 import java.time.ZonedDateTime
 
 object HankeFactory : Factory<Hanke>() {
@@ -80,6 +81,16 @@ object HankeFactory : Factory<Hanke>() {
 
         this.alueet.add(alue)
 
+        return this
+    }
+
+    fun Hanke.withTormaystarkasteluTulos(
+        perusIndeksi: Float = 1f,
+        pyorailyIndeksi: Float = 1f,
+        joukkoliikenneIndeksi: Float = 1f,
+    ): Hanke {
+        this.tormaystarkasteluTulos =
+            TormaystarkasteluTulos(perusIndeksi, pyorailyIndeksi, joukkoliikenneIndeksi)
         return this
     }
 

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/validation/CompleteHankeValidatorTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/validation/CompleteHankeValidatorTest.kt
@@ -1,0 +1,204 @@
+package fi.hel.haitaton.hanke.validation
+
+import fi.hel.haitaton.hanke.Vaihe
+import fi.hel.haitaton.hanke.domain.Hanke
+import fi.hel.haitaton.hanke.factory.HankeFactory
+import fi.hel.haitaton.hanke.factory.HankeFactory.withHankealue
+import fi.hel.haitaton.hanke.factory.HankeFactory.withTormaystarkasteluTulos
+import fi.hel.haitaton.hanke.factory.HankeFactory.withYhteystiedot
+import fi.hel.haitaton.hanke.touch
+import java.util.stream.Stream
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+internal class CompleteHankeValidatorTest {
+    private fun completeHanke() =
+        HankeFactory.create().withHankealue().withYhteystiedot().withTormaystarkasteluTulos()
+
+    @Test
+    fun `true when hanke has all mandatory fields`() {
+        assertTrue(CompleteHankeValidator.isHankeComplete(completeHanke()))
+    }
+
+    @Test
+    fun `true when arvioijat missing`() {
+        assertTrue(
+            CompleteHankeValidator.isHankeComplete(
+                completeHanke().apply { arvioijat = mutableListOf() }
+            )
+        )
+    }
+
+    @Test
+    fun `true when toteuttajat missing`() {
+        assertTrue(
+            CompleteHankeValidator.isHankeComplete(
+                completeHanke().apply { toteuttajat = mutableListOf() }
+            )
+        )
+    }
+
+    @ParameterizedTest(name = "false when {0}")
+    @MethodSource("draftHankkeet")
+    fun `false when hanke is missing a mandatory field`(case: String, hanke: Hanke) {
+        case.touch()
+        assertFalse(CompleteHankeValidator.isHankeComplete(hanke))
+    }
+
+    private fun draftHankkeet(): Stream<Arguments> =
+        Stream.of(
+            Arguments.of("nimi missing", completeHanke().apply { nimi = null }),
+            Arguments.of("nimi empty", completeHanke().apply { nimi = "" }),
+            Arguments.of("nimi blank", completeHanke().apply { nimi = "   \t\n\t   " }),
+            Arguments.of("kuvaus missing", completeHanke().apply { kuvaus = null }),
+            Arguments.of("kuvaus empty", completeHanke().apply { kuvaus = "" }),
+            Arguments.of("kuvaus blank", completeHanke().apply { kuvaus = "   \t\n\t   " }),
+            Arguments.of(
+                "tyomaaKatuosoite missing",
+                completeHanke().apply { tyomaaKatuosoite = null }
+            ),
+            Arguments.of("tyomaaKatuosoite empty", completeHanke().apply { tyomaaKatuosoite = "" }),
+            Arguments.of(
+                "tyomaaKatuosoite blank",
+                completeHanke().apply { tyomaaKatuosoite = "   \t\n\t   " }
+            ),
+            Arguments.of("vaihe missing", completeHanke().apply { vaihe = null }),
+            Arguments.of(
+                "suunnitteluVaihe missing",
+                completeHanke().apply {
+                    vaihe = Vaihe.SUUNNITTELU
+                    suunnitteluVaihe = null
+                }
+            ),
+            Arguments.of("alueet empty", completeHanke().apply { alueet = mutableListOf() }),
+            Arguments.of(
+                "alueet.haittaAlkuPvm missing",
+                completeHanke().apply { alueet[0].haittaAlkuPvm = null }
+            ),
+            Arguments.of(
+                "alueet.haittaLoppuPvm missing",
+                completeHanke().apply { alueet[0].haittaLoppuPvm = null }
+            ),
+            Arguments.of(
+                "alueet.meluHaitta missing",
+                completeHanke().apply { alueet[0].meluHaitta = null }
+            ),
+            Arguments.of(
+                "alueet.polyHaitta missing",
+                completeHanke().apply { alueet[0].polyHaitta = null }
+            ),
+            Arguments.of(
+                "alueet.tarinaHaitta missing",
+                completeHanke().apply { alueet[0].tarinaHaitta = null }
+            ),
+            Arguments.of(
+                "alueet.kaistaHaitta missing",
+                completeHanke().apply { alueet[0].kaistaHaitta = null }
+            ),
+            Arguments.of(
+                "alueet.kaistaPituusHaitta missing",
+                completeHanke().apply { alueet[0].kaistaPituusHaitta = null }
+            ),
+            Arguments.of(
+                "alueet.geometriat missing",
+                completeHanke().apply { alueet[0].geometriat = null }
+            ),
+            Arguments.of(
+                "alueet.geometriat.featureCollection missing",
+                completeHanke().apply { alueet[0].geometriat!!.featureCollection = null }
+            ),
+            Arguments.of(
+                "alueet.geometriat.featureCollection.features missing",
+                completeHanke().apply { alueet[0].geometriat!!.featureCollection!!.features = null }
+            ),
+            Arguments.of(
+                "alueet.geometriat.featureCollection.features empty",
+                completeHanke().apply {
+                    alueet[0].geometriat!!.featureCollection!!.features = listOf()
+                }
+            ),
+            Arguments.of("omistajat empty", completeHanke().apply { omistajat = mutableListOf() }),
+            Arguments.of(
+                "omistajat.etunimi empty",
+                completeHanke().apply { omistajat[0].etunimi = "" }
+            ),
+            Arguments.of(
+                "omistajat.etunimi blank",
+                completeHanke().apply { omistajat[0].etunimi = "   \t\n\t   " }
+            ),
+            Arguments.of(
+                "omistajat.sukunimi empty",
+                completeHanke().apply { omistajat[0].sukunimi = "" }
+            ),
+            Arguments.of(
+                "omistajat.sukunimi blank",
+                completeHanke().apply { omistajat[0].sukunimi = "   \t\n\t   " }
+            ),
+            Arguments.of(
+                "omistajat.email empty",
+                completeHanke().apply { omistajat[0].email = "" }
+            ),
+            Arguments.of(
+                "omistajat.email blank",
+                completeHanke().apply { omistajat[0].email = "   \t\n\t   " }
+            ),
+            Arguments.of(
+                "arvioijat.etunimi empty",
+                completeHanke().apply { arvioijat[0].etunimi = "" }
+            ),
+            Arguments.of(
+                "arvioijat.etunimi blank",
+                completeHanke().apply { arvioijat[0].etunimi = "   \t\n\t   " }
+            ),
+            Arguments.of(
+                "arvioijat.sukunimi empty",
+                completeHanke().apply { arvioijat[0].sukunimi = "" }
+            ),
+            Arguments.of(
+                "arvioijat.sukunimi blank",
+                completeHanke().apply { arvioijat[0].sukunimi = "   \t\n\t   " }
+            ),
+            Arguments.of(
+                "arvioijat.email empty",
+                completeHanke().apply { arvioijat[0].email = "" }
+            ),
+            Arguments.of(
+                "arvioijat.email blank",
+                completeHanke().apply { arvioijat[0].email = "   \t\n\t   " }
+            ),
+            Arguments.of(
+                "toteuttajat.etunimi empty",
+                completeHanke().apply { toteuttajat[0].etunimi = "" }
+            ),
+            Arguments.of(
+                "toteuttajat.etunimi blank",
+                completeHanke().apply { toteuttajat[0].etunimi = "   \t\n\t   " }
+            ),
+            Arguments.of(
+                "toteuttajat.sukunimi empty",
+                completeHanke().apply { toteuttajat[0].sukunimi = "" }
+            ),
+            Arguments.of(
+                "toteuttajat.sukunimi blank",
+                completeHanke().apply { toteuttajat[0].sukunimi = "   \t\n\t   " }
+            ),
+            Arguments.of(
+                "toteuttajat.email empty",
+                completeHanke().apply { toteuttajat[0].email = "" }
+            ),
+            Arguments.of(
+                "toteuttajat.email blank",
+                completeHanke().apply { toteuttajat[0].email = "   \t\n\t   " }
+            ),
+            Arguments.of(
+                "tormaystarkasteluTulos missing",
+                completeHanke().apply { tormaystarkasteluTulos = null }
+            ),
+        )
+}


### PR DESCRIPTION
# Description

The public hanke list has been failing when some hanke didn't have a starting date, but had a tormaystarkastustulos. A hanke was deemed public when it had a tormaystarkastustulos, even though it might not have other mandatory fields. This was against the spec.

Implement proper checks if a hanke is a draft. I.e. check individually that all mandatory fields are present and non-empty.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1444

## Type of change

- [X] Bug fix 
- [ ] New feature 
- [ ] Other

# Instructions for testing
Please describe tests how this change or new feature can be tested.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 