### PR TITLE
HAI-1376 Prevent orphaned geometriat

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/geometria/GeometriatDaoImplITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/geometria/GeometriatDaoImplITest.kt
@@ -3,7 +3,7 @@ package fi.hel.haitaton.hanke.geometria
 import assertk.assertAll
 import assertk.assertThat
 import assertk.assertions.isEqualTo
-import assertk.assertions.isNotNull
+import assertk.assertions.isNull
 import fi.hel.haitaton.hanke.DatabaseTest
 import fi.hel.haitaton.hanke.asJsonResource
 import java.time.ZonedDateTime
@@ -80,13 +80,13 @@ internal class GeometriatDaoImplITest : DatabaseTest() {
         // Delete
         geometriatDao.deleteGeometriat(geometriat)
         // check that all was deleted correctly
-        assertThat(geometriatDao.retrieveGeometriat(geometriaId)).isNotNull()
-        assertThat(getGeometriaCount()).isEqualTo(1)
+        assertThat(geometriatDao.retrieveGeometriat(geometriaId)).isNull()
+        assertThat(getGeometriaCount()).isEqualTo(0)
         assertThat(getHankeGeometriaCount()).isEqualTo(0)
     }
 
     private fun getGeometriaCount(): Int? =
-        jdbcTemplate.queryForObject("SELECT COUNT(*) FROM geometriat") { rs, _ -> rs.getInt(1) }
+        jdbcTemplate.queryForObject("SELECT COUNT(*) FROM geometriat", Int::class.java)
     private fun getHankeGeometriaCount(): Int? =
-        jdbcTemplate.queryForObject("SELECT COUNT(*) FROM HankeGeometria") { rs, _ -> rs.getInt(1) }
+        jdbcTemplate.queryForObject("SELECT COUNT(*) FROM HankeGeometria", Int::class.java)
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/geometria/GeometriatDaoImpl.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/geometria/GeometriatDaoImpl.kt
@@ -89,6 +89,12 @@ class GeometriatDaoImpl(private val jdbcOperations: JdbcOperations) : Geometriat
             }
         }
 
+        private fun deleteGeometriat(geometriat: Geometriat, jdbcOperations: JdbcOperations) {
+            jdbcOperations.update("DELETE FROM Geometriat WHERE id = ?") { ps ->
+                ps.setInt(1, geometriat.id!!)
+            }
+        }
+
         private fun deleteHankeGeometriaRows(
             geometriat: Geometriat,
             jdbcOperations: JdbcOperations,
@@ -238,10 +244,8 @@ class GeometriatDaoImpl(private val jdbcOperations: JdbcOperations) : Geometriat
 
     override fun deleteGeometriat(geometriat: Geometriat) {
         with(jdbcOperations) {
-            // update master row
-            updateGeometriat(geometriat, this)
-            // delete old geometry rows
-            deleteHankeGeometriaRows(geometriat, this)
+            // delete master row, hankegeometria rows are removed with cascading
+            deleteGeometriat(geometriat, this)
         }
     }
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/geometria/GeometriatServiceImpl.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/geometria/GeometriatServiceImpl.kt
@@ -20,13 +20,11 @@ open class GeometriatServiceImpl(private val hankeGeometriaDao: GeometriatDao) :
             if (geometriat.id != null) hankeGeometriaDao.retrieveGeometriat(geometriat.id!!)
             else null
         val hasFeatures = geometriat.hasFeatures()
-        if (oldGeometriat == null && !hasFeatures) {
-            throw IllegalArgumentException("New Geometriat does not contain any Features")
-        }
-
         val username = SecurityContextHolder.getContext().authentication.name
 
         return when {
+            oldGeometriat == null && !hasFeatures ->
+                throw IllegalArgumentException("New Geometriat does not contain any Features")
             !hasFeatures -> {
                 // DELETE
                 geometriat.id = oldGeometriat!!.id

--- a/services/hanke-service/src/main/resources/db/changelog/changesets/022-add-trigger-for-removing-orphaned-geometriat.sql
+++ b/services/hanke-service/src/main/resources/db/changelog/changesets/022-add-trigger-for-removing-orphaned-geometriat.sql
@@ -1,0 +1,21 @@
+--liquibase formatted sql
+--changeset Topias Heinonen:022-add-trigger-for-removing-orphaned-geometriat
+--comment: Add trigger for deleting orphaned geometriat after deleting a hankealue
+
+CREATE FUNCTION clean_geometriat_after_delete()
+    RETURNS TRIGGER
+    LANGUAGE PLPGSQL
+AS '
+BEGIN
+    IF OLD.geometriat IS NOT NULL THEN
+        DELETE FROM geometriat WHERE id = OLD.geometriat;
+    END IF;
+    RETURN OLD;
+END;
+';
+
+CREATE TRIGGER after_alue_delete
+    AFTER DELETE
+    ON hankealue
+    FOR EACH ROW
+EXECUTE FUNCTION clean_geometriat_after_delete();

--- a/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -71,3 +71,5 @@ databaseChangeLog:
       file: db/changelog/changesets/020-create-lock-table.yml
   - include:
       file: db/changelog/changesets/021-add-status-and-remove-savetype-in-hanke.yml
+  - include:
+      file: db/changelog/changesets/022-add-trigger-for-removing-orphaned-geometriat.sql


### PR DESCRIPTION
# Description

Add a database trigger to delete geometriat of deleted hankealue. This ensures there are no orphaned geometriat left behind after a hankealue is removed.

I tried other ways of tackling this, but they proved ineffective or very complex. The removal of hankealueet is more implicit than explicit, leveraging JPA's orphan removal. The geometriat is not an JPA entity, however, so the orphan removal doesn't reach them.

One of these abandoned ways was changing how geometries are deleted in GeometriatDao(Impl). Deleting is changed to actually delete the geometriat-table row when asked to. It used to make sense to always have a geometria for a hanke, but with the introduction of hankealueet, this no longer feels like the case.

There's also some small refactoring. These were done for abandoned approaches, but seemed useful overall.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1376

## Type of change

- [X] Bug fix 
- [ ] New feature 
- [ ] Other

# Instructions for testing
Previously, if you added two hankealue to a hanke and removed one, an orphaned row would remain in geometriat-table. This should be fixed now.
1. Create a hanke.
2. Add two hankealue.
3. Change page so they are saved.
4. Check the number of geometriat in DB: `select count(*) from geometriat ;`, note the count.
5. In the UI, remove one hankealue.
6. Check the number of geometriat in DB: `select count(*) from geometriat ;`, should be one less than before.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 
