### PR TITLE
HAI-1347 Rewrite getting current application status

### DIFF
--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/CableReportService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/CableReportService.kt
@@ -4,12 +4,6 @@ import java.time.ZonedDateTime
 
 interface CableReportService {
 
-    fun getCurrentStatus(applicationId: Int): ApplicationStatus?
-    fun getApplicationStatusEvents(
-        applicationId: Int,
-        eventsAfter: ZonedDateTime
-    ): List<ApplicationStatusEvent>
-
     fun getApplicationStatusHistories(
         applicationIds: List<Int>,
         eventsAfter: ZonedDateTime

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationService.kt
@@ -181,14 +181,10 @@ open class ApplicationService(
 
     private fun isStillPending(application: ApplicationEntity): Boolean {
         // If there's no alluid then we haven't successfully sent this to ALLU yet (at all)
-        val id = application.alluid ?: return true
+        val alluid = application.alluid ?: return true
 
-        // If we already have an id but there's no status available then the application is still
-        // pendingOnClient because ALLU doesn't report status events for applications that are in
-        // the "meta state" pendingOnClient
-        val currentStatus = cableReportService.getCurrentStatus(id) ?: return true
+        val currentStatus = cableReportService.getApplicationInformation(alluid).status
 
-        // We've already sent this application with pendingOnClient: false
         return currentStatus in listOf(ApplicationStatus.PENDING, ApplicationStatus.PENDING_CLIENT)
     }
 

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceTest.kt
@@ -134,19 +134,20 @@ class ApplicationServiceTest {
         every { applicationRepo.findOneByIdAndUserId(3, username) } returns applicationEntity
         every { applicationRepo.save(applicationEntity) } returns applicationEntity
         justRun { cableReportService.update(42, any()) }
-        every { cableReportService.getCurrentStatus(42) } returns null
+        every { cableReportService.getApplicationInformation(42) } returns
+            AlluDataFactory.createAlluApplicationResponse(42)
         every { geometriatDao.validateGeometria(any()) } returns null
 
         service.updateApplicationData(3, applicationData, username)
 
-        verify {
-            disclosureLogService.saveDisclosureLogsForAllu(applicationData, Status.SUCCESS)
+        verifyOrder {
             applicationRepo.findOneByIdAndUserId(3, username)
-            applicationRepo.save(applicationEntity)
-            cableReportService.update(42, any())
-            cableReportService.getCurrentStatus(42)
-            applicationLoggingService.logUpdate(any(), any(), username)
             geometriatDao.validateGeometria(any())
+            cableReportService.getApplicationInformation(42)
+            cableReportService.update(42, any())
+            disclosureLogService.saveDisclosureLogsForAllu(applicationData, Status.SUCCESS)
+            applicationRepo.save(applicationEntity)
+            applicationLoggingService.logUpdate(any(), any(), username)
         }
     }
 
@@ -194,7 +195,7 @@ class ApplicationServiceTest {
         every { applicationRepo.save(any()) } answers { firstArg() }
         every { cableReportService.create(any()) } returns 42
         every { cableReportService.getApplicationInformation(42) } returns
-            AlluDataFactory.createAlluApplication(42)
+            AlluDataFactory.createAlluApplicationResponse(42)
 
         service.sendApplication(3, username)
 

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/AlluDataFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/AlluDataFactory.kt
@@ -178,7 +178,7 @@ class AlluDataFactory(val applicationRepository: ApplicationRepository) {
                 applicationData,
             )
 
-        fun createAlluApplication(
+        fun createAlluApplicationResponse(
             id: Int = 42,
             status: ApplicationStatus = ApplicationStatus.PENDING
         ) =


### PR DESCRIPTION
# Description

We need to get the current application status from Allu to know if we can still update an application. Previously, this has been done using the application history query. This has problems, though. It requests more information than we need, since it gets the complete history from Allu. Also, there's a need to deduce the current status from the list of histories. And, perhaps most importantly, the history doesn't return anything after the application has been added for the first time. It only starts returning results after the application has been updated.

Replace the history query with the get application data query. This only returns the current status of the application and it returns the status for all applications, whether or not they've been updated.

This seems like both more efficient and more reliable.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1347

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [X] Other

# Instructions for testing
Sending and updating applications still work.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 

# Other relevant info
First merge #257 and this on top of that.