### PR TITLE
HAI-1464 Add rock excavation to application data

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceITest.kt
@@ -941,6 +941,7 @@ class ApplicationServiceITest : DatabaseTest() {
                 "identificationNumber": "identification",
                 "clientApplicationKind": "applicationKind",
                 "workDescription": "Work description.",
+                "rockExcavation": false,
                 "contractorWithContacts": {
                   $customerWithContactsJson
                 },

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationData.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationData.kt
@@ -48,6 +48,7 @@ data class CableReportApplicationData(
     val clientApplicationKind: String,
     val workDescription: String,
     val contractorWithContacts: CustomerWithContacts, // työn suorittaja
+    val rockExcavation: Boolean?,
 
     // Common, not required
     val postalAddress: PostalAddress? = null,
@@ -67,6 +68,11 @@ data class CableReportApplicationData(
         copy(applicationType = applicationType, pendingOnClient = pendingOnClient)
 
     override fun toAlluData(): AlluCableReportApplicationData {
+        val rockExcavation =
+            rockExcavation
+                ?: throw AlluDataException("applicationData.rockExcavation", "Can't be null")
+        val workDescription =
+            workDescription + if (rockExcavation) "\nLouhitaan" else "\nEi louhita"
         return AlluCableReportApplicationData(
             name,
             customerWithContacts.toAlluData("applicationData.customerWithContacts"),

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/AlluDataFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/AlluDataFactory.kt
@@ -113,7 +113,8 @@ class AlluDataFactory(val applicationRepository: ApplicationRepository) {
                 identificationNumber,
                 clientApplicationKind,
                 workDescription,
-                contractorWithContacts
+                contractorWithContacts,
+                false
             )
 
         fun createApplication(

--- a/services/hanke-service/src/test/resources/fi/hel/haitaton/hanke/application/applicationData.json
+++ b/services/hanke-service/src/test/resources/fi/hel/haitaton/hanke/application/applicationData.json
@@ -47,6 +47,7 @@
   "maintenanceWork": true,
   "pendingOnClient": true,
   "workDescription": "Testihakemuksen kuvaus.",
+  "rockExcavation": false,
   "constructionWork": true,
   "customerReference": null,
   "invoicingCustomer": null,


### PR DESCRIPTION
# Description

Add a field for rock excavation to application data.

If it's set, a row of text is added to the work description of the application: Either 'Louhitaan' or 'Ei louhita'.

If it's not set, it will prevent the application from being sent as it's considere incomplete.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1464

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
Please describe tests how this change or new feature can be tested.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 

# Other relevant info
First merge #260 and then this one.