### PR TITLE
HAI-1470 Update applications only if changed

### DIFF
--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationController.kt
@@ -73,7 +73,7 @@ class ApplicationController(
     @Operation(
         summary = "Create a new application",
         description =
-            "Creates a new application. The new application is created as a draft, " +
+            "Returns the created application. The new application is created as a draft, " +
                 "i.e. with true in pendingOnClient. The draft is not sent to Allu."
     )
     @ApiResponses(
@@ -98,12 +98,13 @@ class ApplicationController(
     @Operation(
         summary = "Update an application",
         description =
-            "Updates an application. The application can be updated until it has started " +
-                "processing on Allu, i.e. it's still pending. If the application has been " +
-                "sent to Allu, it will be updated there as well. If an Allu-update is " +
-                "required, but it fails, the local version will not be updated. The " +
-                "pendingOnClient value can't be changed with this endpoint. Use POST " +
-                "/hakemukset/{id}/send-application for that."
+            """Returns the updated application.
+               The application can be updated until it has started processing in Allu, i.e. it's still pending.
+               If the application hasn't changed since the last update, nothing more is done.
+               If the application has been sent to Allu, it will be updated there as well.
+               If an Allu-update is required, but it fails, the local version will not be updated.
+               The pendingOnClient value can't be changed with this endpoint. Use POST /hakemukset/{id}/send-application for that.
+            """
     )
     @ApiResponses(
         value =
@@ -174,10 +175,12 @@ class ApplicationController(
     @Operation(
         summary = "Send an application to Allu",
         description =
-            "Sends an application to Allu. Sets the pendingOnClient value of the application to false. " +
-                "This means the application is no longer a draft. A clerk at Allu can start " +
-                "processing the application after this call. The application can still be updated " +
-                "after this call, up until a clerk has started to process the application."
+            """Returns the application with updated status fields.
+               Sets the pendingOnClient value of the application to false. This means the application is no longer a draft.
+               A clerk at Allu can start processing the application after this call.
+               The application can still be updated after this call, up until a clerk has started to process the application.
+               Updating should be done with the update endpoint, calling this endpoint multiple times does nothing.
+            """
     )
     @ApiResponses(
         value =

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceTest.kt
@@ -137,15 +137,16 @@ class ApplicationServiceTest {
         every { cableReportService.getApplicationInformation(42) } returns
             AlluDataFactory.createAlluApplicationResponse(42)
         every { geometriatDao.validateGeometria(any()) } returns null
+        val updatedData = applicationData.copy(rockExcavation = !applicationData.rockExcavation!!)
 
-        service.updateApplicationData(3, applicationData, username)
+        service.updateApplicationData(3, updatedData, username)
 
         verifyOrder {
             applicationRepo.findOneByIdAndUserId(3, username)
             geometriatDao.validateGeometria(any())
             cableReportService.getApplicationInformation(42)
             cableReportService.update(42, any())
-            disclosureLogService.saveDisclosureLogsForAllu(applicationData, Status.SUCCESS)
+            disclosureLogService.saveDisclosureLogsForAllu(updatedData, Status.SUCCESS)
             applicationRepo.save(applicationEntity)
             applicationLoggingService.logUpdate(any(), any(), username)
         }
@@ -166,10 +167,11 @@ class ApplicationServiceTest {
                 "Self-intersection",
                 """{"type":"Point","coordinates":[25494009.65639264,6679886.142116806]}"""
             )
+        val updatedData = applicationData.copy(rockExcavation = !applicationData.rockExcavation!!)
 
         val exception =
             assertThrows<ApplicationGeometryException> {
-                service.updateApplicationData(3, applicationData, username)
+                service.updateApplicationData(3, updatedData, username)
             }
 
         assertThat(exception)


### PR DESCRIPTION
# Description

Add check to application update to see if it has actually changed. Do the related actions like updating Allu only when updating.

Only send applications if they are drafts. After the first time it's been marked as non-draft, the sending endpoint doesn't change anything anymore. changes are uploaded with the update endpoint after the application has been uploaded.

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
Change pages in the cable report form in UI (http://localhost:3001/fi/johtoselvityshakemus?hanke=HAI23-1). This will send update requests. See backend logs to see that nothing much is happening.

Pressing the send button on the last page of the cable report application for a second or a third time shouldn't do much on the backend side.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 