### PR TITLE
HAI-1399 Add sanitization of incoming geolocation feature data

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
@@ -223,10 +223,7 @@ class HankeServiceITests : DatabaseTest() {
 
         val result = hankeService.createHanke(hanke)
 
-        assertFeaturePropertiesIsReset(
-            result,
-            mutableMapOf("hankeTunnus" to hanke.hankeTunnus)
-        )
+        assertFeaturePropertiesIsReset(result, mutableMapOf("hankeTunnus" to hanke.hankeTunnus))
     }
 
     @Test
@@ -242,10 +239,7 @@ class HankeServiceITests : DatabaseTest() {
 
         val result = hankeService.updateHanke(updatedHanke)
 
-        assertFeaturePropertiesIsReset(
-            result,
-            mutableMapOf("hankeTunnus" to hanke.hankeTunnus)
-        )
+        assertFeaturePropertiesIsReset(result, mutableMapOf("hankeTunnus" to hanke.hankeTunnus))
     }
 
     @Test
@@ -1258,10 +1252,7 @@ class HankeServiceITests : DatabaseTest() {
         )
     }
 
-    private fun assertFeaturePropertiesIsReset(
-        hanke: Hanke,
-        propertiesWanted: Map<String, Any?>
-    ) {
+    private fun assertFeaturePropertiesIsReset(hanke: Hanke, propertiesWanted: Map<String, Any?>) {
         assertThat(hanke.alueet).isNotEmpty
         hanke.alueet.forEach { alue ->
             val features = alue.geometriat?.featureCollection?.features

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
@@ -215,7 +215,7 @@ class HankeServiceITests : DatabaseTest() {
     }
 
     @Test
-    fun `createHanke sanitizes feature properties`() {
+    fun `createHanke resets feature properties`() {
         val hanke = getATestHanke().withHankealue()
         hanke.alueet[0].geometriat?.featureCollection?.features?.forEach {
             it.properties["something"] = "fishy"
@@ -223,14 +223,14 @@ class HankeServiceITests : DatabaseTest() {
 
         val result = hankeService.createHanke(hanke)
 
-        assertFeaturePropertiesContainOnlyDesiredFields(
+        assertFeaturePropertiesIsReset(
             result,
             mutableMapOf("hankeTunnus" to hanke.hankeTunnus)
         )
     }
 
     @Test
-    fun `updateHanke sanitizes feature properties`() {
+    fun `updateHanke resets feature properties`() {
         val hanke = getATestHanke().withHankealue()
         val createdHanke = hankeService.createHanke(hanke)
         val updatedHanke =
@@ -242,7 +242,7 @@ class HankeServiceITests : DatabaseTest() {
 
         val result = hankeService.updateHanke(updatedHanke)
 
-        assertFeaturePropertiesContainOnlyDesiredFields(
+        assertFeaturePropertiesIsReset(
             result,
             mutableMapOf("hankeTunnus" to hanke.hankeTunnus)
         )
@@ -1258,13 +1258,12 @@ class HankeServiceITests : DatabaseTest() {
         )
     }
 
-    private fun assertFeaturePropertiesContainOnlyDesiredFields(
+    private fun assertFeaturePropertiesIsReset(
         hanke: Hanke,
         propertiesWanted: Map<String, Any?>
     ) {
-        val alueet = hanke.alueet
-        assertThat(alueet.size).isEqualTo(2)
-        alueet.forEach { alue ->
+        assertThat(hanke.alueet).isNotEmpty
+        hanke.alueet.forEach { alue ->
             val features = alue.geometriat?.featureCollection?.features
             assertThat(features).isNotEmpty
             features?.forEach { feature ->

--- a/services/hanke-service/src/integrationTest/resources/fi/hel/haitaton/hanke/geometria/hankeGeometriat.json
+++ b/services/hanke-service/src/integrationTest/resources/fi/hel/haitaton/hanke/geometria/hankeGeometriat.json
@@ -27,9 +27,7 @@
             6562789.70
           ]
         },
-        "properties": {
-          "geometryType": "KUOPPA"
-        }
+        "properties": {}
       }
     ]
   },

--- a/services/hanke-service/src/integrationTest/resources/fi/hel/haitaton/hanke/logging/expectedHankeWithPoints.json.mustache
+++ b/services/hanke-service/src/integrationTest/resources/fi/hel/haitaton/hanke/logging/expectedHankeWithPoints.json.mustache
@@ -69,8 +69,7 @@
                 ]
               },
               "properties": {
-                "hankeTunnus": "{{hankeTunnus}}",
-                "geometryType": "KUOPPA"
+                "hankeTunnus": "{{hankeTunnus}}"
               }
             }
           ]

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeServiceImpl.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeServiceImpl.kt
@@ -287,7 +287,7 @@ open class HankeServiceImpl(
 
         hankeEntity.listOfHankeAlueet.forEach {
             val alue = createHankealueDomainObjectFromEntity(it)
-            alue.geometriat?.includeHankeProperties(h)
+            alue.geometriat?.sanitizeFeatureProperties(h)
             h.alueet.add(alue)
         }
 
@@ -535,7 +535,7 @@ open class HankeServiceImpl(
         source.tarinaHaitta?.let { result.tarinaHaitta = source.tarinaHaitta }
         source.geometriat?.let {
             it.id = result.geometriat ?: it.id
-            it.includeHankeProperties(hanke)
+            it.sanitizeFeatureProperties(hanke)
             val saved = geometriatService.saveGeometriat(it)
             result.geometriat = saved?.id
         }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeServiceImpl.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeServiceImpl.kt
@@ -287,7 +287,7 @@ open class HankeServiceImpl(
 
         hankeEntity.listOfHankeAlueet.forEach {
             val alue = createHankealueDomainObjectFromEntity(it)
-            alue.geometriat?.sanitizeFeatureProperties(h)
+            alue.geometriat?.ensureOnlyRequiredFeatureProperties(h)
             h.alueet.add(alue)
         }
 
@@ -535,7 +535,7 @@ open class HankeServiceImpl(
         source.tarinaHaitta?.let { result.tarinaHaitta = source.tarinaHaitta }
         source.geometriat?.let {
             it.id = result.geometriat ?: it.id
-            it.sanitizeFeatureProperties(hanke)
+            it.ensureOnlyRequiredFeatureProperties(hanke)
             val saved = geometriatService.saveGeometriat(it)
             result.geometriat = saved?.id
         }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeServiceImpl.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeServiceImpl.kt
@@ -287,7 +287,7 @@ open class HankeServiceImpl(
 
         hankeEntity.listOfHankeAlueet.forEach {
             val alue = createHankealueDomainObjectFromEntity(it)
-            alue.geometriat?.ensureOnlyRequiredFeatureProperties(h)
+            alue.geometriat?.resetFeatureProperties(h)
             h.alueet.add(alue)
         }
 
@@ -535,7 +535,7 @@ open class HankeServiceImpl(
         source.tarinaHaitta?.let { result.tarinaHaitta = source.tarinaHaitta }
         source.geometriat?.let {
             it.id = result.geometriat ?: it.id
-            it.ensureOnlyRequiredFeatureProperties(hanke)
+            it.resetFeatureProperties(hanke)
             val saved = geometriatService.saveGeometriat(it)
             result.geometriat = saved?.id
         }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/geometria/Geometriat.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/geometria/Geometriat.kt
@@ -22,7 +22,7 @@ data class Geometriat(
         return this
     }
 
-    fun ensureOnlyRequiredFeatureProperties(hanke: Hanke) {
+    fun resetFeatureProperties(hanke: Hanke) {
         this.featureCollection?.let { featureCollection ->
             featureCollection.features.forEach { feature ->
                 feature.properties = mutableMapOf<String, Any?>("hankeTunnus" to hanke.hankeTunnus)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/geometria/Geometriat.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/geometria/Geometriat.kt
@@ -22,14 +22,10 @@ data class Geometriat(
         return this
     }
 
-    fun includeHankeProperties(hanke: Hanke) {
+    fun sanitizeFeatureProperties(hanke: Hanke) {
         this.featureCollection?.let { featureCollection ->
             featureCollection.features.forEach { feature ->
-                if (feature.properties == null) {
-                    feature.properties = mutableMapOf()
-                }
-                feature.properties["hankeTunnus"] = hanke.hankeTunnus
-                // Add here other properties when needed
+                feature.properties = mutableMapOf<String, Any?>("hankeTunnus" to hanke.hankeTunnus)
             }
         }
     }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/geometria/Geometriat.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/geometria/Geometriat.kt
@@ -22,7 +22,7 @@ data class Geometriat(
         return this
     }
 
-    fun sanitizeFeatureProperties(hanke: Hanke) {
+    fun ensureOnlyRequiredFeatureProperties(hanke: Hanke) {
         this.featureCollection?.let { featureCollection ->
             featureCollection.features.forEach { feature ->
                 feature.properties = mutableMapOf<String, Any?>("hankeTunnus" to hanke.hankeTunnus)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/geometria/GeometriatServiceImpl.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/geometria/GeometriatServiceImpl.kt
@@ -74,7 +74,7 @@ open class GeometriatServiceImpl(private val hankeGeometriaDao: GeometriatDao) :
      */
     override fun loadGeometriat(hanke: Hanke): Geometriat? {
         val geometriat = hankeGeometriaDao.retrieveGeometriat(hanke.id!!)
-        geometriat?.ensureOnlyRequiredFeatureProperties(hanke)
+        geometriat?.resetFeatureProperties(hanke)
         return geometriat
     }
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/geometria/GeometriatServiceImpl.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/geometria/GeometriatServiceImpl.kt
@@ -74,7 +74,7 @@ open class GeometriatServiceImpl(private val hankeGeometriaDao: GeometriatDao) :
      */
     override fun loadGeometriat(hanke: Hanke): Geometriat? {
         val geometriat = hankeGeometriaDao.retrieveGeometriat(hanke.id!!)
-        geometriat?.includeHankeProperties(hanke)
+        geometriat?.sanitizeFeatureProperties(hanke)
         return geometriat
     }
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/geometria/GeometriatServiceImpl.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/geometria/GeometriatServiceImpl.kt
@@ -74,7 +74,7 @@ open class GeometriatServiceImpl(private val hankeGeometriaDao: GeometriatDao) :
      */
     override fun loadGeometriat(hanke: Hanke): Geometriat? {
         val geometriat = hankeGeometriaDao.retrieveGeometriat(hanke.id!!)
-        geometriat?.sanitizeFeatureProperties(hanke)
+        geometriat?.ensureOnlyRequiredFeatureProperties(hanke)
         return geometriat
     }
 

--- a/services/hanke-service/src/test/resources/fi/hel/haitaton/hanke/geometria/hankeGeometriat.json
+++ b/services/hanke-service/src/test/resources/fi/hel/haitaton/hanke/geometria/hankeGeometriat.json
@@ -27,9 +27,7 @@
             6562789.70
           ]
         },
-        "properties": {
-          "geometryType": "KUOPPA"
-        }
+        "properties": {}
       }
     ]
   },


### PR DESCRIPTION
# Description

Geometriat.featureCollection.features.properties is a map that can pretty much contain anything. Furthermore, hankeTunnus is the only entry we are interested in.

This commit removes unwanted properties by replacing the properties with a new map with hankeTunnus key / value. Everything else is discarded.

P.s. Jira ticket mentions a validation and error throwing as an alternative solution. I chose not to do that as it would be a breaking change in the api.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1399

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [x] Other

# Instructions for testing

1. Create a new hanke containing properties that are of no interest (POST http://localhost:3001/api/hankkeet). For example, add this to your payload:
```
{
  "geometriat": {
    "featureCollection": {
      "type": "FeatureCollection",
      "features": [
        {
          "type": "Feature",
          "geometry": {
            "type": "Polygon",
            "coordinates": [
              [
                [25496070.09, 6679284.13],
                [25496070.27, 6679254.8],
                [25496091.46, 6679255.59],
                [25496070.09, 6679284.13]
              ]
            ]
          },
          "properties": { "fooBar": "this should not exist" }
        }
      ],
      "crs": {
        "type": "name",
        "properties": { "name": "urn:ogc:def:crs:EPSG::3879" }
      }
    }
  }
}
```
2. Check that the created hanke does contains only properties: "properties": { "hankeTunnus": <your hanke tunnus> }
3. You can use a PUT request to verify that modification works the same way as the POST

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 