### PR TITLE
HAI-1524 Fix PDF area calculation and JSON deserialization

### DIFF
--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationService.kt
@@ -310,7 +310,8 @@ open class ApplicationService(
     }
 
     private fun getApplicationDataAsPdf(data: CableReportApplicationData): Attachment {
-        val totalArea = geometriatDao.calculateArea(data.geometry!!)
+        val totalArea =
+            geometriatDao.calculateCombinedArea(data.areas?.map { it.geometry } ?: listOf())
         val areas = data.areas?.map { geometriatDao.calculateArea(it.geometry) } ?: listOf()
         val attachmentMetadata =
             AttachmentMetadata(

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/configuration/Configuration.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/configuration/Configuration.kt
@@ -1,13 +1,11 @@
 package fi.hel.haitaton.hanke.configuration
 
-import com.fasterxml.jackson.databind.ObjectMapper
 import fi.hel.haitaton.hanke.HankeRepository
 import fi.hel.haitaton.hanke.HankeService
 import fi.hel.haitaton.hanke.HankeServiceImpl
 import fi.hel.haitaton.hanke.HanketunnusService
 import fi.hel.haitaton.hanke.HanketunnusServiceImpl
 import fi.hel.haitaton.hanke.IdCounterRepository
-import fi.hel.haitaton.hanke.OBJECT_MAPPER
 import fi.hel.haitaton.hanke.allu.AlluProperties
 import fi.hel.haitaton.hanke.allu.AlluStatusRepository
 import fi.hel.haitaton.hanke.allu.CableReportService
@@ -68,8 +66,6 @@ class Configuration {
         val httpClient = HttpClient.create().secure { t -> t.sslContext(sslContext) }
         return webClientBuilder.clientConnector(ReactorClientHttpConnector(httpClient)).build()
     }
-
-    @Bean fun objectMapper(): ObjectMapper = OBJECT_MAPPER
 
     @Bean
     fun applicationService(

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/Hanke.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/Hanke.kt
@@ -1,7 +1,6 @@
 package fi.hel.haitaton.hanke.domain
 
 import com.fasterxml.jackson.annotation.JsonIgnore
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonView
 import fi.hel.haitaton.hanke.ChangeLogView
 import fi.hel.haitaton.hanke.Haitta13
@@ -20,7 +19,6 @@ import fi.hel.haitaton.hanke.tormaystarkastelu.TormaystarkasteluTulos
 import java.time.ZonedDateTime
 import java.time.temporal.ChronoUnit
 
-@JsonIgnoreProperties(ignoreUnknown = true)
 data class Hanke(
     @JsonView(ChangeLogView::class) override var id: Int?,
     @JsonView(ChangeLogView::class) var hankeTunnus: String?,

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/Hankealue.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/Hankealue.kt
@@ -1,6 +1,5 @@
 package fi.hel.haitaton.hanke.domain
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonView
 import fi.hel.haitaton.hanke.ChangeLogView
 import fi.hel.haitaton.hanke.Haitta13
@@ -11,7 +10,6 @@ import java.time.ZonedDateTime
 
 /** NOTE Remember to update PublicHankealue after changes */
 @JsonView(ChangeLogView::class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 data class Hankealue(
     override var id: Int? = null,
     var hankeId: Int? = null,

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/geometria/GeometriatDao.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/geometria/GeometriatDao.kt
@@ -1,6 +1,7 @@
 package fi.hel.haitaton.hanke.geometria
 
 import org.geojson.GeoJsonObject
+import org.geojson.Polygon
 
 interface GeometriatDao {
     fun createGeometriat(geometriat: Geometriat): Geometriat
@@ -31,4 +32,5 @@ interface GeometriatDao {
     data class InvalidDetail(val reason: String, val location: String)
 
     fun calculateArea(geometria: GeoJsonObject): Float?
+    fun calculateCombinedArea(geometriat: List<Polygon>): Float?
 }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceTest.kt
@@ -139,7 +139,7 @@ class ApplicationServiceTest {
         every { cableReportService.getApplicationInformation(42) } returns
             AlluDataFactory.createAlluApplicationResponse(42)
         every { geometriatDao.validateGeometria(any()) } returns null
-        every { geometriatDao.calculateArea(any()) } returns 100f
+        every { geometriatDao.calculateCombinedArea(any()) } returns 100f
         val updatedData = applicationData.copy(rockExcavation = !applicationData.rockExcavation!!)
 
         service.updateApplicationData(3, updatedData, username)
@@ -148,7 +148,7 @@ class ApplicationServiceTest {
             applicationRepo.findOneByIdAndUserId(3, username)
             geometriatDao.validateGeometria(any())
             cableReportService.getApplicationInformation(42)
-            geometriatDao.calculateArea(any())
+            geometriatDao.calculateCombinedArea(any())
             cableReportService.update(42, any())
             disclosureLogService.saveDisclosureLogsForAllu(updatedData, Status.SUCCESS)
             cableReportService.addAttachment(42, any())
@@ -204,14 +204,14 @@ class ApplicationServiceTest {
         justRun { cableReportService.addAttachment(42, any()) }
         every { cableReportService.getApplicationInformation(42) } returns
             AlluDataFactory.createAlluApplicationResponse(42)
-        every { geometriatDao.calculateArea(any()) } returns 100f
+        every { geometriatDao.calculateCombinedArea(any()) } returns 100f
 
         service.sendApplication(3, username)
 
         val expectedApplication = applicationData.copy(pendingOnClient = false)
         verifyOrder {
             applicationRepo.findOneByIdAndUserId(3, username)
-            geometriatDao.calculateArea(any())
+            geometriatDao.calculateCombinedArea(any())
             cableReportService.create(any())
             disclosureLogService.saveDisclosureLogsForAllu(expectedApplication, Status.SUCCESS)
             cableReportService.addAttachment(42, any())
@@ -230,7 +230,7 @@ class ApplicationServiceTest {
                 applicationData = applicationData
             )
         every { applicationRepo.findOneByIdAndUserId(3, username) } returns applicationEntity
-        every { geometriatDao.calculateArea(any()) } returns 100f
+        every { geometriatDao.calculateCombinedArea(any()) } returns 100f
         every { cableReportService.create(any()) } throws AlluException(listOf())
 
         assertThrows<AlluException> { service.sendApplication(3, username) }
@@ -238,7 +238,7 @@ class ApplicationServiceTest {
         val expectedApplication = applicationData.copy(pendingOnClient = false)
         verifyOrder {
             applicationRepo.findOneByIdAndUserId(3, username)
-            geometriatDao.calculateArea(any())
+            geometriatDao.calculateCombinedArea(any())
             cableReportService.create(any())
             disclosureLogService.saveDisclosureLogsForAllu(
                 expectedApplication,
@@ -258,7 +258,7 @@ class ApplicationServiceTest {
                 applicationData = applicationData
             )
         every { applicationRepo.findOneByIdAndUserId(3, username) } returns applicationEntity
-        every { geometriatDao.calculateArea(any()) } returns 500f
+        every { geometriatDao.calculateCombinedArea(any()) } returns 500f
         every { cableReportService.create(any()) } throws AlluLoginException(RuntimeException())
 
         assertThrows<AlluLoginException> { service.sendApplication(3, username) }
@@ -266,7 +266,7 @@ class ApplicationServiceTest {
         verifyOrder {
             disclosureLogService wasNot called
             applicationRepo.findOneByIdAndUserId(3, username)
-            geometriatDao.calculateArea(any())
+            geometriatDao.calculateCombinedArea(any())
             cableReportService.create(any())
         }
     }
@@ -286,7 +286,7 @@ class ApplicationServiceTest {
             )
         every { applicationRepo.findOneByIdAndUserId(3, username) } returns applicationEntity
         every { applicationRepo.save(any()) } answers { firstArg() }
-        every { geometriatDao.calculateArea(any()) } returns 100f
+        every { geometriatDao.calculateCombinedArea(any()) } returns 100f
         every { cableReportService.create(any()) } returns 852
         justRun { cableReportService.addAttachment(852, any()) }
         every { cableReportService.getApplicationInformation(852) } returns
@@ -302,7 +302,7 @@ class ApplicationServiceTest {
                 .copy(workDescription = applicationData.workDescription + "\n" + expectedSuffix)
         verifyOrder {
             applicationRepo.findOneByIdAndUserId(3, username)
-            geometriatDao.calculateArea(any())
+            geometriatDao.calculateCombinedArea(any())
             cableReportService.create(expectedAlluData)
             disclosureLogService.saveDisclosureLogsForAllu(expectedApplicationData, Status.SUCCESS)
             cableReportService.addAttachment(852, any())


### PR DESCRIPTION
# Description

Fix area calculation while forming the application data PDF to Allu by using the application area objects from the new API. the individual areas were already calculated using the new object, but the total area wasn't. Make sure that overlapping polygons in the area are only calculated once.

Remove the `@Bean` for ObjectMapper. I thought it helped with sending the dates to Allu in the correct format, but now after further testing, the dates are sent just fine without it. It broke other things, because the Spring Boot default ObjectMapper ignores unknown fields, but our custom configuration doesn't. The `@JsonIgnoreProperties` annotations that were added as an emergency fix can now be removed.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1524

## Type of change

- [X] Bug fix 
- [ ] New feature 
- [ ] Other

# Checklist:

- [X] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 