### PR TITLE
HAI-1488 Remove old geometry from hankealue

### DIFF
--- a/githooks/pre-push
+++ b/githooks/pre-push
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+./gradlew build integrationTest

--- a/services/hanke-service/README.md
+++ b/services/hanke-service/README.md
@@ -34,6 +34,18 @@ for full API description) (and other sub-URLs similarly):
 > http://localhost:8080/hankkeet/<id> \
 > http://localhost:8080/hankkeet/<id>/geometriat
 
+### Git hooks
+
+A pre-push git hook for running all checks is created when building the project
+with Gradle. The hooks can also be added or updated manually with the command:
+```
+$ ./gradlew installGitHooks
+```
+
+This adds a hook that will build the project and run all tests and other checks
+before any push you make. The checks need to be run successfully for the push to
+happen. If necessary, the checks can be skipped with `git push --no-verify`.
+
 ### Swagger UI
 
 Swagger UI (see https://springdoc.org/) and OpenAPI v3 description (JSON). Note though that the swagger

--- a/services/hanke-service/build.gradle.kts
+++ b/services/hanke-service/build.gradle.kts
@@ -142,3 +142,12 @@ tasks {
 	}
 
 }
+
+tasks.register("installGitHook", Copy::class) {
+	from(file("$rootDir/githooks"))
+	into(file("$rootDir/.git/hooks"))
+	fileMode = 0b0111101101 // -rwxr-xr-x
+}
+tasks.named("build") {
+	dependsOn(tasks.named("installGitHook"))
+}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationData.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationData.kt
@@ -9,7 +9,6 @@ import fi.hel.haitaton.hanke.NotInChangeLogView
 import fi.hel.haitaton.hanke.allu.AlluApplicationData
 import fi.hel.haitaton.hanke.allu.AlluCableReportApplicationData
 import java.time.ZonedDateTime
-import org.geojson.GeometryCollection
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonTypeInfo(
@@ -25,7 +24,6 @@ sealed interface ApplicationData {
     val applicationType: ApplicationType
     val name: String
     val pendingOnClient: Boolean
-    val geometry: GeometryCollection?
     val areas: List<ApplicationArea>?
 
     fun copy(pendingOnClient: Boolean): ApplicationData
@@ -39,7 +37,6 @@ data class CableReportApplicationData(
     // Common, required
     override val name: String,
     val customerWithContacts: CustomerWithContacts,
-    override val geometry: GeometryCollection?,
     override val areas: List<ApplicationArea>?,
     val startTime: ZonedDateTime?,
     val endTime: ZonedDateTime?,

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationService.kt
@@ -232,13 +232,8 @@ open class ApplicationService(
         customMessageOnFailure: (GeometriatDao.InvalidDetail) -> String
     ) {
         val areas = newApplicationData.areas
-        val geometry = newApplicationData.geometry
         if (areas != null) {
             geometriatDao.validateGeometriat(areas.map { it.geometry })?.let {
-                throw ApplicationGeometryException(customMessageOnFailure(it))
-            }
-        } else if (geometry != null) {
-            geometriatDao.validateGeometria(newApplicationData.geometry!!)?.let {
                 throw ApplicationGeometryException(customMessageOnFailure(it))
             }
         }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/AlluDataFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/AlluDataFactory.kt
@@ -16,8 +16,9 @@ import fi.hel.haitaton.hanke.application.Customer
 import fi.hel.haitaton.hanke.application.CustomerWithContacts
 import fi.hel.haitaton.hanke.application.PostalAddress
 import fi.hel.haitaton.hanke.application.StreetAddress
+import fi.hel.haitaton.hanke.asJsonResource
 import java.time.ZonedDateTime
-import org.geojson.GeometryCollection
+import org.geojson.Polygon
 import org.springframework.stereotype.Component
 
 @Component
@@ -94,10 +95,15 @@ class AlluDataFactory(val applicationRepository: ApplicationRepository) {
             orderer: Boolean = false
         ) = Contact(name, postalAddress, email, phone, orderer)
 
+        fun createApplicationArea(
+            name: String = "Area name",
+            geometry: Polygon =
+                "/fi/hel/haitaton/hanke/geometria/toinen_polygoni.json".asJsonResource(),
+        ): ApplicationArea = ApplicationArea(name, geometry)
+
         fun createCableReportApplicationData(
             name: String = defaultApplicationName,
-            geometry: GeometryCollection? = GeometryCollection(),
-            areas: List<ApplicationArea>? = null,
+            areas: List<ApplicationArea>? = listOf(createApplicationArea()),
             startTime: ZonedDateTime? = DateFactory.getStartDatetime(),
             endTime: ZonedDateTime? = DateFactory.getEndDatetime(),
             pendingOnClient: Boolean = false,
@@ -116,7 +122,6 @@ class AlluDataFactory(val applicationRepository: ApplicationRepository) {
             CableReportApplicationData(
                 applicationType = ApplicationType.CABLE_REPORT,
                 name = name,
-                geometry = geometry,
                 areas = areas,
                 startTime = startTime,
                 endTime = endTime,

--- a/services/hanke-service/src/test/resources/fi/hel/haitaton/hanke/application/applicationData.json
+++ b/services/hanke-service/src/test/resources/fi/hel/haitaton/hanke/application/applicationData.json
@@ -4,17 +4,17 @@
   "name": "Testihakemus",
   "startTime": "2022-10-23T21:00:00.000Z",
   "endTime": "2022-10-27T21:00:00.000Z",
-  "geometry": {
-    "crs": {
-      "type": "name",
-      "properties": {
-        "name": "EPSG:3879"
-      }
-    },
-    "type": "GeometryCollection",
-    "geometries": [
-      {
+  "areas": [
+    {
+      "name": "Ensimmäinen alue",
+      "geometry": {
         "type": "Polygon",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "urn:ogc:def:crs:EPSG::3879"
+          }
+        },
         "coordinates": [
           [
             [
@@ -40,8 +40,8 @@
           ]
         ]
       }
-    ]
-  },
+    }
+  ],
   "emergencyWork": false,
   "postalAddress": null,
   "maintenanceWork": true,


### PR DESCRIPTION
# Description

Remove old geometry field from hankealue. This has been replaced by the areas -field. The frontend has been updated, so the geometry-field is now safe to remove.

Also added a gradle command to install a git hook. This is not run automatically, but can be run with `./gradlew installGitHook`

### Jira Issue: 

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [X] Other

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 
