### PR TITLE
HAI-1406 Prevent deletion of hanke if it is being handled in allu

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
@@ -1,8 +1,12 @@
 package fi.hel.haitaton.hanke
 
+import com.ninjasquad.springmockk.MockkBean
+import fi.hel.haitaton.hanke.allu.ApplicationStatus
+import fi.hel.haitaton.hanke.application.ApplicationService
 import fi.hel.haitaton.hanke.domain.Hanke
 import fi.hel.haitaton.hanke.domain.HankeYhteystieto
 import fi.hel.haitaton.hanke.domain.Hankealue
+import fi.hel.haitaton.hanke.factory.AlluDataFactory
 import fi.hel.haitaton.hanke.factory.DateFactory
 import fi.hel.haitaton.hanke.factory.HankeFactory
 import fi.hel.haitaton.hanke.factory.HankeFactory.withGeneratedArvioija
@@ -20,6 +24,11 @@ import fi.hel.haitaton.hanke.logging.Status
 import fi.hel.haitaton.hanke.logging.UserRole
 import fi.hel.haitaton.hanke.test.TestUtils
 import fi.hel.haitaton.hanke.test.TestUtils.nextYear
+import io.mockk.Called
+import io.mockk.clearAllMocks
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.verify
 import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoUnit
 import javax.persistence.EntityManager
@@ -30,15 +39,20 @@ import org.assertj.core.api.Assertions.byLessThan
 import org.geojson.Feature
 import org.geojson.LngLatAlt
 import org.geojson.Polygon
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
 import org.skyscreamer.jsonassert.JSONAssert
 import org.skyscreamer.jsonassert.JSONCompareMode
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.security.test.context.support.WithMockUser
 import org.springframework.test.context.ActiveProfiles
@@ -54,11 +68,22 @@ private const val USER_NAME = "test7358"
 @WithMockUser(USER_NAME)
 class HankeServiceITests : DatabaseTest() {
 
+    @MockkBean private lateinit var applicationService: ApplicationService
     @Autowired private lateinit var hankeService: HankeService
     @Autowired private lateinit var auditLogRepository: AuditLogRepository
     @Autowired private lateinit var hankeRepository: HankeRepository
     @Autowired private lateinit var jdbcTemplate: JdbcTemplate
     @Autowired private lateinit var entityManager: EntityManager
+
+    @BeforeEach
+    fun clearMocks() {
+        clearAllMocks()
+    }
+
+    @AfterEach
+    fun checkMocks() {
+        confirmVerified(applicationService)
+    }
 
     // Some tests also use and check loadHanke()'s return value because at one time the update
     // action was returning different set of data than loadHanke (bug), so it is a sort of
@@ -968,7 +993,7 @@ class HankeServiceITests : DatabaseTest() {
         assertEquals(0, auditLogRepository.count())
         TestUtils.addMockedRequestIp()
 
-        hankeService.deleteHanke(hankeWithTulos, "testUser")
+        hankeService.deleteHanke(hankeWithTulos.id!!, "testUser")
 
         val hankeLogs = auditLogRepository.findByType(ObjectType.HANKE)
         assertEquals(1, hankeLogs.size)
@@ -1010,7 +1035,7 @@ class HankeServiceITests : DatabaseTest() {
         assertEquals(0, auditLogRepository.count())
         TestUtils.addMockedRequestIp()
 
-        hankeService.deleteHanke(hanke, "testUser")
+        hankeService.deleteHanke(hanke.id!!, "testUser")
 
         val logs = auditLogRepository.findByType(ObjectType.YHTEYSTIETO)
         assertEquals(3, logs.size)
@@ -1048,6 +1073,84 @@ class HankeServiceITests : DatabaseTest() {
             toteuttajaEvent.target.objectBefore,
             JSONCompareMode.NON_EXTENSIBLE
         )
+    }
+
+    @Test
+    fun `deleteHanke when hanke does not exist should not try delete`() {
+        val deleted = hankeService.deleteHanke(123, USER_NAME)
+
+        assertThat(deleted).isFalse
+        verify { applicationService wasNot Called }
+    }
+
+    @Test
+    fun `deleteHanke hanke when no hakemus should delete hanke`() {
+        val hanke = hankeService.createHanke(HankeFactory.create(id = null))
+
+        val deleted = hankeService.deleteHanke(hanke.id!!, USER_NAME)
+
+        assertThat(deleted).isTrue
+        assertThat(hankeRepository.findByIdOrNull(hanke.id)).isNull()
+        verify { applicationService wasNot Called }
+    }
+
+    @Test
+    fun `deleteHanke when hakemus status is null in db and in pending allu should delete hanke`() {
+        val hakemusAlluId = 356
+        val hanke = initHankeWithHakemus(null, hakemusAlluId)
+        every { applicationService.isStillPending(hakemusAlluId) } returns true
+
+        val deleted = hankeService.deleteHanke(hanke.id!!, USER_NAME)
+
+        assertThat(deleted).isTrue
+        assertThat(hankeRepository.findByIdOrNull(hanke.id)).isNull()
+        verify { applicationService.isStillPending(hakemusAlluId) }
+    }
+
+    @ParameterizedTest(name = "{displayName} ({arguments})")
+    @EnumSource(value = ApplicationStatus::class, names = ["PENDING", "PENDING_CLIENT"])
+    fun `deleteHanke when hakemus is pending in db and in allu should delete hanke`(
+        status: ApplicationStatus
+    ) {
+        val hakemusAlluId = 356
+        val hanke = initHankeWithHakemus(status, hakemusAlluId)
+        every { applicationService.isStillPending(hakemusAlluId) } returns true
+
+        val deleted = hankeService.deleteHanke(hanke.id!!, USER_NAME)
+
+        assertThat(deleted).isTrue
+        assertThat(hankeRepository.findByIdOrNull(hanke.id)).isNull()
+        verify { applicationService.isStillPending(hakemusAlluId) }
+    }
+
+    @ParameterizedTest(name = "{displayName} ({arguments})")
+    @EnumSource(value = ApplicationStatus::class, names = ["PENDING", "PENDING_CLIENT"])
+    fun `deleteHanke hakemus is pending in db but not pending in allu should throw`(
+        status: ApplicationStatus
+    ) {
+        val hakemusAlluId = 123
+        val hanke = initHankeWithHakemus(status, hakemusAlluId)
+        every { applicationService.isStillPending(hakemusAlluId) } returns false
+
+        assertThrows<HankeAlluConflictException> { hankeService.deleteHanke(hanke.id!!, USER_NAME) }
+
+        assertThat(hankeRepository.findByIdOrNull(hanke.id)).isNotNull
+        verify { applicationService.isStillPending(hakemusAlluId) }
+    }
+
+    @ParameterizedTest(name = "{displayName} ({arguments})")
+    @EnumSource(
+        value = ApplicationStatus::class,
+        mode = EnumSource.Mode.EXCLUDE,
+        names = ["PENDING", "PENDING_CLIENT"]
+    )
+    fun `deleteHanke not pending anymore should throw`(status: ApplicationStatus) {
+        val hanke = initHankeWithHakemus(status, 56)
+
+        assertThrows<HankeAlluConflictException> { hankeService.deleteHanke(hanke.id!!, USER_NAME) }
+
+        assertThat(hankeRepository.findByIdOrNull(hanke.id)).isNotNull
+        verify { applicationService wasNot Called }
     }
 
     @Test
@@ -1251,6 +1354,23 @@ class HankeServiceITests : DatabaseTest() {
             JSONCompareMode.NON_EXTENSIBLE
         )
     }
+
+    private fun initHankeWithHakemus(
+        applicationStatus: ApplicationStatus?,
+        alluId: Int
+    ): HankeEntity =
+        hankeRepository.save(
+            HankeEntity(hankeTunnus = "HAI23-1").apply {
+                this.hakemukset =
+                    mutableSetOf(
+                        AlluDataFactory.createApplicationEntity(
+                            hanke = this,
+                            alluStatus = applicationStatus,
+                            alluid = alluId,
+                        )
+                    )
+            }
+        )
 
     private fun assertFeaturePropertiesIsReset(hanke: Hanke, propertiesWanted: Map<String, Any?>) {
         assertThat(hanke.alueet).isNotEmpty

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
@@ -45,6 +45,7 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -261,6 +262,24 @@ class HankeServiceITests : DatabaseTest() {
         val expectedHakemus = hanke.hakemukset.first().toDomainObject()
         assertThat(result.first).usingRecursiveComparison().isEqualTo(expectedHanke)
         assertThat(result.second).hasSameElementsAs(listOf(expectedHakemus))
+    }
+
+    @Test
+    fun `getHankeHakemuksetPair hanke does not exist throws not found`() {
+        val exception =
+            assertThrows<HankeNotFoundException> { hankeService.getHankeHakemuksetPair("HAI-1234") }
+
+        assertThat(exception).hasMessage("Hanke HAI-1234 not found")
+    }
+
+    @Test
+    fun `getHankeHakemuksetPair when no hakemukset returns hanke and empty list`() {
+        val hanke = hankeService.createHanke(HankeFactory.create())
+
+        val result = hankeService.getHankeHakemuksetPair(hanke.hankeTunnus!!)
+
+        assertThat(result.first).usingRecursiveComparison().isEqualTo(hanke)
+        assertTrue(result.second.isEmpty())
     }
 
     @Test

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceITest.kt
@@ -264,7 +264,7 @@ class ApplicationServiceITest : DatabaseTest() {
         permissionService.setPermission(hanke.id!!, username, Role.HAKEMUSASIOINTI)
         permissionService.setPermission(hanke2.id!!, "otherUser", Role.HAKEMUSASIOINTI)
 
-        alluDataFactory.saveApplicationEntities(3, username, hanke = hanke) { i, application ->
+        alluDataFactory.saveApplicationEntities(3, username, hanke = hanke) { _, application ->
             application.userId = username
             application.applicationData =
                 AlluDataFactory.createCableReportApplicationData(

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceITest.kt
@@ -58,6 +58,8 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
 import org.skyscreamer.jsonassert.JSONAssert
 import org.skyscreamer.jsonassert.JSONCompareMode
 import org.springframework.beans.factory.annotation.Autowired
@@ -264,7 +266,7 @@ class ApplicationServiceITest : DatabaseTest() {
         permissionService.setPermission(hanke.id!!, username, Role.HAKEMUSASIOINTI)
         permissionService.setPermission(hanke2.id!!, "otherUser", Role.HAKEMUSASIOINTI)
 
-        alluDataFactory.saveApplicationEntities(3, username, hanke = hanke) { _, application ->
+        alluDataFactory.saveApplicationEntities(3, username, hanke = hanke) { i, application ->
             application.userId = username
             application.applicationData =
                 AlluDataFactory.createCableReportApplicationData(
@@ -1086,6 +1088,51 @@ class ApplicationServiceITest : DatabaseTest() {
                 username
             )
         }
+    }
+
+    @ParameterizedTest(name = "{displayName} ({arguments})")
+    @EnumSource(value = ApplicationStatus::class, names = ["PENDING", "PENDING_CLIENT"])
+    fun `isStillPending when status is pending and allu confirms should return true`(
+        status: ApplicationStatus
+    ) {
+        val alluId = 123
+        val application = AlluDataFactory.createApplication(alluid = alluId, alluStatus = status)
+        every { cableReportServiceAllu.getApplicationInformation(alluId) } returns
+            AlluDataFactory.createAlluApplicationResponse(status = status)
+
+        assertTrue(applicationService.isStillPending(application))
+
+        verify { cableReportServiceAllu.getApplicationInformation(alluId) }
+    }
+
+    @ParameterizedTest(name = "{displayName} ({arguments})")
+    @EnumSource(value = ApplicationStatus::class, names = ["PENDING", "PENDING_CLIENT"])
+    fun `isStillPending when status is pending but status in allu in handling should return false`(
+        status: ApplicationStatus
+    ) {
+        val alluId = 123
+        val application = AlluDataFactory.createApplication(alluid = alluId, alluStatus = status)
+        every { cableReportServiceAllu.getApplicationInformation(alluId) } returns
+            AlluDataFactory.createAlluApplicationResponse(status = ApplicationStatus.HANDLING)
+
+        assertFalse(applicationService.isStillPending(application))
+
+        verify { cableReportServiceAllu.getApplicationInformation(alluId) }
+    }
+
+    @ParameterizedTest(name = "{displayName} ({arguments})")
+    @EnumSource(
+        value = ApplicationStatus::class,
+        mode = EnumSource.Mode.EXCLUDE,
+        names = ["PENDING", "PENDING_CLIENT"]
+    )
+    fun `isStillPending when status is not pending should return false`(status: ApplicationStatus) {
+        val alluId = 123
+        val application = AlluDataFactory.createApplication(alluid = alluId, alluStatus = status)
+
+        assertFalse(applicationService.isStillPending(application))
+
+        verify { cableReportServiceAllu wasNot Called }
     }
 
     val customerWithContactsJson =

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/ControllerExceptionHandler.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/ControllerExceptionHandler.kt
@@ -61,6 +61,14 @@ class ControllerExceptionHandler {
         return HankeError.HAI1029
     }
 
+    @ExceptionHandler(HankeAlluConflictException::class)
+    @ResponseStatus(HttpStatus.CONFLICT)
+    @Hidden
+    fun hankeAlluConflictException(ex: HankeAlluConflictException): HankeError {
+        logger.warn { ex.message }
+        return HankeError.HAI2003
+    }
+
     @ExceptionHandler(IllegalArgumentException::class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     @Hidden

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeController.kt
@@ -114,17 +114,17 @@ class HankeController(
     fun deleteHanke(@PathVariable hankeTunnus: String) {
         logger.info { "Deleting hanke: $hankeTunnus" }
 
-        val hanke = hankeService.loadHanke(hankeTunnus) ?: throw HankeNotFoundException(hankeTunnus)
-        val hankeId = hanke.id!!
+        val hankeId =
+            hankeService.getHankeId(hankeTunnus) ?: throw HankeNotFoundException(hankeTunnus)
 
         val userId = currentUserId()
         if (!permissionService.hasPermission(hankeId, userId, PermissionCode.DELETE)) {
             throw HankeNotFoundException(hankeTunnus)
         }
 
-        hankeService.deleteHanke(hanke, userId)
-
-        logger.info { "Deleted Hanke: ${hanke.toLogString()}" }
+        hankeService.deleteHanke(hankeId, userId).let { result ->
+            logger.info { "Deletion of Hanke: $hankeTunnus successful: $result" }
+        }
     }
 
     @ResponseStatus(HttpStatus.BAD_REQUEST)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeController.kt
@@ -114,9 +114,7 @@ class HankeController(
     fun deleteHanke(@PathVariable hankeTunnus: String) {
         logger.info { "Deleting hanke: $hankeTunnus" }
 
-        hankeService.getHankeHakemuksetPair(hankeTunnus).let {
-            val hanke = it.first
-            val hakemukset = it.second
+        hankeService.getHankeHakemuksetPair(hankeTunnus).let { (hanke, hakemukset) ->
             val hankeId = hanke.id!!
             val userId = currentUserId()
             if (!permissionService.hasPermission(hankeId, userId, PermissionCode.DELETE)) {

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeController.kt
@@ -114,16 +114,16 @@ class HankeController(
     fun deleteHanke(@PathVariable hankeTunnus: String) {
         logger.info { "Deleting hanke: $hankeTunnus" }
 
-        val hankeId =
-            hankeService.getHankeId(hankeTunnus) ?: throw HankeNotFoundException(hankeTunnus)
-
-        val userId = currentUserId()
-        if (!permissionService.hasPermission(hankeId, userId, PermissionCode.DELETE)) {
-            throw HankeNotFoundException(hankeTunnus)
-        }
-
-        hankeService.deleteHanke(hankeId, userId).let { result ->
-            logger.info { "Deletion of Hanke: $hankeTunnus successful: $result" }
+        hankeService.getHankeHakemuksetPair(hankeTunnus).let {
+            val hanke = it.first
+            val hakemukset = it.second
+            val hankeId = hanke.id!!
+            val userId = currentUserId()
+            if (!permissionService.hasPermission(hankeId, userId, PermissionCode.DELETE)) {
+                throw HankeNotFoundException(hankeTunnus)
+            }
+            hankeService.deleteHanke(hanke, hakemukset, userId)
+            logger.info { "Deleted Hanke: ${hanke.toLogString()}" }
         }
     }
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeError.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeError.kt
@@ -57,6 +57,8 @@ class HankeArgumentException(message: String) : RuntimeException(message)
 class HankeYhteystietoNotFoundException(val hankeId: Int, ytId: Int) :
     RuntimeException("HankeYhteystiedot $ytId not found for Hanke $hankeId")
 
+class HankeAlluConflictException(message: String) : RuntimeException(message)
+
 class DatabaseStateException(message: String) : RuntimeException(message)
 
 class HankeYhteystietoProcessingRestrictedException(message: String) : RuntimeException(message)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeService.kt
@@ -1,5 +1,6 @@
 package fi.hel.haitaton.hanke
 
+import fi.hel.haitaton.hanke.application.Application
 import fi.hel.haitaton.hanke.domain.Hanke
 import org.springframework.transaction.annotation.Transactional
 
@@ -10,11 +11,13 @@ interface HankeService {
 
     fun getHankeId(hankeTunnus: String): Int?
 
+    fun getHankeHakemuksetPair(hankeTunnus: String): Pair<Hanke, List<Application>>
+
     @Transactional fun createHanke(hanke: Hanke): Hanke
 
     @Transactional fun updateHanke(hanke: Hanke): Hanke
 
-    @Transactional fun deleteHanke(hankeId: Int, userId: String): Boolean
+    @Transactional fun deleteHanke(hanke: Hanke, hakemukset: List<Application>, userId: String)
 
     fun loadAllHanke(): List<Hanke>
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeService.kt
@@ -14,7 +14,7 @@ interface HankeService {
 
     @Transactional fun updateHanke(hanke: Hanke): Hanke
 
-    @Transactional fun deleteHanke(hanke: Hanke, userId: String)
+    @Transactional fun deleteHanke(hankeId: Int, userId: String): Boolean
 
     fun loadAllHanke(): List<Hanke>
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationService.kt
@@ -214,6 +214,15 @@ open class ApplicationService(
         return Pair(filename, pdfBytes)
     }
 
+    open fun isStillPending(alluid: Int?): Boolean {
+        // If there's no alluid then we haven't successfully sent this to ALLU yet (at all)
+        alluid ?: return true
+
+        val currentStatus = cableReportService.getApplicationInformation(alluid).status
+
+        return currentStatus in listOf(ApplicationStatus.PENDING, ApplicationStatus.PENDING_CLIENT)
+    }
+
     /** Cancel an application that's been sent to Allu. */
     private fun cancelApplication(alluid: Int, id: Long?) {
         if (isStillPending(alluid)) {
@@ -266,15 +275,6 @@ open class ApplicationService(
 
     private fun getById(id: Long): ApplicationEntity {
         return applicationRepository.findOneById(id) ?: throw ApplicationNotFoundException(id)
-    }
-
-    private fun isStillPending(alluid: Int?): Boolean {
-        // If there's no alluid then we haven't successfully sent this to ALLU yet (at all)
-        alluid ?: return true
-
-        val currentStatus = cableReportService.getApplicationInformation(alluid).status
-
-        return currentStatus in listOf(ApplicationStatus.PENDING, ApplicationStatus.PENDING_CLIENT)
     }
 
     private fun getApplicationInformationFromAllu(alluid: Int): AlluApplicationResponse? {

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/configuration/Configuration.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/configuration/Configuration.kt
@@ -22,7 +22,6 @@ import fi.hel.haitaton.hanke.logging.DisclosureLogService
 import fi.hel.haitaton.hanke.logging.HankeLoggingService
 import fi.hel.haitaton.hanke.organisaatio.OrganisaatioRepository
 import fi.hel.haitaton.hanke.organisaatio.OrganisaatioService
-import fi.hel.haitaton.hanke.permissions.PermissionRepository
 import fi.hel.haitaton.hanke.permissions.PermissionService
 import fi.hel.haitaton.hanke.tormaystarkastelu.LuokitteluRajaArvotService
 import fi.hel.haitaton.hanke.tormaystarkastelu.LuokitteluRajaArvotServiceHardCoded
@@ -101,17 +100,17 @@ class Configuration {
         geometriatService: GeometriatService,
         hanketunnusService: HanketunnusService,
         auditLogService: AuditLogService,
-        permissionRepository: PermissionRepository,
         hankeLoggingService: HankeLoggingService,
+        applicationService: ApplicationService,
     ): HankeService =
         HankeServiceImpl(
             hankeRepository,
-            permissionRepository,
             tormaystarkasteluLaskentaService,
             hanketunnusService,
             geometriatService,
             auditLogService,
             hankeLoggingService,
+            applicationService,
         )
 
     @Bean


### PR DESCRIPTION
# Description

Hanke can only be deleted if it has not proceeded to being handled in Allu. This commit checks application statuses (and throws exception if they are) before proceeding to hanke deletion. 

### Jira Issue:  https://helsinkisolutionoffice.atlassian.net/browse/HAI-1406

## Type of change

- [ ] Bug fix 
- [x] New feature 
- [ ] Other

# Instructions for testing
Please describe tests how this change or new feature can be tested.

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 
