### PR TITLE
HAI-1327/HSL bus trunk lines determined by data

### DIFF
--- a/scripts/gis-material-update/README.md
+++ b/scripts/gis-material-update/README.md
@@ -237,7 +237,7 @@ Files (names configured in `config.yaml`)
 
 Configure and activate python virtual environment.
 
-Run following in `gis-material_update/process` -directory.
+Run following in `gis-material-update/process` -directory.
 
 ```sh
 [(venv)::process/]$ python -m unittest discover -v

--- a/scripts/gis-material-update/process/modules/hsl.py
+++ b/scripts/gis-material-update/process/modules/hsl.py
@@ -188,23 +188,6 @@ class HslBuses(GisProcessor):
             else:
                 return 0
 
-    def _route_is_trunk(self, route_id: str) -> str:
-        """Check if route is trunk route."""
-        is_trunk_route = {
-            r"^1500.*": "yes",
-            r"^2200.*": "yes",
-            r"^2510.*": "yes",
-            r"^2550.*": "yes",
-            r"^4560.*": "yes",
-            r"^1018.*": "almost",
-            r"^1039.*": "almost",
-            r"^1040.*": "almost",
-        }
-        for pattern, result in is_trunk_route.items():
-            if re.match(pattern, route_id):
-                return result
-        return "no"
-
     def _process_hsl_bus_lines(self) -> pd.DataFrame:
         """Process GTFS material."""
         service_ids_day = self._pick_service_ids_for_one_day(self.transit_day())

--- a/scripts/gis-material-update/process/modules/hsl.py
+++ b/scripts/gis-material-update/process/modules/hsl.py
@@ -332,9 +332,9 @@ class HslBuses(GisProcessor):
     def _add_trunk_descriptor(self, shapes: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
         """Add trunk line descriptor column."""
         retval = shapes.copy()
-        retval["trunk"] = retval.apply(
-            lambda r: self._route_is_trunk(r.route_id), axis=1
-        )
+        retval["trunk"] = "no"
+        # 702 - express bus service == trunk line
+        retval.loc[retval["route_type"] == 702, "trunk"] = "yes"
         return retval
 
     def process(self) -> None:

--- a/scripts/gis-material-update/process/test/test_hsl.py
+++ b/scripts/gis-material-update/process/test/test_hsl.py
@@ -217,17 +217,11 @@ class TestHslInternals(unittest.TestCase):
         )
         self.assertEqual(parsed_time.get("next_day"), True)
 
-    def test_trunk_route(self):
-        candidates_true = [
-            ("1500", "yes"),
-            ("15001", "yes"),
-            (" 1500", "no"),
-            ("_2511", "no"),
-            ("1041", "no"),
-            ("1040", "almost"),
-        ]
-        for r_id, result in candidates_true:
-            self.assertEqual(self.hsl._route_is_trunk(r_id), result)
+    def test_trunk_route_assign(self):
+        df = gpd.GeoDataFrame([700, 701, 702, 703], columns=["route_type"])
+        df_trunk = self.hsl._add_trunk_descriptor(df)
+        is_trunk_line = df_trunk.loc[:, "trunk"].tolist()
+        self.assertEqual(is_trunk_line, ["no", "no", "yes", "no"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description

HSL trunk lines are now determined by data, not hard-coded to source code.

### Jira Issue: 

https://helsinkisolutionoffice.atlassian.net/browse/HAI-1327

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [x] Other

# Instructions for testing

Prerequisite: fetch `hsl` and `hki` source materials, as per instructions in the README

Go to directory: `haitaton-backend/scripts/gis-material-update/process`

(create and) activate Python virtual environment, run:

```
 python -m unittest discover -v
```

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 

# Other relevant info

None
