### PR TITLE
HAI-1345 Fix for database migrations

### DIFF
--- a/services/hanke-service/src/main/resources/db/changelog/changesets/024-connect-application-to-hanke.yml
+++ b/services/hanke-service/src/main/resources/db/changelog/changesets/024-connect-application-to-hanke.yml
@@ -3,6 +3,8 @@ databaseChangeLog:
       id: 024-connect-application-to-hanke
       author: Niko Junkala
       changes:
+        - delete:
+            tableName: applications
         - addColumn:
             tableName: applications
             columns:

--- a/services/hanke-service/src/main/resources/db/changelog/changesets/025-clear-existing-applications.sql
+++ b/services/hanke-service/src/main/resources/db/changelog/changesets/025-clear-existing-applications.sql
@@ -1,1 +1,0 @@
-DELETE FROM applications;

--- a/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -77,5 +77,3 @@ databaseChangeLog:
       file: db/changelog/changesets/023-add-nimi-to-hankealue.yml
   - include:
       file: db/changelog/changesets/024-connect-application-to-hanke.yml
-  - include:
-      file: db/changelog/changesets/025-clear-existing-applications.sql


### PR DESCRIPTION
# Description

The previous commit for HAI-1345 deleted all applications because the existing applications are not linked with hankkeet. Unfortunately, they remove deleted only after the migration adding the foreign key from applications to hanke. So if there are applications, the migration will fail with
```
org.postgresql.util.PSQLException: ERROR: column "hanke_id" of relation "applications" contains null values
```

To fix this, do the delete before adding the foreign key.

Modifying migrations afterwards is kind of taboo, but it should be fine in this instance, since the migrations haven't been deployed anywhere yet.

## Type of change

- [X] Bug fix 
- [ ] New feature 
- [ ] Other

# Instructions for testing
Create an application with commit e5f0f6ca9021c38668626cea5196ca89004bb4c8 (before adding the migrations). Then change to this branch, and starting the application should succeed.

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 