### PR TITLE
HAI-1407 Add functionality to cancel and delete applications in hanke deletion

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
@@ -30,6 +30,7 @@ import io.mockk.Called
 import io.mockk.clearAllMocks
 import io.mockk.confirmVerified
 import io.mockk.every
+import io.mockk.justRun
 import io.mockk.verify
 import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoUnit
@@ -1121,12 +1122,15 @@ class HankeServiceITests : DatabaseTest() {
         val hakemusAlluId = 356
         val hanke = initHankeWithHakemus(hakemusAlluId)
         val hakemukset = hanke.hakemukset.map { it.toApplication() }
+        val hakemusId = hakemukset.first().id!!
         every { applicationService.isStillPending(hakemukset.first()) } returns true
+        justRun { applicationService.delete(hakemusId, USER_NAME) }
 
         hankeService.deleteHanke(hanke.toDomainObject(), hakemukset, USER_NAME)
 
         assertThat(hankeRepository.findByIdOrNull(hanke.id)).isNull()
         verify { applicationService.isStillPending(hakemukset.first()) }
+        verify { applicationService.delete(hakemusId, USER_NAME) }
     }
 
     @Test

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceITest.kt
@@ -68,14 +68,14 @@ import org.springframework.security.test.context.support.WithMockUser
 import org.springframework.test.context.ActiveProfiles
 import org.testcontainers.junit.jupiter.Testcontainers
 
-private const val USER_NAME = "test7358"
+private const val USERNAME = "test7358"
 
 private val dataWithoutAreas = AlluDataFactory.createCableReportApplicationData(areas = listOf())
 
 @Testcontainers
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("default")
-@WithMockUser(USER_NAME)
+@WithMockUser(USERNAME)
 class ApplicationServiceITest : DatabaseTest() {
     @MockkBean private lateinit var cableReportServiceAllu: CableReportService
     @Autowired private lateinit var applicationService: ApplicationService
@@ -120,7 +120,7 @@ class ApplicationServiceITest : DatabaseTest() {
                     hankeTunnus = hanke.hankeTunnus!!,
                     applicationData = dataWithoutAreas
                 ),
-                USER_NAME
+                USERNAME
             )
 
         val applicationLogs = auditLogRepository.findByType(ObjectType.APPLICATION)
@@ -134,7 +134,7 @@ class ApplicationServiceITest : DatabaseTest() {
         assertThat(event::status).isEqualTo(Status.SUCCESS)
         assertThat(event::failureDescription).isNull()
         assertThat(event::appVersion).isEqualTo("1")
-        assertThat(event.actor::userId).isEqualTo(USER_NAME)
+        assertThat(event.actor::userId).isEqualTo(USERNAME)
         assertThat(event.actor::role).isEqualTo(UserRole.USER)
         assertThat(event.actor::ipAddress).isEqualTo(TestUtils.mockedIp)
         assertThat(event.target::id).isEqualTo(application.id?.toString())
@@ -161,7 +161,7 @@ class ApplicationServiceITest : DatabaseTest() {
                     hankeTunnus = hanke.hankeTunnus!!,
                     applicationData = dataWithoutAreas
                 ),
-                USER_NAME
+                USERNAME
             )
         auditLogRepository.deleteAll()
         assertThat(auditLogRepository.findAll()).isEmpty()
@@ -170,7 +170,7 @@ class ApplicationServiceITest : DatabaseTest() {
         applicationService.updateApplicationData(
             application.id!!,
             dataWithoutAreas.copy(name = "Modified application"),
-            USER_NAME
+            USERNAME
         )
 
         val applicationLogs = auditLogRepository.findByType(ObjectType.APPLICATION)
@@ -184,7 +184,7 @@ class ApplicationServiceITest : DatabaseTest() {
         assertThat(event::status).isEqualTo(Status.SUCCESS)
         assertThat(event::failureDescription).isNull()
         assertThat(event::appVersion).isEqualTo("1")
-        assertThat(event.actor::userId).isEqualTo(USER_NAME)
+        assertThat(event.actor::userId).isEqualTo(USERNAME)
         assertThat(event.actor::role).isEqualTo(UserRole.USER)
         assertThat(event.actor::ipAddress).isEqualTo(TestUtils.mockedIp)
         assertThat(event.target::id).isEqualTo(application.id?.toString())
@@ -216,13 +216,13 @@ class ApplicationServiceITest : DatabaseTest() {
         TestUtils.addMockedRequestIp()
         val hanke = createHankeEntity()
         val application =
-            alluDataFactory.saveApplicationEntity(USER_NAME, hanke = hanke) { it.alluid = null }
+            alluDataFactory.saveApplicationEntity(USERNAME, hanke = hanke) { it.alluid = null }
         assertThat(auditLogRepository.findAll()).isEmpty()
 
         applicationService.updateApplicationData(
             application.id!!,
             application.applicationData,
-            USER_NAME
+            USERNAME
         )
 
         val applicationLogs = auditLogRepository.findByType(ObjectType.APPLICATION)
@@ -235,13 +235,13 @@ class ApplicationServiceITest : DatabaseTest() {
         TestUtils.addMockedRequestIp()
         val hanke = createHankeEntity()
         val application =
-            alluDataFactory.saveApplicationEntity(USER_NAME, hanke = hanke) { it.alluid = 2 }
+            alluDataFactory.saveApplicationEntity(USERNAME, hanke = hanke) { it.alluid = 2 }
         assertThat(auditLogRepository.findAll()).isEmpty()
 
         applicationService.updateApplicationData(
             application.id!!,
             application.applicationData,
-            USER_NAME
+            USERNAME
         )
 
         verify { cableReportServiceAllu wasNot Called }
@@ -251,7 +251,7 @@ class ApplicationServiceITest : DatabaseTest() {
     fun `getAllApplicationsForUser with no applications returns empty list`() {
         assertThat(applicationRepository.findAll()).isEmpty()
 
-        val response = applicationService.getAllApplicationsForUser(USER_NAME)
+        val response = applicationService.getAllApplicationsForUser(USERNAME)
 
         assertEquals(listOf<Application>(), response)
         verify { cableReportServiceAllu wasNot Called }
@@ -263,28 +263,28 @@ class ApplicationServiceITest : DatabaseTest() {
         val otherUser = "otherUser"
         val hanke = hankeRepository.save(HankeEntity(hankeTunnus = "HAI-1234"))
         val hanke2 = hankeRepository.save(HankeEntity(hankeTunnus = "HAI-1235"))
-        permissionService.setPermission(hanke.id!!, USER_NAME, Role.HAKEMUSASIOINTI)
+        permissionService.setPermission(hanke.id!!, USERNAME, Role.HAKEMUSASIOINTI)
         permissionService.setPermission(hanke2.id!!, "otherUser", Role.HAKEMUSASIOINTI)
 
-        alluDataFactory.saveApplicationEntities(3, USER_NAME, hanke = hanke) { _, application ->
-            application.userId = USER_NAME
+        alluDataFactory.saveApplicationEntities(3, USERNAME, hanke = hanke) { _, application ->
+            application.userId = USERNAME
             application.applicationData =
                 AlluDataFactory.createCableReportApplicationData(
-                    name = "Application data for $USER_NAME"
+                    name = "Application data for $USERNAME"
                 )
         }
         alluDataFactory.saveApplicationEntities(3, "otherUser", hanke = hanke2)
 
         assertThat(applicationRepository.findAll()).hasSize(6)
-        assertThat(applicationRepository.getAllByUserId(USER_NAME)).hasSize(3)
+        assertThat(applicationRepository.getAllByUserId(USERNAME)).hasSize(3)
         assertThat(applicationRepository.getAllByUserId(otherUser)).hasSize(3)
 
-        val response = applicationService.getAllApplicationsForUser(USER_NAME)
+        val response = applicationService.getAllApplicationsForUser(USERNAME)
 
         assertThat(response).hasSize(3)
         assertThat(response)
             .extracting { a -> a.applicationData.name }
-            .each { name -> name.isEqualTo("Application data for $USER_NAME") }
+            .each { name -> name.isEqualTo("Application data for $USERNAME") }
         verify { cableReportServiceAllu wasNot Called }
     }
 
@@ -294,15 +294,14 @@ class ApplicationServiceITest : DatabaseTest() {
         val hanke = hankeRepository.save(HankeEntity(hankeTunnus = "HAI-1234"))
         val hanke2 = hankeRepository.save(HankeEntity(hankeTunnus = "HAI-1235"))
         val hanke3 = hankeRepository.save(HankeEntity(hankeTunnus = "HAI-1236"))
-        permissionService.setPermission(hanke.id!!, USER_NAME, Role.HAKEMUSASIOINTI)
-        permissionService.setPermission(hanke2.id!!, USER_NAME, Role.HAKEMUSASIOINTI)
-        val application1 =
-            alluDataFactory.saveApplicationEntity(username = USER_NAME, hanke = hanke)
+        permissionService.setPermission(hanke.id!!, USERNAME, Role.HAKEMUSASIOINTI)
+        permissionService.setPermission(hanke2.id!!, USERNAME, Role.HAKEMUSASIOINTI)
+        val application1 = alluDataFactory.saveApplicationEntity(username = USERNAME, hanke = hanke)
         val application2 =
             alluDataFactory.saveApplicationEntity(username = "secondUser", hanke = hanke2)
         alluDataFactory.saveApplicationEntity(username = "thirdUser", hanke = hanke3)
 
-        val response = applicationService.getAllApplicationsForUser(USER_NAME).map { it.id }
+        val response = applicationService.getAllApplicationsForUser(USERNAME).map { it.id }
 
         assertThat(applicationRepository.findAll()).hasSize(3)
         assertThat(response).containsExactlyInAnyOrder(application1.id, application2.id)
@@ -320,7 +319,7 @@ class ApplicationServiceITest : DatabaseTest() {
     @Test
     fun `getApplicationById returns correct application`() {
         val hanke = hankeRepository.save(HankeEntity(hankeTunnus = "HAI-1234"))
-        val applications = alluDataFactory.saveApplicationEntities(3, USER_NAME, hanke = hanke)
+        val applications = alluDataFactory.saveApplicationEntities(3, USERNAME, hanke = hanke)
         val selectedId = applications[1].id!!
         assertThat(applicationRepository.findAll()).hasSize(3)
 
@@ -344,7 +343,7 @@ class ApplicationServiceITest : DatabaseTest() {
             )
         assertTrue(cableReportApplicationData.pendingOnClient)
 
-        val response = applicationService.create(newApplication, USER_NAME)
+        val response = applicationService.create(newApplication, USERNAME)
 
         assertNotEquals(givenId, response.id)
         assertEquals(null, response.alluid)
@@ -378,7 +377,7 @@ class ApplicationServiceITest : DatabaseTest() {
                 hankeTunnus = hanke.hankeTunnus!!,
             )
 
-        val response = applicationService.create(newApplication, USER_NAME)
+        val response = applicationService.create(newApplication, USERNAME)
 
         assertTrue(response.applicationData.pendingOnClient)
         val savedApplication = applicationRepository.findById(response.id!!).get()
@@ -406,11 +405,11 @@ class ApplicationServiceITest : DatabaseTest() {
 
         val exception =
             assertThrows<ApplicationGeometryException> {
-                applicationService.create(newApplication, USER_NAME)
+                applicationService.create(newApplication, USERNAME)
             }
 
         assertEquals(
-            """Invalid geometry received when creating a new application for user $USER_NAME, reason = Self-intersection, location = {"type":"Point","coordinates":[25494009.65639264,6679886.142116806]}""",
+            """Invalid geometry received when creating a new application for user $USERNAME, reason = Self-intersection, location = {"type":"Point","coordinates":[25494009.65639264,6679886.142116806]}""",
             exception.message
         )
     }
@@ -423,7 +422,7 @@ class ApplicationServiceITest : DatabaseTest() {
             applicationService.updateApplicationData(
                 1234,
                 AlluDataFactory.createCableReportApplicationData(),
-                USER_NAME
+                USERNAME
             )
         }
     }
@@ -431,16 +430,12 @@ class ApplicationServiceITest : DatabaseTest() {
     @Test
     fun `updateApplicationData saves new application data to database`() {
         val hanke = createHankeEntity()
-        val application = alluDataFactory.saveApplicationEntity(USER_NAME, hanke = hanke)
+        val application = alluDataFactory.saveApplicationEntity(USERNAME, hanke = hanke)
         val newApplicationData =
             AlluDataFactory.createCableReportApplicationData(name = "Uudistettu johtoselvitys")
 
         val response =
-            applicationService.updateApplicationData(
-                application.id!!,
-                newApplicationData,
-                USER_NAME
-            )
+            applicationService.updateApplicationData(application.id!!, newApplicationData, USERNAME)
 
         assertEquals(null, response.alluid)
         assertEquals(application.applicationType, response.applicationType)
@@ -461,7 +456,7 @@ class ApplicationServiceITest : DatabaseTest() {
     fun `updateApplicationData with application that's already saved to Allu is updated in Allu`() {
         val hanke = createHankeEntity()
         val application =
-            alluDataFactory.saveApplicationEntity(USER_NAME, hanke = hanke) { it.alluid = 21 }
+            alluDataFactory.saveApplicationEntity(USERNAME, hanke = hanke) { it.alluid = 21 }
         val newApplicationData =
             AlluDataFactory.createCableReportApplicationData(name = "Uudistettu johtoselvitys")
         every { cableReportServiceAllu.getApplicationInformation(21) } returns
@@ -470,11 +465,7 @@ class ApplicationServiceITest : DatabaseTest() {
         justRun { cableReportServiceAllu.addAttachment(21, any()) }
 
         val response =
-            applicationService.updateApplicationData(
-                application.id!!,
-                newApplicationData,
-                USER_NAME
-            )
+            applicationService.updateApplicationData(application.id!!, newApplicationData, USERNAME)
 
         assertEquals(newApplicationData, response.applicationData)
         val savedApplication = applicationRepository.findById(application.id!!).orElseThrow()
@@ -494,7 +485,7 @@ class ApplicationServiceITest : DatabaseTest() {
     fun `updateApplicationData doesn't save to database if Allu update fails`() {
         val hanke = createHankeEntity()
         val application =
-            alluDataFactory.saveApplicationEntity(USER_NAME, hanke = hanke) { it.alluid = 21 }
+            alluDataFactory.saveApplicationEntity(USERNAME, hanke = hanke) { it.alluid = 21 }
         val newApplicationData =
             AlluDataFactory.createCableReportApplicationData(name = "Uudistettu johtoselvitys")
         every { cableReportServiceAllu.getApplicationInformation(21) } returns
@@ -507,7 +498,7 @@ class ApplicationServiceITest : DatabaseTest() {
                 applicationService.updateApplicationData(
                     application.id!!,
                     newApplicationData,
-                    USER_NAME
+                    USERNAME
                 )
             }
 
@@ -524,7 +515,7 @@ class ApplicationServiceITest : DatabaseTest() {
     fun `updateApplicationData with application that's pending on Allu is updated in Allu`() {
         val hanke = createHankeEntity()
         val application =
-            alluDataFactory.saveApplicationEntity(USER_NAME, hanke = hanke) {
+            alluDataFactory.saveApplicationEntity(USERNAME, hanke = hanke) {
                 it.alluid = 21
                 it.applicationData = it.applicationData.copy(pendingOnClient = false)
             }
@@ -539,11 +530,7 @@ class ApplicationServiceITest : DatabaseTest() {
         justRun { cableReportServiceAllu.addAttachment(21, any()) }
 
         val response =
-            applicationService.updateApplicationData(
-                application.id!!,
-                newApplicationData,
-                USER_NAME
-            )
+            applicationService.updateApplicationData(application.id!!, newApplicationData, USERNAME)
 
         assertEquals(21, response.alluid)
         assertEquals(newApplicationData, response.applicationData)
@@ -565,7 +552,7 @@ class ApplicationServiceITest : DatabaseTest() {
     fun `updateApplicationData with application that's pending on Allu is not updated on Allu if new data is invalid`() {
         val hanke = createHankeEntity()
         val application =
-            alluDataFactory.saveApplicationEntity(USER_NAME, hanke = hanke) {
+            alluDataFactory.saveApplicationEntity(USERNAME, hanke = hanke) {
                 it.apply {
                     alluid = 21
                     applicationData = applicationData.copy(pendingOnClient = false)
@@ -584,7 +571,7 @@ class ApplicationServiceITest : DatabaseTest() {
                 applicationService.updateApplicationData(
                     application.id!!,
                     newApplicationData,
-                    USER_NAME
+                    USERNAME
                 )
             }
 
@@ -606,7 +593,7 @@ class ApplicationServiceITest : DatabaseTest() {
     fun `updateApplicationData doesn't update pendingOnClient`() {
         val hanke = createHankeEntity()
         val application =
-            alluDataFactory.saveApplicationEntity(USER_NAME, hanke = hanke) {
+            alluDataFactory.saveApplicationEntity(USERNAME, hanke = hanke) {
                 it.alluid = 21
                 it.applicationData = it.applicationData.copy(pendingOnClient = false)
             }
@@ -622,11 +609,7 @@ class ApplicationServiceITest : DatabaseTest() {
         justRun { cableReportServiceAllu.addAttachment(21, any()) }
 
         val response =
-            applicationService.updateApplicationData(
-                application.id!!,
-                newApplicationData,
-                USER_NAME
-            )
+            applicationService.updateApplicationData(application.id!!, newApplicationData, USERNAME)
 
         assertFalse(response.applicationData.pendingOnClient)
         val savedApplication = applicationRepository.findById(application.id!!).get()
@@ -642,18 +625,14 @@ class ApplicationServiceITest : DatabaseTest() {
     fun `updateApplicationData with application that's already beyond pending in Allu is not updated`() {
         val hanke = createHankeEntity()
         val application =
-            alluDataFactory.saveApplicationEntity(USER_NAME, hanke = hanke) { it.alluid = 21 }
+            alluDataFactory.saveApplicationEntity(USERNAME, hanke = hanke) { it.alluid = 21 }
         val newApplicationData =
             AlluDataFactory.createCableReportApplicationData(name = "Uudistettu johtoselvitys")
         every { cableReportServiceAllu.getApplicationInformation(21) } returns
             AlluDataFactory.createAlluApplicationResponse(21, ApplicationStatus.HANDLING)
 
         assertThrows<ApplicationAlreadyProcessingException> {
-            applicationService.updateApplicationData(
-                application.id!!,
-                newApplicationData,
-                USER_NAME
-            )
+            applicationService.updateApplicationData(application.id!!, newApplicationData, USERNAME)
         }
 
         val savedApplications = applicationRepository.findAll()
@@ -672,7 +651,7 @@ class ApplicationServiceITest : DatabaseTest() {
     fun `updateApplicationData throws exception with invalid geometry in areas`() {
         val hanke = createHankeEntity()
         val application =
-            alluDataFactory.saveApplicationEntity(USER_NAME, hanke = hanke) { it.alluid = 21 }
+            alluDataFactory.saveApplicationEntity(USERNAME, hanke = hanke) { it.alluid = 21 }
         val cableReportApplicationData =
             AlluDataFactory.createCableReportApplicationData(
                 areas =
@@ -689,12 +668,12 @@ class ApplicationServiceITest : DatabaseTest() {
                 applicationService.updateApplicationData(
                     application.id!!,
                     cableReportApplicationData,
-                    USER_NAME
+                    USERNAME
                 )
             }
 
         assertEquals(
-            """Invalid geometry received when updating application for user $USER_NAME, id=${application.id}, alluid=${application.alluid}, reason = Self-intersection, location = {"type":"Point","coordinates":[25494009.65639264,6679886.142116806]}""",
+            """Invalid geometry received when updating application for user $USERNAME, id=${application.id}, alluid=${application.alluid}, reason = Self-intersection, location = {"type":"Point","coordinates":[25494009.65639264,6679886.142116806]}""",
             exception.message
         )
     }
@@ -704,7 +683,7 @@ class ApplicationServiceITest : DatabaseTest() {
         assertThat(applicationRepository.findAll()).isEmpty()
 
         assertThrows<ApplicationNotFoundException> {
-            applicationService.sendApplication(1234, USER_NAME)
+            applicationService.sendApplication(1234, USERNAME)
         }
     }
 
@@ -712,7 +691,7 @@ class ApplicationServiceITest : DatabaseTest() {
     fun `sendApplication sets pendingOnClient to false`() {
         val hanke = createHankeEntity()
         val application =
-            alluDataFactory.saveApplicationEntity(USER_NAME, hanke = hanke) {
+            alluDataFactory.saveApplicationEntity(USERNAME, hanke = hanke) {
                 it.alluid = 21
                 it.applicationData = it.applicationData.copy(pendingOnClient = true)
             }
@@ -726,7 +705,7 @@ class ApplicationServiceITest : DatabaseTest() {
         every { cableReportServiceAllu.getApplicationInformation(21) } returns
             AlluDataFactory.createAlluApplicationResponse(21, ApplicationStatus.PENDING)
 
-        val response = applicationService.sendApplication(application.id!!, USER_NAME)
+        val response = applicationService.sendApplication(application.id!!, USERNAME)
 
         val responseApplicationData = response.applicationData as CableReportApplicationData
         assertFalse(responseApplicationData.pendingOnClient)
@@ -746,7 +725,7 @@ class ApplicationServiceITest : DatabaseTest() {
     fun `sendApplication creates new application to Allu and saves ID and status to database`() {
         val hanke = createHankeEntity()
         val application =
-            alluDataFactory.saveApplicationEntity(USER_NAME, hanke = hanke) { it.alluid = null }
+            alluDataFactory.saveApplicationEntity(USERNAME, hanke = hanke) { it.alluid = null }
         val applicationData = application.applicationData as CableReportApplicationData
         val pendingApplicationData = applicationData.copy(pendingOnClient = false)
         every { cableReportServiceAllu.create(pendingApplicationData.toAlluData()) } returns 26
@@ -754,7 +733,7 @@ class ApplicationServiceITest : DatabaseTest() {
         every { cableReportServiceAllu.getApplicationInformation(26) } returns
             AlluDataFactory.createAlluApplicationResponse(26)
 
-        val response = applicationService.sendApplication(application.id!!, USER_NAME)
+        val response = applicationService.sendApplication(application.id!!, USERNAME)
 
         assertEquals(26, response.alluid)
         assertEquals(pendingApplicationData, response.applicationData)
@@ -780,14 +759,14 @@ class ApplicationServiceITest : DatabaseTest() {
     fun `sendApplication with application that's been sent before is not sent again`() {
         val hanke = createHankeEntity()
         val application =
-            alluDataFactory.saveApplicationEntity(USER_NAME, hanke = hanke) {
+            alluDataFactory.saveApplicationEntity(USERNAME, hanke = hanke) {
                 it.alluid = 21
                 it.applicationData = it.applicationData.copy(pendingOnClient = false)
             }
         every { cableReportServiceAllu.getApplicationInformation(21) } returns
             AlluDataFactory.createAlluApplicationResponse(21, ApplicationStatus.PENDING)
 
-        applicationService.sendApplication(application.id!!, USER_NAME)
+        applicationService.sendApplication(application.id!!, USERNAME)
 
         verify { cableReportServiceAllu.getApplicationInformation(21) }
         verify(exactly = 0) { cableReportServiceAllu.update(any(), any()) }
@@ -797,7 +776,7 @@ class ApplicationServiceITest : DatabaseTest() {
     fun `sendApplication with application that's already beyond pending in Allu is not sent`() {
         val hanke = createHankeEntity()
         val application =
-            alluDataFactory.saveApplicationEntity(USER_NAME, hanke = hanke) {
+            alluDataFactory.saveApplicationEntity(USERNAME, hanke = hanke) {
                 it.alluid = 21
                 it.applicationData = it.applicationData.copy(pendingOnClient = false)
             }
@@ -805,7 +784,7 @@ class ApplicationServiceITest : DatabaseTest() {
             AlluDataFactory.createAlluApplicationResponse(21, ApplicationStatus.DECISIONMAKING)
 
         assertThrows<ApplicationAlreadyProcessingException> {
-            applicationService.sendApplication(application.id!!, USER_NAME)
+            applicationService.sendApplication(application.id!!, USERNAME)
         }
 
         verify { cableReportServiceAllu.getApplicationInformation(21) }
@@ -815,7 +794,7 @@ class ApplicationServiceITest : DatabaseTest() {
     fun `sendApplication sends application and saves alluid even if status query fails`() {
         val hanke = createHankeEntity()
         val application =
-            alluDataFactory.saveApplicationEntity(USER_NAME, hanke = hanke) { it.alluid = null }
+            alluDataFactory.saveApplicationEntity(USERNAME, hanke = hanke) { it.alluid = null }
         val applicationData = application.applicationData as CableReportApplicationData
         val pendingApplicationData = applicationData.copy(pendingOnClient = false)
         every { cableReportServiceAllu.create(pendingApplicationData.toAlluData()) } returns 26
@@ -823,7 +802,7 @@ class ApplicationServiceITest : DatabaseTest() {
         every { cableReportServiceAllu.getApplicationInformation(26) } throws
             AlluException(listOf())
 
-        val response = applicationService.sendApplication(application.id!!, USER_NAME)
+        val response = applicationService.sendApplication(application.id!!, USERNAME)
 
         assertEquals(26, response.alluid)
         assertEquals(pendingApplicationData, response.applicationData)
@@ -846,17 +825,17 @@ class ApplicationServiceITest : DatabaseTest() {
     fun `delete with unknown ID throws exception`() {
         assertThat(applicationRepository.findAll()).isEmpty()
 
-        assertThrows<ApplicationNotFoundException> { applicationService.delete(1234, USER_NAME) }
+        assertThrows<ApplicationNotFoundException> { applicationService.delete(1234, USERNAME) }
     }
 
     @Test
     fun `delete with an application not yet in Allu just deletes application`() {
         val hanke = createHankeEntity()
         val application =
-            alluDataFactory.saveApplicationEntity(USER_NAME, hanke = hanke) { it.alluid = null }
+            alluDataFactory.saveApplicationEntity(USERNAME, hanke = hanke) { it.alluid = null }
         assertThat(applicationRepository.findAll()).hasSize(1)
 
-        applicationService.delete(application.id!!, USER_NAME)
+        applicationService.delete(application.id!!, USERNAME)
 
         assertThat(applicationRepository.findAll()).isEmpty()
         verify { cableReportServiceAllu wasNot Called }
@@ -873,12 +852,12 @@ class ApplicationServiceITest : DatabaseTest() {
                     hankeTunnus = hanke.hankeTunnus!!,
                     applicationData = dataWithoutAreas
                 ),
-                USER_NAME
+                USERNAME
             )
         auditLogRepository.deleteAll()
         assertThat(auditLogRepository.findAll()).isEmpty()
 
-        applicationService.delete(application.id!!, USER_NAME)
+        applicationService.delete(application.id!!, USERNAME)
 
         val applicationLogs = auditLogRepository.findByType(ObjectType.APPLICATION)
         assertThat(applicationLogs).hasSize(1)
@@ -891,7 +870,7 @@ class ApplicationServiceITest : DatabaseTest() {
         assertThat(event::status).isEqualTo(Status.SUCCESS)
         assertThat(event::failureDescription).isNull()
         assertThat(event::appVersion).isEqualTo("1")
-        assertThat(event.actor::userId).isEqualTo(USER_NAME)
+        assertThat(event.actor::userId).isEqualTo(USERNAME)
         assertThat(event.actor::role).isEqualTo(UserRole.USER)
         assertThat(event.actor::ipAddress).isEqualTo(TestUtils.mockedIp)
         assertThat(event.target::id).isEqualTo(application.id?.toString())
@@ -911,13 +890,13 @@ class ApplicationServiceITest : DatabaseTest() {
     fun `delete with a pending application in Allu cancels application before deleting it`() {
         val hanke = createHankeEntity()
         val application =
-            alluDataFactory.saveApplicationEntity(USER_NAME, hanke = hanke) { it.alluid = 73 }
+            alluDataFactory.saveApplicationEntity(USERNAME, hanke = hanke) { it.alluid = 73 }
         assertThat(applicationRepository.findAll()).hasSize(1)
         every { cableReportServiceAllu.getApplicationInformation(73) } returns
             AlluDataFactory.createAlluApplicationResponse(73, ApplicationStatus.PENDING)
         justRun { cableReportServiceAllu.cancel(73) }
 
-        applicationService.delete(application.id!!, USER_NAME)
+        applicationService.delete(application.id!!, USERNAME)
 
         assertThat(applicationRepository.findAll()).hasSize(0)
         verifyOrder {
@@ -930,13 +909,13 @@ class ApplicationServiceITest : DatabaseTest() {
     fun `delete with a non-pending application in Allu throws exception`() {
         val hanke = createHankeEntity()
         val application =
-            alluDataFactory.saveApplicationEntity(USER_NAME, hanke = hanke) { it.alluid = 73 }
+            alluDataFactory.saveApplicationEntity(USERNAME, hanke = hanke) { it.alluid = 73 }
         assertThat(applicationRepository.findAll()).hasSize(1)
         every { cableReportServiceAllu.getApplicationInformation(73) } returns
             AlluDataFactory.createAlluApplicationResponse(73, ApplicationStatus.APPROVED)
 
         assertThrows<ApplicationAlreadyProcessingException> {
-            applicationService.delete(application.id!!, USER_NAME)
+            applicationService.delete(application.id!!, USERNAME)
         }
 
         assertThat(applicationRepository.findAll()).hasSize(1)
@@ -946,7 +925,7 @@ class ApplicationServiceITest : DatabaseTest() {
     @Test
     fun `downloadDecision with unknown ID throws exception`() {
         assertThrows<ApplicationNotFoundException> {
-            applicationService.downloadDecision(1234, USER_NAME)
+            applicationService.downloadDecision(1234, USERNAME)
         }
     }
 
@@ -954,10 +933,10 @@ class ApplicationServiceITest : DatabaseTest() {
     fun `downloadDecision without alluid throws exception`() {
         val hanke = createHankeEntity()
         val application =
-            alluDataFactory.saveApplicationEntity(USER_NAME, hanke = hanke) { it.alluid = null }
+            alluDataFactory.saveApplicationEntity(USERNAME, hanke = hanke) { it.alluid = null }
 
         assertThrows<ApplicationDecisionNotFoundException> {
-            applicationService.downloadDecision(application.id!!, USER_NAME)
+            applicationService.downloadDecision(application.id!!, USERNAME)
         }
 
         verify { cableReportServiceAllu wasNot Called }
@@ -967,12 +946,12 @@ class ApplicationServiceITest : DatabaseTest() {
     fun `downloadDecision without decision in Allu throws exception`() {
         val hanke = createHankeEntity()
         val application =
-            alluDataFactory.saveApplicationEntity(USER_NAME, hanke = hanke) { it.alluid = 134 }
+            alluDataFactory.saveApplicationEntity(USERNAME, hanke = hanke) { it.alluid = 134 }
         every { cableReportServiceAllu.getDecisionPdf(134) }
             .throws(ApplicationDecisionNotFoundException(""))
 
         assertThrows<ApplicationDecisionNotFoundException> {
-            applicationService.downloadDecision(application.id!!, USER_NAME)
+            applicationService.downloadDecision(application.id!!, USERNAME)
         }
 
         verify { cableReportServiceAllu.getDecisionPdf(134) }
@@ -983,13 +962,13 @@ class ApplicationServiceITest : DatabaseTest() {
         val pdfBytes = "/fi/hel/haitaton/hanke/decision/fake-decision.pdf".getResourceAsBytes()
         val hanke = createHankeEntity()
         val application =
-            alluDataFactory.saveApplicationEntity(USER_NAME, hanke = hanke) {
+            alluDataFactory.saveApplicationEntity(USERNAME, hanke = hanke) {
                 it.alluid = 134
                 it.applicationIdentifier = "JS230001"
             }
         every { cableReportServiceAllu.getDecisionPdf(134) }.returns(pdfBytes)
 
-        val (filename, bytes) = applicationService.downloadDecision(application.id!!, USER_NAME)
+        val (filename, bytes) = applicationService.downloadDecision(application.id!!, USERNAME)
 
         assertThat(filename).isNotNull().isEqualTo("JS230001")
         assertThat(bytes).isEqualTo(pdfBytes)
@@ -1001,13 +980,13 @@ class ApplicationServiceITest : DatabaseTest() {
         val pdfBytes = "/fi/hel/haitaton/hanke/decision/fake-decision.pdf".getResourceAsBytes()
         val hanke = createHankeEntity()
         val application =
-            alluDataFactory.saveApplicationEntity(USER_NAME, hanke = hanke) {
+            alluDataFactory.saveApplicationEntity(USERNAME, hanke = hanke) {
                 it.alluid = 134
                 it.applicationIdentifier = null
             }
         every { cableReportServiceAllu.getDecisionPdf(134) }.returns(pdfBytes)
 
-        val (filename, bytes) = applicationService.downloadDecision(application.id!!, USER_NAME)
+        val (filename, bytes) = applicationService.downloadDecision(application.id!!, USERNAME)
 
         assertThat(filename).isNotNull().isEqualTo("paatos")
         assertThat(bytes).isEqualTo(pdfBytes)
@@ -1038,7 +1017,7 @@ class ApplicationServiceITest : DatabaseTest() {
         assertThat(applicationRepository.findAll()).isEmpty()
         assertEquals(placeholderUpdateTime, alluStatusRepository.getLastUpdateTime().asUtc())
         val hanke = createHankeEntity()
-        alluDataFactory.saveApplicationEntity(USER_NAME, hanke = hanke) { it.alluid = alluid }
+        alluDataFactory.saveApplicationEntity(USERNAME, hanke = hanke) { it.alluid = alluid }
         val firstEventTime = ZonedDateTime.parse("2022-09-05T14:15:16Z")
         val history =
             ApplicationHistoryFactory.create(applicationId = alluid)
@@ -1077,8 +1056,8 @@ class ApplicationServiceITest : DatabaseTest() {
         assertThat(applicationRepository.findAll()).isEmpty()
         assertEquals(placeholderUpdateTime, alluStatusRepository.getLastUpdateTime().asUtc())
         val hanke = createHankeEntity()
-        alluDataFactory.saveApplicationEntity(USER_NAME, hanke = hanke) { it.alluid = alluid }
-        alluDataFactory.saveApplicationEntity(USER_NAME, hanke = hanke) { it.alluid = alluid + 2 }
+        alluDataFactory.saveApplicationEntity(USERNAME, hanke = hanke) { it.alluid = alluid }
+        alluDataFactory.saveApplicationEntity(USERNAME, hanke = hanke) { it.alluid = alluid + 2 }
         val histories =
             listOf(
                 ApplicationHistoryFactory.create(alluid, "JS2300082"),
@@ -1106,7 +1085,7 @@ class ApplicationServiceITest : DatabaseTest() {
         assertThrows<HankeNotFoundException> {
             applicationService.create(
                 AlluDataFactory.createApplication(id = null, hankeTunnus = ""),
-                USER_NAME
+                USERNAME
             )
         }
     }

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceITest.kt
@@ -68,14 +68,14 @@ import org.springframework.security.test.context.support.WithMockUser
 import org.springframework.test.context.ActiveProfiles
 import org.testcontainers.junit.jupiter.Testcontainers
 
-private const val username = "test7358"
+private const val USER_NAME = "test7358"
 
 private val dataWithoutAreas = AlluDataFactory.createCableReportApplicationData(areas = listOf())
 
 @Testcontainers
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("default")
-@WithMockUser(username)
+@WithMockUser(USER_NAME)
 class ApplicationServiceITest : DatabaseTest() {
     @MockkBean private lateinit var cableReportServiceAllu: CableReportService
     @Autowired private lateinit var applicationService: ApplicationService
@@ -120,7 +120,7 @@ class ApplicationServiceITest : DatabaseTest() {
                     hankeTunnus = hanke.hankeTunnus!!,
                     applicationData = dataWithoutAreas
                 ),
-                username
+                USER_NAME
             )
 
         val applicationLogs = auditLogRepository.findByType(ObjectType.APPLICATION)
@@ -134,7 +134,7 @@ class ApplicationServiceITest : DatabaseTest() {
         assertThat(event::status).isEqualTo(Status.SUCCESS)
         assertThat(event::failureDescription).isNull()
         assertThat(event::appVersion).isEqualTo("1")
-        assertThat(event.actor::userId).isEqualTo(username)
+        assertThat(event.actor::userId).isEqualTo(USER_NAME)
         assertThat(event.actor::role).isEqualTo(UserRole.USER)
         assertThat(event.actor::ipAddress).isEqualTo(TestUtils.mockedIp)
         assertThat(event.target::id).isEqualTo(application.id?.toString())
@@ -161,7 +161,7 @@ class ApplicationServiceITest : DatabaseTest() {
                     hankeTunnus = hanke.hankeTunnus!!,
                     applicationData = dataWithoutAreas
                 ),
-                username
+                USER_NAME
             )
         auditLogRepository.deleteAll()
         assertThat(auditLogRepository.findAll()).isEmpty()
@@ -170,7 +170,7 @@ class ApplicationServiceITest : DatabaseTest() {
         applicationService.updateApplicationData(
             application.id!!,
             dataWithoutAreas.copy(name = "Modified application"),
-            username
+            USER_NAME
         )
 
         val applicationLogs = auditLogRepository.findByType(ObjectType.APPLICATION)
@@ -184,7 +184,7 @@ class ApplicationServiceITest : DatabaseTest() {
         assertThat(event::status).isEqualTo(Status.SUCCESS)
         assertThat(event::failureDescription).isNull()
         assertThat(event::appVersion).isEqualTo("1")
-        assertThat(event.actor::userId).isEqualTo(username)
+        assertThat(event.actor::userId).isEqualTo(USER_NAME)
         assertThat(event.actor::role).isEqualTo(UserRole.USER)
         assertThat(event.actor::ipAddress).isEqualTo(TestUtils.mockedIp)
         assertThat(event.target::id).isEqualTo(application.id?.toString())
@@ -216,13 +216,13 @@ class ApplicationServiceITest : DatabaseTest() {
         TestUtils.addMockedRequestIp()
         val hanke = createHankeEntity()
         val application =
-            alluDataFactory.saveApplicationEntity(username, hanke = hanke) { it.alluid = null }
+            alluDataFactory.saveApplicationEntity(USER_NAME, hanke = hanke) { it.alluid = null }
         assertThat(auditLogRepository.findAll()).isEmpty()
 
         applicationService.updateApplicationData(
             application.id!!,
             application.applicationData,
-            username
+            USER_NAME
         )
 
         val applicationLogs = auditLogRepository.findByType(ObjectType.APPLICATION)
@@ -235,13 +235,13 @@ class ApplicationServiceITest : DatabaseTest() {
         TestUtils.addMockedRequestIp()
         val hanke = createHankeEntity()
         val application =
-            alluDataFactory.saveApplicationEntity(username, hanke = hanke) { it.alluid = 2 }
+            alluDataFactory.saveApplicationEntity(USER_NAME, hanke = hanke) { it.alluid = 2 }
         assertThat(auditLogRepository.findAll()).isEmpty()
 
         applicationService.updateApplicationData(
             application.id!!,
             application.applicationData,
-            username
+            USER_NAME
         )
 
         verify { cableReportServiceAllu wasNot Called }
@@ -251,7 +251,7 @@ class ApplicationServiceITest : DatabaseTest() {
     fun `getAllApplicationsForUser with no applications returns empty list`() {
         assertThat(applicationRepository.findAll()).isEmpty()
 
-        val response = applicationService.getAllApplicationsForUser(username)
+        val response = applicationService.getAllApplicationsForUser(USER_NAME)
 
         assertEquals(listOf<Application>(), response)
         verify { cableReportServiceAllu wasNot Called }
@@ -263,28 +263,28 @@ class ApplicationServiceITest : DatabaseTest() {
         val otherUser = "otherUser"
         val hanke = hankeRepository.save(HankeEntity(hankeTunnus = "HAI-1234"))
         val hanke2 = hankeRepository.save(HankeEntity(hankeTunnus = "HAI-1235"))
-        permissionService.setPermission(hanke.id!!, username, Role.HAKEMUSASIOINTI)
+        permissionService.setPermission(hanke.id!!, USER_NAME, Role.HAKEMUSASIOINTI)
         permissionService.setPermission(hanke2.id!!, "otherUser", Role.HAKEMUSASIOINTI)
 
-        alluDataFactory.saveApplicationEntities(3, username, hanke = hanke) { i, application ->
-            application.userId = username
+        alluDataFactory.saveApplicationEntities(3, USER_NAME, hanke = hanke) { _, application ->
+            application.userId = USER_NAME
             application.applicationData =
                 AlluDataFactory.createCableReportApplicationData(
-                    name = "Application data for $username"
+                    name = "Application data for $USER_NAME"
                 )
         }
         alluDataFactory.saveApplicationEntities(3, "otherUser", hanke = hanke2)
 
         assertThat(applicationRepository.findAll()).hasSize(6)
-        assertThat(applicationRepository.getAllByUserId(username)).hasSize(3)
+        assertThat(applicationRepository.getAllByUserId(USER_NAME)).hasSize(3)
         assertThat(applicationRepository.getAllByUserId(otherUser)).hasSize(3)
 
-        val response = applicationService.getAllApplicationsForUser(username)
+        val response = applicationService.getAllApplicationsForUser(USER_NAME)
 
         assertThat(response).hasSize(3)
         assertThat(response)
             .extracting { a -> a.applicationData.name }
-            .each { name -> name.isEqualTo("Application data for $username") }
+            .each { name -> name.isEqualTo("Application data for $USER_NAME") }
         verify { cableReportServiceAllu wasNot Called }
     }
 
@@ -294,14 +294,15 @@ class ApplicationServiceITest : DatabaseTest() {
         val hanke = hankeRepository.save(HankeEntity(hankeTunnus = "HAI-1234"))
         val hanke2 = hankeRepository.save(HankeEntity(hankeTunnus = "HAI-1235"))
         val hanke3 = hankeRepository.save(HankeEntity(hankeTunnus = "HAI-1236"))
-        permissionService.setPermission(hanke.id!!, username, Role.HAKEMUSASIOINTI)
-        permissionService.setPermission(hanke2.id!!, username, Role.HAKEMUSASIOINTI)
-        val application1 = alluDataFactory.saveApplicationEntity(username = username, hanke = hanke)
+        permissionService.setPermission(hanke.id!!, USER_NAME, Role.HAKEMUSASIOINTI)
+        permissionService.setPermission(hanke2.id!!, USER_NAME, Role.HAKEMUSASIOINTI)
+        val application1 =
+            alluDataFactory.saveApplicationEntity(username = USER_NAME, hanke = hanke)
         val application2 =
             alluDataFactory.saveApplicationEntity(username = "secondUser", hanke = hanke2)
         alluDataFactory.saveApplicationEntity(username = "thirdUser", hanke = hanke3)
 
-        val response = applicationService.getAllApplicationsForUser(username).map { it.id }
+        val response = applicationService.getAllApplicationsForUser(USER_NAME).map { it.id }
 
         assertThat(applicationRepository.findAll()).hasSize(3)
         assertThat(response).containsExactlyInAnyOrder(application1.id, application2.id)
@@ -319,7 +320,7 @@ class ApplicationServiceITest : DatabaseTest() {
     @Test
     fun `getApplicationById returns correct application`() {
         val hanke = hankeRepository.save(HankeEntity(hankeTunnus = "HAI-1234"))
-        val applications = alluDataFactory.saveApplicationEntities(3, username, hanke = hanke)
+        val applications = alluDataFactory.saveApplicationEntities(3, USER_NAME, hanke = hanke)
         val selectedId = applications[1].id!!
         assertThat(applicationRepository.findAll()).hasSize(3)
 
@@ -343,7 +344,7 @@ class ApplicationServiceITest : DatabaseTest() {
             )
         assertTrue(cableReportApplicationData.pendingOnClient)
 
-        val response = applicationService.create(newApplication, username)
+        val response = applicationService.create(newApplication, USER_NAME)
 
         assertNotEquals(givenId, response.id)
         assertEquals(null, response.alluid)
@@ -377,7 +378,7 @@ class ApplicationServiceITest : DatabaseTest() {
                 hankeTunnus = hanke.hankeTunnus!!,
             )
 
-        val response = applicationService.create(newApplication, username)
+        val response = applicationService.create(newApplication, USER_NAME)
 
         assertTrue(response.applicationData.pendingOnClient)
         val savedApplication = applicationRepository.findById(response.id!!).get()
@@ -405,11 +406,11 @@ class ApplicationServiceITest : DatabaseTest() {
 
         val exception =
             assertThrows<ApplicationGeometryException> {
-                applicationService.create(newApplication, username)
+                applicationService.create(newApplication, USER_NAME)
             }
 
         assertEquals(
-            """Invalid geometry received when creating a new application for user $username, reason = Self-intersection, location = {"type":"Point","coordinates":[25494009.65639264,6679886.142116806]}""",
+            """Invalid geometry received when creating a new application for user $USER_NAME, reason = Self-intersection, location = {"type":"Point","coordinates":[25494009.65639264,6679886.142116806]}""",
             exception.message
         )
     }
@@ -422,7 +423,7 @@ class ApplicationServiceITest : DatabaseTest() {
             applicationService.updateApplicationData(
                 1234,
                 AlluDataFactory.createCableReportApplicationData(),
-                username
+                USER_NAME
             )
         }
     }
@@ -430,12 +431,16 @@ class ApplicationServiceITest : DatabaseTest() {
     @Test
     fun `updateApplicationData saves new application data to database`() {
         val hanke = createHankeEntity()
-        val application = alluDataFactory.saveApplicationEntity(username, hanke = hanke)
+        val application = alluDataFactory.saveApplicationEntity(USER_NAME, hanke = hanke)
         val newApplicationData =
             AlluDataFactory.createCableReportApplicationData(name = "Uudistettu johtoselvitys")
 
         val response =
-            applicationService.updateApplicationData(application.id!!, newApplicationData, username)
+            applicationService.updateApplicationData(
+                application.id!!,
+                newApplicationData,
+                USER_NAME
+            )
 
         assertEquals(null, response.alluid)
         assertEquals(application.applicationType, response.applicationType)
@@ -456,7 +461,7 @@ class ApplicationServiceITest : DatabaseTest() {
     fun `updateApplicationData with application that's already saved to Allu is updated in Allu`() {
         val hanke = createHankeEntity()
         val application =
-            alluDataFactory.saveApplicationEntity(username, hanke = hanke) { it.alluid = 21 }
+            alluDataFactory.saveApplicationEntity(USER_NAME, hanke = hanke) { it.alluid = 21 }
         val newApplicationData =
             AlluDataFactory.createCableReportApplicationData(name = "Uudistettu johtoselvitys")
         every { cableReportServiceAllu.getApplicationInformation(21) } returns
@@ -465,7 +470,11 @@ class ApplicationServiceITest : DatabaseTest() {
         justRun { cableReportServiceAllu.addAttachment(21, any()) }
 
         val response =
-            applicationService.updateApplicationData(application.id!!, newApplicationData, username)
+            applicationService.updateApplicationData(
+                application.id!!,
+                newApplicationData,
+                USER_NAME
+            )
 
         assertEquals(newApplicationData, response.applicationData)
         val savedApplication = applicationRepository.findById(application.id!!).orElseThrow()
@@ -485,7 +494,7 @@ class ApplicationServiceITest : DatabaseTest() {
     fun `updateApplicationData doesn't save to database if Allu update fails`() {
         val hanke = createHankeEntity()
         val application =
-            alluDataFactory.saveApplicationEntity(username, hanke = hanke) { it.alluid = 21 }
+            alluDataFactory.saveApplicationEntity(USER_NAME, hanke = hanke) { it.alluid = 21 }
         val newApplicationData =
             AlluDataFactory.createCableReportApplicationData(name = "Uudistettu johtoselvitys")
         every { cableReportServiceAllu.getApplicationInformation(21) } returns
@@ -498,7 +507,7 @@ class ApplicationServiceITest : DatabaseTest() {
                 applicationService.updateApplicationData(
                     application.id!!,
                     newApplicationData,
-                    username
+                    USER_NAME
                 )
             }
 
@@ -515,7 +524,7 @@ class ApplicationServiceITest : DatabaseTest() {
     fun `updateApplicationData with application that's pending on Allu is updated in Allu`() {
         val hanke = createHankeEntity()
         val application =
-            alluDataFactory.saveApplicationEntity(username, hanke = hanke) {
+            alluDataFactory.saveApplicationEntity(USER_NAME, hanke = hanke) {
                 it.alluid = 21
                 it.applicationData = it.applicationData.copy(pendingOnClient = false)
             }
@@ -530,7 +539,11 @@ class ApplicationServiceITest : DatabaseTest() {
         justRun { cableReportServiceAllu.addAttachment(21, any()) }
 
         val response =
-            applicationService.updateApplicationData(application.id!!, newApplicationData, username)
+            applicationService.updateApplicationData(
+                application.id!!,
+                newApplicationData,
+                USER_NAME
+            )
 
         assertEquals(21, response.alluid)
         assertEquals(newApplicationData, response.applicationData)
@@ -552,7 +565,7 @@ class ApplicationServiceITest : DatabaseTest() {
     fun `updateApplicationData with application that's pending on Allu is not updated on Allu if new data is invalid`() {
         val hanke = createHankeEntity()
         val application =
-            alluDataFactory.saveApplicationEntity(username, hanke = hanke) {
+            alluDataFactory.saveApplicationEntity(USER_NAME, hanke = hanke) {
                 it.apply {
                     alluid = 21
                     applicationData = applicationData.copy(pendingOnClient = false)
@@ -571,7 +584,7 @@ class ApplicationServiceITest : DatabaseTest() {
                 applicationService.updateApplicationData(
                     application.id!!,
                     newApplicationData,
-                    username
+                    USER_NAME
                 )
             }
 
@@ -593,7 +606,7 @@ class ApplicationServiceITest : DatabaseTest() {
     fun `updateApplicationData doesn't update pendingOnClient`() {
         val hanke = createHankeEntity()
         val application =
-            alluDataFactory.saveApplicationEntity(username, hanke = hanke) {
+            alluDataFactory.saveApplicationEntity(USER_NAME, hanke = hanke) {
                 it.alluid = 21
                 it.applicationData = it.applicationData.copy(pendingOnClient = false)
             }
@@ -609,7 +622,11 @@ class ApplicationServiceITest : DatabaseTest() {
         justRun { cableReportServiceAllu.addAttachment(21, any()) }
 
         val response =
-            applicationService.updateApplicationData(application.id!!, newApplicationData, username)
+            applicationService.updateApplicationData(
+                application.id!!,
+                newApplicationData,
+                USER_NAME
+            )
 
         assertFalse(response.applicationData.pendingOnClient)
         val savedApplication = applicationRepository.findById(application.id!!).get()
@@ -625,14 +642,18 @@ class ApplicationServiceITest : DatabaseTest() {
     fun `updateApplicationData with application that's already beyond pending in Allu is not updated`() {
         val hanke = createHankeEntity()
         val application =
-            alluDataFactory.saveApplicationEntity(username, hanke = hanke) { it.alluid = 21 }
+            alluDataFactory.saveApplicationEntity(USER_NAME, hanke = hanke) { it.alluid = 21 }
         val newApplicationData =
             AlluDataFactory.createCableReportApplicationData(name = "Uudistettu johtoselvitys")
         every { cableReportServiceAllu.getApplicationInformation(21) } returns
             AlluDataFactory.createAlluApplicationResponse(21, ApplicationStatus.HANDLING)
 
         assertThrows<ApplicationAlreadyProcessingException> {
-            applicationService.updateApplicationData(application.id!!, newApplicationData, username)
+            applicationService.updateApplicationData(
+                application.id!!,
+                newApplicationData,
+                USER_NAME
+            )
         }
 
         val savedApplications = applicationRepository.findAll()
@@ -651,7 +672,7 @@ class ApplicationServiceITest : DatabaseTest() {
     fun `updateApplicationData throws exception with invalid geometry in areas`() {
         val hanke = createHankeEntity()
         val application =
-            alluDataFactory.saveApplicationEntity(username, hanke = hanke) { it.alluid = 21 }
+            alluDataFactory.saveApplicationEntity(USER_NAME, hanke = hanke) { it.alluid = 21 }
         val cableReportApplicationData =
             AlluDataFactory.createCableReportApplicationData(
                 areas =
@@ -668,12 +689,12 @@ class ApplicationServiceITest : DatabaseTest() {
                 applicationService.updateApplicationData(
                     application.id!!,
                     cableReportApplicationData,
-                    username
+                    USER_NAME
                 )
             }
 
         assertEquals(
-            """Invalid geometry received when updating application for user $username, id=${application.id}, alluid=${application.alluid}, reason = Self-intersection, location = {"type":"Point","coordinates":[25494009.65639264,6679886.142116806]}""",
+            """Invalid geometry received when updating application for user $USER_NAME, id=${application.id}, alluid=${application.alluid}, reason = Self-intersection, location = {"type":"Point","coordinates":[25494009.65639264,6679886.142116806]}""",
             exception.message
         )
     }
@@ -683,7 +704,7 @@ class ApplicationServiceITest : DatabaseTest() {
         assertThat(applicationRepository.findAll()).isEmpty()
 
         assertThrows<ApplicationNotFoundException> {
-            applicationService.sendApplication(1234, username)
+            applicationService.sendApplication(1234, USER_NAME)
         }
     }
 
@@ -691,7 +712,7 @@ class ApplicationServiceITest : DatabaseTest() {
     fun `sendApplication sets pendingOnClient to false`() {
         val hanke = createHankeEntity()
         val application =
-            alluDataFactory.saveApplicationEntity(username, hanke = hanke) {
+            alluDataFactory.saveApplicationEntity(USER_NAME, hanke = hanke) {
                 it.alluid = 21
                 it.applicationData = it.applicationData.copy(pendingOnClient = true)
             }
@@ -705,7 +726,7 @@ class ApplicationServiceITest : DatabaseTest() {
         every { cableReportServiceAllu.getApplicationInformation(21) } returns
             AlluDataFactory.createAlluApplicationResponse(21, ApplicationStatus.PENDING)
 
-        val response = applicationService.sendApplication(application.id!!, username)
+        val response = applicationService.sendApplication(application.id!!, USER_NAME)
 
         val responseApplicationData = response.applicationData as CableReportApplicationData
         assertFalse(responseApplicationData.pendingOnClient)
@@ -725,7 +746,7 @@ class ApplicationServiceITest : DatabaseTest() {
     fun `sendApplication creates new application to Allu and saves ID and status to database`() {
         val hanke = createHankeEntity()
         val application =
-            alluDataFactory.saveApplicationEntity(username, hanke = hanke) { it.alluid = null }
+            alluDataFactory.saveApplicationEntity(USER_NAME, hanke = hanke) { it.alluid = null }
         val applicationData = application.applicationData as CableReportApplicationData
         val pendingApplicationData = applicationData.copy(pendingOnClient = false)
         every { cableReportServiceAllu.create(pendingApplicationData.toAlluData()) } returns 26
@@ -733,7 +754,7 @@ class ApplicationServiceITest : DatabaseTest() {
         every { cableReportServiceAllu.getApplicationInformation(26) } returns
             AlluDataFactory.createAlluApplicationResponse(26)
 
-        val response = applicationService.sendApplication(application.id!!, username)
+        val response = applicationService.sendApplication(application.id!!, USER_NAME)
 
         assertEquals(26, response.alluid)
         assertEquals(pendingApplicationData, response.applicationData)
@@ -759,14 +780,14 @@ class ApplicationServiceITest : DatabaseTest() {
     fun `sendApplication with application that's been sent before is not sent again`() {
         val hanke = createHankeEntity()
         val application =
-            alluDataFactory.saveApplicationEntity(username, hanke = hanke) {
+            alluDataFactory.saveApplicationEntity(USER_NAME, hanke = hanke) {
                 it.alluid = 21
                 it.applicationData = it.applicationData.copy(pendingOnClient = false)
             }
         every { cableReportServiceAllu.getApplicationInformation(21) } returns
             AlluDataFactory.createAlluApplicationResponse(21, ApplicationStatus.PENDING)
 
-        applicationService.sendApplication(application.id!!, username)
+        applicationService.sendApplication(application.id!!, USER_NAME)
 
         verify { cableReportServiceAllu.getApplicationInformation(21) }
         verify(exactly = 0) { cableReportServiceAllu.update(any(), any()) }
@@ -776,7 +797,7 @@ class ApplicationServiceITest : DatabaseTest() {
     fun `sendApplication with application that's already beyond pending in Allu is not sent`() {
         val hanke = createHankeEntity()
         val application =
-            alluDataFactory.saveApplicationEntity(username, hanke = hanke) {
+            alluDataFactory.saveApplicationEntity(USER_NAME, hanke = hanke) {
                 it.alluid = 21
                 it.applicationData = it.applicationData.copy(pendingOnClient = false)
             }
@@ -784,7 +805,7 @@ class ApplicationServiceITest : DatabaseTest() {
             AlluDataFactory.createAlluApplicationResponse(21, ApplicationStatus.DECISIONMAKING)
 
         assertThrows<ApplicationAlreadyProcessingException> {
-            applicationService.sendApplication(application.id!!, username)
+            applicationService.sendApplication(application.id!!, USER_NAME)
         }
 
         verify { cableReportServiceAllu.getApplicationInformation(21) }
@@ -794,7 +815,7 @@ class ApplicationServiceITest : DatabaseTest() {
     fun `sendApplication sends application and saves alluid even if status query fails`() {
         val hanke = createHankeEntity()
         val application =
-            alluDataFactory.saveApplicationEntity(username, hanke = hanke) { it.alluid = null }
+            alluDataFactory.saveApplicationEntity(USER_NAME, hanke = hanke) { it.alluid = null }
         val applicationData = application.applicationData as CableReportApplicationData
         val pendingApplicationData = applicationData.copy(pendingOnClient = false)
         every { cableReportServiceAllu.create(pendingApplicationData.toAlluData()) } returns 26
@@ -802,7 +823,7 @@ class ApplicationServiceITest : DatabaseTest() {
         every { cableReportServiceAllu.getApplicationInformation(26) } throws
             AlluException(listOf())
 
-        val response = applicationService.sendApplication(application.id!!, username)
+        val response = applicationService.sendApplication(application.id!!, USER_NAME)
 
         assertEquals(26, response.alluid)
         assertEquals(pendingApplicationData, response.applicationData)
@@ -825,17 +846,17 @@ class ApplicationServiceITest : DatabaseTest() {
     fun `delete with unknown ID throws exception`() {
         assertThat(applicationRepository.findAll()).isEmpty()
 
-        assertThrows<ApplicationNotFoundException> { applicationService.delete(1234, username) }
+        assertThrows<ApplicationNotFoundException> { applicationService.delete(1234, USER_NAME) }
     }
 
     @Test
     fun `delete with an application not yet in Allu just deletes application`() {
         val hanke = createHankeEntity()
         val application =
-            alluDataFactory.saveApplicationEntity(username, hanke = hanke) { it.alluid = null }
+            alluDataFactory.saveApplicationEntity(USER_NAME, hanke = hanke) { it.alluid = null }
         assertThat(applicationRepository.findAll()).hasSize(1)
 
-        applicationService.delete(application.id!!, username)
+        applicationService.delete(application.id!!, USER_NAME)
 
         assertThat(applicationRepository.findAll()).isEmpty()
         verify { cableReportServiceAllu wasNot Called }
@@ -852,12 +873,12 @@ class ApplicationServiceITest : DatabaseTest() {
                     hankeTunnus = hanke.hankeTunnus!!,
                     applicationData = dataWithoutAreas
                 ),
-                username
+                USER_NAME
             )
         auditLogRepository.deleteAll()
         assertThat(auditLogRepository.findAll()).isEmpty()
 
-        applicationService.delete(application.id!!, username)
+        applicationService.delete(application.id!!, USER_NAME)
 
         val applicationLogs = auditLogRepository.findByType(ObjectType.APPLICATION)
         assertThat(applicationLogs).hasSize(1)
@@ -870,7 +891,7 @@ class ApplicationServiceITest : DatabaseTest() {
         assertThat(event::status).isEqualTo(Status.SUCCESS)
         assertThat(event::failureDescription).isNull()
         assertThat(event::appVersion).isEqualTo("1")
-        assertThat(event.actor::userId).isEqualTo(username)
+        assertThat(event.actor::userId).isEqualTo(USER_NAME)
         assertThat(event.actor::role).isEqualTo(UserRole.USER)
         assertThat(event.actor::ipAddress).isEqualTo(TestUtils.mockedIp)
         assertThat(event.target::id).isEqualTo(application.id?.toString())
@@ -890,13 +911,13 @@ class ApplicationServiceITest : DatabaseTest() {
     fun `delete with a pending application in Allu cancels application before deleting it`() {
         val hanke = createHankeEntity()
         val application =
-            alluDataFactory.saveApplicationEntity(username, hanke = hanke) { it.alluid = 73 }
+            alluDataFactory.saveApplicationEntity(USER_NAME, hanke = hanke) { it.alluid = 73 }
         assertThat(applicationRepository.findAll()).hasSize(1)
         every { cableReportServiceAllu.getApplicationInformation(73) } returns
             AlluDataFactory.createAlluApplicationResponse(73, ApplicationStatus.PENDING)
         justRun { cableReportServiceAllu.cancel(73) }
 
-        applicationService.delete(application.id!!, username)
+        applicationService.delete(application.id!!, USER_NAME)
 
         assertThat(applicationRepository.findAll()).hasSize(0)
         verifyOrder {
@@ -909,13 +930,13 @@ class ApplicationServiceITest : DatabaseTest() {
     fun `delete with a non-pending application in Allu throws exception`() {
         val hanke = createHankeEntity()
         val application =
-            alluDataFactory.saveApplicationEntity(username, hanke = hanke) { it.alluid = 73 }
+            alluDataFactory.saveApplicationEntity(USER_NAME, hanke = hanke) { it.alluid = 73 }
         assertThat(applicationRepository.findAll()).hasSize(1)
         every { cableReportServiceAllu.getApplicationInformation(73) } returns
             AlluDataFactory.createAlluApplicationResponse(73, ApplicationStatus.APPROVED)
 
         assertThrows<ApplicationAlreadyProcessingException> {
-            applicationService.delete(application.id!!, username)
+            applicationService.delete(application.id!!, USER_NAME)
         }
 
         assertThat(applicationRepository.findAll()).hasSize(1)
@@ -925,7 +946,7 @@ class ApplicationServiceITest : DatabaseTest() {
     @Test
     fun `downloadDecision with unknown ID throws exception`() {
         assertThrows<ApplicationNotFoundException> {
-            applicationService.downloadDecision(1234, username)
+            applicationService.downloadDecision(1234, USER_NAME)
         }
     }
 
@@ -933,10 +954,10 @@ class ApplicationServiceITest : DatabaseTest() {
     fun `downloadDecision without alluid throws exception`() {
         val hanke = createHankeEntity()
         val application =
-            alluDataFactory.saveApplicationEntity(username, hanke = hanke) { it.alluid = null }
+            alluDataFactory.saveApplicationEntity(USER_NAME, hanke = hanke) { it.alluid = null }
 
         assertThrows<ApplicationDecisionNotFoundException> {
-            applicationService.downloadDecision(application.id!!, username)
+            applicationService.downloadDecision(application.id!!, USER_NAME)
         }
 
         verify { cableReportServiceAllu wasNot Called }
@@ -946,12 +967,12 @@ class ApplicationServiceITest : DatabaseTest() {
     fun `downloadDecision without decision in Allu throws exception`() {
         val hanke = createHankeEntity()
         val application =
-            alluDataFactory.saveApplicationEntity(username, hanke = hanke) { it.alluid = 134 }
+            alluDataFactory.saveApplicationEntity(USER_NAME, hanke = hanke) { it.alluid = 134 }
         every { cableReportServiceAllu.getDecisionPdf(134) }
             .throws(ApplicationDecisionNotFoundException(""))
 
         assertThrows<ApplicationDecisionNotFoundException> {
-            applicationService.downloadDecision(application.id!!, username)
+            applicationService.downloadDecision(application.id!!, USER_NAME)
         }
 
         verify { cableReportServiceAllu.getDecisionPdf(134) }
@@ -962,13 +983,13 @@ class ApplicationServiceITest : DatabaseTest() {
         val pdfBytes = "/fi/hel/haitaton/hanke/decision/fake-decision.pdf".getResourceAsBytes()
         val hanke = createHankeEntity()
         val application =
-            alluDataFactory.saveApplicationEntity(username, hanke = hanke) {
+            alluDataFactory.saveApplicationEntity(USER_NAME, hanke = hanke) {
                 it.alluid = 134
                 it.applicationIdentifier = "JS230001"
             }
         every { cableReportServiceAllu.getDecisionPdf(134) }.returns(pdfBytes)
 
-        val (filename, bytes) = applicationService.downloadDecision(application.id!!, username)
+        val (filename, bytes) = applicationService.downloadDecision(application.id!!, USER_NAME)
 
         assertThat(filename).isNotNull().isEqualTo("JS230001")
         assertThat(bytes).isEqualTo(pdfBytes)
@@ -980,13 +1001,13 @@ class ApplicationServiceITest : DatabaseTest() {
         val pdfBytes = "/fi/hel/haitaton/hanke/decision/fake-decision.pdf".getResourceAsBytes()
         val hanke = createHankeEntity()
         val application =
-            alluDataFactory.saveApplicationEntity(username, hanke = hanke) {
+            alluDataFactory.saveApplicationEntity(USER_NAME, hanke = hanke) {
                 it.alluid = 134
                 it.applicationIdentifier = null
             }
         every { cableReportServiceAllu.getDecisionPdf(134) }.returns(pdfBytes)
 
-        val (filename, bytes) = applicationService.downloadDecision(application.id!!, username)
+        val (filename, bytes) = applicationService.downloadDecision(application.id!!, USER_NAME)
 
         assertThat(filename).isNotNull().isEqualTo("paatos")
         assertThat(bytes).isEqualTo(pdfBytes)
@@ -1017,7 +1038,7 @@ class ApplicationServiceITest : DatabaseTest() {
         assertThat(applicationRepository.findAll()).isEmpty()
         assertEquals(placeholderUpdateTime, alluStatusRepository.getLastUpdateTime().asUtc())
         val hanke = createHankeEntity()
-        alluDataFactory.saveApplicationEntity(username, hanke = hanke) { it.alluid = alluid }
+        alluDataFactory.saveApplicationEntity(USER_NAME, hanke = hanke) { it.alluid = alluid }
         val firstEventTime = ZonedDateTime.parse("2022-09-05T14:15:16Z")
         val history =
             ApplicationHistoryFactory.create(applicationId = alluid)
@@ -1056,8 +1077,8 @@ class ApplicationServiceITest : DatabaseTest() {
         assertThat(applicationRepository.findAll()).isEmpty()
         assertEquals(placeholderUpdateTime, alluStatusRepository.getLastUpdateTime().asUtc())
         val hanke = createHankeEntity()
-        alluDataFactory.saveApplicationEntity(username, hanke = hanke) { it.alluid = alluid }
-        alluDataFactory.saveApplicationEntity(username, hanke = hanke) { it.alluid = alluid + 2 }
+        alluDataFactory.saveApplicationEntity(USER_NAME, hanke = hanke) { it.alluid = alluid }
+        alluDataFactory.saveApplicationEntity(USER_NAME, hanke = hanke) { it.alluid = alluid + 2 }
         val histories =
             listOf(
                 ApplicationHistoryFactory.create(alluid, "JS2300082"),
@@ -1085,7 +1106,7 @@ class ApplicationServiceITest : DatabaseTest() {
         assertThrows<HankeNotFoundException> {
             applicationService.create(
                 AlluDataFactory.createApplication(id = null, hankeTunnus = ""),
-                username
+                USER_NAME
             )
         }
     }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeServiceImpl.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeServiceImpl.kt
@@ -200,6 +200,11 @@ open class HankeServiceImpl(
                 "Hanke ${hanke.hankeTunnus} has hakemus in Allu processing. Cannot delete."
             )
         }
+
+        hakemukset.forEach { hakemus ->
+            hakemus.id?.let { id -> applicationService.delete(id, userId) }
+        }
+
         hankeRepository.deleteById(hankeId)
         hankeLoggingService.logDelete(hanke, userId)
     }


### PR DESCRIPTION
# Description

If hanke deletion has proceeded to post validity check, all pending applications need to be:
- canceled in Allu
- deleted from database

After this, the hanke can be deleted.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1407

## Type of change

- [ ] Bug fix 
- [x] New feature 
- [ ] Other

# Instructions for testing
Create hanke and add hakemus for it. If hakemus status is suitable (null, pending or pending_client) hanke deletion (along with hakemus) is allowed and successful. If hakemus has proceeded to Allu handling, endpoint will return 409 conflict status.

# Checklist:

- [x] I have written new tests (if applicable)
- [x] have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 
