### PR TITLE
HAI-1314/tram infra processing

### DIFF
--- a/scripts/gis-material-update/README.md
+++ b/scripts/gis-material-update/README.md
@@ -115,7 +115,7 @@ Where `<source>` is currently one of:
 - `hki` - Helsinki area GIS material, polygon
 - `osm` - OpenStreetMap export of Finland (with focus area clipping)
 - `helsinki_osm_lines` - line geometry export from `osm`, covering area of city of Helsinki
-- `ylre_katualue` - Helsinki YLRE street areas, polygons.
+- `ylre_katualueet` - Helsinki YLRE street areas, polygons.
 - `ylre_katuosat` - Helsinki YLRE parts, polygons.
 - `maka_autoliikennemaarat` - Traffic volumes (car traffic)
 

--- a/scripts/gis-material-update/README.md
+++ b/scripts/gis-material-update/README.md
@@ -233,6 +233,26 @@ Files (names configured in `config.yaml`)
 - ylre_classes_orig_polys.gpkg
 - tormays_ylre_classes_polys.gpkg
 
+### `tram_infra`
+
+Docker example run (ensure that image build and file copying is
+already performed as instructed above):
+
+```sh
+docker-compose up -d gis-db
+docker-compose run --rm gis-fetch hki osm helsinki_osm_lines
+docker-compose run --rm gis-process tram_infra
+docker-compose stop gis-db
+```
+
+Processed GIS material is available in:
+haitaton-gis-output
+
+Files (names configured in `config.yaml`)
+
+- tram_lines_infra.gpkg
+- tormays_tram_lines_infra_polys.gpkg
+
 # Run tests
 
 Configure and activate python virtual environment.

--- a/scripts/gis-material-update/README.md
+++ b/scripts/gis-material-update/README.md
@@ -304,3 +304,29 @@ Basic principle is the following:
   - add new processing class
   - implement necessary functionality
   - add produced GIS material to database
+
+# Miscellaneous instructions
+
+## Creating python virtual environment
+
+To create python environment:
+
+```sh
+# Python installation is required
+[gis-material-update/process]$ python -m venv venv
+[gis-material-update/process]$ source venv/bin/activate
+[(venv) gis-material-update/process]$ pip install --upgrade pip
+[(venv) gis-material-update/process]$ pip install -r requirements.txt
+```
+
+To exit from already activated virtual environment:
+
+```
+[(venv) gis-material-update/process]$ ./venv/bin/deactivate
+```
+
+To activate already created virtual environment:
+
+```
+[gis-material-update/process]$ ./venv/bin/activate
+```

--- a/scripts/gis-material-update/README.md
+++ b/scripts/gis-material-update/README.md
@@ -112,8 +112,8 @@ docker-compose run --rm gis-fetch <source_1> ... <source_N>
 Where `<source>` is currently one of:
 
 - `hsl` - HSL bus schedules
-- `hki` - Helsinki area GIS material, polygon, scale 1:1000000
-- `osm` - OpenStreetMap export of Finland
+- `hki` - Helsinki area GIS material, polygon
+- `osm` - OpenStreetMap export of Finland (with focus area clipping)
 - `helsinki_osm_lines` - line geometry export from `osm`, covering area of city of Helsinki
 - `ylre_katualue` - Helsinki YLRE street areas, polygons.
 - `ylre_katuosat` - Helsinki YLRE parts, polygons.
@@ -137,8 +137,7 @@ Prerequisites:
 
 Materials are expected to be previously fetched to local directory.
 
-Intersection is computed using OGR VRT driver in actual fetch operation. Due to
-large area in OSM material, computation takes tens of minutes to complete.
+Intersection is computed using OGR VRT driver in actual fetch operation.
 
 ## Run processing
 
@@ -235,6 +234,8 @@ Files (names configured in `config.yaml`)
 
 ### `tram_infra`
 
+Prerequisite: fetched `osm`, `hki` and `helsinki_osm_lines` -materials.
+
 Docker example run (ensure that image build and file copying is
 already performed as instructed above):
 
@@ -248,7 +249,7 @@ docker-compose stop gis-db
 Processed GIS material is available in:
 haitaton-gis-output
 
-Files (names configured in `config.yaml`)
+Output files (names configured in `config.yaml`)
 
 - tram_infra.gpkg
 - tormays_tram_infra_polys.gpkg

--- a/scripts/gis-material-update/README.md
+++ b/scripts/gis-material-update/README.md
@@ -250,12 +250,14 @@ haitaton-gis-output
 
 Files (names configured in `config.yaml`)
 
-- tram_lines_infra.gpkg
-- tormays_tram_lines_infra_polys.gpkg
+- tram_infra.gpkg
+- tormays_tram_infra_polys.gpkg
 
 # Run tests
 
 Configure and activate python virtual environment.
+
+Fetch all source data, as described above.
 
 Run following in `gis-material-update/process` -directory.
 

--- a/scripts/gis-material-update/config.yaml
+++ b/scripts/gis-material-update/config.yaml
@@ -46,7 +46,7 @@ hki:
 tram_infra:
   local_file: "helsinki-osm-lines.gpkg"
   target_file: "tram_lines_infra.gpkg"
-  target_buffer_file: "tormays_tram_lines_infra.gpkg"
+  target_buffer_file: "tormays_tram_lines_infra_polys.gpkg"
   buffer:
     - 20
 

--- a/scripts/gis-material-update/config.yaml
+++ b/scripts/gis-material-update/config.yaml
@@ -32,17 +32,23 @@ osm:
   addr: "/vsicurl/https://download.geofabrik.de/europe/finland-latest.osm.pbf"
   layer: "lines"
   local_file: "finland-latest.gpkg"
-  extra_args: "-oo INTERLEAVED_READING=YES"
+  extra_args: "-oo INTERLEAVED_READING=YES -spat 24.8105462481479 60.086424133713 25.2725829816252 60.3068159059038"
 helsinki_osm_lines:
   addr: "/haitaton-gis/osm_vrt_clip.vrt"
   local_file: "helsinki-osm-lines.gpkg"
   extra_args: "-dialect sqlite -nln lines -sql"
   extra_quoted_args: "SELECT lines.* FROM lines, area WHERE ST_Intersects(lines.geom, area.geom)"
 hki:
-  addr: "WFS:https://geo.stat.fi/geoserver/tilastointialueet/wfs"
-  layer: "tilastointialueet:kunta1000k"
-  local_file: "helsinki_alue.gpkg"
+  addr: "WFS:https://kartta.hel.fi/ws/geoserver/avoindata/wfs"
+  layer: Seutukartta_aluejako_kuntarajat
+  local_file: helsinki_alue.gpkg
   extra_args: "-nln alue -where kunta='091'"
+tram_infra:
+  local_file: "helsinki-osm-lines.gpkg"
+  target_file: "tram_lines_infra.gpkg"
+  target_buffer_file: "tormays_tram_lines_infra.gpkg"
+  buffer:
+    - 20
 
 common:
   download_path: "/downloads"

--- a/scripts/gis-material-update/config.yaml
+++ b/scripts/gis-material-update/config.yaml
@@ -45,8 +45,8 @@ hki:
   extra_args: "-nln alue -where kunta='091'"
 tram_infra:
   local_file: "helsinki-osm-lines.gpkg"
-  target_file: "tram_lines_infra.gpkg"
-  target_buffer_file: "tormays_tram_lines_infra_polys.gpkg"
+  target_file: "tram_infra.gpkg"
+  target_buffer_file: "tormays_tram_infra_polys.gpkg"
   buffer:
     - 20
 

--- a/scripts/gis-material-update/process/modules/tram_infra.py
+++ b/scripts/gis-material-update/process/modules/tram_infra.py
@@ -46,9 +46,7 @@ class TramInfra(GisProcessor):
 
         df_list = []
         for i, r in tram_lines.iterrows():
-            df_list.append(
-                pd.DataFrame(dict_values_to_list(other_tag_to_dict(r.other_tags)))
-            )
+            df_list.append(pd.DataFrame(dict_values_to_list(r.tag_dict)))
         df_new = pd.concat(df_list)
         df_new.index = tram_lines.index
         trams = tram_lines.join(df_new, how="inner").drop(["tag_dict"], axis=1)
@@ -70,7 +68,7 @@ class TramInfra(GisProcessor):
         self._process_result_polygons = target_infra_polys
 
     def persist_to_database(self):
-        engine = create_engine(self._cfg.pg_conn_uri())
+        engine = create_engine(self._cfg.pg_conn_uri(), future=True)
 
         # persist original results for debugging and development
         debug_schema = "debug"
@@ -113,7 +111,7 @@ class TramInfra(GisProcessor):
         # tram line infra as debug material
         target_infra_file_name = self._cfg.target_file("tram_infra")
 
-        tram_lines = self._process_result_lines.reset_index()
+        tram_lines = self._process_result_lines.reset_index(drop=True)
 
         schema = gpd.io.file.infer_schema(tram_lines)
         schema["properties"]["infra"] = "int32"
@@ -125,7 +123,7 @@ class TramInfra(GisProcessor):
 
         # instruct Geopandas for correct data type in file write
         # fid is originally as index, obtain fid as column...
-        tormays_polygons = self._process_result_polygons.reset_index()
+        tormays_polygons = self._process_result_polygons.reset_index(drop=True)
 
         schema = gpd.io.file.infer_schema(tormays_polygons)
         schema["properties"]["infra"] = "int32"

--- a/scripts/gis-material-update/process/process_data.py
+++ b/scripts/gis-material-update/process/process_data.py
@@ -12,6 +12,8 @@ from modules.ylre_katualueet import YlreKatualueet
 from modules.ylre_katuosat import YlreKatuosat
 from modules.tram_infra import TramInfra
 
+DEFAULT_DEPLOYMENT_PROFILE = "local_development"
+
 
 def process_item(item: str, cfg: Config):
     print(f"Processing item: {item}")
@@ -44,11 +46,15 @@ def instantiate_processor(item: str, cfg: Config) -> GisProcessor:
 if __name__ == "__main__":
 
     deployment_profile = os.environ.get("TORMAYS_DEPLOYMENT_PROFILE")
-
+    use_deployment_profile = DEFAULT_DEPLOYMENT_PROFILE
     if deployment_profile in ["local_docker_development", "local_development"]:
         use_deployment_profile = deployment_profile
     else:
-        raise ValueError("Deployment profile is not detected")
+        print(
+            "Deployment profile environment variable is not set, defaulting to '{}'".format(
+                DEFAULT_DEPLOYMENT_PROFILE
+            )
+        )
 
     print("Using deployment profile: '{}'".format(use_deployment_profile))
 

--- a/scripts/gis-material-update/process/process_data.py
+++ b/scripts/gis-material-update/process/process_data.py
@@ -10,6 +10,7 @@ from modules.autoliikennemaarat import MakaAutoliikennemaarat
 from modules.hsl import HslBuses
 from modules.ylre_katualueet import YlreKatualueet
 from modules.ylre_katuosat import YlreKatuosat
+from modules.tram_infra import TramInfra
 
 
 def process_item(item: str, cfg: Config):
@@ -31,6 +32,8 @@ def instantiate_processor(item: str, cfg: Config) -> GisProcessor:
         return YlreKatuosat(cfg)
     elif item == "ylre_katualueet":
         return YlreKatualueet(cfg)
+    elif item == "tram_infra":
+        return TramInfra(cfg)
     else:
         try:
             raise RuntimeError("Configuration not recognized: {}".format(item))

--- a/scripts/gis-material-update/process/test/compare_utils.py
+++ b/scripts/gis-material-update/process/test/compare_utils.py
@@ -1,0 +1,28 @@
+"""Common compare utils for tests."""
+import geopandas as gpd
+
+
+class TormaysCheckerMixin(object):
+    def check_unique_geometry_type(
+        self, data: gpd.GeoDataFrame = None, geom_type: str = "linestring"
+    ):
+        geom_names = data.geometry.geom_type.unique().tolist()
+
+        # Only one geometry type
+        self.assertEqual(len(geom_names), 1)
+        # Geometry is geom_type
+        self.assertEqual(geom_names[0].lower(), geom_type)
+
+    def check_geometry_has_configured_crs(
+        self, data: gpd.GeoDataFrame = None, crs: str = "EPSG:3879"
+    ):
+        self.assertEqual(data.geometry.crs, crs)
+
+    def check_geom_data_attributes(
+        self, data: gpd.GeoDataFrame = None, ref_attributes: list[str] = None
+    ):
+        attributes = set(ref_attributes)
+        self.assertEqual(set(data.columns.tolist()), attributes)
+
+    def check_geom_data_min_area(self, data: gpd.GeoDataFrame = None):
+        self.assertGreater(min(data.area), 0.0)

--- a/scripts/gis-material-update/process/test/test_hsl.py
+++ b/scripts/gis-material-update/process/test/test_hsl.py
@@ -3,12 +3,12 @@ import geopandas as gpd
 import pandas as pd
 import unittest
 
-
+from test.compare_utils import TormaysCheckerMixin
 from modules.config import Config
 from modules.hsl import HslBuses
 
 
-class TestHslLines(unittest.TestCase):
+class TestHslLines(TormaysCheckerMixin, unittest.TestCase):
     """Test that final output contains correct geometry and attributes."""
 
     @classmethod
@@ -21,38 +21,24 @@ class TestHslLines(unittest.TestCase):
         cls._target_lines_dataframe = hsl._process_result_lines
 
     def test_line_geometry_is_linestring(self):
-        lines = self._target_lines_dataframe
-        geom_names = lines.geometry.geom_type.unique().tolist()
-
-        # Only one geometry type
-        self.assertEqual(len(geom_names), 1)
-        # Geometry is LineString
-        self.assertEqual(geom_names[0].lower(), "linestring")
+        self.check_unique_geometry_type(self._target_lines_dataframe, "linestring")
 
     def test_tormays_geometry_is_polygon(self):
-        polygons = self._target_buffer_dataframe
-        geom_names = polygons.geometry.geom_type.unique().tolist()
-
-        # Only one geometry type
-        self.assertEqual(len(geom_names), 1)
-        # Geometry is Polygon
-        self.assertEqual(geom_names[0].lower(), "polygon")
+        self.check_unique_geometry_type(self._target_buffer_dataframe, "polygon")
 
     def test_tormays_geometry_has_configured_crs(self):
-        polygons = self._target_buffer_dataframe
-
-        self.assertEqual(polygons.geometry.crs, self.cfg.crs())
+        self.check_geometry_has_configured_crs(
+            self._target_buffer_dataframe, self.cfg.crs()
+        )
 
     def test_tormays_attributes(self):
-        tormays = self._target_buffer_dataframe
-        attributes = set(["direction_id", "route_id", "rush_hour", "trunk", "geometry"])
-
-        self.assertEqual(set(tormays.columns.tolist()), attributes)
+        self.check_geom_data_attributes(
+            self._target_buffer_dataframe,
+            ["direction_id", "route_id", "rush_hour", "trunk", "geometry"],
+        )
 
     def test_tormays_min_area(self):
-        tormays = self._target_buffer_dataframe
-
-        self.assertGreater(min(tormays.area), 0.0)
+        self.check_geom_data_min_area(self._target_buffer_dataframe)
 
 
 class TestHslGtfs(unittest.TestCase):

--- a/scripts/gis-material-update/process/test/test_hsl.py
+++ b/scripts/gis-material-update/process/test/test_hsl.py
@@ -14,12 +14,14 @@ class TestHslLines(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.cfg = Config()
-        filename = cls.cfg.target_buffer_file("hsl")
-        cls._target_buffer_dataframe = gpd.read_file(filename)
+        hsl = HslBuses(cls.cfg, validate_gtfs=False)
+        hsl.process()
+
+        cls._target_buffer_dataframe = hsl._process_result_polygons
+        cls._target_lines_dataframe = hsl._process_result_lines
 
     def test_line_geometry_is_linestring(self):
-        filename = self.cfg.target_file("hsl")
-        lines = gpd.read_file(filename)
+        lines = self._target_lines_dataframe
         geom_names = lines.geometry.geom_type.unique().tolist()
 
         # Only one geometry type

--- a/scripts/gis-material-update/process/test/test_tram_infra.py
+++ b/scripts/gis-material-update/process/test/test_tram_infra.py
@@ -1,0 +1,54 @@
+import unittest
+import geopandas as gpd
+
+from modules.config import Config
+from modules.tram_infra import TramInfra
+
+
+class TestTramInfra(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.cfg = Config()
+        tram_infra = TramInfra(cls.cfg)
+        tram_infra.process()
+
+        cls._target_buffer_dataframe = tram_infra._process_result_polygons
+        cls._target_lines_dataframe = tram_infra._process_result_lines
+
+    def test_line_geometry_is_linestring(self):
+        lines = self._target_lines_dataframe
+        geom_names = lines.geometry.geom_type.unique().tolist()
+
+        # Only one geometry type
+        self.assertEqual(len(geom_names), 1)
+        # Geometry is LineString
+        self.assertEqual(geom_names[0].lower(), "linestring")
+
+    def test_tormays_geometry_is_polygon(self):
+        polygons = self._target_buffer_dataframe
+        geom_names = polygons.geometry.geom_type.unique().tolist()
+
+        # Only one geometry type
+        self.assertEqual(len(geom_names), 1)
+        # Geometry is Polygon
+        self.assertEqual(geom_names[0].lower(), "polygon")
+
+    def test_tormays_geometry_has_configured_crs(self):
+        polygons = self._target_buffer_dataframe
+
+        self.assertEqual(polygons.geometry.crs, self.cfg.crs())
+
+    def test_tormays_attributes(self):
+        tormays = self._target_buffer_dataframe
+        attributes = set(["infra", "geometry"])
+
+        self.assertEqual(set(tormays.columns.tolist()), attributes)
+
+    def test_tormays_min_area(self):
+        tormays = self._target_buffer_dataframe
+
+        self.assertGreater(min(tormays.area), 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/gis-material-update/process/test/test_tram_infra.py
+++ b/scripts/gis-material-update/process/test/test_tram_infra.py
@@ -1,11 +1,11 @@
 import unittest
-import geopandas as gpd
 
+from test.compare_utils import TormaysCheckerMixin
 from modules.config import Config
 from modules.tram_infra import TramInfra
 
 
-class TestTramInfra(unittest.TestCase):
+class TestTramInfra(TormaysCheckerMixin, unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.cfg = Config()
@@ -16,38 +16,23 @@ class TestTramInfra(unittest.TestCase):
         cls._target_lines_dataframe = tram_infra._process_result_lines
 
     def test_line_geometry_is_linestring(self):
-        lines = self._target_lines_dataframe
-        geom_names = lines.geometry.geom_type.unique().tolist()
-
-        # Only one geometry type
-        self.assertEqual(len(geom_names), 1)
-        # Geometry is LineString
-        self.assertEqual(geom_names[0].lower(), "linestring")
+        self.check_unique_geometry_type(self._target_lines_dataframe, "linestring")
 
     def test_tormays_geometry_is_polygon(self):
-        polygons = self._target_buffer_dataframe
-        geom_names = polygons.geometry.geom_type.unique().tolist()
-
-        # Only one geometry type
-        self.assertEqual(len(geom_names), 1)
-        # Geometry is Polygon
-        self.assertEqual(geom_names[0].lower(), "polygon")
+        self.check_unique_geometry_type(self._target_buffer_dataframe, "polygon")
 
     def test_tormays_geometry_has_configured_crs(self):
-        polygons = self._target_buffer_dataframe
-
-        self.assertEqual(polygons.geometry.crs, self.cfg.crs())
+        self.check_geometry_has_configured_crs(
+            self._target_buffer_dataframe, self.cfg.crs()
+        )
 
     def test_tormays_attributes(self):
-        tormays = self._target_buffer_dataframe
-        attributes = set(["infra", "geometry"])
-
-        self.assertEqual(set(tormays.columns.tolist()), attributes)
+        self.check_geom_data_attributes(
+            self._target_buffer_dataframe, ["infra", "geometry"]
+        )
 
     def test_tormays_min_area(self):
-        tormays = self._target_buffer_dataframe
-
-        self.assertGreater(min(tormays.area), 0.0)
+        self.check_geom_data_min_area(self._target_buffer_dataframe)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description

Implemented tram infra tormays-material processing.

Also implemented following enhancements:
- reading OSM data (speedup obtained by clipping, config.yaml)
- fixed Helsinki municipality area GIS material source (config.yaml)
- implemented default deployment profile (process_data.py)
- fixed HSL test case: don't require pre-existing processed output files (test/test_hsl.py)

### Jira Issue: 

[HAI-1314](https://helsinkisolutionoffice.atlassian.net/browse/HAI-1314)

## Type of change

- [ ] Bug fix 
- [x] New feature 
- [ ] Other

# Instructions for testing

## Running the code in docker containers.

See README for preparing containers (building containers, copying files). After these initial steps, run fetch and process as separate docker runs. See exact details from README:
```
docker-compose up -d gis-db
docker-compose run --rm gis-fetch hki osm helsinki_osm_lines
docker-compose run --rm gis-process tram_infra
docker-compose stop gis-db
```

Results are in `haitaton-gis-output` local directory.

## Testing (Python unittests)

Prerequisite: fetch source materials as per instructions in the README (section: tram_infra)

Go to directory: haitaton-backend/scripts/gis-material-update/process

(create and) activate Python virtual environment in process -directory
run `python -m unittest test/test_tram_infra.py`

### To run all tests

obtain all source materials
```
docker-compose run --rm gis-fetch hsl hki osm helsinki_osm_lines maka_autoliikennemaarat ylre_katuosat ylre_katualueet
```
(create and) activate Python virtual environment in process -directory
run 
`python -m unittest discover -v`

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 

# Other relevant info

None

[HAI-1314]: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1314?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ