### PR TITLE
HAI-1498 Add endpoint to get applications by hanke

### DIFF
--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeError.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeError.kt
@@ -49,7 +49,7 @@ enum class HankeError(val errorMessage: String) {
     }
 }
 
-class HankeNotFoundException(val hankeTunnus: String) :
+class HankeNotFoundException(val hankeTunnus: String?) :
     RuntimeException("Hanke $hankeTunnus not found")
 
 class HankeArgumentException(message: String) : RuntimeException(message)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationsResponse.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationsResponse.kt
@@ -1,0 +1,3 @@
+package fi.hel.haitaton.hanke.application
+
+data class ApplicationsResponse(val applications: List<Application>)


### PR DESCRIPTION
# Description

Add endpoint to fetch all applications of given hanke. Applications are a part of hanke, thus a correct place for the endpoint is under hanke domain.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1498

## Type of change

- [ ] Bug fix 
- [x] New feature 
- [ ] Other

# Instructions for testing
- Create hanke and add one or more applications.
- perform GET /hankkeet/${hankeTunnus}/hakemukset

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 

# Other relevant info
Please describe here if there is e.g. some requirements for this change or
 other info that the tester/user needs to know.