### PR TITLE
HAI-1505 Hanke field changes based on Allu

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeControllerITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeControllerITests.kt
@@ -383,7 +383,6 @@ class HankeControllerITests(@Autowired override val mockMvc: MockMvc) : Controll
         hankeToBeUpdated.tyomaaKatuosoite = "Testikatu 1"
         hankeToBeUpdated.tyomaaTyyppi.add(TyomaaTyyppi.VESI)
         hankeToBeUpdated.tyomaaTyyppi.add(TyomaaTyyppi.KAASUJOHTO)
-        hankeToBeUpdated.tyomaaKoko = TyomaaKoko.LAAJA_TAI_USEA_KORTTELI
         val alue = Hankealue()
         alue.haittaAlkuPvm = DateFactory.getStartDatetime()
         alue.haittaLoppuPvm = DateFactory.getEndDatetime()

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeRepositoryITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeRepositoryITests.kt
@@ -51,7 +51,6 @@ constructor(val entityManager: TestEntityManager, val hankeRepository: HankeRepo
         baseHankeEntity.tyomaaKatuosoite = "katu 1"
         baseHankeEntity.tyomaaTyyppi.add(TyomaaTyyppi.VESI)
         baseHankeEntity.tyomaaTyyppi.add(TyomaaTyyppi.MUU)
-        baseHankeEntity.tyomaaKoko = TyomaaKoko.LAAJA_TAI_USEA_KORTTELI
         baseHankeEntity.haittaAlkuPvm = date
         baseHankeEntity.haittaLoppuPvm = date
         baseHankeEntity.kaistaHaitta = TodennakoinenHaittaPaaAjoRatojenKaistajarjestelyihin.KAKSI
@@ -81,7 +80,6 @@ constructor(val entityManager: TestEntityManager, val hankeRepository: HankeRepo
 
         assertThat(loadedHanke.tyomaaKatuosoite).isEqualTo("katu 1")
         assertThat(loadedHanke.tyomaaTyyppi).contains(TyomaaTyyppi.VESI, TyomaaTyyppi.MUU)
-        assertThat(loadedHanke.tyomaaKoko).isEqualTo(TyomaaKoko.LAAJA_TAI_USEA_KORTTELI)
         assertThat(loadedHanke.haittaAlkuPvm).isEqualTo(date)
         assertThat(loadedHanke.haittaLoppuPvm).isEqualTo(date)
         assertThat(loadedHanke.kaistaHaitta)

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
@@ -133,7 +133,6 @@ class HankeServiceITests : DatabaseTest() {
 
         assertThat(returnedHanke.tyomaaKatuosoite).isEqualTo("Testikatu 1")
         assertThat(returnedHanke.tyomaaTyyppi).contains(TyomaaTyyppi.VESI, TyomaaTyyppi.MUU)
-        assertThat(returnedHanke.tyomaaKoko).isEqualTo(TyomaaKoko.LAAJA_TAI_USEA_KORTTELI)
         assertThat(returnedHanke.getHaittaAlkuPvm()).isEqualTo(expectedDateAlku)
         assertThat(returnedHanke.getHaittaLoppuPvm()).isEqualTo(expectedDateLoppu)
         assertThat(returnedHanke.alueet[0].kaistaHaitta)
@@ -1188,7 +1187,6 @@ class HankeServiceITests : DatabaseTest() {
         TestUtils.addMockedRequestIp()
         val hankeBeforeSave = HankeFactory.create(id = null)
         hankeBeforeSave.tyomaaKatuosoite = "Testikatu 1"
-        hankeBeforeSave.tyomaaKoko = TyomaaKoko.LAAJA_TAI_USEA_KORTTELI
         hankeBeforeSave.tyomaaTyyppi = mutableSetOf(TyomaaTyyppi.VESI, TyomaaTyyppi.MUU)
 
         val hanke = hankeService.createHanke(hankeBeforeSave)
@@ -1222,7 +1220,6 @@ class HankeServiceITests : DatabaseTest() {
     fun `updateHanke creates audit log entry for updated hanke`() {
         val hankeBeforeSave = HankeFactory.create(id = null)
         hankeBeforeSave.tyomaaKatuosoite = "Testikatu 1"
-        hankeBeforeSave.tyomaaKoko = TyomaaKoko.LAAJA_TAI_USEA_KORTTELI
         hankeBeforeSave.tyomaaTyyppi = mutableSetOf(TyomaaTyyppi.VESI, TyomaaTyyppi.MUU)
         val hanke = hankeService.createHanke(hankeBeforeSave)
         val geometria: Geometriat =
@@ -1329,7 +1326,6 @@ class HankeServiceITests : DatabaseTest() {
     fun `updateHanke creates audit log entry even if there are no changes`() {
         val hankeBeforeSave = HankeFactory.create(id = null)
         hankeBeforeSave.tyomaaKatuosoite = "Testikatu 1"
-        hankeBeforeSave.tyomaaKoko = TyomaaKoko.LAAJA_TAI_USEA_KORTTELI
         hankeBeforeSave.tyomaaTyyppi = mutableSetOf(TyomaaTyyppi.VESI, TyomaaTyyppi.MUU)
         val hanke = hankeService.createHanke(hankeBeforeSave)
         auditLogRepository.deleteAll()

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/allu/CableReportServiceAlluITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/allu/CableReportServiceAlluITests.kt
@@ -257,12 +257,6 @@ class CableReportServiceAlluITests {
                 type = CustomerType.COMPANY,
                 name = "Haitaton Oy Ab",
                 country = "FI",
-                postalAddress =
-                    PostalAddress(
-                        streetAddress = StreetAddress("Haittatie 6"),
-                        postalCode = "12345",
-                        city = "Haitaton City"
-                    ),
                 email = "info@haitaton.fi",
                 phone = "042-555-6125",
                 registryKey = "101010-FAKE",
@@ -273,12 +267,6 @@ class CableReportServiceAlluITests {
         val hannu =
             Contact(
                 name = "Hannu Haitaton",
-                postalAddress =
-                    PostalAddress(
-                        streetAddress = StreetAddress("Haittatie 8"),
-                        postalCode = "12345",
-                        city = "Haitaton City"
-                    ),
                 email = "hannu@haitaton.fi",
                 phone = "042-555-5216",
                 orderer = true
@@ -286,12 +274,6 @@ class CableReportServiceAlluITests {
         val kerttu =
             Contact(
                 name = "Kerttu Haitaton",
-                postalAddress =
-                    PostalAddress(
-                        streetAddress = StreetAddress("Haittatie 8"),
-                        postalCode = "12345",
-                        city = "Haitaton City"
-                    ),
                 email = "kerttu@haitaton.fi",
                 phone = "042-555-2182",
                 orderer = false

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationControllerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationControllerITest.kt
@@ -10,7 +10,8 @@ import fi.hel.haitaton.hanke.andReturnBody
 import fi.hel.haitaton.hanke.factory.AlluDataFactory
 import fi.hel.haitaton.hanke.factory.AlluDataFactory.Companion.withContacts
 import fi.hel.haitaton.hanke.getResourceAsBytes
-import fi.hel.haitaton.hanke.permissions.PermissionCode
+import fi.hel.haitaton.hanke.permissions.PermissionCode.EDIT_APPLICATIONS
+import fi.hel.haitaton.hanke.permissions.PermissionCode.VIEW
 import fi.hel.haitaton.hanke.permissions.PermissionService
 import fi.hel.haitaton.hanke.toJsonString
 import io.mockk.Called
@@ -26,7 +27,8 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.context.annotation.Import
-import org.springframework.http.MediaType
+import org.springframework.http.MediaType.APPLICATION_JSON
+import org.springframework.http.MediaType.APPLICATION_PDF
 import org.springframework.security.test.context.support.WithMockUser
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
@@ -37,6 +39,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
 private const val USERNAME = "testUser"
 private const val HANKE_TUNNUS = "HAI-1234"
+private const val BASE_URL = "/hakemukset"
 
 @WebMvcTest(ApplicationController::class)
 @Import(IntegrationTestConfiguration::class)
@@ -62,7 +65,7 @@ class ApplicationControllerITest(@Autowired override val mockMvc: MockMvc) : Con
 
     @Test
     fun `getAll without user ID returns 401`() {
-        get("/hakemukset").andExpect(status().isUnauthorized)
+        get(BASE_URL).andExpect(status().isUnauthorized)
 
         verify { applicationService wasNot Called }
     }
@@ -72,7 +75,7 @@ class ApplicationControllerITest(@Autowired override val mockMvc: MockMvc) : Con
     fun `getAll with no accessible applications returns empty list`() {
         every { applicationService.getAllApplicationsForUser(USERNAME) } returns listOf()
 
-        get("/hakemukset").andExpect(status().isOk).andExpect(content().json("[]"))
+        get(BASE_URL).andExpect(status().isOk).andExpect(content().json("[]"))
 
         verify { applicationService.getAllApplicationsForUser(USERNAME) }
     }
@@ -83,7 +86,7 @@ class ApplicationControllerITest(@Autowired override val mockMvc: MockMvc) : Con
         every { applicationService.getAllApplicationsForUser(USERNAME) } returns
             AlluDataFactory.createApplications(3)
 
-        get("/hakemukset")
+        get(BASE_URL)
             .andExpect(status().isOk)
             .andExpect(jsonPath("$").isArray)
             .andExpect(jsonPath("$.length()").value(3))
@@ -93,7 +96,7 @@ class ApplicationControllerITest(@Autowired override val mockMvc: MockMvc) : Con
 
     @Test
     fun `getById without user ID returns 401`() {
-        get("/hakemukset/1234").andExpect(status().isUnauthorized)
+        get("$BASE_URL/1234").andExpect(status().isUnauthorized)
 
         verify { applicationService wasNot Called }
     }
@@ -101,34 +104,36 @@ class ApplicationControllerITest(@Autowired override val mockMvc: MockMvc) : Con
     @Test
     @WithMockUser(USERNAME)
     fun `getById with unknown ID returns 404`() {
-        every { applicationService.getApplicationById(1234) } throws
-            ApplicationNotFoundException(1234)
+        val id = 1234L
+        every { applicationService.getApplicationById(id) } throws ApplicationNotFoundException(id)
 
-        get("/hakemukset/1234").andExpect(status().isNotFound)
+        get("$BASE_URL/$id").andExpect(status().isNotFound)
 
-        verify { applicationService.getApplicationById(1234) }
+        verify { applicationService.getApplicationById(id) }
     }
 
     @Test
     @WithMockUser(USERNAME)
     fun `getById with known ID returns application`() {
-        every { applicationService.getApplicationById(1234) } returns
-            AlluDataFactory.createApplication(id = 1234, hankeTunnus = HANKE_TUNNUS)
-        every { hankeService.getHankeId(HANKE_TUNNUS) } returns 42
-        every { permissionService.hasPermission(42, USERNAME, PermissionCode.VIEW) } returns true
+        val id = 1234L
+        val hankeId = 42
+        every { applicationService.getApplicationById(id) } returns
+            AlluDataFactory.createApplication(id = id, hankeTunnus = HANKE_TUNNUS)
+        every { hankeService.getHankeId(HANKE_TUNNUS) } returns hankeId
+        every { permissionService.hasPermission(hankeId, USERNAME, VIEW) } returns true
 
-        get("/hakemukset/1234")
+        get("$BASE_URL/$id")
             .andExpect(status().isOk)
             .andExpect(jsonPath("$.applicationType").value("CABLE_REPORT"))
             .andExpect(jsonPath("$.applicationData.applicationType").value("CABLE_REPORT"))
 
-        verify { applicationService.getApplicationById(1234) }
-        verify { permissionService.hasPermission(42, USERNAME, PermissionCode.VIEW) }
+        verify { applicationService.getApplicationById(id) }
+        verify { permissionService.hasPermission(hankeId, USERNAME, VIEW) }
     }
 
     @Test
     fun `create without logged in user returns 401`() {
-        post("/hakemukset", AlluDataFactory.createApplication(id = null))
+        post(BASE_URL, AlluDataFactory.createApplication(id = null))
             .andExpect(status().isUnauthorized)
 
         verify { applicationService wasNot Called }
@@ -137,7 +142,7 @@ class ApplicationControllerITest(@Autowired override val mockMvc: MockMvc) : Con
     @Test
     @WithMockUser(USERNAME)
     fun `create without body returns 400`() {
-        post("/hakemukset").andExpect(status().isBadRequest)
+        post(BASE_URL).andExpect(status().isBadRequest)
 
         verify { applicationService wasNot Called }
     }
@@ -145,21 +150,20 @@ class ApplicationControllerITest(@Autowired override val mockMvc: MockMvc) : Con
     @Test
     @WithMockUser(USERNAME)
     fun `create with proper application creates application`() {
+        val hankeId = 42
         val newApplication =
             AlluDataFactory.createApplication(id = null, hankeTunnus = HANKE_TUNNUS)
         val createdApplication = newApplication.copy(id = 1234)
         every { applicationService.create(newApplication, USERNAME) } returns createdApplication
-        every { hankeService.getHankeId(HANKE_TUNNUS) } returns 42
-        every {
-            permissionService.hasPermission(42, USERNAME, PermissionCode.EDIT_APPLICATIONS)
-        } returns true
+        every { hankeService.getHankeId(HANKE_TUNNUS) } returns hankeId
+        every { permissionService.hasPermission(hankeId, USERNAME, EDIT_APPLICATIONS) } returns true
 
         val response: Application =
-            post("/hakemukset", newApplication).andExpect(status().isOk).andReturnBody()
+            post(BASE_URL, newApplication).andExpect(status().isOk).andReturnBody()
 
         assertEquals(createdApplication, response)
         verify { applicationService.create(newApplication, USERNAME) }
-        verify { permissionService.hasPermission(42, USERNAME, PermissionCode.EDIT_APPLICATIONS) }
+        verify { permissionService.hasPermission(hankeId, USERNAME, EDIT_APPLICATIONS) }
     }
 
     @Test
@@ -169,7 +173,7 @@ class ApplicationControllerITest(@Autowired override val mockMvc: MockMvc) : Con
         val content: ObjectNode = OBJECT_MAPPER.valueToTree(application)
         (content.get("applicationData") as ObjectNode).remove("applicationType")
 
-        postRaw("/hakemukset", content.toJsonString()).andExpect(status().isBadRequest)
+        postRaw(BASE_URL, content.toJsonString()).andExpect(status().isBadRequest)
 
         verify { applicationService wasNot Called }
     }
@@ -181,7 +185,7 @@ class ApplicationControllerITest(@Autowired override val mockMvc: MockMvc) : Con
         val content: ObjectNode = OBJECT_MAPPER.valueToTree(application)
         content.remove("applicationType")
 
-        postRaw("/hakemukset", content.toJsonString())
+        postRaw(BASE_URL, content.toJsonString())
             .andDo { print(it) }
             .andExpect(status().isBadRequest)
 
@@ -200,14 +204,14 @@ class ApplicationControllerITest(@Autowired override val mockMvc: MockMvc) : Con
         val application =
             AlluDataFactory.createApplication(id = null, applicationData = applicationData)
 
-        post("/hakemukset", application).andExpect(status().isBadRequest)
+        post(BASE_URL, application).andExpect(status().isBadRequest)
 
         verify { applicationService wasNot Called }
     }
 
     @Test
     fun `update without logged in user returns 401`() {
-        put("/hakemukset/1234", AlluDataFactory.createApplication())
+        put("$BASE_URL/1234", AlluDataFactory.createApplication())
             .andExpect(status().isUnauthorized)
 
         verify { applicationService wasNot Called }
@@ -216,7 +220,7 @@ class ApplicationControllerITest(@Autowired override val mockMvc: MockMvc) : Con
     @Test
     @WithMockUser(USERNAME)
     fun `update without body returns 400`() {
-        put("/hakemukset/1234").andExpect(status().isBadRequest)
+        put("$BASE_URL/1234").andExpect(status().isBadRequest)
 
         verify { applicationService wasNot Called }
     }
@@ -233,7 +237,7 @@ class ApplicationControllerITest(@Autowired override val mockMvc: MockMvc) : Con
         val application =
             AlluDataFactory.createApplication(id = null, applicationData = applicationData)
 
-        put("/hakemukset/1234", application).andExpect(status().isBadRequest)
+        put("$BASE_URL/1234", application).andExpect(status().isBadRequest)
 
         verify { applicationService wasNot Called }
     }
@@ -241,25 +245,24 @@ class ApplicationControllerITest(@Autowired override val mockMvc: MockMvc) : Con
     @Test
     @WithMockUser(USERNAME)
     fun `update with known id returns ok`() {
+        val id = 1234L
         val application = AlluDataFactory.createApplication(hankeTunnus = HANKE_TUNNUS)
-        every { applicationService.getApplicationById(1234) } returns application
+        every { applicationService.getApplicationById(id) } returns application
         every {
-            applicationService.updateApplicationData(1234, application.applicationData, USERNAME)
+            applicationService.updateApplicationData(id, application.applicationData, USERNAME)
         } returns application
         every { hankeService.getHankeId(HANKE_TUNNUS) } returns 42
-        every {
-            permissionService.hasPermission(42, USERNAME, PermissionCode.EDIT_APPLICATIONS)
-        } returns true
+        every { permissionService.hasPermission(42, USERNAME, EDIT_APPLICATIONS) } returns true
 
         val response: Application =
-            put("/hakemukset/1234", application).andExpect(status().isOk).andReturnBody()
+            put("$BASE_URL/$id", application).andExpect(status().isOk).andReturnBody()
 
         assertEquals(application, response)
         verify {
-            applicationService.updateApplicationData(1234, application.applicationData, USERNAME)
+            applicationService.updateApplicationData(id, application.applicationData, USERNAME)
         }
-        verify { applicationService.getApplicationById(1234) }
-        verify { permissionService.hasPermission(42, USERNAME, PermissionCode.EDIT_APPLICATIONS) }
+        verify { applicationService.getApplicationById(id) }
+        verify { permissionService.hasPermission(42, USERNAME, EDIT_APPLICATIONS) }
     }
 
     @Test
@@ -269,7 +272,7 @@ class ApplicationControllerITest(@Autowired override val mockMvc: MockMvc) : Con
         val content: ObjectNode = OBJECT_MAPPER.valueToTree(application)
         (content.get("applicationData") as ObjectNode).remove("applicationType")
 
-        putRaw("/hakemukset/1234", content.toJsonString()).andExpect(status().isBadRequest)
+        putRaw("$BASE_URL/1234", content.toJsonString()).andExpect(status().isBadRequest)
 
         verify { applicationService wasNot Called }
     }
@@ -281,7 +284,7 @@ class ApplicationControllerITest(@Autowired override val mockMvc: MockMvc) : Con
         val content: ObjectNode = OBJECT_MAPPER.valueToTree(application)
         content.remove("applicationType")
 
-        putRaw("/hakemukset/1234", content.toJsonString())
+        putRaw("$BASE_URL/1234", content.toJsonString())
             .andDo { print(it) }
             .andExpect(status().isBadRequest)
 
@@ -291,50 +294,48 @@ class ApplicationControllerITest(@Autowired override val mockMvc: MockMvc) : Con
     @Test
     @WithMockUser(USERNAME)
     fun `update with unknown id returns 404`() {
+        val id = 1234L
         val application = AlluDataFactory.createApplication(hankeTunnus = HANKE_TUNNUS)
-        every { applicationService.getApplicationById(1234) } returns application
+        every { applicationService.getApplicationById(id) } returns application
         every {
-            applicationService.updateApplicationData(1234, application.applicationData, USERNAME)
-        } throws ApplicationNotFoundException(1234)
+            applicationService.updateApplicationData(id, application.applicationData, USERNAME)
+        } throws ApplicationNotFoundException(id)
         every { hankeService.getHankeId(HANKE_TUNNUS) } returns 42
-        every {
-            permissionService.hasPermission(42, USERNAME, PermissionCode.EDIT_APPLICATIONS)
-        } returns true
+        every { permissionService.hasPermission(42, USERNAME, EDIT_APPLICATIONS) } returns true
 
-        put("/hakemukset/1234", application).andExpect(status().isNotFound)
+        put("$BASE_URL/$id", application).andExpect(status().isNotFound)
 
-        verify { applicationService.getApplicationById(1234) }
+        verify { applicationService.getApplicationById(id) }
         verify {
-            applicationService.updateApplicationData(1234, application.applicationData, USERNAME)
+            applicationService.updateApplicationData(id, application.applicationData, USERNAME)
         }
-        verify { permissionService.hasPermission(42, USERNAME, PermissionCode.EDIT_APPLICATIONS) }
+        verify { permissionService.hasPermission(42, USERNAME, EDIT_APPLICATIONS) }
     }
 
     @Test
     @WithMockUser(USERNAME)
     fun `update with application that's no longer pending returns 409`() {
+        val id = 1234L
         val application = AlluDataFactory.createApplication(hankeTunnus = HANKE_TUNNUS)
-        every { applicationService.getApplicationById(1234) } returns application
+        every { applicationService.getApplicationById(id) } returns application
         every {
-            applicationService.updateApplicationData(1234, application.applicationData, USERNAME)
-        } throws ApplicationAlreadyProcessingException(1234, 21)
+            applicationService.updateApplicationData(id, application.applicationData, USERNAME)
+        } throws ApplicationAlreadyProcessingException(id, 21)
         every { hankeService.getHankeId(HANKE_TUNNUS) } returns 42
-        every {
-            permissionService.hasPermission(42, USERNAME, PermissionCode.EDIT_APPLICATIONS)
-        } returns true
+        every { permissionService.hasPermission(42, USERNAME, EDIT_APPLICATIONS) } returns true
 
-        put("/hakemukset/1234", application).andExpect(status().isConflict)
+        put("$BASE_URL/$id", application).andExpect(status().isConflict)
 
-        verify { applicationService.getApplicationById(1234) }
+        verify { applicationService.getApplicationById(id) }
         verify {
-            applicationService.updateApplicationData(1234, application.applicationData, USERNAME)
+            applicationService.updateApplicationData(id, application.applicationData, USERNAME)
         }
-        verify { permissionService.hasPermission(42, USERNAME, PermissionCode.EDIT_APPLICATIONS) }
+        verify { permissionService.hasPermission(42, USERNAME, EDIT_APPLICATIONS) }
     }
 
     @Test
     fun `sendApplication without logged in user returns 401`() {
-        post("/hakemukset/1234/send-application").andExpect(status().isUnauthorized)
+        post("$BASE_URL/1234/send-application").andExpect(status().isUnauthorized)
 
         verify { applicationService wasNot Called }
     }
@@ -342,138 +343,132 @@ class ApplicationControllerITest(@Autowired override val mockMvc: MockMvc) : Con
     @Test
     @WithMockUser(USERNAME)
     fun `sendApplication without body sends application to Allu and returns the result`() {
+        val id = 1234L
         val application = AlluDataFactory.createApplication(hankeTunnus = HANKE_TUNNUS)
         every { hankeService.getHankeId(HANKE_TUNNUS) } returns 42
-        every { applicationService.getApplicationById(1234) } returns application
-        every { applicationService.sendApplication(1234, USERNAME) } returns application
-        every {
-            permissionService.hasPermission(42, USERNAME, PermissionCode.EDIT_APPLICATIONS)
-        } returns true
+        every { applicationService.getApplicationById(id) } returns application
+        every { applicationService.sendApplication(id, USERNAME) } returns application
+        every { permissionService.hasPermission(42, USERNAME, EDIT_APPLICATIONS) } returns true
 
         val response: Application =
-            post("/hakemukset/1234/send-application").andExpect(status().isOk).andReturnBody()
+            post("$BASE_URL/$id/send-application").andExpect(status().isOk).andReturnBody()
 
         assertEquals(application, response)
-        verify { applicationService.getApplicationById(1234) }
-        verify { applicationService.sendApplication(1234, USERNAME) }
-        verify { permissionService.hasPermission(42, USERNAME, PermissionCode.EDIT_APPLICATIONS) }
+        verify { applicationService.getApplicationById(id) }
+        verify { applicationService.sendApplication(id, USERNAME) }
+        verify { permissionService.hasPermission(42, USERNAME, EDIT_APPLICATIONS) }
     }
 
     @Test
     @WithMockUser(USERNAME)
     fun `sendApplication ignores request body`() {
-        val application = AlluDataFactory.createApplication(id = 1234, alluid = 21)
+        val id = 1234L
+        val application = AlluDataFactory.createApplication(id = id, alluid = 21)
         every { hankeService.getHankeId(HANKE_TUNNUS) } returns 42
-        every {
-            permissionService.hasPermission(42, USERNAME, PermissionCode.EDIT_APPLICATIONS)
-        } returns true
-        every { applicationService.getApplicationById(1234) } returns application
-        every { applicationService.sendApplication(1234, USERNAME) } returns application
+        every { permissionService.hasPermission(42, USERNAME, EDIT_APPLICATIONS) } returns true
+        every { applicationService.getApplicationById(id) } returns application
+        every { applicationService.sendApplication(id, USERNAME) } returns application
 
         val response: Application =
-            post("/hakemukset/1234/send-application", application.copy(alluid = 9999))
+            post("$BASE_URL/$id/send-application", application.copy(alluid = 9999))
                 .andExpect(status().isOk)
                 .andReturnBody()
 
         assertEquals(application, response)
-        verify { applicationService.getApplicationById(1234) }
-        verify { permissionService.hasPermission(42, USERNAME, PermissionCode.EDIT_APPLICATIONS) }
-        verify { applicationService.sendApplication(1234, USERNAME) }
+        verify { applicationService.getApplicationById(id) }
+        verify { permissionService.hasPermission(42, USERNAME, EDIT_APPLICATIONS) }
+        verify { applicationService.sendApplication(id, USERNAME) }
     }
 
     @Test
     @WithMockUser(USERNAME)
     fun `sendApplication ignores even broken request body`() {
+        val id = 1234L
         val application = AlluDataFactory.createApplication()
         val content: ObjectNode = OBJECT_MAPPER.valueToTree(application)
         (content.get("applicationData") as ObjectNode).remove("applicationType")
         every { hankeService.getHankeId(HANKE_TUNNUS) } returns 42
-        every {
-            permissionService.hasPermission(42, USERNAME, PermissionCode.EDIT_APPLICATIONS)
-        } returns true
-        every { applicationService.getApplicationById(1234) } returns application
-        every { applicationService.sendApplication(1234, USERNAME) } returns application
+        every { permissionService.hasPermission(42, USERNAME, EDIT_APPLICATIONS) } returns true
+        every { applicationService.getApplicationById(id) } returns application
+        every { applicationService.sendApplication(id, USERNAME) } returns application
 
         val response: Application =
-            postRaw("/hakemukset/1234/send-application", content.toJsonString())
+            postRaw("$BASE_URL/$id/send-application", content.toJsonString())
                 .andExpect(status().isOk)
                 .andReturnBody()
 
         assertEquals(application, response)
-        verify { applicationService.getApplicationById(1234) }
-        verify { permissionService.hasPermission(42, USERNAME, PermissionCode.EDIT_APPLICATIONS) }
-        verify { applicationService.sendApplication(1234, USERNAME) }
+        verify { applicationService.getApplicationById(id) }
+        verify { permissionService.hasPermission(42, USERNAME, EDIT_APPLICATIONS) }
+        verify { applicationService.sendApplication(id, USERNAME) }
     }
 
     @Test
     @WithMockUser(USERNAME)
     fun `sendApplication with unknown id returns 404`() {
+        val id = 1234L
         every { hankeService.getHankeId(HANKE_TUNNUS) } returns 42
-        every { applicationService.getApplicationById(1234) } throws
-            ApplicationNotFoundException(1234)
+        every { applicationService.getApplicationById(id) } throws ApplicationNotFoundException(id)
 
-        post("/hakemukset/1234/send-application").andExpect(status().isNotFound)
+        post("$BASE_URL/$id/send-application").andExpect(status().isNotFound)
 
-        verify { applicationService.getApplicationById(1234) }
+        verify { applicationService.getApplicationById(id) }
     }
 
     @Test
     @WithMockUser(USERNAME)
     fun `sendApplication with application that's no longer pending returns 409`() {
+        val id = 1234L
         every { hankeService.getHankeId(HANKE_TUNNUS) } returns 42
-        every {
-            permissionService.hasPermission(42, USERNAME, PermissionCode.EDIT_APPLICATIONS)
-        } returns true
-        every { applicationService.getApplicationById(1234) } returns
-            AlluDataFactory.createApplication(id = 1234, hankeTunnus = HANKE_TUNNUS)
-        every { applicationService.sendApplication(1234, USERNAME) } throws
-            ApplicationAlreadyProcessingException(1234, 21)
+        every { permissionService.hasPermission(42, USERNAME, EDIT_APPLICATIONS) } returns true
+        every { applicationService.getApplicationById(id) } returns
+            AlluDataFactory.createApplication(id = id, hankeTunnus = HANKE_TUNNUS)
+        every { applicationService.sendApplication(id, USERNAME) } throws
+            ApplicationAlreadyProcessingException(id, 21)
 
-        post("/hakemukset/1234/send-application").andExpect(status().isConflict)
+        post("$BASE_URL/$id/send-application").andExpect(status().isConflict)
 
-        verify { applicationService.getApplicationById(1234) }
-        verify { permissionService.hasPermission(42, USERNAME, PermissionCode.EDIT_APPLICATIONS) }
-        verify { applicationService.sendApplication(1234, USERNAME) }
+        verify { applicationService.getApplicationById(id) }
+        verify { permissionService.hasPermission(42, USERNAME, EDIT_APPLICATIONS) }
+        verify { applicationService.sendApplication(id, USERNAME) }
     }
 
     @Test
     @WithMockUser(USERNAME)
     fun `sendApplication with invalid application data returns 409`() {
+        val id = 1234L
         every { hankeService.getHankeId(HANKE_TUNNUS) } returns 42
-        every {
-            permissionService.hasPermission(42, USERNAME, PermissionCode.EDIT_APPLICATIONS)
-        } returns true
-        every { applicationService.getApplicationById(1234) } returns
-            AlluDataFactory.createApplication(id = 1234, hankeTunnus = HANKE_TUNNUS)
-        every { applicationService.sendApplication(1234, USERNAME) } throws
+        every { permissionService.hasPermission(42, USERNAME, EDIT_APPLICATIONS) } returns true
+        every { applicationService.getApplicationById(id) } returns
+            AlluDataFactory.createApplication(id = id, hankeTunnus = HANKE_TUNNUS)
+        every { applicationService.sendApplication(id, USERNAME) } throws
             AlluDataException("applicationData.some.path", AlluDataError.EMPTY_OR_NULL)
 
-        post("/hakemukset/1234/send-application").andExpect(status().isConflict)
+        post("$BASE_URL/$id/send-application").andExpect(status().isConflict)
 
-        verify { permissionService.hasPermission(42, USERNAME, PermissionCode.EDIT_APPLICATIONS) }
-        verify { applicationService.getApplicationById(1234) }
-        verify { applicationService.sendApplication(1234, USERNAME) }
+        verify { permissionService.hasPermission(42, USERNAME, EDIT_APPLICATIONS) }
+        verify { applicationService.getApplicationById(id) }
+        verify { applicationService.sendApplication(id, USERNAME) }
     }
 
     @Test
     @WithMockUser(USERNAME)
     fun `sendApplication without hanke permissions is not allowed`() {
+        val id = 11L
         every { hankeService.getHankeId(any()) } returns 42
-        every { applicationService.getApplicationById(11) } returns
-            AlluDataFactory.createApplication(id = 11, hankeTunnus = HANKE_TUNNUS)
-        every {
-            permissionService.hasPermission(42, USERNAME, PermissionCode.EDIT_APPLICATIONS)
-        } returns false
+        every { applicationService.getApplicationById(id) } returns
+            AlluDataFactory.createApplication(id = id, hankeTunnus = HANKE_TUNNUS)
+        every { permissionService.hasPermission(42, USERNAME, EDIT_APPLICATIONS) } returns false
 
-        post("/hakemukset/11/send-application").andExpect(status().isNotFound)
+        post("$BASE_URL/$id/send-application").andExpect(status().isNotFound)
 
-        verify { applicationService.getApplicationById(11) }
-        verify { permissionService.hasPermission(42, USERNAME, PermissionCode.EDIT_APPLICATIONS) }
+        verify { applicationService.getApplicationById(id) }
+        verify { permissionService.hasPermission(42, USERNAME, EDIT_APPLICATIONS) }
     }
 
     @Test
     fun `delete without user ID returns 401`() {
-        delete("/hakemukset/1").andExpect(status().isUnauthorized)
+        delete("$BASE_URL/1").andExpect(status().isUnauthorized)
 
         verify { applicationService wasNot Called }
     }
@@ -481,70 +476,67 @@ class ApplicationControllerITest(@Autowired override val mockMvc: MockMvc) : Con
     @Test
     @WithMockUser(USERNAME)
     fun `delete with unknown id returns 404`() {
-        every { applicationService.getApplicationById(1234) } throws
-            ApplicationNotFoundException(1234)
+        val id = 1234L
+        every { applicationService.getApplicationById(id) } throws ApplicationNotFoundException(id)
 
-        delete("/hakemukset/1234").andExpect(status().isNotFound)
+        delete("$BASE_URL/$id").andExpect(status().isNotFound)
 
-        verify { applicationService.getApplicationById(1234) }
+        verify { applicationService.getApplicationById(id) }
     }
 
     @Test
     @WithMockUser(USERNAME)
     fun `delete with known id deletes application`() {
+        val id = 1234L
         every { hankeService.getHankeId(any()) } returns 42
-        every {
-            permissionService.hasPermission(42, USERNAME, PermissionCode.EDIT_APPLICATIONS)
-        } returns true
-        every { applicationService.getApplicationById(1234) } returns
-            AlluDataFactory.createApplication(id = 1234, hankeTunnus = HANKE_TUNNUS)
-        justRun { applicationService.delete(1234, USERNAME) }
+        every { permissionService.hasPermission(42, USERNAME, EDIT_APPLICATIONS) } returns true
+        every { applicationService.getApplicationById(id) } returns
+            AlluDataFactory.createApplication(id = id, hankeTunnus = HANKE_TUNNUS)
+        justRun { applicationService.delete(id, USERNAME) }
 
-        delete("/hakemukset/1234").andExpect(status().isOk).andExpect(content().string(""))
+        delete("$BASE_URL/$id").andExpect(status().isOk).andExpect(content().string(""))
 
-        verify { permissionService.hasPermission(42, USERNAME, PermissionCode.EDIT_APPLICATIONS) }
-        verify { applicationService.getApplicationById(1234) }
-        verify { applicationService.delete(1234, USERNAME) }
+        verify { permissionService.hasPermission(42, USERNAME, EDIT_APPLICATIONS) }
+        verify { applicationService.getApplicationById(id) }
+        verify { applicationService.delete(id, USERNAME) }
     }
 
     @Test
     @WithMockUser(USERNAME)
     fun `delete with non-pending application in allu returns 409 Conflict`() {
+        val id = 1234L
         every { hankeService.getHankeId(any()) } returns 42
-        every {
-            permissionService.hasPermission(42, USERNAME, PermissionCode.EDIT_APPLICATIONS)
-        } returns true
-        every { applicationService.getApplicationById(1234) } returns
-            AlluDataFactory.createApplication(id = 1234, hankeTunnus = HANKE_TUNNUS)
-        every { applicationService.delete(1234, USERNAME) } throws
-            ApplicationAlreadyProcessingException(1234, 41)
+        every { permissionService.hasPermission(42, USERNAME, EDIT_APPLICATIONS) } returns true
+        every { applicationService.getApplicationById(id) } returns
+            AlluDataFactory.createApplication(id = id, hankeTunnus = HANKE_TUNNUS)
+        every { applicationService.delete(id, USERNAME) } throws
+            ApplicationAlreadyProcessingException(id, 41)
 
-        delete("/hakemukset/1234").andExpect(status().isConflict)
+        delete("$BASE_URL/$id").andExpect(status().isConflict)
 
-        verify { applicationService.getApplicationById(1234) }
-        verify { permissionService.hasPermission(42, USERNAME, PermissionCode.EDIT_APPLICATIONS) }
-        verify { applicationService.delete(1234, USERNAME) }
+        verify { applicationService.getApplicationById(id) }
+        verify { permissionService.hasPermission(42, USERNAME, EDIT_APPLICATIONS) }
+        verify { applicationService.delete(id, USERNAME) }
     }
 
     @Test
     @WithMockUser(USERNAME)
     fun `delete without hanke permissions is not allowed`() {
+        val id = 11L
         every { hankeService.getHankeId(any()) } returns 42
-        every { applicationService.getApplicationById(11) } returns
-            AlluDataFactory.createApplication(id = 11, hankeTunnus = HANKE_TUNNUS)
-        every {
-            permissionService.hasPermission(42, USERNAME, PermissionCode.EDIT_APPLICATIONS)
-        } returns false
+        every { applicationService.getApplicationById(id) } returns
+            AlluDataFactory.createApplication(id = id, hankeTunnus = HANKE_TUNNUS)
+        every { permissionService.hasPermission(42, USERNAME, EDIT_APPLICATIONS) } returns false
 
-        delete("/hakemukset/11").andExpect(status().isNotFound)
+        delete("$BASE_URL/11").andExpect(status().isNotFound)
 
-        verify { applicationService.getApplicationById(11) }
-        verify { permissionService.hasPermission(42, USERNAME, PermissionCode.EDIT_APPLICATIONS) }
+        verify { applicationService.getApplicationById(id) }
+        verify { permissionService.hasPermission(42, USERNAME, EDIT_APPLICATIONS) }
     }
 
     @Test
     fun `downloadDecision without user returns 401`() {
-        get("/hakemukset/1/paatos").andExpect(status().isUnauthorized)
+        get("$BASE_URL/1/paatos").andExpect(status().isUnauthorized)
 
         verify { applicationService wasNot Called }
     }
@@ -552,89 +544,93 @@ class ApplicationControllerITest(@Autowired override val mockMvc: MockMvc) : Con
     @Test
     @WithMockUser(USERNAME)
     fun `downloadDecision with unknown ID returns 404`() {
-        every { applicationService.getApplicationById(11) } throws ApplicationNotFoundException(11)
+        val id = 11L
+        every { applicationService.getApplicationById(id) } throws ApplicationNotFoundException(id)
 
-        get("/hakemukset/11/paatos", MediaType.APPLICATION_PDF, MediaType.APPLICATION_JSON)
+        get("$BASE_URL/$id/paatos", APPLICATION_PDF, APPLICATION_JSON)
             .andExpect(status().isNotFound)
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(content().contentType(APPLICATION_JSON))
             .andExpect(jsonPath("errorCode").value("HAI2001"))
             .andExpect(jsonPath("errorMessage").value("Application not found"))
 
-        verify { applicationService.getApplicationById(11) }
+        verify { applicationService.getApplicationById(id) }
     }
 
     @Test
     @WithMockUser(USERNAME)
     fun `downloadDecision when application has no decision returns 404`() {
+        val id = 11L
         every { hankeService.getHankeId(any()) } returns 42
-        every { permissionService.hasPermission(42, USERNAME, PermissionCode.VIEW) } returns true
-        every { applicationService.getApplicationById(11) } returns
-            AlluDataFactory.createApplication(id = 11, hankeTunnus = HANKE_TUNNUS)
-        every { applicationService.downloadDecision(11, USERNAME) } throws
+        every { permissionService.hasPermission(42, USERNAME, VIEW) } returns true
+        every { applicationService.getApplicationById(id) } returns
+            AlluDataFactory.createApplication(id = id, hankeTunnus = HANKE_TUNNUS)
+        every { applicationService.downloadDecision(id, USERNAME) } throws
             ApplicationDecisionNotFoundException("Decision not found in Allu. alluid=23")
 
-        get("/hakemukset/11/paatos", MediaType.APPLICATION_PDF, MediaType.APPLICATION_JSON)
+        get("$BASE_URL/11/paatos", APPLICATION_PDF, APPLICATION_JSON)
             .andExpect(status().isNotFound)
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(content().contentType(APPLICATION_JSON))
             .andExpect(jsonPath("errorCode").value("HAI2006"))
             .andExpect(jsonPath("errorMessage").value("Application decision not found"))
 
-        verify { applicationService.getApplicationById(11) }
-        verify { permissionService.hasPermission(42, USERNAME, PermissionCode.VIEW) }
-        verify { applicationService.downloadDecision(11, USERNAME) }
+        verify { applicationService.getApplicationById(id) }
+        verify { permissionService.hasPermission(42, USERNAME, VIEW) }
+        verify { applicationService.downloadDecision(id, USERNAME) }
     }
 
     @Test
     @WithMockUser(USERNAME)
     fun `downloadDecision with known id returns bytes and correct headers`() {
         every { hankeService.getHankeId(HANKE_TUNNUS) } returns 42
-        every { permissionService.hasPermission(42, USERNAME, PermissionCode.VIEW) } returns true
+        every { permissionService.hasPermission(42, USERNAME, VIEW) } returns true
         every { applicationService.getApplicationById(11) } returns
             AlluDataFactory.createApplication(id = 11, hankeTunnus = HANKE_TUNNUS)
         val pdfBytes = "/fi/hel/haitaton/hanke/decision/fake-decision.pdf".getResourceAsBytes()
         every { applicationService.downloadDecision(11, USERNAME) } returns
             Pair("JS230001", pdfBytes)
 
-        get("/hakemukset/11/paatos", MediaType.APPLICATION_PDF, MediaType.APPLICATION_JSON)
+        get("$BASE_URL/11/paatos", APPLICATION_PDF, APPLICATION_JSON)
             .andExpect(status().isOk)
             .andExpect(header().string("Content-Disposition", "inline; filename=JS230001.pdf"))
-            .andExpect(content().contentType(MediaType.APPLICATION_PDF))
+            .andExpect(content().contentType(APPLICATION_PDF))
             .andExpect(content().bytes(pdfBytes))
 
         verify { applicationService.getApplicationById(11) }
-        verify { permissionService.hasPermission(42, USERNAME, PermissionCode.VIEW) }
+        verify { permissionService.hasPermission(42, USERNAME, VIEW) }
         verify { applicationService.downloadDecision(11, USERNAME) }
     }
 
     @Test
     @WithMockUser(USERNAME)
     fun `downloadDecision without hanke permissions is not allowed`() {
+        val id = 11L
         every { hankeService.getHankeId(any()) } returns 42
-        every { applicationService.getApplicationById(11) } returns
-            AlluDataFactory.createApplication(id = 11, hankeTunnus = HANKE_TUNNUS)
-        every { permissionService.hasPermission(42, USERNAME, PermissionCode.VIEW) } returns false
+        every { applicationService.getApplicationById(id) } returns
+            AlluDataFactory.createApplication(id = id, hankeTunnus = HANKE_TUNNUS)
+        every { permissionService.hasPermission(42, USERNAME, VIEW) } returns false
 
-        get("/hakemukset/11/paatos", MediaType.APPLICATION_PDF, MediaType.APPLICATION_JSON)
+        get("$BASE_URL/$id/paatos", APPLICATION_PDF, APPLICATION_JSON)
             .andExpect(status().isNotFound)
 
-        verify { applicationService.getApplicationById(11) }
-        verify { permissionService.hasPermission(42, USERNAME, PermissionCode.VIEW) }
+        verify { applicationService.getApplicationById(id) }
+        verify { permissionService.hasPermission(42, USERNAME, VIEW) }
     }
 
     @Test
     @WithMockUser(USERNAME)
     fun `Application and hanke can be linked`() {
-        every { applicationService.getApplicationById(1234) } returns
-            AlluDataFactory.createApplication(id = 1234, hankeTunnus = HANKE_TUNNUS)
+        val id = 1234L
+        every { applicationService.getApplicationById(id) } returns
+            AlluDataFactory.createApplication(id = id, hankeTunnus = HANKE_TUNNUS)
         every { hankeService.getHankeId(HANKE_TUNNUS) } returns 42
-        every { permissionService.hasPermission(42, USERNAME, PermissionCode.VIEW) } returns true
+        every { permissionService.hasPermission(42, USERNAME, VIEW) } returns true
 
-        get("/hakemukset/1234")
+        get("$BASE_URL/$id")
             .andExpect(status().isOk)
             .andExpect(jsonPath("$.hankeTunnus").value(HANKE_TUNNUS))
 
-        verify { applicationService.getApplicationById(1234) }
-        verify { permissionService.hasPermission(42, USERNAME, PermissionCode.VIEW) }
+        verify { applicationService.getApplicationById(id) }
+        verify { permissionService.hasPermission(42, USERNAME, VIEW) }
     }
 
     @Test
@@ -645,7 +641,7 @@ class ApplicationControllerITest(@Autowired override val mockMvc: MockMvc) : Con
         val json = objectMapper.valueToTree<ObjectNode>(newApplication)
         json.remove("hankeTunnus")
         val text = json.asText()
-        postRaw("/hakemukset", text).andExpect(status().isBadRequest)
+        postRaw(BASE_URL, text).andExpect(status().isBadRequest)
     }
 
     @Test
@@ -654,12 +650,10 @@ class ApplicationControllerITest(@Autowired override val mockMvc: MockMvc) : Con
         val newApplication =
             AlluDataFactory.createApplication(id = null, hankeTunnus = HANKE_TUNNUS)
         every { hankeService.getHankeId(HANKE_TUNNUS) } returns 42
-        every {
-            permissionService.hasPermission(42, USERNAME, PermissionCode.EDIT_APPLICATIONS)
-        } returns false
+        every { permissionService.hasPermission(42, USERNAME, EDIT_APPLICATIONS) } returns false
 
-        post("/hakemukset", newApplication).andExpect(status().isNotFound)
+        post(BASE_URL, newApplication).andExpect(status().isNotFound)
 
-        verify { permissionService.hasPermission(42, USERNAME, PermissionCode.EDIT_APPLICATIONS) }
+        verify { permissionService.hasPermission(42, USERNAME, EDIT_APPLICATIONS) }
     }
 }

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationControllerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationControllerITest.kt
@@ -8,6 +8,7 @@ import fi.hel.haitaton.hanke.IntegrationTestConfiguration
 import fi.hel.haitaton.hanke.OBJECT_MAPPER
 import fi.hel.haitaton.hanke.andReturnBody
 import fi.hel.haitaton.hanke.factory.AlluDataFactory
+import fi.hel.haitaton.hanke.factory.AlluDataFactory.Companion.withContacts
 import fi.hel.haitaton.hanke.getResourceAsBytes
 import fi.hel.haitaton.hanke.permissions.PermissionCode
 import fi.hel.haitaton.hanke.permissions.PermissionService
@@ -188,6 +189,23 @@ class ApplicationControllerITest(@Autowired override val mockMvc: MockMvc) : Con
     }
 
     @Test
+    @WithMockUser(USERNAME)
+    fun `create with invalid y-tunnus returns 400`() {
+        val applicationData =
+            AlluDataFactory.createCableReportApplicationData(
+                customerWithContacts =
+                    AlluDataFactory.createCompanyCustomer(registryKey = "281192-937W")
+                        .withContacts()
+            )
+        val application =
+            AlluDataFactory.createApplication(id = null, applicationData = applicationData)
+
+        post("/hakemukset", application).andExpect(status().isBadRequest)
+
+        verify { applicationService wasNot Called }
+    }
+
+    @Test
     fun `update without logged in user returns 401`() {
         put("/hakemukset/1234", AlluDataFactory.createApplication())
             .andExpect(status().isUnauthorized)
@@ -199,6 +217,23 @@ class ApplicationControllerITest(@Autowired override val mockMvc: MockMvc) : Con
     @WithMockUser(USERNAME)
     fun `update without body returns 400`() {
         put("/hakemukset/1234").andExpect(status().isBadRequest)
+
+        verify { applicationService wasNot Called }
+    }
+
+    @Test
+    @WithMockUser(USERNAME)
+    fun `update with invalid y-tunnus returns 400`() {
+        val applicationData =
+            AlluDataFactory.createCableReportApplicationData(
+                customerWithContacts =
+                    AlluDataFactory.createCompanyCustomer(registryKey = "281192-937W")
+                        .withContacts()
+            )
+        val application =
+            AlluDataFactory.createApplication(id = null, applicationData = applicationData)
+
+        put("/hakemukset/1234", application).andExpect(status().isBadRequest)
 
         verify { applicationService wasNot Called }
     }

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceITest.kt
@@ -1294,13 +1294,6 @@ class ApplicationServiceITest : DatabaseTest() {
              "type": "COMPANY",
              "name": "DNA",
              "country": "FI",
-             "postalAddress": {
-               "streetAddress": {
-                 "streetName": "Katu 1"
-               },
-               "postalCode": "00100",
-               "city": "Helsinki"
-             },
              "email": "info@dna.test",
              "phone": "+3581012345678",
              "registryKey": "3766028-0",
@@ -1311,13 +1304,6 @@ class ApplicationServiceITest : DatabaseTest() {
            "contacts": [
              {
                "name": "Teppo Testihenkilö",
-               "postalAddress": {
-                 "streetAddress": {
-                   "streetName": "Katu 1"
-                 },
-                 "postalCode": "00100",
-                 "city": "Helsinki"
-               },
                "email": "teppo@example.test",
                "phone": "04012345678",
                "orderer": false

--- a/services/hanke-service/src/integrationTest/resources/fi/hel/haitaton/hanke/logging/expectedHankeWithPoints.json.mustache
+++ b/services/hanke-service/src/integrationTest/resources/fi/hel/haitaton/hanke/logging/expectedHankeWithPoints.json.mustache
@@ -24,7 +24,6 @@
     "MUU",
     "VESI"
   ],
-  "tyomaaKoko": "LAAJA_TAI_USEA_KORTTELI",
   "alueet": [
 {{#alueId}}
     {

--- a/services/hanke-service/src/integrationTest/resources/fi/hel/haitaton/hanke/logging/expectedHankeWithPolygon.json.mustache
+++ b/services/hanke-service/src/integrationTest/resources/fi/hel/haitaton/hanke/logging/expectedHankeWithPolygon.json.mustache
@@ -24,7 +24,6 @@
     "MUU",
     "VESI"
   ],
-  "tyomaaKoko": "LAAJA_TAI_USEA_KORTTELI",
   "alueet": [
 {{#alueId}}
     {

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeError.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeError.kt
@@ -32,6 +32,7 @@ enum class HankeError(val errorMessage: String) {
     HAI2005("Invalid application geometry"),
     HAI2006("Application decision not found"),
     HAI2007("Application geometry not inside any hankealue"),
+    HAI2008("Application contains invalid data"),
     ;
 
     val errorCode: String

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeServiceImpl.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeServiceImpl.kt
@@ -317,7 +317,6 @@ open class HankeServiceImpl(
 
         h.tyomaaKatuosoite = hankeEntity.tyomaaKatuosoite
         h.tyomaaTyyppi = hankeEntity.tyomaaTyyppi
-        h.tyomaaKoko = hankeEntity.tyomaaKoko
 
         createSeparateYhteystietoListsFromEntityData(h, hankeEntity)
 
@@ -542,7 +541,6 @@ open class HankeServiceImpl(
         hanke.suunnitteluVaihe?.let { entity.suunnitteluVaihe = hanke.suunnitteluVaihe }
         hanke.tyomaaKatuosoite?.let { entity.tyomaaKatuosoite = hanke.tyomaaKatuosoite }
         entity.tyomaaTyyppi = hanke.tyomaaTyyppi
-        hanke.tyomaaKoko?.let { entity.tyomaaKoko = hanke.tyomaaKoko }
 
         // Merge hankealueet
         mergeDataInto(hanke.alueet, entity.listOfHankeAlueet) { source, target ->

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Persistence.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Persistence.kt
@@ -88,13 +88,6 @@ enum class TyomaaTyyppi {
 }
 
 /** NOTE Järjestys täytyy olla pienimmästä suurimpaan */
-enum class TyomaaKoko {
-    SUPPEA_TAI_PISTE,
-    YLI_10M_TAI_KORTTELI,
-    LAAJA_TAI_USEA_KORTTELI
-}
-
-/** NOTE Järjestys täytyy olla pienimmästä suurimpaan */
 enum class TodennakoinenHaittaPaaAjoRatojenKaistajarjestelyihin(
     override val value: Int,
     override val explanation: String
@@ -175,8 +168,6 @@ class HankeEntity(
     @CollectionTable(name = "hanketyomaatyyppi", joinColumns = [JoinColumn(name = "hankeid")])
     @Enumerated(EnumType.STRING)
     var tyomaaTyyppi: MutableSet<TyomaaTyyppi> = mutableSetOf()
-
-    @Enumerated(EnumType.STRING) var tyomaaKoko: TyomaaKoko? = null
 
     // --------------- Hankkeen haitat -------------------
     var haittaAlkuPvm: LocalDate? = null // NOTE: stored and handled in UTC, not in "local" time

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Utils.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Utils.kt
@@ -1,5 +1,6 @@
 package fi.hel.haitaton.hanke
 
+import fi.hel.haitaton.hanke.domain.BusinessId
 import java.time.LocalDateTime
 import java.time.ZonedDateTime
 import org.springframework.security.core.context.SecurityContextHolder
@@ -15,3 +16,38 @@ fun getCurrentTimeUTCAsLocalTime(): LocalDateTime {
 }
 
 fun currentUserId(): String = SecurityContextHolder.getContext().authentication.name
+
+/**
+ * Valid businessId (y-tunnus) requirements:
+ * 1. format NNNNNNN-T, where N = sequence number and T = check number.
+ * 2. documentation of check mark calculation:
+ * ```
+ *     - https://www.vero.fi/globalassets/tietoa-verohallinnosta/ohjelmistokehittajille/yritys--ja-yhteis%C3%B6tunnuksen-ja-henkil%C3%B6tunnuksen-tarkistusmerkin-tarkistuslaskenta.pdf
+ * ```
+ *
+ * Only verifies that the id is of valid form. It does not guarantee that it actually exists.
+ */
+fun BusinessId.isValid(): Boolean {
+    if (length != 9 || this[7] != '-' || this[8] == '1') {
+        throw InvalidApplicationDataException("Y-tunnus: $this is of incorrect form.")
+    }
+    substringBefore("-")
+        .map { it.digitToInt() }
+        .zip(listOf(7, 9, 10, 5, 8, 4, 2))
+        .sumOf { (num, multiplier) -> num * multiplier }
+        .mod(11)
+        .let { remainder ->
+            val check = substringAfter("-").toInt()
+            val result = 11 - remainder
+
+            if ((remainder == 0 && 0 == check) || result == check) {
+                return true
+            }
+
+            throw InvalidApplicationDataException(
+                "$this has incorrect check number, expected $result"
+            )
+        }
+}
+
+class InvalidApplicationDataException(message: String) : RuntimeException(message)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/AlluCommonDomain.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/AlluCommonDomain.kt
@@ -3,6 +3,7 @@ package fi.hel.haitaton.hanke.allu
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonView
 import fi.hel.haitaton.hanke.ChangeLogView
+import fi.hel.haitaton.hanke.domain.BusinessId
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class CustomerWithContacts(val customer: Customer, val contacts: List<Contact>)
@@ -10,7 +11,6 @@ data class CustomerWithContacts(val customer: Customer, val contacts: List<Conta
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class Contact(
     val name: String?,
-    val postalAddress: PostalAddress?,
     val email: String?,
     val phone: String?,
     val orderer: Boolean = false
@@ -22,10 +22,9 @@ data class Customer(
     val type: CustomerType,
     val name: String,
     val country: String, // ISO 3166-1 alpha-2 country code
-    val postalAddress: PostalAddress?,
     val email: String?,
     val phone: String?,
-    val registryKey: String?, // ssn or y-tunnus
+    val registryKey: BusinessId?, // y-tunnus
     val ovt: String?, // e-invoice identifier (ovt-tunnus)
     val invoicingOperator: String?, // e-invoicing operator code
     val sapCustomerNumber: String? // customer's sap number

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationController.kt
@@ -3,11 +3,11 @@ package fi.hel.haitaton.hanke.application
 import fi.hel.haitaton.hanke.HankeError
 import fi.hel.haitaton.hanke.HankeNotFoundException
 import fi.hel.haitaton.hanke.HankeService
-import fi.hel.haitaton.hanke.InvalidApplicationDataException
 import fi.hel.haitaton.hanke.currentUserId
 import fi.hel.haitaton.hanke.logging.DisclosureLogService
 import fi.hel.haitaton.hanke.permissions.PermissionCode
 import fi.hel.haitaton.hanke.permissions.PermissionService
+import fi.hel.haitaton.hanke.validation.InvalidApplicationDataException
 import fi.hel.haitaton.hanke.validation.ValidApplication
 import io.swagger.v3.oas.annotations.Hidden
 import io.swagger.v3.oas.annotations.Operation

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/Hanke.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/Hanke.kt
@@ -9,7 +9,6 @@ import fi.hel.haitaton.hanke.KaistajarjestelynPituus
 import fi.hel.haitaton.hanke.NotInChangeLogView
 import fi.hel.haitaton.hanke.SuunnitteluVaihe
 import fi.hel.haitaton.hanke.TodennakoinenHaittaPaaAjoRatojenKaistajarjestelyihin
-import fi.hel.haitaton.hanke.TyomaaKoko
 import fi.hel.haitaton.hanke.TyomaaTyyppi
 import fi.hel.haitaton.hanke.Vaihe
 import fi.hel.haitaton.hanke.geometria.Geometriat
@@ -46,7 +45,6 @@ data class Hanke(
     // --------------- Hankkeen lisätiedot / Työmaan tiedot -------------------
     @JsonView(ChangeLogView::class) var tyomaaKatuosoite: String? = null
     @JsonView(ChangeLogView::class) var tyomaaTyyppi = mutableSetOf<TyomaaTyyppi>()
-    @JsonView(ChangeLogView::class) var tyomaaKoko: TyomaaKoko? = null
 
     // --------------- Hankkeen haitat -------------------
     fun kaistaHaitat(): Set<TodennakoinenHaittaPaaAjoRatojenKaistajarjestelyihin> {

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/TypeAliases.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/TypeAliases.kt
@@ -1,0 +1,4 @@
+package fi.hel.haitaton.hanke.domain
+
+/** Y-tunnus. */
+typealias BusinessId = String

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/gdpr/GdprInfo.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/gdpr/GdprInfo.kt
@@ -1,24 +1,18 @@
 package fi.hel.haitaton.hanke.gdpr
 
+import fi.hel.haitaton.hanke.domain.BusinessId
+
 data class GdprInfo(
     val name: String? = null,
     val phone: String? = null,
     val email: String? = null,
     val ipAddress: String? = null,
     val organisation: GdprOrganisation? = null,
-    val address: GdprAddress? = null,
 )
 
 data class GdprOrganisation(
     val id: Int? = null,
     val name: String? = null,
-    val registryKey: String? = null,
+    val registryKey: BusinessId? = null,
     val department: String? = null,
-)
-
-data class GdprAddress(
-    val street: String? = null,
-    val city: String? = null,
-    val postalCode: String? = null,
-    val country: String? = null,
 )

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/validation/ApplicationValidator.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/validation/ApplicationValidator.kt
@@ -1,0 +1,28 @@
+package fi.hel.haitaton.hanke.validation
+
+import fi.hel.haitaton.hanke.InvalidApplicationDataException
+import fi.hel.haitaton.hanke.application.Application
+import fi.hel.haitaton.hanke.application.CableReportApplicationData
+import fi.hel.haitaton.hanke.isValid
+import javax.validation.ConstraintValidator
+import javax.validation.ConstraintValidatorContext
+
+class ApplicationValidator : ConstraintValidator<ValidApplication, Application> {
+    override fun isValid(application: Application?, context: ConstraintValidatorContext?): Boolean {
+
+        val applicationData =
+            application?.applicationData
+                ?: throw InvalidApplicationDataException("Application data missing.")
+
+        return when (applicationData) {
+            is CableReportApplicationData ->
+                listOfNotNull(
+                        applicationData.customerWithContacts.customer,
+                        applicationData.contractorWithContacts.customer,
+                        applicationData.representativeWithContacts?.customer,
+                        applicationData.propertyDeveloperWithContacts?.customer,
+                    )
+                    .all { it.registryKey == null || it.registryKey.isValid() }
+        }
+    }
+}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/validation/ApplicationValidator.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/validation/ApplicationValidator.kt
@@ -1,9 +1,8 @@
 package fi.hel.haitaton.hanke.validation
 
-import fi.hel.haitaton.hanke.InvalidApplicationDataException
 import fi.hel.haitaton.hanke.application.Application
 import fi.hel.haitaton.hanke.application.CableReportApplicationData
-import fi.hel.haitaton.hanke.isValid
+import fi.hel.haitaton.hanke.isValidBusinessId
 import javax.validation.ConstraintValidator
 import javax.validation.ConstraintValidatorContext
 
@@ -22,7 +21,15 @@ class ApplicationValidator : ConstraintValidator<ValidApplication, Application> 
                         applicationData.representativeWithContacts?.customer,
                         applicationData.propertyDeveloperWithContacts?.customer,
                     )
-                    .all { it.registryKey == null || it.registryKey.isValid() }
+                    .all {
+                        when {
+                            it.registryKey == null -> true
+                            it.registryKey.isValidBusinessId() -> true
+                            else -> throw InvalidApplicationDataException("Y-tunnus invalid.")
+                        }
+                    }
         }
     }
 }
+
+class InvalidApplicationDataException(message: String) : RuntimeException(message)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/validation/ValidApplication.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/validation/ValidApplication.kt
@@ -1,0 +1,15 @@
+package fi.hel.haitaton.hanke.validation
+
+import javax.validation.Constraint
+import javax.validation.Payload
+import kotlin.reflect.KClass
+
+@Target(AnnotationTarget.VALUE_PARAMETER)
+@Retention(AnnotationRetention.RUNTIME)
+@Constraint(validatedBy = [ApplicationValidator::class])
+@MustBeDocumented
+annotation class ValidApplication(
+    val message: String = "",
+    val groups: Array<KClass<*>> = [],
+    val payload: Array<KClass<out Payload>> = []
+)

--- a/services/hanke-service/src/main/resources/db/changelog/changesets/026-drop-tyomaakoko-from-hanke.yml
+++ b/services/hanke-service/src/main/resources/db/changelog/changesets/026-drop-tyomaakoko-from-hanke.yml
@@ -1,0 +1,10 @@
+databaseChangeLog:
+  - changeSet:
+      id: 026-drop-tyomaakoko-from-hanke
+      author: Niko Pitkonen
+      changes:
+        - dropColumn:
+            tableName: hanke
+            columns:
+              - column:
+                  name: tyomaakoko

--- a/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -79,3 +79,5 @@ databaseChangeLog:
       file: db/changelog/changesets/024-connect-application-to-hanke.yml
   - include:
       file: db/changelog/changesets/025-add-perustaja-nimi-sahkoposti-to-hanke.yml
+  - include:
+      file: db/changelog/changesets/026-drop-tyomaakoko-from-hanke.yml

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/UtilsKtTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/UtilsKtTest.kt
@@ -1,0 +1,37 @@
+package fi.hel.haitaton.hanke
+
+import fi.hel.haitaton.hanke.domain.BusinessId
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+
+class UtilsKtTest {
+
+    @ParameterizedTest
+    @ValueSource(
+        strings =
+            [
+                "2182805-0",
+                "7126070-7",
+                "1164243-9",
+                "3227510-5",
+                "3362438-9",
+                "7743551-2",
+                "8634465-5",
+                "0407327-4",
+                "7542843-1",
+                "6545312-3"
+            ]
+    )
+    fun `isValid when valid businessId returns true`(businessId: BusinessId) {
+        assertTrue(businessId.isValidBusinessId())
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+        strings = ["21828053-0", "71260-7", "1164243-", "3227510", "3362438-4", "0100007-1"]
+    )
+    fun `isValid when not valid businessId returns false`(businessId: BusinessId) {
+        assertFalse(businessId.isValidBusinessId())
+    }
+}

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/allu/ApplicationPdfServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/allu/ApplicationPdfServiceTest.kt
@@ -55,7 +55,6 @@ internal class ApplicationPdfServiceTest {
                                 .withContacts(
                                     AlluDataFactory.createContact(
                                         "Teppo Tilaaja",
-                                        null,
                                         "teppo@tilaajat.info",
                                         "0406584321",
                                         orderer = true,

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/AlluDataFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/AlluDataFactory.kt
@@ -38,7 +38,6 @@ class AlluDataFactory(val applicationRepository: ApplicationRepository) {
             type: CustomerType? = CustomerType.PERSON,
             name: String = "Teppo Testihenkilö",
             country: String = "FI",
-            postalAddress: PostalAddress? = createPostalAddress(),
             email: String? = "teppo@example.test",
             phone: String? = "04012345678",
             registryKey: String? = "281192-937W",
@@ -50,7 +49,6 @@ class AlluDataFactory(val applicationRepository: ApplicationRepository) {
                 type,
                 name,
                 country,
-                postalAddress,
                 email,
                 phone,
                 registryKey,
@@ -63,7 +61,6 @@ class AlluDataFactory(val applicationRepository: ApplicationRepository) {
             type: CustomerType? = CustomerType.COMPANY,
             name: String = "DNA",
             country: String = "FI",
-            postalAddress: PostalAddress? = createPostalAddress(),
             email: String? = "info@dna.test",
             phone: String? = "+3581012345678",
             registryKey: String? = "3766028-0",
@@ -75,7 +72,6 @@ class AlluDataFactory(val applicationRepository: ApplicationRepository) {
                 type,
                 name,
                 country,
-                postalAddress,
                 email,
                 phone,
                 registryKey,
@@ -89,11 +85,10 @@ class AlluDataFactory(val applicationRepository: ApplicationRepository) {
 
         fun createContact(
             name: String? = "Teppo Testihenkilö",
-            postalAddress: PostalAddress? = createPostalAddress(),
             email: String? = "teppo@example.test",
             phone: String? = "04012345678",
             orderer: Boolean = false
-        ) = Contact(name, postalAddress, email, phone, orderer)
+        ) = Contact(name, email, phone, orderer)
 
         fun createApplicationArea(
             name: String = "Area name",

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeFactory.kt
@@ -2,7 +2,6 @@ package fi.hel.haitaton.hanke.factory
 
 import fi.hel.haitaton.hanke.HankeStatus
 import fi.hel.haitaton.hanke.SuunnitteluVaihe
-import fi.hel.haitaton.hanke.TyomaaKoko
 import fi.hel.haitaton.hanke.TyomaaTyyppi
 import fi.hel.haitaton.hanke.Vaihe
 import fi.hel.haitaton.hanke.domain.Hanke
@@ -78,7 +77,6 @@ object HankeFactory : Factory<Hanke>() {
         this.tyomaaKatuosoite = "Testikatu 1"
         this.tyomaaTyyppi.add(TyomaaTyyppi.VESI)
         this.tyomaaTyyppi.add(TyomaaTyyppi.MUU)
-        this.tyomaaKoko = TyomaaKoko.LAAJA_TAI_USEA_KORTTELI
 
         this.alueet.add(alue)
 

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/logging/DisclosureLogServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/logging/DisclosureLogServiceTest.kt
@@ -4,8 +4,6 @@ import fi.hel.haitaton.hanke.allu.CustomerType
 import fi.hel.haitaton.hanke.application.Contact
 import fi.hel.haitaton.hanke.application.Customer
 import fi.hel.haitaton.hanke.application.CustomerWithContacts
-import fi.hel.haitaton.hanke.application.PostalAddress
-import fi.hel.haitaton.hanke.application.StreetAddress
 import fi.hel.haitaton.hanke.factory.AlluDataFactory
 import fi.hel.haitaton.hanke.factory.AlluDataFactory.Companion.withContacts
 import fi.hel.haitaton.hanke.factory.AuditLogEntryFactory
@@ -203,8 +201,7 @@ internal class DisclosureLogServiceTest {
         val customerWithoutContacts =
             AlluDataFactory.createCompanyCustomer(name = "First").withContacts()
         val contractorWithoutContacts =
-            AlluDataFactory.createCompanyCustomer(name = "Second")
-                .withContacts(Contact("", PostalAddress(StreetAddress(""), "", ""), "", ""))
+            AlluDataFactory.createCompanyCustomer(name = "Second").withContacts(Contact("", "", ""))
         val application =
             AlluDataFactory.createApplication(
                 applicationData =
@@ -222,10 +219,9 @@ internal class DisclosureLogServiceTest {
 
     @Test
     fun `saveDisclosureLogsForApplication doesn't save entries for blank customers`() {
-        val blankCustomer =
-            Customer(type = CustomerType.PERSON, "", "", null, "", "", "", "", "", "")
+        val blankCustomer = Customer(type = CustomerType.PERSON, "", "", "", "", "", "", "", "")
         val blankCustomerWithCountry =
-            Customer(type = CustomerType.PERSON, "", "FI", null, "", "", "", "", "", "")
+            Customer(type = CustomerType.PERSON, "", "FI", "", "", "", "", "", "")
         val customerWithoutContacts = CustomerWithContacts(blankCustomer, listOf())
         val contractorWithoutContacts = CustomerWithContacts(blankCustomerWithCountry, listOf())
         val application =

--- a/services/hanke-service/src/test/resources/fi/hel/haitaton/hanke/application/applicationData.json
+++ b/services/hanke-service/src/test/resources/fi/hel/haitaton/hanke/application/applicationData.json
@@ -57,14 +57,7 @@
         "name": "Teppo Testihenkilö",
         "email": "teppo@example.test",
         "phone": "04012345678",
-        "orderer": true,
-        "postalAddress": {
-          "city": "Helsinki",
-          "postalCode": "00100",
-          "streetAddress": {
-            "streetName": "Katu 1"
-          }
-        }
+        "orderer": true
       }
     ],
     "customer": {
@@ -75,13 +68,6 @@
       "phone": "04012345678",
       "country": "FI",
       "registryKey": "281192-937W",
-      "postalAddress": {
-        "city": "Helsinki",
-        "postalCode": "00100",
-        "streetAddress": {
-          "streetName": "Katu 1"
-        }
-      },
       "invoicingOperator": null,
       "sapCustomerNumber": null
     }
@@ -95,14 +81,7 @@
         "name": "Teppo Testihenkilö",
         "email": "teppo@dna.test",
         "phone": "04012345678",
-        "orderer": true,
-        "postalAddress": {
-          "city": "Helsinki",
-          "postalCode": "04100",
-          "streetAddress": {
-            "streetName": "Dnapolku 3"
-          }
-        }
+        "orderer": true
       }
     ],
     "customer": {
@@ -113,13 +92,6 @@
       "phone": "+3581012345678",
       "country": "FI",
       "registryKey": "3766028-0",
-      "postalAddress": {
-        "city": "Helsinki",
-        "postalCode": "04100",
-        "streetAddress": {
-          "streetName": "Dnapolku 3"
-        }
-      },
       "invoicingOperator": null,
       "sapCustomerNumber": null
     }


### PR DESCRIPTION
# Description

Changes to hanke / Allu data objects based on Allu requirements.

1. Remove field TyomaaKoko
2. Disallow usage of personal identity code in registryKey. Previously this field was either personal identity code or business identity (y-tunnus). 
3. Remove person related address data.

BusinessId validation is done according to Verohallinto documentation: https://www.vero.fi/globalassets/tietoa-verohallinnosta/ohjelmistokehittajille/yritys--ja-yhteis%C3%B6tunnuksen-ja-henkil%C3%B6tunnuksen-tarkistusmerkin-tarkistuslaskenta.pdf

HAI-1349 needs to be merged before this.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1505

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [x] Other

# Instructions for testing
Please describe tests how this change or new feature can be tested.

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 