### PR TITLE
HAI-1571 Fix for database migration

### DIFF
--- a/services/hanke-service/src/main/resources/db/changelog/changesets/027-add-generated-to-hanke.yml
+++ b/services/hanke-service/src/main/resources/db/changelog/changesets/027-add-generated-to-hanke.yml
@@ -10,5 +10,9 @@ databaseChangeLog:
               - column:
                   name: generated
                   type: boolean
+                  defaultValueBoolean: false
                   constraints:
                     nullable: false
+        - dropDefaultValue:
+            tableName: hanke
+            columnName: generated


### PR DESCRIPTION
The database migration that adds the generated-column to hanke table didn't work if there are any existing hanke in the table.

It failed with:
```
org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'liquibase' defined in class path resource [org/springframework/boot/autoconfigure/liquibase/LiquibaseAutoConfiguration$LiquibaseConfiguration.class]: Invocation of init method failed; nested exception is liquibase.exception.MigrationFailedException: Migration failed for change set db/changelog/changesets/027-add-generated-to-hanke.yml::027-add-generated-to-hanke::admin:
     Reason: liquibase.exception.DatabaseException: ERROR: column "generated" of relation "hanke" contains null values [Failed SQL: (0) ALTER TABLE public.hanke ADD generated BOOLEAN NOT NULL]
```

Fix the migration by setting a default value for the column. This sets all pre-existing hankkeet to be non-generated, which they should be. The possibility to create generated hanke didn't exist before the failing migration.

The default value is removed after the column is added.