### PR TITLE
HAI-1538 cycling infra

### DIFF
--- a/scripts/gis-material-update/README.md
+++ b/scripts/gis-material-update/README.md
@@ -34,6 +34,8 @@ Local development database is set up with PostGIS spatial support.
 
 ## Volume mappings
 
+Local directory `data` is mapped to fetch container.
+
 Local directory `haitaton-downloads` is mapped to fetch and processing containers.
 
 Local directory `haitaton-gis-output` is mapped to processing container.
@@ -118,6 +120,7 @@ Where `<source>` is currently one of:
 - `ylre_katualueet` - Helsinki YLRE street areas, polygons.
 - `ylre_katuosat` - Helsinki YLRE parts, polygons.
 - `maka_autoliikennemaarat` - Traffic volumes (car traffic)
+- `cycle_infra` - Cycle infra (local file)
 
 Data files are downloaded to `./haitaton-downloads` -directory.
 
@@ -275,6 +278,26 @@ Output files (names configured in `config.yaml`)
 
 - tram_lines.gpkg
 - tormays_tram_lines_polys.gpkg
+
+### `cycle_infra`
+
+Docker example run (ensure that image build and file copying is
+already performed as instructed above):
+
+```sh
+docker-compose up -d gis-db
+docker-compose run --rm gis-fetch cycle_infra
+docker-compose run --rm gis-process cycle_infra
+docker-compose stop gis-db
+```
+
+Processed GIS material is available in:
+haitaton-gis-output
+
+Output files (names configured in `config.yaml`)
+
+- cycle_infra.gpkg
+- tormays_cycle_infra_polys.gpkg
 
 # Run tests
 

--- a/scripts/gis-material-update/README.md
+++ b/scripts/gis-material-update/README.md
@@ -281,6 +281,8 @@ Output files (names configured in `config.yaml`)
 
 ### `cycle_infra`
 
+Prerequisite: copy source file to `data` -directory. See `data/README.md`
+
 Docker example run (ensure that image build and file copying is
 already performed as instructed above):
 

--- a/scripts/gis-material-update/config.yaml
+++ b/scripts/gis-material-update/config.yaml
@@ -59,7 +59,7 @@ cycle_infra:
   addr: "/local_data/helsinki_cycleways.gpkg"
   local_file: "helsinki_cycleways.gpkg"
   target_file: "cycle_infra.gpkg"
-  target_buffer_file: "tormays_cycle_infra.gpkg"
+  target_buffer_file: "tormays_cycle_infra_polys.gpkg"
   buffer:
     - 20
 

--- a/scripts/gis-material-update/config.yaml
+++ b/scripts/gis-material-update/config.yaml
@@ -55,6 +55,13 @@ tram_lines:
   target_buffer_file: "tormays_tram_lines_polys.gpkg"
   buffer:
     - 35
+cycle_infra:
+  addr: "/local_data/helsinki_cycleways.gpkg"
+  local_file: "helsinki_cycleways.gpkg"
+  target_file: "cycle_infra.gpkg"
+  target_buffer_file: "tormays_cycle_infra.gpkg"
+  buffer:
+    - 20
 
 common:
   download_path: "/downloads"

--- a/scripts/gis-material-update/config.yaml
+++ b/scripts/gis-material-update/config.yaml
@@ -70,8 +70,6 @@ common:
 # pyynnöstä toimitetut
 bussiliikenne_kriittinen:
 pienalueet_kantakaupunki_yleiskaava:
-polkupyora_prioriteetti:
-polkupyora_paareitti:
 liikennevaylat:
 
 local_development:

--- a/scripts/gis-material-update/data/README.md
+++ b/scripts/gis-material-update/data/README.md
@@ -1,14 +1,34 @@
 # Contents
 
-This directory is for saving external files.
+This directory is for saving external source files,
+e.g. GIS materials provided via email.
 
-## Cycling routes
+# Usage
 
-In the near future, cycling routes are obtaine from API.
+Ideally, there would be no need to copy files into this directory, but all source
+materials should be available via API or via download from public sources.
 
-### File: helsinki_cycleways.gpkg
+Materials that are not yet available via public sources, are listed in this document.
 
-Process existing materials:
+## Cycling infra
+
+In the near future, cycling routes are obtained from API.
+
+Currently cycling infra is read from combined Geopackage [file](https://helsinginkaupunki.sharepoint.com/:u:/r/sites/KYMPHaitaton/Jaetut%20asiakirjat/General/02_Taustamateriaalit/Laastariaineisto/haitaton_2_input/helsinki_cycleways.gpkg?csf=1&web=1&e=pR3rqm)
+
+### Instructions to generate combined file
+
+If (for any reason) there is a need to generate combined cycling infra file,
+it can be done using following procedure.
+
+Cycling infra source materials are available:
+
+- [Main routes](https://helsinginkaupunki.sharepoint.com/:u:/r/sites/KYMPHaitaton/Jaetut%20asiakirjat/General/02_Taustamateriaalit/Laastariaineisto/haitaton2spatial/input/Helsinki_pp_paareitit.zip?csf=1&web=1&e=gT8SUz)
+- [prioritized routes](https://helsinginkaupunki.sharepoint.com/:u:/r/sites/KYMPHaitaton/Jaetut%20asiakirjat/General/02_Taustamateriaalit/Laastariaineisto/haitaton2spatial/input/priorisoidut_reitit.zip?csf=1&web=1&e=75maG1)
+
+Extract zipped shapefiles.
+
+Create one cycling output file combining both infra data:
 
 ```sh
 $ ogr2ogr -nln pp -nlt MULTILINESTRING \

--- a/scripts/gis-material-update/data/README.md
+++ b/scripts/gis-material-update/data/README.md
@@ -1,0 +1,20 @@
+# Contents
+
+This directory is for saving external files.
+
+## Cycling routes
+
+In the near future, cycling routes are obtaine from API.
+
+### File: helsinki_cycleways.gpkg
+
+Process existing materials:
+
+```sh
+$ ogr2ogr -nln pp -nlt MULTILINESTRING \
+    -f GPKG helsinki_cycleways.gpkg \
+    -sql "SELECT 'main' as type FROM Helsinki_pp_paareitit" Helsinki_pp_paareitit Helsinki_pp_paareitit
+$ ogr2ogr -nln pp -nlt MULTILINESTRING \
+    -f GPKG helsinki_cycleways.gpkg \
+    -sql "SELECT 'prio' as type FROM priorisoidut_reitit" -append priorisoidut_reitit priorisoidut_reitit
+```

--- a/scripts/gis-material-update/data/README.md
+++ b/scripts/gis-material-update/data/README.md
@@ -12,9 +12,10 @@ Materials that are not yet available via public sources, are listed in this docu
 
 ## Cycling infra
 
-In the near future, cycling routes are obtained from API.
+Current implementation assumes cycling infra source file in this directory.
 
-Currently cycling infra is read from combined Geopackage [file](https://helsinginkaupunki.sharepoint.com/:u:/r/sites/KYMPHaitaton/Jaetut%20asiakirjat/General/02_Taustamateriaalit/Laastariaineisto/haitaton_2_input/helsinki_cycleways.gpkg?csf=1&web=1&e=pR3rqm)
+Copy [source file](https://helsinginkaupunki.sharepoint.com/:u:/r/sites/KYMPHaitaton/Jaetut%20asiakirjat/General/02_Taustamateriaalit/Laastariaineisto/haitaton_2_input/helsinki_cycleways.gpkg?csf=1&web=1&e=pR3rqm)
+from Sharepoint to this directory.
 
 ### Instructions to generate combined file
 

--- a/scripts/gis-material-update/data/README.md
+++ b/scripts/gis-material-update/data/README.md
@@ -34,8 +34,8 @@ Create one cycling output file combining both infra data:
 ```sh
 $ ogr2ogr -nln pp -nlt MULTILINESTRING \
     -f GPKG helsinki_cycleways.gpkg \
-    -sql "SELECT 'main' as type FROM Helsinki_pp_paareitit" Helsinki_pp_paareitit Helsinki_pp_paareitit
+    -sql "SELECT 'main' as type FROM Helsinki_pp_paareitit" Helsinki_pp_paareitit.shp Helsinki_pp_paareitit
 $ ogr2ogr -nln pp -nlt MULTILINESTRING \
     -f GPKG helsinki_cycleways.gpkg \
-    -sql "SELECT 'prio' as type FROM priorisoidut_reitit" -append priorisoidut_reitit priorisoidut_reitit
+    -sql "SELECT 'prio' as type FROM priorisoidut_reitit" -append priorisoidut_reitit.shp priorisoidut_reitit
 ```

--- a/scripts/gis-material-update/data/README.md
+++ b/scripts/gis-material-update/data/README.md
@@ -19,7 +19,7 @@ from Sharepoint to this directory.
 
 ### Instructions to generate combined file
 
-If (for any reason) there is a need to generate combined cycling infra file,
+If (for any reason) there is a need to regenerate the cycling infra source file,
 it can be done using following procedure.
 
 Cycling infra source materials are available:

--- a/scripts/gis-material-update/docker-compose.yml
+++ b/scripts/gis-material-update/docker-compose.yml
@@ -38,6 +38,7 @@ services:
       context: .
       dockerfile: fetch/Dockerfile
     volumes:
+      - ./data:/local_data
       - haitaton_gis_prepare:/haitaton-gis
       - ./haitaton-downloads:/downloads
       - ./haitaton-gis-output:/gis-output

--- a/scripts/gis-material-update/fetch/fetch_data.sh
+++ b/scripts/gis-material-update/fetch/fetch_data.sh
@@ -64,6 +64,10 @@ case $data_object in
 hsl)
     wget -O "$local_file" "$addr"
     ;;
+# plain cp from local file system
+cycle_infra)
+    cp "$addr" "$local_file"
+    ;;
 # plain WFS fetch
 hki|ylre_katualueet|ylre_katuosat|maka_autoliikennemaarat|osm|helsinki_osm_lines)
     ogr2ogr -progress -f GPKG "$local_file" ${extra_args:+$extra_args} ${extra_quoted_args:+"$extra_quoted_args"} "$addr" "$layer"

--- a/scripts/gis-material-update/process/modules/cycling_infra.py
+++ b/scripts/gis-material-update/process/modules/cycling_infra.py
@@ -1,0 +1,76 @@
+import geopandas as gpd
+import pandas as pd
+from sqlalchemy import create_engine, text
+
+from modules.config import Config
+from modules.gis_processing import GisProcessor
+
+
+class CycleInfra(GisProcessor):
+    """Process cycle route infra."""
+
+    def __init__(self, cfg: Config):
+        self._cfg = cfg
+        self._process_result_lines = None
+        self._process_result_polygons = None
+        self._debug_result_lines = None
+
+        file_name = cfg.local_file("cycle_infra")
+
+        self._lines = gpd.read_file(file_name)
+
+    def process(self):
+        self._process_result_lines = self._lines
+
+        # Buffering configuration
+        buffers = self._cfg.buffer("cycle_infra")
+        if len(buffers) != 1:
+            raise ValueError("Unknown number of buffer values")
+
+        # buffer lines
+        target_infra_polys = self._process_result_lines.copy()
+        target_infra_polys["geometry"] = target_infra_polys.buffer(buffers[0])
+
+        # save to instance
+        self._process_result_polygons = target_infra_polys
+
+    def persist_to_database(self):
+        engine = create_engine(self._cfg.pg_conn_uri(), future=True)
+
+        # persist route lines to database
+        self._process_result_lines.to_postgis(
+            "cycle_infra",
+            engine,
+            "public",
+            if_exists="replace",
+            index=True,
+            index_label="fid",
+        )
+
+        # persist polygons to database
+        self._process_result_polygons.to_postgis(
+            "cycle_infra_polys",
+            engine,
+            "public",
+            if_exists="replace",
+            index=True,
+            index_label="fid",
+        )
+
+    def save_to_file(self):
+        """Save processing results to file."""
+        # cycle line infra as debug material
+        target_infra_file_name = self._cfg.target_file("cycle_infra")
+
+        cycle_lines = self._process_result_lines.reset_index(drop=True)
+
+        cycle_lines.to_file(target_infra_file_name, driver="GPKG")
+
+        # tormays GIS material
+        target_buffer_file_name = self._cfg.target_buffer_file("cycle_infra")
+
+        # instruct Geopandas for correct data type in file write
+        # fid is originally as index, obtain fid as column...
+        tormays_polygons = self._process_result_polygons.reset_index(drop=True)
+
+        tormays_polygons.to_file(target_buffer_file_name, driver="GPKG")

--- a/scripts/gis-material-update/process/process_data.py
+++ b/scripts/gis-material-update/process/process_data.py
@@ -12,6 +12,7 @@ from modules.ylre_katualueet import YlreKatualueet
 from modules.ylre_katuosat import YlreKatuosat
 from modules.tram_infra import TramInfra
 from modules.tram_lines import TramLines
+from modules.cycling_infra import CycleInfra
 
 DEFAULT_DEPLOYMENT_PROFILE = "local_development"
 
@@ -39,6 +40,8 @@ def instantiate_processor(item: str, cfg: Config) -> GisProcessor:
         return TramInfra(cfg)
     elif item == "tram_lines":
         return TramLines(cfg)
+    elif item == "cycle_infra":
+        return CycleInfra(cfg)
     else:
         try:
             raise RuntimeError("Configuration not recognized: {}".format(item))

--- a/scripts/gis-material-update/process/test/compare_utils.py
+++ b/scripts/gis-material-update/process/test/compare_utils.py
@@ -26,3 +26,10 @@ class TormaysCheckerMixin(object):
 
     def check_geom_data_min_area(self, data: gpd.GeoDataFrame = None):
         self.assertGreater(min(data.area), 0.0)
+
+    def check_geometry_type_is_in_list(
+        self, data: gpd.GeoDataFrame = None, geometries: list[str] = None
+    ):
+        geom_names = data.geometry.geom_type.unique().tolist()
+        for gn in geom_names:
+            self.assertIn(gn.lower(), geometries)

--- a/scripts/gis-material-update/process/test/test_cycle_infra.py
+++ b/scripts/gis-material-update/process/test/test_cycle_infra.py
@@ -1,0 +1,42 @@
+import unittest
+
+from test.compare_utils import TormaysCheckerMixin
+from modules.config import Config
+from modules.cycling_infra import CycleInfra
+
+
+class TestCycleInfra(TormaysCheckerMixin, unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.cfg = Config()
+        cycle_infra = CycleInfra(cls.cfg)
+        cycle_infra.process()
+
+        cls._target_buffer_dataframe = cycle_infra._process_result_polygons
+        cls._target_lines_dataframe = cycle_infra._process_result_lines
+
+    def test_line_geometry_is_multilinestring(self):
+        self.check_unique_geometry_type(self._target_lines_dataframe, "multilinestring")
+
+    def test_tormays_geometry_is_polygon_or_multipolygon(self):
+        accepted_geometries = ["multipolygon", "polygon"]
+        self.check_geometry_type_is_in_list(
+            self._target_buffer_dataframe, accepted_geometries
+        )
+
+    def test_tormays_geometry_has_configured_crs(self):
+        self.check_geometry_has_configured_crs(
+            self._target_buffer_dataframe, self.cfg.crs()
+        )
+
+    def test_tormays_attributes(self):
+        self.check_geom_data_attributes(
+            self._target_buffer_dataframe, ["type", "geometry"]
+        )
+
+    def test_tormays_min_area(self):
+        self.check_geom_data_min_area(self._target_buffer_dataframe)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Description

Created GIS tormays-materials from cycling routes.

* Combine existing prioritized and main cycling route materials into one
* provide method (directory) for inputting existing materials, not available from public sources

### Jira Issue: 

[HAI-1538](https://helsinkisolutionoffice.atlassian.net/browse/HAI-1538)

## Type of change

- [ ] Bug fix 
- [x] New feature 
- [ ] Other

# Instructions for testing

## Running the code in docker containers.

See README for preparing containers (building containers, copying files). After these initial steps, run fetch and process as separate docker runs. See exact details
* `data/README.md`: for downloading required prerequisite from Sharepoint
* `README.md` : for processing

```
docker-compose up -d gis-db
docker-compose run --rm gis-fetch cycle_infra
docker-compose run --rm gis-process cycle_infra
docker-compose stop gis-db
```

Results are in haitaton-gis-output local directory.

## Testing (Python unittest)

Prerequisite: fetch source materials as per instructions in the README (section: cycle_infra)

Go to directory: `haitaton-backend/scripts/gis-material-update/process`

(create and) activate Python virtual environment in process -directory
run `python -m unittest test/test_cycle_infra.py`

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 

# Other relevant info

None for now.

[HAI-1538]: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1538?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ