### PR TITLE
HAI-1461 Add support for downloading big files from Allu

### DIFF
--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/configuration/Configuration.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/configuration/Configuration.kt
@@ -54,11 +54,13 @@ class Configuration {
     @Bean
     fun cableReportService(webClientBuilder: WebClient.Builder): CableReportService {
         val webClient =
-            if (alluTrustInsecure) createInsecureTrustingWebClient(webClientBuilder)
-            else webClientBuilder
+            webClientWithLargeBuffer(
+                if (alluTrustInsecure) createInsecureTrustingWebClient(webClientBuilder)
+                else webClientBuilder
+            )
         val alluProps =
             AlluProperties(baseUrl = alluBaseUrl, username = alluUsername, password = alluPassword)
-        return CableReportServiceAllu(webClientWithLargeBuffer(webClient), alluProps)
+        return CableReportServiceAllu(webClient, alluProps)
     }
 
     private fun createInsecureTrustingWebClient(


### PR DESCRIPTION
# Description

Spring web client can only download about 250kB files to memory by default. Downloading bigger files in memory leads to `org.springframework.core.io.buffer.DataBufferLimitException: Exceeded limit on max bytes to buffer : 262144`.

This could be increased by setting `spring.codec.max-in-memory-size`, but that would affect other parts of Spring as well.

Instead, increase the codec max memory size only for WebClient.

### Jira Issue: 

## Type of change

- [X] Bug fix 
- [ ] New feature 
- [ ] Other

# Instructions for testing
1. Create a johtoselvityshakemus and send it to Allu.
2. In Allu, add a large (>256kB) attachment to the decision and make the decision.
3. Download it from Haitaton.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have run the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to Confluence
 or other location: 
