### PR TITLE
HAI-1319 Tokens for new hanke contacts

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
@@ -1556,9 +1556,9 @@ class HankeServiceITests : DatabaseTest() {
 
     private fun expectedYhteyshenkilot(i: Int) =
         """[{
-            | "etunimi": "etu$i$i",
-            | "sukunimi": "suku$i$i",
-            | "email": "email$i$i",
+            | "etunimi": "yhteys-etu$i",
+            | "sukunimi": "yhteys-suku$i",
+            | "email": "yhteys-email$i",
             | "puhelinnumero": "010$i$i$i$i$i$i$i"
             | }]""".trimMargin()
 

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaServiceITest.kt
@@ -243,7 +243,7 @@ class HankeKayttajaServiceITest : DatabaseTest() {
 
     @Test
     fun `saveNewTokensFromHanke with pre-existing permissions does not create duplicate`() {
-        val hanke = hankeFactory.save(HankeFactory.create())
+        val hanke = hankeFactory.save()
         saveUserAndPermission(hanke, "Existing User One", "ali.kontakti@meili.com")
 
         hankeKayttajaService.saveNewTokensFromHanke(
@@ -282,19 +282,19 @@ class HankeKayttajaServiceITest : DatabaseTest() {
     /** Single digit: main contact, double-digit: sub contact. */
     private val expectedNames =
         arrayOf(
-            "etu11 suku11",
-            "etu22 suku22",
-            "etu33 suku33",
-            "etu44 suku44",
+            "yhteys-etu1 yhteys-suku1",
+            "yhteys-etu2 yhteys-suku2",
+            "yhteys-etu3 yhteys-suku3",
+            "yhteys-etu4 yhteys-suku4",
         )
 
     /** Single digit: main contact, double-digit: sub contact. */
     private val expectedEmails =
         arrayOf(
-            "email11",
-            "email22",
-            "email33",
-            "email44",
+            "yhteys-email1",
+            "yhteys-email2",
+            "yhteys-email3",
+            "yhteys-email4",
         )
 
     private fun saveUserAndToken(

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaServiceITest.kt
@@ -279,7 +279,6 @@ class HankeKayttajaServiceITest : DatabaseTest() {
         k.transform { it.kayttajaTunniste }.isNotNull()
     }
 
-    /** Single digit: main contact, double-digit: sub contact. */
     private val expectedNames =
         arrayOf(
             "yhteys-etu1 yhteys-suku1",
@@ -288,7 +287,6 @@ class HankeKayttajaServiceITest : DatabaseTest() {
             "yhteys-etu4 yhteys-suku4",
         )
 
-    /** Single digit: main contact, double-digit: sub contact. */
     private val expectedEmails =
         arrayOf(
             "yhteys-email1",

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaServiceITest.kt
@@ -1,6 +1,7 @@
 package fi.hel.haitaton.hanke.permissions
 
 import assertk.assertThat
+import assertk.assertions.containsExactly
 import assertk.assertions.containsExactlyInAnyOrder
 import assertk.assertions.each
 import assertk.assertions.hasSize
@@ -15,6 +16,8 @@ import fi.hel.haitaton.hanke.domain.Hanke
 import fi.hel.haitaton.hanke.factory.AlluDataFactory
 import fi.hel.haitaton.hanke.factory.AlluDataFactory.Companion.withContacts
 import fi.hel.haitaton.hanke.factory.HankeFactory
+import fi.hel.haitaton.hanke.factory.HankeFactory.Companion.withYhteystiedot
+import fi.hel.haitaton.hanke.factory.HankeYhteystietoFactory
 import fi.hel.haitaton.hanke.test.Asserts.isRecent
 import java.time.OffsetDateTime
 import org.junit.jupiter.api.Test
@@ -79,13 +82,7 @@ class HankeKayttajaServiceITest : DatabaseTest() {
 
         val tunnisteet = kayttajaTunnisteRepository.findAll()
         assertThat(tunnisteet).hasSize(4)
-        assertThat(tunnisteet).each { tunniste ->
-            tunniste.transform { it.role }.isEqualTo(Role.KATSELUOIKEUS)
-            tunniste.transform { it.createdAt }.isRecent()
-            tunniste.transform { it.sentAt }.isNull()
-            tunniste.transform { it.tunniste }.matches(Regex(kayttajaTunnistePattern))
-            tunniste.transform { it.hankeKayttaja }.isNotNull()
-        }
+        assertTunnisteet(tunnisteet)
         val kayttajat = hankeKayttajaRepository.findAll()
         assertThat(kayttajat).hasSize(4)
         assertThat(kayttajat).each { kayttaja ->
@@ -209,6 +206,97 @@ class HankeKayttajaServiceITest : DatabaseTest() {
                 "email4",
             )
     }
+
+    @Test
+    fun `saveNewTokensFromHanke does nothing if hanke has no contacts`() {
+        hankeKayttajaService.saveNewTokensFromHanke(HankeFactory.create())
+
+        assertThat(kayttajaTunnisteRepository.findAll()).isEmpty()
+        assertThat(hankeKayttajaRepository.findAll()).isEmpty()
+    }
+
+    @Test
+    fun `saveNewTokensFromHanke creates tokens for unique ones`() {
+        val hanke =
+            hankeFactory.save(
+                HankeFactory.create()
+                    .withYhteystiedot(
+                        // each has a duplicate
+                        omistajat = listOf(1, 1),
+                        rakennuttajat = listOf(2, 2),
+                        toteuttajat = listOf(3, 3),
+                        muut = listOf(4, 4)
+                    )
+            )
+        assertThat(hanke.extractYhteystiedot()).hasSize(8)
+
+        hankeKayttajaService.saveNewTokensFromHanke(hanke)
+
+        val tunnisteet: List<KayttajaTunnisteEntity> = kayttajaTunnisteRepository.findAll()
+        val kayttajat: List<HankeKayttajaEntity> = hankeKayttajaRepository.findAll()
+        assertThat(tunnisteet).hasSize(4) // 4 yhteyshenkilo subcontacts.
+        assertThat(kayttajat).hasSize(4)
+        assertTunnisteet(tunnisteet)
+        assertKayttajat(kayttajat, hanke.id)
+    }
+
+    @Test
+    fun `saveNewTokensFromHanke with pre-existing permissions does not create duplicate`() {
+        val hanke = hankeFactory.save(HankeFactory.create())
+        saveUserAndPermission(hanke, "Existing User One", "ali.kontakti@meili.com")
+
+        hankeKayttajaService.saveNewTokensFromHanke(
+            hanke.apply { this.omistajat.add(HankeYhteystietoFactory.create()) }
+        )
+
+        val tunnisteet = kayttajaTunnisteRepository.findAll()
+        assertThat(tunnisteet).isEmpty()
+        assertTunnisteet(tunnisteet)
+        val kayttajat = hankeKayttajaRepository.findAll()
+        assertThat(kayttajat).hasSize(1)
+        assertThat(kayttajat.map { it.sahkoposti })
+            .containsExactly(
+                "ali.kontakti@meili.com",
+            )
+    }
+
+    private fun assertTunnisteet(tunnisteet: List<KayttajaTunnisteEntity>) =
+        assertThat(tunnisteet).each { t ->
+            t.transform { it.id }.isNotNull()
+            t.transform { it.role }.isEqualTo(Role.KATSELUOIKEUS)
+            t.transform { it.createdAt }.isRecent()
+            t.transform { it.sentAt }.isNull()
+            t.transform { it.tunniste }.matches(Regex(kayttajaTunnistePattern))
+            t.transform { it.hankeKayttaja }.isNotNull()
+        }
+
+    private fun assertKayttajat(kayttajat: List<HankeKayttajaEntity>, hankeId: Int?) =
+        assertThat(kayttajat).each { k ->
+            k.transform { it.id }.isNotNull()
+            k.transform { it.nimi }.isIn(*expectedNames)
+            k.transform { it.sahkoposti }.isIn(*expectedEmails)
+            k.transform { it.hankeId }.isEqualTo(hankeId)
+            k.transform { it.permission }.isNull()
+            k.transform { it.kayttajaTunniste }.isNotNull()
+        }
+
+    /** Single digit: main contact, double-digit: sub contact. */
+    private val expectedNames =
+        arrayOf(
+            "etu11 suku11",
+            "etu22 suku22",
+            "etu33 suku33",
+            "etu44 suku44",
+        )
+
+    /** Single digit: main contact, double-digit: sub contact. */
+    private val expectedEmails =
+        arrayOf(
+            "email11",
+            "email22",
+            "email33",
+            "email44",
+        )
 
     private fun saveUserAndToken(
         hanke: Hanke,

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeYhteystietoEntity.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeYhteystietoEntity.kt
@@ -121,4 +121,6 @@ data class Yhteyshenkilo(
     val sukunimi: String,
     val email: String,
     val puhelinnumero: String,
-)
+) {
+    fun wholeName(): String = "$etunimi $sukunimi".trim()
+}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeYhteystietoEntity.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeYhteystietoEntity.kt
@@ -122,5 +122,5 @@ data class Yhteyshenkilo(
     val email: String,
     val puhelinnumero: String,
 ) {
-    fun wholeName(): String = "$etunimi $sukunimi".trim()
+    fun fullName(): String = listOf(etunimi, sukunimi).filter { it.isNotBlank() }.joinToString(" ")
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/configuration/Configuration.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/configuration/Configuration.kt
@@ -106,6 +106,7 @@ class Configuration {
         hankeLoggingService: HankeLoggingService,
         applicationService: ApplicationService,
         permissionService: PermissionService,
+        hankeKayttajaService: HankeKayttajaService,
     ): HankeService =
         HankeServiceImpl(
             hankeRepository,
@@ -115,7 +116,8 @@ class Configuration {
             auditLogService,
             hankeLoggingService,
             applicationService,
-            permissionService
+            permissionService,
+            hankeKayttajaService,
         )
 
     @Bean

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaService.kt
@@ -31,13 +31,8 @@ class HankeKayttajaService(
             hanke
                 .extractYhteystiedot()
                 .flatMap { it.alikontaktit }
-                .mapNotNull { person ->
-                    val name = person.fullName()
-                    when {
-                        name.isBlank() || person.email.isBlank() -> null
-                        else -> UserContact(name, person.email)
-                    }
-                }
+                .filterNot { it.fullName().isBlank() || it.email.isBlank() }
+                .map { UserContact(it.fullName(), it.email) }
 
         filterNewContacts(hankeId, contacts).forEach { contact -> createToken(hankeId, contact) }
     }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaService.kt
@@ -32,7 +32,7 @@ class HankeKayttajaService(
                 .extractYhteystiedot()
                 .flatMap { it.alikontaktit }
                 .mapNotNull { person ->
-                    val name = person.wholeName()
+                    val name = person.fullName()
                     when {
                         name.isBlank() || person.email.isBlank() -> null
                         else -> UserContact(name, person.email)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/UserContactDto.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/UserContactDto.kt
@@ -1,3 +1,0 @@
-package fi.hel.haitaton.hanke.permissions
-
-data class UserContactDto(val name: String, val email: String)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/UserContactDto.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/UserContactDto.kt
@@ -1,0 +1,3 @@
+package fi.hel.haitaton.hanke.permissions
+
+data class UserContactDto(val name: String, val email: String)

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/YhteyshenkiloTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/YhteyshenkiloTest.kt
@@ -2,7 +2,6 @@ package fi.hel.haitaton.hanke
 
 import assertk.assertThat
 import assertk.assertions.isEqualTo
-import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
 
@@ -21,7 +20,7 @@ class YhteyshenkiloTest {
         expectedResult: String
     ) {
         Yhteyshenkilo(firstName, lastName, "dummymail", "04012345678").let {
-            assertThat(it.wholeName()).isEqualTo(expectedResult)
+            assertThat(it.fullName()).isEqualTo(expectedResult)
         }
     }
 }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/YhteyshenkiloTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/YhteyshenkiloTest.kt
@@ -1,0 +1,27 @@
+package fi.hel.haitaton.hanke
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+
+class YhteyshenkiloTest {
+
+    @ParameterizedTest
+    @CsvSource(
+        "Matti,Meikalainen,Matti Meikalainen",
+        "'',Meikalainen,Meikalainen",
+        "Matti,'',Matti",
+        "'','',''"
+    )
+    fun `wholeName concatenates first and last names`(
+        firstName: String,
+        lastName: String,
+        expectedResult: String
+    ) {
+        Yhteyshenkilo(firstName, lastName, "dummymail", "04012345678").let {
+            assertThat(it.wholeName()).isEqualTo(expectedResult)
+        }
+    }
+}

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeFactory.kt
@@ -38,6 +38,8 @@ class HankeFactory(private val hankeService: HankeService) {
             )
         )
 
+    fun save(hanke: Hanke) = hankeService.createHanke(hanke)
+
     companion object {
 
         const val defaultHankeTunnus = "HAI21-1"

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeYhteystietoFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeYhteystietoFactory.kt
@@ -47,9 +47,9 @@ object HankeYhteystietoFactory {
             alikontaktit =
                 listOf(
                     Yhteyshenkilo(
-                        sukunimi = "suku$i",
-                        etunimi = "etu$i",
-                        email = "email$i",
+                        sukunimi = "suku$i$i",
+                        etunimi = "etu$i$i",
+                        email = "email$i$i",
                         puhelinnumero = dummyPhoneNumber(i),
                     )
                 )

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeYhteystietoFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeYhteystietoFactory.kt
@@ -47,9 +47,9 @@ object HankeYhteystietoFactory {
             alikontaktit =
                 listOf(
                     Yhteyshenkilo(
-                        sukunimi = "suku$i$i",
-                        etunimi = "etu$i$i",
-                        email = "email$i$i",
+                        sukunimi = "yhteys-suku$i",
+                        etunimi = "yhteys-etu$i",
+                        email = "yhteys-email$i",
                         puhelinnumero = dummyPhoneNumber(i),
                     )
                 )


### PR DESCRIPTION
# Description

When creating or updating hanke, save users and user tokens for all new contact persons. Note: contact person is Yhteyshenkilo and not HankeYhteystieto.

A contact is new, if there isn't already a user with the same email on the hanke.

The user tokens can be used to invite the user to Haitaton.
### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1319

## Type of change

- [ ] Bug fix 
- [x] New feature 
- [ ] Other

# Instructions for testing

Frontend does not yet support the same data model as backend. Hence:

1. In the ui (devtools open), create hakemus and try adding a subcontact (yhteyshenkilo). The request will fail but
    -  take take request payload and copy it somewhere
    - modify one of the alikontaktit fields as follows:
```
      "alikontaktit": [
        {
          "etunimi": "Matti",
          "sukunimi": "Meikäläinen",
          "email": "foobar@mail.com",
          "puhelinnumero": ""
        }
      ] 
```   
3. Use curl etc PUT http://localhost:3001/api/hankkeet/<HANKE_TUNNUS> with modified payload. 
4. After, there should be rows in hanke_kayttaja and kayttaja_tunniste matching the input.
5. Create request should work withe same payload (POST api/hankkeet)

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 
