### PR TITLE
HAI-1533 Add virus scanning client for received files

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,20 +28,20 @@ services:
     restart: unless-stopped
     networks:
       - backbone
-  api:
+  clamav-api:
     image: benzino77/clamav-rest-api
     container_name: clamav-rest
     restart: unless-stopped
-    command: ['/usr/bin/wait-for-it', '-h', 'clamd', '-p', '3310', '-s', '-t', '120', '--', 'npm', 'start']
+    command: [ '/usr/bin/wait-for-it', '-h', 'clamd', '-p', '3310', '-s', '-t', '120', '--', 'npm', 'start' ]
     depends_on:
       - clamd
     environment:
       - NODE_ENV=production
       - CLAMD_IP=clamd
       - APP_FORM_KEY=FILES
-      - APP_PORT=3000
+      - APP_PORT=3030
     ports:
-      - '3030:3000'
+      - '3030:3030'
     networks:
       - backbone
 
@@ -75,7 +75,7 @@ services:
       HAITATON_PASSWORD: haitaton
       HAITATON_OAUTH2_CLIENT_ID: https://api.hel.fi/auth/haitatonapidev
       HAITATON_OAUTH2_USER_INFO_URI: https://tunnistamo.test.hel.ninja/openid/userinfo
-#      HAITATON_CORS_ALLOWED_ORIGINS: http://localhost:8000
+      #      HAITATON_CORS_ALLOWED_ORIGINS: http://localhost:8000
       ALLU_BASEURL: ${ALLU_BASEURL}
       ALLU_USERNAME: ${ALLU_USERNAME}
       ALLU_PASSWORD: ${ALLU_PASSWORD}
@@ -84,9 +84,10 @@ services:
       MAIL_SENDER_HOST: smtp4dev
       MAIL_SENDER_PORT: 25
       HAITATON_EMAIL_ENABLED: true
+      CLAMAV_BASE_URL: http://clamav-api:3030
     depends_on:
       - db
-      - api
+      - clamav-api
     command: [ "./wait-for-it.sh", "-t", "30", "--strict", "db:5432", "--", "java", "-jar", "haitaton.jar" ]
     networks:
       backbone:

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/security/FileScanServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/security/FileScanServiceITest.kt
@@ -55,7 +55,7 @@ class FileScanServiceITest : DatabaseTest() {
 
         val result =
             service.scanFiles(
-                setOf(
+                listOf(
                     Pair(FILE_ONE, ByteArray(100)),
                     Pair(FILE_TWO, ByteArray(150)),
                     Pair(FILE_THREE, ByteArray(200))
@@ -71,7 +71,9 @@ class FileScanServiceITest : DatabaseTest() {
         mockWebServer.enqueue(response(body(results = successResults(1).plus(failResults(1)))))
 
         val result =
-            service.scanFiles(setOf(Pair(FILE_ONE, ByteArray(100)), Pair(FILE_TWO, ByteArray(150))))
+            service.scanFiles(
+                listOf(Pair(FILE_ONE, ByteArray(100)), Pair(FILE_TWO, ByteArray(150)))
+            )
 
         assertThat(result.hasInfected()).isTrue()
         assertThat(result).isDataClassEqualTo(expectedFailResult())
@@ -83,7 +85,7 @@ class FileScanServiceITest : DatabaseTest() {
         mockWebServer.enqueue(MockResponse().setResponseCode(status))
 
         assertThrows<WebClientResponseException> {
-            service.scanFiles(setOf(Pair(FILE_ONE, ByteArray(100))))
+            service.scanFiles(listOf(Pair(FILE_ONE, ByteArray(100))))
         }
     }
 
@@ -92,7 +94,9 @@ class FileScanServiceITest : DatabaseTest() {
         mockWebServer.enqueue(response(body(success = false, results = failResults(2))))
 
         assertThrows<FileScanException> {
-            service.scanFiles(setOf(Pair(FILE_ONE, ByteArray(100)), Pair(FILE_TWO, ByteArray(300))))
+            service.scanFiles(
+                listOf(Pair(FILE_ONE, ByteArray(100)), Pair(FILE_TWO, ByteArray(300)))
+            )
         }
     }
 

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/security/FileScanServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/security/FileScanServiceITest.kt
@@ -62,7 +62,7 @@ class FileScanServiceITest : DatabaseTest() {
                 )
             )
 
-        assertThat(result.virusDetected).isFalse()
+        assertThat(result.hasInfected()).isFalse()
         assertThat(result).isDataClassEqualTo(expectedSuccessResult())
     }
 
@@ -73,7 +73,7 @@ class FileScanServiceITest : DatabaseTest() {
         val result =
             service.scanFiles(setOf(Pair(FILE_ONE, ByteArray(100)), Pair(FILE_TWO, ByteArray(150))))
 
-        assertThat(result.virusDetected).isTrue()
+        assertThat(result.hasInfected()).isTrue()
         assertThat(result).isDataClassEqualTo(expectedFailResult())
     }
 
@@ -115,33 +115,28 @@ class FileScanServiceITest : DatabaseTest() {
             FileResult(name = "file$it.pdf", isInfected = false, viruses = emptyList())
         }
 
-    private fun expectedSuccessResult(): FileScanResult =
-        FileScanResult(
-            virusDetected = false,
-            FileScanResponse(
-                true,
-                FileScanData(
-                    result =
-                        listOf(
-                            FileResult(FILE_ONE, isInfected = false, viruses = emptyList()),
-                            FileResult(FILE_TWO, isInfected = false, viruses = emptyList()),
-                            FileResult(FILE_THREE, isInfected = false, viruses = emptyList()),
-                        )
-                )
+    private fun expectedSuccessResult(): FileScanResponse =
+        FileScanResponse(
+            true,
+            FileScanData(
+                result =
+                    listOf(
+                        FileResult(FILE_ONE, isInfected = false, viruses = emptyList()),
+                        FileResult(FILE_TWO, isInfected = false, viruses = emptyList()),
+                        FileResult(FILE_THREE, isInfected = false, viruses = emptyList()),
+                    )
             )
         )
-    private fun expectedFailResult(): FileScanResult =
-        FileScanResult(
-            virusDetected = true,
-            FileScanResponse(
-                true,
-                FileScanData(
-                    result =
-                        listOf(
-                            FileResult(FILE_ONE, isInfected = false, viruses = emptyList()),
-                            FileResult(FILE_ONE, isInfected = true, viruses = listOf("virus1")),
-                        )
-                )
+
+    private fun expectedFailResult(): FileScanResponse =
+        FileScanResponse(
+            true,
+            FileScanData(
+                result =
+                    listOf(
+                        FileResult(FILE_ONE, isInfected = false, viruses = emptyList()),
+                        FileResult(FILE_ONE, isInfected = true, viruses = listOf("virus1")),
+                    )
             )
         )
 }

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/security/FileScanServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/security/FileScanServiceITest.kt
@@ -1,7 +1,7 @@
 package fi.hel.haitaton.hanke.security
 
 import assertk.assertThat
-import assertk.assertions.isDataClassEqualTo
+import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
 import assertk.assertions.isTrue
 import fi.hel.haitaton.hanke.DatabaseTest
@@ -63,7 +63,7 @@ class FileScanServiceITest : DatabaseTest() {
             )
 
         assertThat(result.hasInfected()).isFalse()
-        assertThat(result).isDataClassEqualTo(expectedSuccessResult())
+        assertThat(result).isEqualTo(expectedSuccessResult())
     }
 
     @Test
@@ -76,7 +76,7 @@ class FileScanServiceITest : DatabaseTest() {
             )
 
         assertThat(result.hasInfected()).isTrue()
-        assertThat(result).isDataClassEqualTo(expectedFailResult())
+        assertThat(result).isEqualTo(expectedFailResult())
     }
 
     @ValueSource(ints = [400, 500])
@@ -119,28 +119,16 @@ class FileScanServiceITest : DatabaseTest() {
             FileResult(name = "file$it.pdf", isInfected = false, viruses = emptyList())
         }
 
-    private fun expectedSuccessResult(): FileScanResponse =
-        FileScanResponse(
-            true,
-            FileScanData(
-                result =
-                    listOf(
-                        FileResult(FILE_ONE, isInfected = false, viruses = emptyList()),
-                        FileResult(FILE_TWO, isInfected = false, viruses = emptyList()),
-                        FileResult(FILE_THREE, isInfected = false, viruses = emptyList()),
-                    )
-            )
+    private fun expectedSuccessResult(): List<FileResult> =
+        listOf(
+            FileResult(FILE_ONE, isInfected = false, viruses = emptyList()),
+            FileResult(FILE_TWO, isInfected = false, viruses = emptyList()),
+            FileResult(FILE_THREE, isInfected = false, viruses = emptyList()),
         )
 
-    private fun expectedFailResult(): FileScanResponse =
-        FileScanResponse(
-            true,
-            FileScanData(
-                result =
-                    listOf(
-                        FileResult(FILE_ONE, isInfected = false, viruses = emptyList()),
-                        FileResult(FILE_ONE, isInfected = true, viruses = listOf("virus1")),
-                    )
-            )
+    private fun expectedFailResult(): List<FileResult> =
+        listOf(
+            FileResult(FILE_ONE, isInfected = false, viruses = emptyList()),
+            FileResult(FILE_ONE, isInfected = true, viruses = listOf("virus1")),
         )
 }

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/security/FileScanServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/security/FileScanServiceITest.kt
@@ -1,0 +1,147 @@
+package fi.hel.haitaton.hanke.security
+
+import assertk.assertThat
+import assertk.assertions.isDataClassEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isTrue
+import fi.hel.haitaton.hanke.DatabaseTest
+import fi.hel.haitaton.hanke.toJsonString
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.web.reactive.function.client.WebClientResponseException
+import org.testcontainers.junit.jupiter.Testcontainers
+
+private const val CONTENT_TYPE = "Content-Type"
+private const val FILE_ONE = "file1.pdf"
+private const val FILE_TWO = "file2.pdf"
+private const val FILE_THREE = "file3.pdf"
+
+@Testcontainers
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    properties = ["haitaton.clamav.baseUrl=http://localhost:6789"]
+)
+@ActiveProfiles("default")
+class FileScanServiceITest : DatabaseTest() {
+
+    @Autowired private lateinit var service: FileScanService
+
+    private lateinit var mockWebServer: MockWebServer
+
+    @BeforeEach
+    fun setup() {
+        mockWebServer = MockWebServer()
+        mockWebServer.start(6789)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        mockWebServer.shutdown()
+    }
+
+    @Test
+    fun `scanFiles when files are ok should succeed`() {
+        mockWebServer.enqueue(response(body(results = successResults(3))))
+
+        val result =
+            service.scanFiles(
+                setOf(
+                    Pair(FILE_ONE, ByteArray(100)),
+                    Pair(FILE_TWO, ByteArray(150)),
+                    Pair(FILE_THREE, ByteArray(200))
+                )
+            )
+
+        assertThat(result.virusDetected).isFalse()
+        assertThat(result).isDataClassEqualTo(expectedSuccessResult())
+    }
+
+    @Test
+    fun `scanFiles when problematic file present should detect`() {
+        mockWebServer.enqueue(response(body(results = successResults(1).plus(failResults(1)))))
+
+        val result =
+            service.scanFiles(setOf(Pair(FILE_ONE, ByteArray(100)), Pair(FILE_TWO, ByteArray(150))))
+
+        assertThat(result.virusDetected).isTrue()
+        assertThat(result).isDataClassEqualTo(expectedFailResult())
+    }
+
+    @ValueSource(ints = [400, 500])
+    @ParameterizedTest
+    fun `scanFiles when http error should throw`(status: Int) {
+        mockWebServer.enqueue(MockResponse().setResponseCode(status))
+
+        assertThrows<WebClientResponseException> {
+            service.scanFiles(setOf(Pair(FILE_ONE, ByteArray(100))))
+        }
+    }
+
+    @Test
+    fun `scanFiles when scan fails should throw`() {
+        mockWebServer.enqueue(response(body(success = false, results = failResults(2))))
+
+        assertThrows<FileScanException> {
+            service.scanFiles(setOf(Pair(FILE_ONE, ByteArray(100)), Pair(FILE_TWO, ByteArray(300))))
+        }
+    }
+
+    private fun response(data: String): MockResponse =
+        MockResponse()
+            .setBody(data)
+            .addHeader(CONTENT_TYPE, APPLICATION_JSON_VALUE)
+            .setResponseCode(200)
+
+    private fun body(success: Boolean = true, results: List<FileResult>): String =
+        FileScanResponse(success, FileScanData(result = results)).toJsonString()
+
+    private fun failResults(amount: Int): List<FileResult> =
+        (1..amount).map {
+            FileResult(name = "file$it.pdf", isInfected = true, viruses = listOf("virus$it"))
+        }
+
+    private fun successResults(amount: Int): List<FileResult> =
+        (1..amount).map {
+            FileResult(name = "file$it.pdf", isInfected = false, viruses = emptyList())
+        }
+
+    private fun expectedSuccessResult(): FileScanResult =
+        FileScanResult(
+            virusDetected = false,
+            FileScanResponse(
+                true,
+                FileScanData(
+                    result =
+                        listOf(
+                            FileResult(FILE_ONE, isInfected = false, viruses = emptyList()),
+                            FileResult(FILE_TWO, isInfected = false, viruses = emptyList()),
+                            FileResult(FILE_THREE, isInfected = false, viruses = emptyList()),
+                        )
+                )
+            )
+        )
+    private fun expectedFailResult(): FileScanResult =
+        FileScanResult(
+            virusDetected = true,
+            FileScanResponse(
+                true,
+                FileScanData(
+                    result =
+                        listOf(
+                            FileResult(FILE_ONE, isInfected = false, viruses = emptyList()),
+                            FileResult(FILE_ONE, isInfected = true, viruses = listOf("virus1")),
+                        )
+                )
+            )
+        )
+}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/configuration/Configuration.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/configuration/Configuration.kt
@@ -54,8 +54,6 @@ class Configuration {
     @Value("\${haitaton.allu.password}") lateinit var alluPassword: String
     @Value("\${haitaton.allu.insecure}") var alluTrustInsecure: Boolean = false
 
-    @Value("\${haitaton.clamav.baseUrl}") lateinit var clamAvUrl: String
-
     @Bean
     fun cableReportService(webClientBuilder: WebClient.Builder): CableReportService {
         val webClient =
@@ -67,12 +65,6 @@ class Configuration {
             AlluProperties(baseUrl = alluBaseUrl, username = alluUsername, password = alluPassword)
         return CableReportServiceAllu(webClient, alluProps)
     }
-
-    @Bean
-    fun fileScanClient(webClientBuilder: WebClient.Builder): WebClient =
-        webClientBuilder.baseUrl(clamAvUrl).build().also {
-            logger.info { "Initialized file scan client with base-url: $clamAvUrl" }
-        }
 
     private fun createInsecureTrustingWebClient(
         webClientBuilder: WebClient.Builder

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/configuration/Configuration.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/configuration/Configuration.kt
@@ -33,6 +33,7 @@ import fi.hel.haitaton.hanke.tormaystarkastelu.TormaystarkasteluTormaysService
 import fi.hel.haitaton.hanke.tormaystarkastelu.TormaystarkasteluTormaysServicePG
 import io.netty.handler.ssl.SslContextBuilder
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory
+import mu.KotlinLogging
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -42,6 +43,8 @@ import org.springframework.jdbc.core.JdbcOperations
 import org.springframework.web.reactive.function.client.WebClient
 import reactor.netty.http.client.HttpClient
 
+private val logger = KotlinLogging.logger {}
+
 @Configuration
 @Profile("default")
 class Configuration {
@@ -50,6 +53,8 @@ class Configuration {
     @Value("\${haitaton.allu.username}") lateinit var alluUsername: String
     @Value("\${haitaton.allu.password}") lateinit var alluPassword: String
     @Value("\${haitaton.allu.insecure}") var alluTrustInsecure: Boolean = false
+
+    @Value("\${haitaton.clamav.baseUrl}") lateinit var clamAvUrl: String
 
     @Bean
     fun cableReportService(webClientBuilder: WebClient.Builder): CableReportService {
@@ -62,6 +67,12 @@ class Configuration {
             AlluProperties(baseUrl = alluBaseUrl, username = alluUsername, password = alluPassword)
         return CableReportServiceAllu(webClient, alluProps)
     }
+
+    @Bean
+    fun fileScanClient(webClientBuilder: WebClient.Builder): WebClient =
+        webClientBuilder.baseUrl(clamAvUrl).build().also {
+            logger.info { "Initialized file scan client with base-url: $clamAvUrl" }
+        }
 
     private fun createInsecureTrustingWebClient(
         webClientBuilder: WebClient.Builder

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/security/FileScanService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/security/FileScanService.kt
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import fi.hel.haitaton.hanke.toJsonString
 import java.time.Duration.ofSeconds
 import mu.KotlinLogging
-import org.apache.commons.lang3.BooleanUtils.isNotFalse
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.core.io.ByteArrayResource
 import org.springframework.http.MediaType.APPLICATION_JSON
@@ -93,6 +92,6 @@ data class FileResult(
 
 class FileScanException(message: String) : RuntimeException(message)
 
-fun List<FileResult>.hasInfected(): Boolean = any { isNotFalse(it.isInfected) }
+fun List<FileResult>.hasInfected(): Boolean = any { it.isInfected != false }
 
-fun List<FileResult>.filterInfected(): List<FileResult> = filter { isNotFalse(it.isInfected) }
+fun List<FileResult>.filterInfected(): List<FileResult> = filter { it.isInfected != false }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/security/FileScanService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/security/FileScanService.kt
@@ -1,0 +1,89 @@
+package fi.hel.haitaton.hanke.security
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import fi.hel.haitaton.hanke.toJsonString
+import java.time.Duration.ofSeconds
+import mu.KotlinLogging
+import org.apache.commons.lang3.BooleanUtils.isNotFalse
+import org.springframework.core.io.ByteArrayResource
+import org.springframework.http.MediaType.APPLICATION_JSON
+import org.springframework.http.MediaType.APPLICATION_PDF
+import org.springframework.http.MediaType.MULTIPART_FORM_DATA
+import org.springframework.http.client.MultipartBodyBuilder
+import org.springframework.stereotype.Service
+import org.springframework.web.reactive.function.BodyInserters.fromMultipartData
+import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.WebClientResponseException
+
+private val logger = KotlinLogging.logger {}
+
+private const val FORM_KEY = "FILES"
+
+@Service
+class FileScanService(
+    private val fileScanClient: WebClient,
+) {
+
+    fun scanFiles(files: Set<Pair<String, ByteArray>>): FileScanResult {
+        logger.info { "Scanning ${files.size} files." }
+        val response = getResults(files).also { it.validateStatus() }
+
+        val virusDetected = response.data.result.any { isNotFalse(it.isInfected) }
+
+        return FileScanResult(virusDetected, response).also { it.logStatus() }
+    }
+
+    private fun getResults(files: Set<Pair<String, ByteArray>>): FileScanResponse {
+        val data =
+            MultipartBodyBuilder()
+                .apply {
+                    files.forEach { (name, bytes) ->
+                        part(FORM_KEY, ByteArrayResource(bytes), APPLICATION_PDF).filename(name)
+                    }
+                }
+                .build()
+
+        return fileScanClient
+            .post()
+            .uri("/api/v1/scan")
+            .contentType(MULTIPART_FORM_DATA)
+            .accept(APPLICATION_JSON)
+            .body(fromMultipartData(data))
+            .retrieve()
+            .bodyToMono(FileScanResponse::class.java)
+            .timeout(ofSeconds(60))
+            .doOnError(WebClientResponseException::class.java) {
+                logger.error { "Error uploading file: $it" }
+            }
+            .blockOptional()
+            .orElseThrow()
+    }
+
+    private fun FileScanResponse.validateStatus() {
+        if (!success) {
+            throw FileScanException("Scan failed, result: ${this.toJsonString()}")
+        }
+    }
+
+    private fun FileScanResult.logStatus() {
+        if (virusDetected) {
+            logger.error { "Infected file detected, scan result: ${this.toJsonString()}" }
+        } else {
+            logger.info { "Files scanned successfully." }
+        }
+    }
+}
+
+data class FileScanResult(val virusDetected: Boolean, val scanResponse: FileScanResponse)
+
+data class FileScanResponse(val success: Boolean, val data: FileScanData)
+
+data class FileScanData(val result: List<FileResult>)
+
+data class FileResult(
+    val name: String,
+    @JsonProperty("is_infected") val isInfected: Boolean?,
+    val viruses: List<String>
+)
+
+class FileScanException(message: String) : RuntimeException(message)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/security/FileScanService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/security/FileScanService.kt
@@ -7,7 +7,7 @@ import mu.KotlinLogging
 import org.apache.commons.lang3.BooleanUtils.isNotFalse
 import org.springframework.core.io.ByteArrayResource
 import org.springframework.http.MediaType.APPLICATION_JSON
-import org.springframework.http.MediaType.APPLICATION_PDF
+import org.springframework.http.MediaType.APPLICATION_OCTET_STREAM
 import org.springframework.http.MediaType.MULTIPART_FORM_DATA
 import org.springframework.http.client.MultipartBodyBuilder
 import org.springframework.stereotype.Service
@@ -24,18 +24,19 @@ class FileScanService(
     private val fileScanClient: WebClient,
 ) {
 
-    fun scanFiles(files: Set<Pair<String, ByteArray>>): FileScanResponse {
+    fun scanFiles(files: List<Pair<String, ByteArray>>): FileScanResponse {
         logger.info { "Scanning ${files.size} files." }
         val result = getResults(files).also { response -> response.validateStatus() }
         return result.also { logStatus(it) }
     }
 
-    private fun getResults(files: Set<Pair<String, ByteArray>>): FileScanResponse {
+    private fun getResults(files: List<Pair<String, ByteArray>>): FileScanResponse {
         val data =
             MultipartBodyBuilder()
                 .apply {
                     files.forEach { (name, bytes) ->
-                        part(FORM_KEY, ByteArrayResource(bytes), APPLICATION_PDF).filename(name)
+                        part(FORM_KEY, ByteArrayResource(bytes), APPLICATION_OCTET_STREAM)
+                            .filename(name)
                     }
                 }
                 .build()

--- a/services/hanke-service/src/main/resources/application.properties
+++ b/services/hanke-service/src/main/resources/application.properties
@@ -7,6 +7,8 @@ haitaton.allu.insecure=${ALLU_INSECURE:false}
 haitaton.allu.updateIntervalMilliSeconds=${ALLU_UPDATE_INTERVAL:60000}
 haitaton.allu.updateInitialDelayMilliSeconds=${ALLU_UPDATE_INITIAL_DELAY:60000}
 
+haitaton.clamav.baseUrl=${CLAMAV_BASE_URL:http://localhost:3030}
+
 # Disable GDPR API until:
 #   1. Profiili-client is operational
 #   2. We have proper authentication for the API.


### PR DESCRIPTION
# Description

Add a webclient to make http calls for file virus scanning. 

Associated changes in azure devops:
- https://dev.azure.com/City-of-Helsinki/haitaton/_git/haitaton-hanke-service-pipelines/pullrequest/4475
- Added CLAMAV_BASE_URL = clamav-rest-api.clamav.svc.cluster.local:3000 for development, testing, staging and production in: https://dev.azure.com/City-of-Helsinki/haitaton/_library?itemType=VariableGroups

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1533

## Type of change

- [ ] Bug fix 
- [x] New feature 
- [ ] Other

# Instructions for testing
At this point, there is no direct way to test this (other than unit tests). 

Functionality can however be tested by:
1. Running the whole stack in docker compose
2. shut down the backend
3. run backend via ./gradlew bootRun with the following code inserted to FileScanService:
```
    @Scheduled(initialDelay = 1000, fixedDelay = 10000)
    fun foo() {
        scanFiles(setOf(Pair("testfile.pdf", ByteArray(1000))))
    }
```
Then you can check the logs that everything works. Example in logs:
```
{"@timestamp":"2023-04-14T13:54:32.927+03:00","@version":"1","message":"Scanning 1 files.","logger_name":"fi.hel.haitaton.hanke.security.FileScanService","thread_name":"scheduling-1","level":"INFO","level_value":20000}
{"@timestamp":"2023-04-14T13:54:32.965+03:00","@version":"1","message":"Files scanned successfully.","logger_name":"fi.hel.haitaton.hanke.security.FileScanService","thread_name":"scheduling-1","level":"INFO","level_value":20000}
```

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 
