### PR TITLE
HAI-XXX Remove unused alkupvm and loppuvm

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeControllerITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeControllerITests.kt
@@ -21,7 +21,6 @@ import io.mockk.confirmVerified
 import io.mockk.every
 import io.mockk.justRun
 import io.mockk.verify
-import java.time.ZonedDateTime
 import java.time.temporal.ChronoUnit
 import org.geojson.FeatureCollection
 import org.junit.jupiter.api.AfterEach
@@ -110,8 +109,6 @@ class HankeControllerITests(@Autowired override val mockMvc: MockMvc) : Controll
             listOf(
                 HankeFactory.create(
                     id = 123,
-                    alkuPvm = DateFactory.getStartDatetime().minusDays(500),
-                    loppuPvm = DateFactory.getEndDatetime().minusDays(450),
                 ),
                 HankeFactory.create(
                     id = 444,
@@ -511,8 +508,6 @@ class HankeControllerITests(@Autowired override val mockMvc: MockMvc) : Controll
                 id = null,
                 hankeTunnus = null,
                 nimi = "Testihanke",
-                alkuPvm = ZonedDateTime.of(2021, 1, 1, 0, 0, 0, 0, TZ_UTC),
-                loppuPvm = ZonedDateTime.of(2021, 12, 31, 0, 0, 0, 0, TZ_UTC),
                 vaihe = Vaihe.OHJELMOINTI,
             )
         every { hankeService.createHanke(any()) } throws RuntimeException("Some error")

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeRepositoryITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeRepositoryITests.kt
@@ -38,8 +38,6 @@ internal class HankeRepositoryITests : DatabaseTest() {
 
     @Test
     fun `basic fields, tyomaa and haitat fields can be round-trip saved and loaded`() {
-        val datetime = LocalDateTime.of(2020, 2, 20, 20, 20)
-        val date = datetime.toLocalDate()
         val baseHankeEntity = createBaseHankeEntity("ABC-123")
         baseHankeEntity.tyomaaKatuosoite = "katu 1"
         baseHankeEntity.tyomaaTyyppi.add(TyomaaTyyppi.VESI)

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
@@ -14,7 +14,6 @@ import fi.hel.haitaton.hanke.domain.YhteystietoTyyppi.YHTEISO
 import fi.hel.haitaton.hanke.domain.YhteystietoTyyppi.YKSITYISHENKILO
 import fi.hel.haitaton.hanke.domain.YhteystietoTyyppi.YRITYS
 import fi.hel.haitaton.hanke.factory.AlluDataFactory
-import fi.hel.haitaton.hanke.factory.DateFactory
 import fi.hel.haitaton.hanke.factory.HankeFactory
 import fi.hel.haitaton.hanke.factory.HankeFactory.Companion.withGeneratedOmistaja
 import fi.hel.haitaton.hanke.factory.HankeFactory.Companion.withGeneratedOmistajat
@@ -1194,8 +1193,6 @@ class HankeServiceITests : DatabaseTest() {
         TestUtils.addMockedRequestIp()
 
         val hanke = hankeService.createHanke(HankeFactory.create(id = null).withHankealue())
-        val alkuPvm = hanke.alueet[0].haittaAlkuPvm!!.toLocalDate()
-        val loppuPvm = hanke.alueet[0].haittaLoppuPvm!!.toLocalDate()
 
         val hankeLogs = auditLogRepository.findByType(ObjectType.HANKE)
         assertEquals(1, hankeLogs.size)
@@ -1581,8 +1578,6 @@ class HankeServiceITests : DatabaseTest() {
         HankeFactory.create(
                 id = null,
                 hankeTunnus = null,
-                alkuPvm = DateFactory.getStartDatetime(),
-                loppuPvm = DateFactory.getEndDatetime(),
                 vaihe = Vaihe.SUUNNITTELU,
                 suunnitteluVaihe = SuunnitteluVaihe.RAKENNUS_TAI_TOTEUTUS,
                 version = null,

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeFactory.kt
@@ -23,16 +23,12 @@ class HankeFactory(private val hankeService: HankeService) {
      */
     fun save(
         nimi: String? = defaultNimi,
-        alkuPvm: ZonedDateTime? = DateFactory.getStartDatetime(),
-        loppuPvm: ZonedDateTime? = DateFactory.getEndDatetime(),
         vaihe: Vaihe? = Vaihe.OHJELMOINTI,
         suunnitteluVaihe: SuunnitteluVaihe? = null,
     ) =
         hankeService.createHanke(
             create(
                 nimi = nimi,
-                alkuPvm = alkuPvm,
-                loppuPvm = loppuPvm,
                 vaihe = vaihe,
                 suunnitteluVaihe = suunnitteluVaihe,
             )
@@ -60,8 +56,6 @@ class HankeFactory(private val hankeService: HankeService) {
             id: Int? = defaultId,
             hankeTunnus: String? = defaultHankeTunnus,
             nimi: String? = defaultNimi,
-            alkuPvm: ZonedDateTime? = DateFactory.getStartDatetime(),
-            loppuPvm: ZonedDateTime? = DateFactory.getEndDatetime(),
             vaihe: Vaihe? = Vaihe.OHJELMOINTI,
             suunnitteluVaihe: SuunnitteluVaihe? = null,
             version: Int? = 1,

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluLaskentaServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluLaskentaServiceTest.kt
@@ -74,12 +74,9 @@ internal class TormaystarkasteluLaskentaServiceTest {
             )
 
         val alkuPvm = ZonedDateTime.of(2021, 3, 4, 0, 0, 0, 0, TZ_UTC)
-        val loppuPvm = alkuPvm!!.plusDays(7)
         val hanke =
             HankeFactory.create(
                 nimi = "hanke",
-                alkuPvm = alkuPvm,
-                loppuPvm = loppuPvm,
                 vaihe = Vaihe.OHJELMOINTI,
                 hankeStatus = HankeStatus.DRAFT
             )


### PR DESCRIPTION
# Description

Compiling results to some warnings e.g:

HankeFactory.kt: (63, 13): Parameter 'alkuPvm' is never used
HankeFactory.kt: (64, 13): Parameter 'loppuPvm' is never used

This commit removes the unused variables.

### Jira Issue: no jira issue

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [x] Other

# Instructions for testing
Please describe tests how this change or new feature can be tested.

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 

# Other relevant info
Please describe here if there is e.g. some requirements for this change or
 other info that the tester/user needs to know.