### PR TITLE
HAI Add not null constraint with default values for yhteyshenkilot

### DIFF
--- a/services/hanke-service/src/main/resources/db/changelog/changesets/031-add-default-value-for-hankeyhteystieto-yhteyshenkilo.yml
+++ b/services/hanke-service/src/main/resources/db/changelog/changesets/031-add-default-value-for-hankeyhteystieto-yhteyshenkilo.yml
@@ -1,0 +1,6 @@
+databaseChangeLog:
+  - changeSet:
+      id: 031-add-default-value-for-hankeyhteystieto-yhteyshenkilo
+      author: Niko Pitkonen
+      changes:
+        - addNotNullConstraint: { tableName: hankeyhteystieto, columnName: yhteyshenkilot, defaultNullValue: '[]' }

--- a/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -89,3 +89,5 @@ databaseChangeLog:
       file: db/changelog/changesets/029-add-columns-hankeyhteystieto.yml
   - include:
       file: db/changelog/changesets/030-update-hanke-date-fields.yml
+  - include:
+      file: db/changelog/changesets/031-add-default-value-for-hankeyhteystieto-yhteyshenkilo.yml


### PR DESCRIPTION
# Description

Add not null constraint with default value of empty list for hankeyhteystiet.yhteyshenkilot.

### Jira Issue: No jira issue.

## Type of change

- [x] Bug fix 
- [ ] New feature 
- [ ] Other

# Instructions for testing
After deployment, you should be able to view hanke information in cloud environments.

# Checklist:

- [ ] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 

# Other relevant info
Please describe here if there is e.g. some requirements for this change or
 other info that the tester/user needs to know.