### PR TITLE
HAI-1556 Upgrade test libraries

### DIFF
--- a/services/hanke-service/build.gradle.kts
+++ b/services/hanke-service/build.gradle.kts
@@ -8,9 +8,9 @@ java.sourceCompatibility = JavaVersion.VERSION_11
 val postgreSQLVersion = "42.2.18"
 val springDocVersion = "1.6.12"
 val geoJsonJacksonVersion = "1.14"
-val mockkVersion = "1.10.2"
-val springmockkVersion = "2.0.3"
-val assertkVersion = "0.23"
+val mockkVersion = "1.13.5"
+val springmockkVersion = "3.1.2"
+val assertkVersion = "0.25"
 
 repositories {
 	mavenCentral()

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeControllerITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeControllerITests.kt
@@ -16,6 +16,7 @@ import fi.hel.haitaton.hanke.permissions.PermissionCode
 import fi.hel.haitaton.hanke.permissions.PermissionService
 import fi.hel.haitaton.hanke.permissions.Role
 import io.mockk.Called
+import io.mockk.checkUnnecessaryStub
 import io.mockk.clearAllMocks
 import io.mockk.confirmVerified
 import io.mockk.every
@@ -65,6 +66,7 @@ class HankeControllerITests(@Autowired override val mockMvc: MockMvc) : Controll
 
     @AfterEach
     fun checkMocks() {
+        checkUnnecessaryStub()
         confirmVerified(permissionService, disclosureLogService, hankeService)
     }
 
@@ -87,7 +89,6 @@ class HankeControllerITests(@Autowired override val mockMvc: MockMvc) : Controll
         every { hankeService.loadHanke(HANKE_TUNNUS) }.returns(hanke)
         every { permissionService.hasPermission(hankeId, USERNAME, PermissionCode.VIEW) }
             .returns(true)
-        justRun { disclosureLogService.saveDisclosureLogsForHanke(hanke, USERNAME) }
 
         get("$BASE_URL/$HANKE_TUNNUS")
             .andExpect(status().isOk)
@@ -120,7 +121,6 @@ class HankeControllerITests(@Autowired override val mockMvc: MockMvc) : Controll
         every { hankeService.loadHankkeetByIds(hankeIds) }.returns(hankkeet)
         every { permissionService.getAllowedHankeIds(USERNAME, PermissionCode.VIEW) }
             .returns(hankeIds)
-        justRun { disclosureLogService.saveDisclosureLogsForHankkeet(hankkeet, USERNAME) }
 
         // we check that we get the two hankeTunnus we expect
         get(BASE_URL)
@@ -154,7 +154,6 @@ class HankeControllerITests(@Autowired override val mockMvc: MockMvc) : Controll
         every { hankeService.loadHankkeetByIds(hankeIds) }.returns(listOf(hanke1, hanke2))
         every { permissionService.getAllowedHankeIds(USERNAME, PermissionCode.VIEW) }
             .returns(hankeIds)
-        justRun { disclosureLogService.saveDisclosureLogsForHankkeet(hankkeet, USERNAME) }
 
         // we check that we get the two hankeTunnus and geometriat we expect
         get("$BASE_URL?geometry=true")
@@ -204,7 +203,6 @@ class HankeControllerITests(@Autowired override val mockMvc: MockMvc) : Controll
             HankeWithApplications(hanke, listOf())
         every { permissionService.hasPermission(hanke.id!!, USERNAME, PermissionCode.VIEW) } returns
             true
-        justRun { disclosureLogService.saveDisclosureLogsForHanke(hanke, USERNAME) }
 
         val response: ApplicationsResponse =
             get("$BASE_URL/$HANKE_TUNNUS/hakemukset").andExpect(status().isOk).andReturnBody()
@@ -223,8 +221,6 @@ class HankeControllerITests(@Autowired override val mockMvc: MockMvc) : Controll
             HankeWithApplications(hanke, applications)
         every { permissionService.hasPermission(hanke.id!!, USERNAME, PermissionCode.VIEW) } returns
             true
-        justRun { disclosureLogService.saveDisclosureLogsForHanke(hanke, USERNAME) }
-        justRun { disclosureLogService.saveDisclosureLogsForApplications(applications, USERNAME) }
 
         val response: ApplicationsResponse =
             get("$BASE_URL/$HANKE_TUNNUS/hakemukset").andExpect(status().isOk).andReturnBody()
@@ -257,7 +253,6 @@ class HankeControllerITests(@Autowired override val mockMvc: MockMvc) : Controll
             )
         every { hankeService.createHanke(any()) }.returns(createdHanke)
         justRun { permissionService.setPermission(any(), any(), Role.KAIKKI_OIKEUDET) }
-        justRun { disclosureLogService.saveDisclosureLogsForHanke(createdHanke, USERNAME) }
 
         postRaw(BASE_URL, hankeToBeMocked.toJsonString())
             .andExpect(status().isOk)
@@ -275,7 +270,6 @@ class HankeControllerITests(@Autowired override val mockMvc: MockMvc) : Controll
         val hanke = HankeFactory.create().withPerustaja()
         every { hankeService.createHanke(any()) } returns hanke
         justRun { permissionService.setPermission(any(), any(), Role.KAIKKI_OIKEUDET) }
-        justRun { disclosureLogService.saveDisclosureLogsForHanke(hanke, USERNAME) }
 
         post(BASE_URL, hanke)
             .andExpect(status().isOk)
@@ -293,7 +287,6 @@ class HankeControllerITests(@Autowired override val mockMvc: MockMvc) : Controll
         every { hankeService.createHanke(hanke.copy(id = null, generated = false)) } returns
             hanke.copy(generated = false)
         justRun { permissionService.setPermission(any(), any(), Role.KAIKKI_OIKEUDET) }
-        justRun { disclosureLogService.saveDisclosureLogsForHanke(hanke, USERNAME) }
 
         post(BASE_URL, hanke).andExpect(status().isOk)
 
@@ -347,7 +340,6 @@ class HankeControllerITests(@Autowired override val mockMvc: MockMvc) : Controll
         every { permissionService.hasPermission(updatedHanke.id!!, USERNAME, PermissionCode.EDIT) }
             .returns(true)
         every { hankeService.updateHanke(any()) }.returns(updatedHanke)
-        justRun { disclosureLogService.saveDisclosureLogsForHanke(updatedHanke, USERNAME) }
 
         putRaw("$BASE_URL/$hanketunnus", hankeToBeUpdated.toJsonString())
             .andExpect(status().isOk)
@@ -376,7 +368,6 @@ class HankeControllerITests(@Autowired override val mockMvc: MockMvc) : Controll
             }
         justRun { permissionService.setPermission(any(), any(), Role.KAIKKI_OIKEUDET) }
         every { hankeService.createHanke(any()) }.returns(expectedHanke)
-        justRun { disclosureLogService.saveDisclosureLogsForHanke(expectedHanke, USERNAME) }
         val expectedContent = expectedHanke.toJsonString()
 
         postRaw(BASE_URL, content)
@@ -426,7 +417,6 @@ class HankeControllerITests(@Autowired override val mockMvc: MockMvc) : Controll
             permissionService.hasPermission(expectedHanke.id!!, USERNAME, PermissionCode.EDIT)
         } returns true
         every { hankeService.updateHanke(any()) } returns expectedHanke
-        justRun { disclosureLogService.saveDisclosureLogsForHanke(expectedHanke, USERNAME) }
 
         // Call it and check results
         putRaw("$BASE_URL/idHankkeelle123", hankeToBeUpdated.toJsonString())
@@ -483,7 +473,6 @@ class HankeControllerITests(@Autowired override val mockMvc: MockMvc) : Controll
         // faking the service call
         every { hankeService.createHanke(any()) }.returns(expectedHanke)
         justRun { permissionService.setPermission(any(), any(), Role.KAIKKI_OIKEUDET) }
-        justRun { disclosureLogService.saveDisclosureLogsForHanke(expectedHanke, USERNAME) }
 
         // Call it and check results
         postRaw(BASE_URL, hankeToBeMocked.toJsonString())

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
@@ -34,6 +34,7 @@ import fi.hel.haitaton.hanke.permissions.KayttajaTunnisteRepository
 import fi.hel.haitaton.hanke.test.TestUtils
 import fi.hel.haitaton.hanke.test.TestUtils.nextYear
 import io.mockk.Called
+import io.mockk.checkUnnecessaryStub
 import io.mockk.clearAllMocks
 import io.mockk.confirmVerified
 import io.mockk.every
@@ -99,6 +100,7 @@ class HankeServiceITests : DatabaseTest() {
 
     @AfterEach
     fun checkMocks() {
+        checkUnnecessaryStub()
         confirmVerified(applicationService)
     }
 

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationControllerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationControllerITest.kt
@@ -17,6 +17,7 @@ import fi.hel.haitaton.hanke.permissions.PermissionCode.VIEW
 import fi.hel.haitaton.hanke.permissions.PermissionService
 import fi.hel.haitaton.hanke.toJsonString
 import io.mockk.Called
+import io.mockk.checkUnnecessaryStub
 import io.mockk.clearAllMocks
 import io.mockk.confirmVerified
 import io.mockk.every
@@ -60,8 +61,7 @@ class ApplicationControllerITest(@Autowired override val mockMvc: MockMvc) : Con
 
     @AfterEach
     fun checkMocks() {
-        // TODO: Needs newer MockK, which needs newer Spring test dependencies
-        // checkUnnecessaryStub()
+        checkUnnecessaryStub()
         confirmVerified(applicationService, permissionService)
     }
 
@@ -425,7 +425,6 @@ class ApplicationControllerITest(@Autowired override val mockMvc: MockMvc) : Con
     @WithMockUser(USERNAME)
     fun `sendApplication with unknown id returns 404`() {
         val id = 1234L
-        every { hankeService.getHankeId(HANKE_TUNNUS) } returns 42
         every { applicationService.getApplicationById(id) } throws ApplicationNotFoundException(id)
 
         post("$BASE_URL/$id/send-application").andExpect(status().isNotFound)

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/AttachmentServiceITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/AttachmentServiceITests.kt
@@ -3,12 +3,10 @@ package fi.hel.haitaton.hanke.attachment
 import fi.hel.haitaton.hanke.DatabaseTest
 import fi.hel.haitaton.hanke.HankeService
 import fi.hel.haitaton.hanke.factory.HankeFactory
-import io.mockk.clearAllMocks
 import java.time.OffsetDateTime
 import java.time.temporal.ChronoUnit
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.byLessThan
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.annotation.Autowired
@@ -27,18 +25,13 @@ private const val FILE_PARAM = "liite"
 @Testcontainers
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("default")
+@WithMockUser(USERNAME)
 class AttachmentServiceITests : DatabaseTest() {
     @Autowired private lateinit var attachmentService: AttachmentService
     @Autowired private lateinit var hankeAttachmentRepository: HankeAttachmentRepository
     @Autowired private lateinit var hankeService: HankeService
 
-    @BeforeEach
-    fun clearMocks() {
-        clearAllMocks()
-    }
-
     @Test
-    @WithMockUser(USERNAME)
     fun `Saving an attachment is possible`() {
         val hanke = HankeFactory.create()
         val createdHanke = hankeService.createHanke(hanke)
@@ -64,7 +57,6 @@ class AttachmentServiceITests : DatabaseTest() {
     }
 
     @Test
-    @WithMockUser(USERNAME)
     fun `Attachments can't be saved without hanke`() {
         assertThrows<AttachmentUploadException> {
             attachmentService.add(
@@ -75,7 +67,6 @@ class AttachmentServiceITests : DatabaseTest() {
     }
 
     @Test
-    @WithMockUser(USERNAME)
     fun `File extension must match content type`() {
         val hanke = HankeFactory.create()
         val createdHanke = hankeService.createHanke(hanke)
@@ -101,7 +92,6 @@ class AttachmentServiceITests : DatabaseTest() {
     }
 
     @Test
-    @WithMockUser(USERNAME)
     fun `Non supported file cannot be uploaded`() {
         val hanke = HankeFactory.create()
         val createdHanke = hankeService.createHanke(hanke)
@@ -114,7 +104,6 @@ class AttachmentServiceITests : DatabaseTest() {
     }
 
     @Test
-    @WithMockUser(USERNAME)
     fun `Can't upload files bigger than 25Mb`() {
         val hanke = HankeFactory.create()
         val createdHanke = hankeService.createHanke(hanke)
@@ -142,7 +131,6 @@ class AttachmentServiceITests : DatabaseTest() {
     }
 
     @Test
-    @WithMockUser(USERNAME)
     fun `Hanke data is downloadable when data is ok`() {
         val hanke = HankeFactory.create()
         val createdHanke = hankeService.createHanke(hanke)
@@ -163,7 +151,6 @@ class AttachmentServiceITests : DatabaseTest() {
     }
 
     @Test
-    @WithMockUser(USERNAME)
     fun `Hanke data not downloadable when state is PENDING`() {
         val hanke = HankeFactory.create()
         val createdHanke = hankeService.createHanke(hanke)
@@ -185,7 +172,6 @@ class AttachmentServiceITests : DatabaseTest() {
     }
 
     @Test
-    @WithMockUser(USERNAME)
     fun `Hanke data not downloadable when state is FAILED`() {
         val hanke = HankeFactory.create()
         val createdHanke = hankeService.createHanke(hanke)
@@ -207,7 +193,6 @@ class AttachmentServiceITests : DatabaseTest() {
     }
 
     @Test
-    @WithMockUser(USERNAME)
     fun `Removing an attachment is possible`() {
         val hanke = HankeFactory.create()
         val createdHanke = hankeService.createHanke(hanke)

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/domain/PublicHankeControllerITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/domain/PublicHankeControllerITests.kt
@@ -8,6 +8,7 @@ import fi.hel.haitaton.hanke.factory.HankeFactory
 import fi.hel.haitaton.hanke.factory.HankeFactory.Companion.withHankealue
 import fi.hel.haitaton.hanke.factory.HankeFactory.Companion.withTormaystarkasteluTulos
 import fi.hel.haitaton.hanke.factory.HankeFactory.Companion.withYhteystiedot
+import io.mockk.checkUnnecessaryStub
 import io.mockk.clearAllMocks
 import io.mockk.confirmVerified
 import io.mockk.every
@@ -37,6 +38,7 @@ class PublicHankeControllerITests(@Autowired override val mockMvc: MockMvc) : Co
 
     @AfterEach
     fun checkMocks() {
+        checkUnnecessaryStub()
         confirmVerified(hankeService)
     }
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/AttachmentController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/AttachmentController.kt
@@ -104,12 +104,11 @@ class AttachmentController(
 
         checkAttachmentPermission(hankeId, currentUserId(), VIEW)
 
-        val metadata = attachmentService.getMetadata(id)
-        val mimeType = URLConnection.guessContentTypeFromName(metadata.fileName)
+        val mimeType = URLConnection.guessContentTypeFromName(attachmentMetadata.fileName)
 
         val headers = HttpHeaders()
         headers.contentType = MediaType.parseMediaType(mimeType)
-        headers.add(CONTENT_DISPOSITION, "attachment; filename=${metadata.fileName}")
+        headers.add(CONTENT_DISPOSITION, "attachment; filename=${attachmentMetadata.fileName}")
 
         val file = attachmentService.getContent(id)
         return ResponseEntity.ok().headers(headers).body(file)

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/application/AlluUpdateServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/application/AlluUpdateServiceTest.kt
@@ -7,6 +7,7 @@ import fi.hel.haitaton.hanke.configuration.LockService
 import fi.hel.haitaton.hanke.factory.ApplicationHistoryFactory
 import fi.hel.haitaton.hanke.test.Asserts.isRecent
 import io.mockk.Called
+import io.mockk.checkUnnecessaryStub
 import io.mockk.clearAllMocks
 import io.mockk.confirmVerified
 import io.mockk.every
@@ -50,6 +51,7 @@ class AlluUpdateServiceTest {
 
     @AfterEach
     fun confirmMocks() {
+        checkUnnecessaryStub()
         confirmVerified(
             alluStatusRepository,
             applicationRepository,

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/application/ApplicationControllerTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/application/ApplicationControllerTest.kt
@@ -5,12 +5,14 @@ import fi.hel.haitaton.hanke.factory.AlluDataFactory
 import fi.hel.haitaton.hanke.logging.DisclosureLogService
 import fi.hel.haitaton.hanke.permissions.PermissionCode
 import fi.hel.haitaton.hanke.permissions.PermissionService
+import io.mockk.checkUnnecessaryStub
 import io.mockk.clearAllMocks
 import io.mockk.confirmVerified
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.security.test.context.support.WithMockUser
@@ -36,12 +38,15 @@ class ApplicationControllerTest {
             permissionService
         )
 
+    @BeforeEach
+    fun clearMocks() {
+        clearAllMocks()
+    }
+
     @AfterEach
     fun cleanUp() {
-        // TODO: Needs newer MockK, which needs newer Spring test dependencies
-        // checkUnnecessaryStub()
+        checkUnnecessaryStub()
         confirmVerified(applicationService, disclosureLogService, permissionService)
-        clearAllMocks()
     }
 
     @Test

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceTest.kt
@@ -24,6 +24,7 @@ import fi.hel.haitaton.hanke.permissions.HankeKayttajaService
 import fi.hel.haitaton.hanke.permissions.PermissionService
 import io.mockk.Called
 import io.mockk.called
+import io.mockk.checkUnnecessaryStub
 import io.mockk.clearAllMocks
 import io.mockk.confirmVerified
 import io.mockk.every
@@ -75,13 +76,12 @@ class ApplicationServiceTest {
 
     @BeforeEach
     fun cleanup() {
-        // TODO: Needs newer MockK, which needs newer Spring test dependencies
-        // checkUnnecessaryStub()
         clearAllMocks()
     }
 
     @AfterEach
     fun verifyMocks() {
+        checkUnnecessaryStub()
         confirmVerified(
             applicationRepo,
             statusRepo,

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/logging/ApplicationLoggingServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/logging/ApplicationLoggingServiceTest.kt
@@ -2,12 +2,14 @@ package fi.hel.haitaton.hanke.logging
 
 import fi.hel.haitaton.hanke.factory.AlluDataFactory
 import io.mockk.called
+import io.mockk.checkUnnecessaryStub
 import io.mockk.clearAllMocks
 import io.mockk.confirmVerified
 import io.mockk.mockk
 import io.mockk.verify
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
 internal class ApplicationLoggingServiceTest {
@@ -17,12 +19,15 @@ internal class ApplicationLoggingServiceTest {
     private val auditLogService: AuditLogService = mockk(relaxed = true)
     private val applicationLoggingService = ApplicationLoggingService(auditLogService)
 
+    @BeforeEach
+    fun clearMocks() {
+        clearAllMocks()
+    }
+
     @AfterEach
     fun cleanUp() {
-        // TODO: Needs newer MockK, which needs newer Spring test dependencies
-        // checkUnnecessaryStub()
+        checkUnnecessaryStub()
         confirmVerified(auditLogService)
-        clearAllMocks()
     }
 
     @Test

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/logging/DisclosureLogServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/logging/DisclosureLogServiceTest.kt
@@ -17,12 +17,14 @@ import fi.hel.haitaton.hanke.gdpr.CollectionNode
 import fi.hel.haitaton.hanke.gdpr.StringNode
 import fi.hel.haitaton.hanke.toJsonString
 import io.mockk.Called
+import io.mockk.checkUnnecessaryStub
 import io.mockk.clearAllMocks
 import io.mockk.confirmVerified
 import io.mockk.mockk
 import io.mockk.verify
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
@@ -35,12 +37,15 @@ internal class DisclosureLogServiceTest {
     private val auditLogService: AuditLogService = mockk(relaxed = true)
     private val disclosureLogService = DisclosureLogService(auditLogService)
 
+    @BeforeEach
+    fun clearMocks() {
+        clearAllMocks()
+    }
+
     @AfterEach
     fun cleanUp() {
-        // TODO: Needs newer MockK, which needs newer Spring test dependencies
-        // checkUnnecessaryStub()
+        checkUnnecessaryStub()
         confirmVerified(auditLogService)
-        clearAllMocks()
     }
 
     @Test

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/logging/HankeLoggingServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/logging/HankeLoggingServiceTest.kt
@@ -3,6 +3,7 @@ package fi.hel.haitaton.hanke.logging
 import fi.hel.haitaton.hanke.factory.HankeFactory
 import fi.hel.haitaton.hanke.factory.HankeFactory.Companion.withYhteystiedot
 import io.mockk.called
+import io.mockk.checkUnnecessaryStub
 import io.mockk.clearAllMocks
 import io.mockk.confirmVerified
 import io.mockk.mockk
@@ -13,6 +14,7 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
 internal class HankeLoggingServiceTest {
@@ -21,12 +23,15 @@ internal class HankeLoggingServiceTest {
     private val auditLogService: AuditLogService = mockk(relaxed = true)
     private val hankeLoggingService = HankeLoggingService(auditLogService)
 
+    @BeforeEach
+    fun clearMocks() {
+        clearAllMocks()
+    }
+
     @AfterEach
     fun cleanUp() {
-        // TODO: Needs newer MockK, which needs newer Spring test dependencies
-        // checkUnnecessaryStub()
+        checkUnnecessaryStub()
         confirmVerified(auditLogService)
-        clearAllMocks()
     }
 
     @Test


### PR DESCRIPTION
Now that we're on Spring Boot 2.4, we can upgrade MockK and assertk to newer versions. This enables the use of `checkUnnecessaryStub()`, which checks whether all stubs are actually used. Unused stubs can be misleading.

Also, since Spring 5.3 that came with Spring Boot 2.4 enables us to use `@Nested` test classes in more places, use it in one as an example.