### PR TITLE
HAI-1525 Fix exception at the end of integration tests

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/email/EmailSenderServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/email/EmailSenderServiceITest.kt
@@ -10,6 +10,7 @@ import assertk.assertions.startsWith
 import com.icegreen.greenmail.configuration.GreenMailConfiguration
 import com.icegreen.greenmail.junit5.GreenMailExtension
 import com.icegreen.greenmail.util.ServerSetupTest
+import fi.hel.haitaton.hanke.DatabaseTest
 import javax.mail.internet.MimeMessage
 import javax.mail.internet.MimeMultipart
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -18,10 +19,12 @@ import org.junit.jupiter.api.extension.RegisterExtension
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
+import org.testcontainers.junit.jupiter.Testcontainers
 
+@Testcontainers
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("default", "emailtest")
-class EmailSenderServiceITest {
+class EmailSenderServiceITest : DatabaseTest() {
 
     @JvmField
     @RegisterExtension

--- a/services/hanke-service/src/test/resources/application-emailtest.properties
+++ b/services/hanke-service/src/test/resources/application-emailtest.properties
@@ -5,4 +5,3 @@ spring.mail.properties.mail.smtp.auth=false
 spring.mail.properties.mail.smtp.starttls.enable=false
 spring.mail.properties.mail.smtp.starttls.required=false
 spring.mail.properties.mail.debug=false
-spring.liquibase.enabled=false


### PR DESCRIPTION
# Description

Since `EmailSenderServiceITest` is an integration test, Spring starts all services when running that test. But since it isn't a `DatabaseTest`, the database is connected in the default port. This is unacceptable, since tests shouldn't interfere with real environments.

Fix this by making `EmailSenderServiceITest` a `DatabaseTest`, so that a test database is properly used.

## Type of change

- [X] Bug fix 
- [ ] New feature 
- [ ] Other

# Instructions for testing
Run integration tests without having a database in port 5432. Or look at the test report for this PR.
