### PR TITLE
HAI-1610 Change name to first and last name in Contact

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceITest.kt
@@ -1408,7 +1408,8 @@ class ApplicationServiceITest : DatabaseTest() {
            },
            "contacts": [
              {
-               "name": "Teppo Testihenkilö",
+               "firstName": "Teppo",
+               "lastName": "Testihenkilö",
                "email": "teppo@example.test",
                "phone": "04012345678",
                "orderer": false

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaServiceITest.kt
@@ -111,7 +111,11 @@ class HankeKayttajaServiceITest : DatabaseTest() {
                         .withContacts(
                             AlluDataFactory.createContact(email = "email1"),
                             AlluDataFactory.createContact(email = "email2"),
-                            AlluDataFactory.createContact(email = "email2", name = "Other Name"),
+                            AlluDataFactory.createContact(
+                                email = "email2",
+                                firstName = "Other",
+                                lastName = "Name"
+                            ),
                         ),
                 contractorWithContacts =
                     AlluDataFactory.createCompanyCustomer()

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/ApplicationPdfService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/ApplicationPdfService.kt
@@ -74,7 +74,7 @@ object ApplicationPdfService {
         "${this.streetAddress.streetName}\n${this.postalCode} ${this.city}"
 
     private fun Contact.format(): String =
-        listOfNotNull(this.name, this.email, this.phone)
+        listOfNotNull(this.fullName(), this.email, this.phone)
             .filter { it.isNotBlank() }
             .joinToString("\n")
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/CustomerWithContacts.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/CustomerWithContacts.kt
@@ -24,18 +24,26 @@ data class CustomerWithContacts(val customer: Customer, val contacts: List<Conta
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class Contact(
-    val name: String?,
+    val firstName: String?,
+    val lastName: String?,
     val email: String?,
     val phone: String?,
     val orderer: Boolean = false,
 ) {
     /** Check if this contact is blank, i.e. it doesn't contain any actual contact information. */
-    @JsonIgnore
-    fun isBlank() = name.isNullOrBlank() && email.isNullOrBlank() && phone.isNullOrBlank()
+    @JsonIgnore fun isBlank() = listOf(firstName, lastName, email, phone).any { it.isNullOrBlank() }
 
     fun hasInformation() = !isBlank()
 
-    fun toAlluData(): AlluContact = AlluContact(name, email, phone, orderer)
+    fun toAlluData(): AlluContact = AlluContact(fullName(), email, phone, orderer)
+
+    fun fullName(): String? {
+        val names = listOf(firstName, lastName)
+        if (names.all { it == null }) {
+            return null
+        }
+        return names.filter { !it.isNullOrBlank() }.joinToString(" ")
+    }
 }
 
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/gdpr/GdprJsonConverter.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/gdpr/GdprJsonConverter.kt
@@ -148,9 +148,9 @@ class GdprJsonConverter(private val organisaatioService: OrganisaatioService) {
         organisation: GdprOrganisation?,
         userInfo: UserInfo,
     ): GdprInfo? {
-        if (contact.name == userInfo.name) {
+        if (contact.fullName() == userInfo.name) {
             return GdprInfo(
-                name = contact.name,
+                name = contact.fullName(),
                 phone = contact.phone,
                 email = contact.email,
                 organisation = organisation,

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaService.kt
@@ -18,8 +18,7 @@ class HankeKayttajaService(
             applicationData
                 .customersWithContacts()
                 .flatMap { it.contacts }
-                .filterNot { it.email.isNullOrBlank() || it.name.isNullOrBlank() }
-                .map { UserContact(it.name!!, it.email!!) }
+                .mapNotNull { userContactOrNull(it.fullName(), it.email) }
 
         filterNewContacts(hankeId, contacts).forEach { contact -> createToken(hankeId, contact) }
     }
@@ -31,8 +30,7 @@ class HankeKayttajaService(
             hanke
                 .extractYhteystiedot()
                 .flatMap { it.alikontaktit }
-                .filterNot { it.fullName().isBlank() || it.email.isBlank() }
-                .map { UserContact(it.fullName(), it.email) }
+                .mapNotNull { userContactOrNull(it.fullName(), it.email) }
 
         filterNewContacts(hankeId, contacts).forEach { contact -> createToken(hankeId, contact) }
     }
@@ -49,6 +47,13 @@ class HankeKayttajaService(
                 kayttajaTunniste = kayttajaTunnisteEntity
             )
         )
+    }
+
+    private fun userContactOrNull(name: String?, email: String?): UserContact? {
+        return when {
+            name.isNullOrBlank() || email.isNullOrBlank() -> null
+            else -> UserContact(name, email)
+        }
     }
 
     private fun filterNewContacts(hankeId: Int, contacts: List<UserContact>): List<UserContact> {

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/allu/ApplicationPdfServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/allu/ApplicationPdfServiceTest.kt
@@ -235,12 +235,14 @@ internal class ApplicationPdfServiceTest {
                             )
                             .withContacts(
                                 AlluDataFactory.createContact(
-                                    name = "Cole Contact",
+                                    firstName = "Cole Contact",
+                                    lastName = "",
                                     email = "cole@company.test",
                                     phone = "050987654321",
                                 ),
                                 AlluDataFactory.createContact(
-                                    name = "Seth Secondary",
+                                    firstName = "Seth",
+                                    lastName = "Secondary",
                                     email = "seth@company.test",
                                     phone = "0505556666",
                                 ),
@@ -254,7 +256,8 @@ internal class ApplicationPdfServiceTest {
                             )
                             .withContacts(
                                 AlluDataFactory.createContact(
-                                    name = "Cody Contractor",
+                                    firstName = "Cody",
+                                    lastName = "Contractor",
                                     email = "cody@contractor.test",
                                     phone = "0501111111",
                                     orderer = true
@@ -277,7 +280,8 @@ internal class ApplicationPdfServiceTest {
                             )
                             .withContacts(
                                 AlluDataFactory.createContact(
-                                    name = "Denise Developer",
+                                    firstName = "Denise",
+                                    lastName = "Developer",
                                     email = "denise@developer.test",
                                     phone = "0502222222"
                                 ),

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/application/ContactTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/application/ContactTest.kt
@@ -1,0 +1,51 @@
+package fi.hel.haitaton.hanke.application
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNull
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+
+private const val DUMMY_EMAIL = "dummymail@mail.com"
+private const val DUMMY_PHONE = "04012345678"
+
+class ContactTest {
+
+    @ParameterizedTest
+    @CsvSource(
+        "Matti,Meikalainen,Matti Meikalainen",
+        "'',Meikalainen,Meikalainen",
+        "Matti,'',Matti",
+        "'','',''"
+    )
+    fun `fullName concatenates first and last names`(
+        firstName: String,
+        lastName: String,
+        expectedResult: String
+    ) {
+        val contact = Contact(firstName, lastName, DUMMY_EMAIL, DUMMY_PHONE)
+        assertThat(contact.fullName()).isEqualTo(expectedResult)
+    }
+
+    @Test
+    fun `fullName when firstName null should provide lastName`() {
+        val contact =
+            Contact(firstName = null, lastName = "Last", email = DUMMY_EMAIL, phone = DUMMY_PHONE)
+        assertThat(contact.fullName()).isEqualTo("Last")
+    }
+
+    @Test
+    fun `fullName when lastName null should provide firstName`() {
+        val contact =
+            Contact(firstName = "First", lastName = null, email = DUMMY_EMAIL, phone = DUMMY_PHONE)
+        assertThat(contact.fullName()).isEqualTo("First")
+    }
+
+    @Test
+    fun `fullName when both names null should provide null`() {
+        val contact =
+            Contact(firstName = null, lastName = null, email = DUMMY_EMAIL, phone = DUMMY_PHONE)
+        assertThat(contact.fullName()).isNull()
+    }
+}

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/AlluDataFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/AlluDataFactory.kt
@@ -85,11 +85,12 @@ class AlluDataFactory(val applicationRepository: ApplicationRepository) {
             CustomerWithContacts(this, contacts.asList())
 
         fun createContact(
-            name: String? = "Teppo Testihenkilö",
+            firstName: String? = "Teppo",
+            lastName: String? = "Testihenkilö",
             email: String? = "teppo@example.test",
             phone: String? = "04012345678",
             orderer: Boolean = false
-        ) = Contact(name, email, phone, orderer)
+        ) = Contact(firstName, lastName, email, phone, orderer)
 
         fun createApplicationArea(
             name: String = "Area name",
@@ -174,11 +175,19 @@ class AlluDataFactory(val applicationRepository: ApplicationRepository) {
                                 name = "$defaultApplicationName #$i",
                                 customerWithContacts =
                                     createCompanyCustomer(name = "Customer #$i")
-                                        .withContacts(createContact(name = "Customer #$i Contact")),
+                                        .withContacts(
+                                            createContact(
+                                                firstName = "Customer #$i",
+                                                lastName = "Contact #$i",
+                                            )
+                                        ),
                                 contractorWithContacts =
                                     createCompanyCustomer(name = "Contractor #$i")
                                         .withContacts(
-                                            createContact(name = "Contractor #$i Contact")
+                                            createContact(
+                                                firstName = "Contractor #$i",
+                                                lastName = "Contact #$i",
+                                            )
                                         )
                             )
                     )

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/gdpr/GdprJsonConverterTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/gdpr/GdprJsonConverterTest.kt
@@ -300,14 +300,20 @@ internal class GdprJsonConverterTest {
             listOf(
                 AlluDataFactory.createContact(),
                 AlluDataFactory.createContact(
-                    name = "Toinen Testihenkilö",
+                    firstName = "Toinen",
+                    lastName = "Testihenkilö",
                     email = "toinen@example.test"
                 ),
                 AlluDataFactory.createContact(
-                    name = "Teppo Toissijainen",
+                    firstName = "Teppo",
+                    lastName = "Toissijainen",
                     email = "toissijainen@example.test"
                 ),
-                AlluDataFactory.createContact(name = TEPPO_TESTI, email = "teppo@yksityinen.test"),
+                AlluDataFactory.createContact(
+                    firstName = TEPPO_TESTI.split(" ")[0],
+                    lastName = TEPPO_TESTI.split(" ")[1],
+                    email = "teppo@yksityinen.test"
+                ),
             )
 
         val result =
@@ -331,7 +337,7 @@ internal class GdprJsonConverterTest {
 
     @Test
     fun `getGdprInfosFromApplicationContact with another name returns null`() {
-        val otherContact = AlluDataFactory.createContact(name = "Another name")
+        val otherContact = AlluDataFactory.createContact(firstName = "Another", lastName = "name")
         val teppoContact = AlluDataFactory.createContact()
         val otherUserInfo = teppoUserInfo(name = "Another")
         val teppoUserInfo = teppoUserInfo()

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/logging/DisclosureLogServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/logging/DisclosureLogServiceTest.kt
@@ -200,7 +200,8 @@ internal class DisclosureLogServiceTest {
         val customerWithoutContacts =
             AlluDataFactory.createCompanyCustomer(name = "First").withContacts()
         val contractorWithoutContacts =
-            AlluDataFactory.createCompanyCustomer(name = "Second").withContacts(Contact("", "", ""))
+            AlluDataFactory.createCompanyCustomer(name = "Second")
+                .withContacts(Contact("", "", "", ""))
         val application =
             AlluDataFactory.createApplication(
                 applicationData =
@@ -301,7 +302,8 @@ internal class DisclosureLogServiceTest {
 
     @Test
     fun `saveDisclosureLogsForApplications logs customers and contacts from all applications while ignoring duplicates`() {
-        val contacts = (1..8).map { AlluDataFactory.createContact(name = "Contact $it") }
+        val contacts =
+            (1..8).map { AlluDataFactory.createContact(firstName = "Contact", lastName = "$it") }
         val customers = (1..4).map { AlluDataFactory.createPersonCustomer(name = "Customer $it") }
         val expectedLogs =
             (contacts.map { AuditLogEntryFactory.createReadEntryForContact(it) } +

--- a/services/hanke-service/src/test/resources/fi/hel/haitaton/hanke/application/applicationData.json
+++ b/services/hanke-service/src/test/resources/fi/hel/haitaton/hanke/application/applicationData.json
@@ -54,7 +54,8 @@
   "customerWithContacts": {
     "contacts": [
       {
-        "name": "Teppo Testihenkilö",
+        "firstName": "Teppo",
+        "lastName": "Testihenkilö",
         "email": "teppo@example.test",
         "phone": "04012345678",
         "orderer": true
@@ -78,7 +79,8 @@
   "contractorWithContacts": {
     "contacts": [
       {
-        "name": "Teppo Testihenkilö",
+        "firstName": "Teppo",
+        "lastName": "Testihenkilö",
         "email": "teppo@dna.test",
         "phone": "04012345678",
         "orderer": true


### PR DESCRIPTION
# Description

Application Contact.name is divided into firstName and lastName.

Note. Allu still expects name information to be a single name attribute. Hence, firstName and lastName needs to be mapped into a full name. Full name will be null if first and last names are null.

Note. Previously saved application data jsonb fields will contain the name information as a full name. These cases will have their firstName and lastName null. It should not cause errors but it might be a good idea to delete these rows from the db.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1610

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [x] Other

# Instructions for testing
This update requires changes in the front-end too. When both are implemented, just create a cable report application and verify that contact data is handled correctly.

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 

# Other relevant info
Please describe here if there is e.g. some requirements for this change or
 other info that the tester/user needs to know.