### PR TITLE
HAI-1617 Improve transaction handling

### DIFF
--- a/services/hanke-service/build.gradle.kts
+++ b/services/hanke-service/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import org.springframework.boot.gradle.tasks.run.BootRun
@@ -126,6 +127,9 @@ tasks {
 	test {
 		useJUnitPlatform()
 		systemProperty("spring.profiles.active", "test")
+		testLogging {
+			exceptionFormat = TestExceptionFormat.FULL
+		}
 	}
 
 	create("integrationTest", Test::class) {

--- a/services/hanke-service/build.gradle.kts
+++ b/services/hanke-service/build.gradle.kts
@@ -128,6 +128,8 @@ tasks {
 		useJUnitPlatform()
 		systemProperty("spring.profiles.active", "test")
 		testLogging {
+			events("passed", "skipped", "failed")
+			showStackTraces = true
 			exceptionFormat = TestExceptionFormat.FULL
 		}
 	}
@@ -140,6 +142,11 @@ tasks {
 		classpath = sourceSets["integrationTest"].runtimeClasspath
 		shouldRunAfter("test")
 		outputs.upToDateWhen { false }
+		testLogging {
+			events("passed", "skipped", "failed")
+			showStackTraces = true
+			exceptionFormat = TestExceptionFormat.FULL
+		}
 	}
 }
 

--- a/services/hanke-service/build.gradle.kts
+++ b/services/hanke-service/build.gradle.kts
@@ -128,7 +128,7 @@ tasks {
 		useJUnitPlatform()
 		systemProperty("spring.profiles.active", "test")
 		testLogging {
-			events("passed", "skipped", "failed")
+			events("skipped", "failed")
 			showStackTraces = true
 			exceptionFormat = TestExceptionFormat.FULL
 		}
@@ -143,7 +143,7 @@ tasks {
 		shouldRunAfter("test")
 		outputs.upToDateWhen { false }
 		testLogging {
-			events("passed", "skipped", "failed")
+			events("skipped", "failed")
 			showStackTraces = true
 			exceptionFormat = TestExceptionFormat.FULL
 		}

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HanketunnusServiceImplITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HanketunnusServiceImplITest.kt
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
-import org.springframework.transaction.annotation.Transactional
 import org.testcontainers.junit.jupiter.Testcontainers
 
 @Testcontainers
@@ -17,7 +16,6 @@ internal class HanketunnusServiceImplITest : DatabaseTest() {
     @Autowired lateinit var hanketunnusService: HanketunnusService
 
     @Test
-    @Transactional
     fun newHanketunnus() {
         val hanketunnus1 = hanketunnusService.newHanketunnus()
         val hanketunnus2 = hanketunnusService.newHanketunnus()

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentServiceITest.kt
@@ -11,7 +11,6 @@ import fi.hel.haitaton.hanke.HankeEntity
 import fi.hel.haitaton.hanke.HankeRepository
 import fi.hel.haitaton.hanke.application.ApplicationEntity
 import fi.hel.haitaton.hanke.application.ApplicationNotFoundException
-import fi.hel.haitaton.hanke.attachment.APPLICATION_ID
 import fi.hel.haitaton.hanke.attachment.FILE_NAME_PDF
 import fi.hel.haitaton.hanke.attachment.HANKE_TUNNUS
 import fi.hel.haitaton.hanke.attachment.USERNAME
@@ -69,7 +68,7 @@ class ApplicationAttachmentServiceITest : DatabaseTest() {
             d.transform { it.createdByUserId }.isEqualTo(USERNAME)
             d.transform { it.createdAt }.isRecent()
             d.transform { it.scanStatus }.isEqualTo(OK)
-            d.transform { it.applicationId }.isEqualTo(APPLICATION_ID)
+            d.transform { it.applicationId }.isEqualTo(application.id)
             d.transform { it.attachmentType }.isEqualTo(MUU)
         }
     }

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentServiceITest.kt
@@ -26,6 +26,7 @@ import fi.hel.haitaton.hanke.attachment.common.AttachmentScanStatus.OK
 import fi.hel.haitaton.hanke.attachment.common.AttachmentUploadException
 import fi.hel.haitaton.hanke.attachment.testFile
 import fi.hel.haitaton.hanke.factory.AlluDataFactory
+import fi.hel.haitaton.hanke.test.Asserts.isRecent
 import java.util.Optional
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -66,7 +67,7 @@ class ApplicationAttachmentServiceITest : DatabaseTest() {
             d.transform { it.id }.isNotNull()
             d.transform { it.fileName }.endsWith("file.pdf")
             d.transform { it.createdByUserId }.isEqualTo(USERNAME)
-            d.transform { it.createdAt }.isNotNull()
+            d.transform { it.createdAt }.isRecent()
             d.transform { it.scanStatus }.isEqualTo(OK)
             d.transform { it.applicationId }.isEqualTo(APPLICATION_ID)
             d.transform { it.attachmentType }.isEqualTo(MUU)
@@ -139,7 +140,7 @@ class ApplicationAttachmentServiceITest : DatabaseTest() {
         assertThat(result.id).isNotNull()
         assertThat(result.createdByUserId).isEqualTo(USERNAME)
         assertThat(result.fileName).isEqualTo(FILE_NAME_PDF)
-        assertThat(result.createdAt).isNotNull()
+        assertThat(result.createdAt).isRecent()
         assertThat(result.applicationId).isEqualTo(application.id)
         assertThat(result.attachmentType).isEqualTo(typeInput)
         assertThat(result.scanStatus).isEqualTo(OK)

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/geometria/GeometriatDaoImplITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/geometria/GeometriatDaoImplITest.kt
@@ -11,7 +11,6 @@ import assertk.assertions.isTrue
 import fi.hel.haitaton.hanke.DatabaseTest
 import fi.hel.haitaton.hanke.asJsonResource
 import java.time.ZonedDateTime
-import javax.transaction.Transactional
 import org.geojson.Point
 import org.geojson.Polygon
 import org.junit.jupiter.api.Test
@@ -25,7 +24,6 @@ import org.testcontainers.junit.jupiter.Testcontainers
 @Testcontainers
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("default")
-@Transactional
 internal class GeometriatDaoImplITest : DatabaseTest() {
 
     private val expectedPolygonArea = 1707f

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/geometria/GeometriatServiceImplITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/geometria/GeometriatServiceImplITest.kt
@@ -21,13 +21,11 @@ import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.security.test.context.support.WithMockUser
 import org.springframework.test.context.ActiveProfiles
-import org.springframework.transaction.annotation.Transactional
 import org.testcontainers.junit.jupiter.Testcontainers
 
 @Testcontainers
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("default")
-@Transactional
 @WithMockUser(username = "test", roles = ["haitaton-user"])
 internal class GeometriatServiceImplITest : DatabaseTest() {
 

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/logging/AuditLogServiceITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/logging/AuditLogServiceITests.kt
@@ -13,7 +13,6 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
-import org.springframework.transaction.annotation.Transactional
 import org.testcontainers.junit.jupiter.Testcontainers
 
 /**
@@ -27,7 +26,6 @@ import org.testcontainers.junit.jupiter.Testcontainers
 @Testcontainers
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("default")
-@Transactional
 class AuditLogServiceITests : DatabaseTest() {
 
     @Autowired private lateinit var entityManager: EntityManager
@@ -52,10 +50,6 @@ class AuditLogServiceITests : DatabaseTest() {
         val savedAuditLogEntry = auditLogService.createAll(listOf(auditLogEntry))[0]
 
         val id = savedAuditLogEntry.id
-        // Make sure the stuff is run to database (though not necessarily committed)
-        entityManager.flush()
-        // Ensure the original entity is no longer in Hibernate's 1st level cache
-        entityManager.clear()
         // Check it is there (using something else than the repository):
         val foundAuditLogEntry = entityManager.find(AuditLogEntryEntity::class.java, id)
         assertThat(foundAuditLogEntry).isNotNull()

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/PermissionServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/PermissionServiceITest.kt
@@ -18,13 +18,11 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.security.test.context.support.WithMockUser
 import org.springframework.test.context.ActiveProfiles
-import org.springframework.transaction.annotation.Transactional
 import org.testcontainers.junit.jupiter.Testcontainers
 
 @Testcontainers
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("default")
-@Transactional
 @WithMockUser(username = "test7358")
 class PermissionServiceITest : DatabaseTest() {
 

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluTormaysServicePGITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluTormaysServicePGITest.kt
@@ -9,7 +9,6 @@ import fi.hel.haitaton.hanke.DatabaseTest
 import fi.hel.haitaton.hanke.asJsonResource
 import fi.hel.haitaton.hanke.geometria.Geometriat
 import fi.hel.haitaton.hanke.geometria.GeometriatDao
-import javax.transaction.Transactional
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
@@ -19,7 +18,6 @@ import org.testcontainers.junit.jupiter.Testcontainers
 @Testcontainers
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("default")
-@Transactional
 internal class TormaystarkasteluTormaysServicePGITest : DatabaseTest() {
 
     @Autowired private lateinit var geometriatDao: GeometriatDao

--- a/services/hanke-service/src/integrationTest/resources/clear-db.sql
+++ b/services/hanke-service/src/integrationTest/resources/clear-db.sql
@@ -1,10 +1,10 @@
 TRUNCATE TABLE
+    application_attachment,
     applications,
     audit_logs,
     geometriat,
-    hanke_attachment,
-    application_attachment,
     hanke,
+    hanke_attachment,
     hanke_kayttaja,
     hankealue,
     hankegeometria,

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeServiceImpl.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeServiceImpl.kt
@@ -80,6 +80,7 @@ open class HankeServiceImpl(
     /**
      * Hanke does not contain hakemukset. This function wraps Hanke and its hakemukset to a pair.
      */
+    @Transactional(readOnly = true)
     override fun getHankeWithApplications(hankeTunnus: String): HankeWithApplications =
         hankeRepository.findByHankeTunnus(hankeTunnus).let { entity ->
             if (entity == null) {
@@ -91,22 +92,27 @@ open class HankeServiceImpl(
             )
         }
 
+    @Transactional(readOnly = true)
     override fun loadHanke(hankeTunnus: String) =
         hankeRepository.findByHankeTunnus(hankeTunnus)?.let {
             createHankeDomainObjectFromEntity(it)
         }
 
+    @Transactional(readOnly = true)
     override fun loadAllHanke() =
         hankeRepository.findAll().map { createHankeDomainObjectFromEntity(it) }
 
+    @Transactional(readOnly = true)
     override fun loadPublicHanke() =
         hankeRepository.findAllByStatus(HankeStatus.PUBLIC).map {
             createHankeDomainObjectFromEntity(it)
         }
 
+    @Transactional(readOnly = true)
     override fun loadHankkeetByIds(ids: List<Int>) =
         hankeRepository.findAllById(ids).map { createHankeDomainObjectFromEntity(it) }
 
+    @Transactional(readOnly = true)
     override fun loadHankkeetByUserId(userId: String) =
         hankeRepository.findAllByCreatedByUserIdOrModifiedByUserId(userId, userId).map {
             createHankeDomainObjectFromEntity(it)

--- a/services/hanke-service/src/main/resources/application.properties
+++ b/services/hanke-service/src/main/resources/application.properties
@@ -19,6 +19,7 @@ spring.datasource.username=${HAITATON_USER:haitaton_user}
 spring.datasource.password=${HAITATON_PASSWORD:haitaton}
 
 # JPA
+spring.jpa.open-in-view=false
 spring.jpa.database-platform=org.hibernate.dialect.PostgreSQL94Dialect
 # This makes the database field names to match the entity member names
 spring.jpa.hibernate.naming.physical-strategy=org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl

--- a/services/hanke-service/src/main/resources/db/changelog/changesets/034-add-delete-cascade-to-hankekayttajat.yml
+++ b/services/hanke-service/src/main/resources/db/changelog/changesets/034-add-delete-cascade-to-hankekayttajat.yml
@@ -1,0 +1,15 @@
+databaseChangeLog:
+  - changeSet:
+      id: 034-add-delete-cascade-to-hankekayttajat
+      author: Topias Heinonen
+      changes:
+        - dropForeignKeyConstraint:
+            baseTableName: hanke_kayttaja
+            constraintName: fk_hankekayttaja_hanke
+        - addForeignKeyConstraint:
+            baseTableName: hanke_kayttaja
+            baseColumnNames: hanke_id
+            constraintName: fk_hankekayttaja_hanke
+            referencedTableName: hanke
+            referencedColumnNames: id
+            onDelete: CASCADE

--- a/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -95,4 +95,5 @@ databaseChangeLog:
       file: db/changelog/changesets/032-create-liitetaulu-hanke.yml
   - include:
       file: db/changelog/changesets/033-create-liitetaulu-hakemus.yml
-
+  - include:
+      file: db/changelog/changesets/034-add-delete-cascade-to-hankekayttajat.yml


### PR DESCRIPTION
# Description

Remove `@Transactional` annotations from test classes, except from some single tests.

Having the transactions open for the duration of tests leads to the tests not reaching the database like they should. This means our tests won't test what they're supposed to. One bug avoided detection because of this (HAI-1618).

Dropping the annotations from test classes causes many tests to fail because the service methods don't manage their own transactions. This is because Open Session In View (OSIV) is enabled by default in Spring Boot, so the service methods have an open session when called inside a single dispatch.

Since we need to add `@Transactional` annotations to service methods anyway now, this is a good to disable OSIV and let the service layer manage their database sessions and transactions.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1617

## Type of change

- [X] Bug fix 
- [ ] New feature 
- [ ] Other