### PR TITLE
HAI-1601 Send email when johtoselvitys is ready

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/email/EmailSenderServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/email/EmailSenderServiceITest.kt
@@ -11,9 +11,9 @@ import com.icegreen.greenmail.configuration.GreenMailConfiguration
 import com.icegreen.greenmail.junit5.GreenMailExtension
 import com.icegreen.greenmail.util.ServerSetupTest
 import fi.hel.haitaton.hanke.DatabaseTest
+import fi.hel.haitaton.hanke.firstReceivedMessage
 import javax.mail.internet.MimeMessage
 import javax.mail.internet.MimeMultipart
-import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
 import org.springframework.beans.factory.annotation.Autowired
@@ -42,7 +42,7 @@ class EmailSenderServiceITest : DatabaseTest() {
             "JS2300001"
         )
 
-        val email = firstReceivedMessage()
+        val email = greenMail.firstReceivedMessage()
         assertThat(email.allRecipients).hasSize(1)
         assertThat(email.allRecipients[0].toString()).isEqualTo("test@test.test")
     }
@@ -55,7 +55,7 @@ class EmailSenderServiceITest : DatabaseTest() {
             "JS2300001"
         )
 
-        val email = firstReceivedMessage()
+        val email = greenMail.firstReceivedMessage()
         assertThat(email.from).hasSize(1)
         assertThat(email.from[0].toString()).isEqualTo("no-reply@hel.fi")
     }
@@ -68,7 +68,7 @@ class EmailSenderServiceITest : DatabaseTest() {
             "JS2300001"
         )
 
-        val email = firstReceivedMessage()
+        val email = greenMail.firstReceivedMessage()
         assertThat(email.subject).isEqualTo("Hakemanne johtoselvitys JS2300001 on käsitelty")
     }
 
@@ -80,7 +80,7 @@ class EmailSenderServiceITest : DatabaseTest() {
             "JS2300001"
         )
 
-        val email = firstReceivedMessage()
+        val email = greenMail.firstReceivedMessage()
         val (textBody, htmlBody) = getBodiesFromHybridEmail(email)
         assertThat(textBody).all {
             contains("JS2300001")
@@ -90,12 +90,6 @@ class EmailSenderServiceITest : DatabaseTest() {
             contains("JS2300001")
             contains("""<a href="http://localhost:3001/fi/hankesalkku/HAI23-001">""")
         }
-    }
-
-    private fun firstReceivedMessage(): MimeMessage {
-        val receivedMessages = greenMail.receivedMessages
-        assertEquals(1, receivedMessages.size)
-        return receivedMessages[0]
     }
 
     /** Returns a (text body, HTML body) pair. */

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/configuration/Configuration.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/configuration/Configuration.kt
@@ -16,6 +16,7 @@ import fi.hel.haitaton.hanke.attachment.application.ApplicationAttachmentService
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentRepository
 import fi.hel.haitaton.hanke.attachment.common.HankeAttachmentRepository
 import fi.hel.haitaton.hanke.attachment.hanke.HankeAttachmentService
+import fi.hel.haitaton.hanke.email.EmailSenderService
 import fi.hel.haitaton.hanke.geometria.GeometriatDao
 import fi.hel.haitaton.hanke.geometria.GeometriatDaoImpl
 import fi.hel.haitaton.hanke.geometria.GeometriatService
@@ -84,6 +85,7 @@ class Configuration {
         disclosureLogService: DisclosureLogService,
         applicationLoggingService: ApplicationLoggingService,
         hankeKayttajaService: HankeKayttajaService,
+        emailSenderService: EmailSenderService,
         geometriatDao: GeometriatDao,
         permissionService: PermissionService,
         hankeRepository: HankeRepository,
@@ -95,6 +97,7 @@ class Configuration {
             disclosureLogService,
             applicationLoggingService,
             hankeKayttajaService,
+            emailSenderService,
             geometriatDao,
             permissionService,
             hankeRepository,

--- a/services/hanke-service/src/main/resources/email/template/johtoselvitys-valmis.html.mustache
+++ b/services/hanke-service/src/main/resources/email/template/johtoselvitys-valmis.html.mustache
@@ -1,9 +1,9 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html>
+<html lang="fi">
 <body>
 <p>Hakemanne johtoselvitys {{applicationIdentifier}} on käsitelty. Lataa selvitys Haitattomasta (<a href="{{baseUrl}}/fi/hankesalkku/{{hankeTunnus}}">{{baseUrl}}/fi/hankesalkku/{{hankeTunnus}}</a>) ja tutustu sen sisältöön huolellisesti.</p>
 
-<p>Miten onnistuimme? Kerro mielipiteesi <a href="">täällä</a>.</p>
+<p>Miten onnistuimme? Kerro mielipiteesi <a href="https://response.questback.com/isa/qbv.dll/bylink?p=x6TIpQ4sCcJt9Dv1T-AuuKa-DssX27rx6er2ohTVVipooPTA8H0u-weNFWY9GsVI0">täällä</a>.</p>
 
 
 

--- a/services/hanke-service/src/main/resources/email/template/johtoselvitys-valmis.text.mustache
+++ b/services/hanke-service/src/main/resources/email/template/johtoselvitys-valmis.text.mustache
@@ -1,6 +1,6 @@
 Hakemanne johtoselvitys {{applicationIdentifier}} on käsitelty. Lataa selvitys Haitattomasta ({{baseUrl}}/fi/hankesalkku/{{hankeTunnus}}) ja tutustu sen sisältöön huolellisesti.
 
-Miten onnistuimme? Kerro mielipiteesi täällä.
+Miten onnistuimme? Kerro mielipiteesi täällä: https://response.questback.com/isa/qbv.dll/bylink?p=x6TIpQ4sCcJt9Dv1T-AuuKa-DssX27rx6er2ohTVVipooPTA8H0u-weNFWY9GsVI0.
 
 
 

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/TestExtensions.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/TestExtensions.kt
@@ -1,11 +1,14 @@
 package fi.hel.haitaton.hanke
 
 import com.fasterxml.jackson.module.kotlin.readValue
+import com.icegreen.greenmail.junit5.GreenMailExtension
 import fi.hel.haitaton.hanke.logging.AuditLogRepository
 import fi.hel.haitaton.hanke.logging.ObjectType
 import java.nio.charset.StandardCharsets
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
+import javax.mail.internet.MimeMessage
+import org.junit.jupiter.api.Assertions
 import org.springframework.test.web.servlet.ResultActions
 
 fun <T> String.asJsonResource(type: Class<T>): T =
@@ -31,6 +34,11 @@ fun AuditLogRepository.findByType(type: ObjectType) =
     this.findAll().filter { it.message.auditEvent.target.type == type }
 
 fun OffsetDateTime.asUtc(): OffsetDateTime = this.withOffsetSameInstant(ZoneOffset.UTC)
+
+fun GreenMailExtension.firstReceivedMessage(): MimeMessage {
+    Assertions.assertEquals(1, receivedMessages.size)
+    return receivedMessages[0]
+}
 
 /**
  * "Uses" a variable without doing anything with it. Used to avoid "Parameter is never used"

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/AlluDataFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/AlluDataFactory.kt
@@ -18,6 +18,7 @@ import fi.hel.haitaton.hanke.application.CustomerWithContacts
 import fi.hel.haitaton.hanke.application.PostalAddress
 import fi.hel.haitaton.hanke.application.StreetAddress
 import fi.hel.haitaton.hanke.asJsonResource
+import fi.hel.haitaton.hanke.factory.AlluDataFactory.Companion.withContacts
 import java.time.ZonedDateTime
 import org.geojson.Polygon
 import org.springframework.stereotype.Component
@@ -28,6 +29,7 @@ class AlluDataFactory(val applicationRepository: ApplicationRepository) {
         const val defaultApplicationId: Long = 1
         const val defaultApplicationName: String = "Johtoselvityksen oletusnimi"
         const val defaultApplicationIdentifier: String = "JS230014"
+        const val teppoEmail = "teppo@example.test"
 
         fun createPostalAddress(
             streetAddress: String = "Katu 1",
@@ -39,7 +41,7 @@ class AlluDataFactory(val applicationRepository: ApplicationRepository) {
             type: CustomerType? = CustomerType.PERSON,
             name: String = "Teppo Testihenkilö",
             country: String = "FI",
-            email: String? = "teppo@example.test",
+            email: String? = teppoEmail,
             phone: String? = "04012345678",
             registryKey: String? = "281192-937W",
             ovt: String? = null,
@@ -81,13 +83,27 @@ class AlluDataFactory(val applicationRepository: ApplicationRepository) {
                 sapCustomerNumber
             )
 
+        fun createCompanyCustomerWithOrderer(): CustomerWithContacts {
+            val customer = createCompanyCustomer()
+            val contact = createContact(orderer = true)
+            return CustomerWithContacts(customer, listOf(contact))
+        }
+
+        fun ApplicationEntity.withCustomer(customer: CustomerWithContacts): ApplicationEntity {
+            applicationData =
+                (applicationData as CableReportApplicationData).copy(
+                    customerWithContacts = customer
+                )
+            return this
+        }
+
         fun Customer.withContacts(vararg contacts: Contact): CustomerWithContacts =
             CustomerWithContacts(this, contacts.asList())
 
         fun createContact(
             firstName: String? = "Teppo",
             lastName: String? = "Testihenkilö",
-            email: String? = "teppo@example.test",
+            email: String? = teppoEmail,
             phone: String? = "04012345678",
             orderer: Boolean = false
         ) = Contact(firstName, lastName, email, phone, orderer)
@@ -214,6 +230,11 @@ class AlluDataFactory(val applicationRepository: ApplicationRepository) {
                 applicationData,
                 hanke = hanke,
             )
+
+        fun ApplicationEntity.withHanke(hanke: HankeEntity): ApplicationEntity {
+            this.hanke = hanke
+            return this
+        }
 
         fun createAlluApplicationResponse(
             id: Int = 42,

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/ApplicationHistoryFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/ApplicationHistoryFactory.kt
@@ -39,6 +39,12 @@ object ApplicationHistoryFactory {
             supervisionEvents = listOf()
         )
 
+    fun create(
+        applicationId: Int = defaultApplicationId,
+        vararg events: ApplicationStatusEvent,
+    ): ApplicationHistory =
+        ApplicationHistory(applicationId, events = events.toList(), supervisionEvents = listOf())
+
     /** Create a status event for an application. */
     fun createEvent(
         eventTime: ZonedDateTime = defaultEventTime,

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeYhteystietoFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeYhteystietoFactory.kt
@@ -13,7 +13,7 @@ object HankeYhteystietoFactory {
         return HankeYhteystieto(
             id = id,
             nimi = "Teppo Testihenkilö",
-            email = "teppo@example.test",
+            email = AlluDataFactory.teppoEmail,
             puhelinnumero = "04012345678",
             organisaatioId = organisaatioId,
             organisaatioNimi = "Organisaatio",


### PR DESCRIPTION
# Description

Send the notification email only to the orderer of the application. That contact is where the applicant has filled in their own information.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1601

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
This can only be tested in the local environment.

1. Make a johtoselvityshakemus.
2. Create a decision for it in Allu.
3. Check that there's a new email in http://localhost:3003/ 

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have run the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to Confluence
 or other location: 

# Other relevant info
This uses new test functionality enabled in HAI-1556 (#299, #300), so those PRs should be merged first. They are in turn waiting for HAI-1274 (#292).