### PR TITLE
HAI-1557 Spring Boot upgrade to 2.5

### DIFF
--- a/services/hanke-service/build.gradle.kts
+++ b/services/hanke-service/build.gradle.kts
@@ -55,8 +55,8 @@ spotless {
 }
 
 plugins {
-	id("org.springframework.boot") version "2.4.13"
-	id("io.spring.dependency-management") version "1.0.10.RELEASE"
+	id("org.springframework.boot") version "2.5.14"
+	id("io.spring.dependency-management") version "1.1.0"
 	id("com.diffplug.spotless") version "6.10.0"
 	kotlin("jvm") version "1.6.10"
 	// Gives kotlin-allopen, which auto-opens classes with certain annotations

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
@@ -1060,7 +1060,7 @@ class HankeServiceITests : DatabaseTest() {
         assertThat(alue.geometriat).isNotNull
         entityManager.flush()
         entityManager.clear()
-        val hankeFromDb = hankeRepository.getOne(updatedHanke.id!!)
+        val hankeFromDb = hankeRepository.getById(updatedHanke.id!!)
         assertThat(hankeFromDb.listOfHankeAlueet).hasSize(1)
         assertThat(hankealueCount()).isEqualTo(1)
         assertThat(geometriatCount()).isEqualTo(1)

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceITest.kt
@@ -803,7 +803,7 @@ class ApplicationServiceITest : DatabaseTest() {
     @Test
     fun `updateApplicationData throws exception when application area is outside hankealue`() {
         val hanke = hankeService.createHanke(HankeFactory.create().withHankealue())
-        val hankeEntity = hankeRepository.getOne(hanke.id!!)
+        val hankeEntity = hankeRepository.getById(hanke.id!!)
         val application =
             alluDataFactory.saveApplicationEntity(USERNAME, hanke = hankeEntity) { it.alluid = 21 }
         val cableReportApplicationData =
@@ -1049,7 +1049,7 @@ class ApplicationServiceITest : DatabaseTest() {
     @Test
     fun `sendApplication throws exception when application area is outside hankealue`() {
         val hanke = hankeService.createHanke(HankeFactory.create().withHankealue())
-        val hankeEntity = hankeRepository.getOne(hanke.id!!)
+        val hankeEntity = hankeRepository.getById(hanke.id!!)
         val application =
             alluDataFactory.saveApplicationEntity(USERNAME, hanke = hankeEntity) {
                 it.applicationData =

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/AttachmentServiceITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/AttachmentServiceITests.kt
@@ -164,7 +164,7 @@ class AttachmentServiceITests : DatabaseTest() {
                     byteArrayOf(1, 2, 3, 4)
                 )
             )
-        val att = hankeAttachmentRepository.getOne(result.id!!)
+        val att = hankeAttachmentRepository.getById(result.id!!)
         att.scanStatus = AttachmentScanStatus.PENDING
         hankeAttachmentRepository.save(att)
 
@@ -185,7 +185,7 @@ class AttachmentServiceITests : DatabaseTest() {
                     byteArrayOf(1, 2, 3, 4)
                 )
             )
-        val att = hankeAttachmentRepository.getOne(result.id!!)
+        val att = hankeAttachmentRepository.getById(result.id!!)
         att.scanStatus = AttachmentScanStatus.FAILED
         hankeAttachmentRepository.save(att)
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationService.kt
@@ -209,7 +209,7 @@ open class ApplicationService(
         updateTime: OffsetDateTime
     ) {
         applicationHistories.forEach { handleApplicationUpdate(it) }
-        val status = alluStatusRepository.getOne(1)
+        val status = alluStatusRepository.getById(1)
         status.historyLastUpdated = updateTime
         alluStatusRepository.save(status)
     }
@@ -354,6 +354,7 @@ open class ApplicationService(
     }
 
     private fun updateApplicationInAllu(alluid: Int, applicationData: ApplicationData) {
+        logger.info { "Uploading updated application with alluId $alluid" }
         when (applicationData) {
             is CableReportApplicationData -> updateCableReportInAllu(alluid, applicationData)
         }


### PR DESCRIPTION
# Description

Upgrade Spring Boot  to 2.5

`getOne` has been deprecated, so replace with `getById`.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1557

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [X] Other