### PR TITLE
HAI-1558 Upgrade to Spring Boot 2.6

### DIFF
--- a/services/hanke-service/build.gradle.kts
+++ b/services/hanke-service/build.gradle.kts
@@ -5,7 +5,6 @@ import org.springframework.boot.gradle.tasks.run.BootRun
 group = "fi.hel.haitaton"
 version = "0.0.1-SNAPSHOT"
 java.sourceCompatibility = JavaVersion.VERSION_11
-val postgreSQLVersion = "42.2.18"
 val springDocVersion = "1.6.12"
 val geoJsonJacksonVersion = "1.14"
 val mockkVersion = "1.13.5"
@@ -55,14 +54,14 @@ spotless {
 }
 
 plugins {
-	id("org.springframework.boot") version "2.5.14"
+	id("org.springframework.boot") version "2.6.14"
 	id("io.spring.dependency-management") version "1.1.0"
 	id("com.diffplug.spotless") version "6.10.0"
-	kotlin("jvm") version "1.6.10"
+	kotlin("jvm") version "1.6.21"
 	// Gives kotlin-allopen, which auto-opens classes with certain annotations
-	kotlin("plugin.spring") version "1.6.10"
+	kotlin("plugin.spring") version "1.6.21"
 	// Gives kotlin-noarg for @Entity, @Embeddable
-	kotlin("plugin.jpa") version "1.6.10"
+	kotlin("plugin.jpa") version "1.6.21"
 	idea
 }
 
@@ -88,7 +87,7 @@ dependencies {
 	implementation("com.github.librepdf:openpdf:1.3.30")
 	implementation("net.pwall.mustache:kotlin-mustache:0.10")
 
-	implementation("org.postgresql:postgresql:$postgreSQLVersion")
+	implementation("org.postgresql:postgresql")
 	implementation("org.springdoc:springdoc-openapi-kotlin:$springDocVersion")
 	implementation("org.springdoc:springdoc-openapi-ui:$springDocVersion")
 
@@ -98,11 +97,14 @@ dependencies {
 	testImplementation("io.mockk:mockk:$mockkVersion")
 	testImplementation("com.ninja-squad:springmockk:$springmockkVersion")
 	testImplementation("com.willowtreeapps.assertk:assertk-jvm:$assertkVersion")
-	testImplementation("org.testcontainers:junit-jupiter:1.15.3")
-	testImplementation("org.testcontainers:postgresql:1.15.2")
 	testImplementation("com.squareup.okhttp3:okhttp:4.9.3")
 	testImplementation("com.squareup.okhttp3:mockwebserver:4.9.3")
 	testImplementation("com.icegreen:greenmail-junit5:1.6.14")
+
+	// Testcontainers
+	implementation(platform("org.testcontainers:testcontainers-bom:1.18.0"))
+	testImplementation("org.testcontainers:junit-jupiter")
+	testImplementation("org.testcontainers:postgresql")
 
 	// Spring Boot Management
 	implementation("org.springframework.boot:spring-boot-starter-actuator")
@@ -136,7 +138,6 @@ tasks {
 		shouldRunAfter("test")
 		outputs.upToDateWhen { false }
 	}
-
 }
 
 tasks.register("installGitHook", Copy::class) {

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/DatabaseTest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/DatabaseTest.kt
@@ -1,14 +1,11 @@
 package fi.hel.haitaton.hanke
 
-import org.springframework.jdbc.core.RowMapper
 import org.springframework.test.context.DynamicPropertyRegistry
 import org.springframework.test.context.DynamicPropertySource
 import org.springframework.test.context.jdbc.Sql
 import org.springframework.test.context.jdbc.SqlMergeMode
 import org.testcontainers.junit.jupiter.Container
 import org.testcontainers.utility.MountableFile
-
-val countMapper = RowMapper { rs, _ -> rs.getInt(1) }
 
 /**
  * Start a Docker container running PostgreSQL with the PostGIS extension. Tests extending this
@@ -27,10 +24,9 @@ abstract class DatabaseTest {
         @Container
         private val container: HaitatonPostgreSQLContainer =
             HaitatonPostgreSQLContainer()
-                .withExposedPorts(5433) // use non-default port
                 .withPassword("test")
                 .withUsername("test")
-                .withCopyFileToContainer(
+                .withCopyToContainer(
                     MountableFile.forClasspathResource(
                         "/fi/hel/haitaton/hanke/tormaystarkastelu/HEL-GIS-data-test.sql"
                     ),


### PR DESCRIPTION
# Description

The upgrade brought with it a new version of AssertJ, which added an overloaded version of `allSatisfy`, which Kotlin can't separate from the previous one. After looking in to how to circumvent the issue, I found it simplest to replace those with asserts with assertk.

Also upgrade the two dependencies, which were giving security warnings in IDEA: PostgreSQL JDBC Driver and Testcontainers. Not that they would be the most critical, but you have to start somewhere.

Testcontainers had a change in 1.16.0 where they
> Only publish exposed ports (#4122)

This caused issues for us, since it seems like there has been a misundestanding on what exposed ports in Testcontainers mean. We were exposing a non-standard port in the Postgres container, probably to not collide with the database running on the host machine. But the exposed ports are from the perspective of the container. All ports are mapped to random ports on the host. So we were telling Testcontainers that the container has an open port 5433 we would like to share to the world, even though Postgres was running in port 5432. The reason it had worked previously, was because Testcontainers exposed all open ports on the container anyway.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1558

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [X] Other