### PR TITLE
HAI-1274 Fix multipart request param bug

### DIFF
--- a/services/hanke-service/build.gradle.kts
+++ b/services/hanke-service/build.gradle.kts
@@ -84,7 +84,7 @@ dependencies {
 	implementation("org.liquibase:liquibase-core")
 	implementation("com.github.blagerweij:liquibase-sessionlock:1.4.0")
 	implementation("com.vladmihalcea:hibernate-types-52:2.14.0")
-	implementation("commons-fileupload:commons-fileupload:1.5")
+	implementation("commons-io:commons-io:2.11.0")
 	implementation("com.github.librepdf:openpdf:1.3.30")
 	implementation("net.pwall.mustache:kotlin-mustache:0.10")
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/configuration/Configuration.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/configuration/Configuration.kt
@@ -42,8 +42,6 @@ import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Profile
 import org.springframework.http.client.reactive.ReactorClientHttpConnector
 import org.springframework.jdbc.core.JdbcOperations
-import org.springframework.web.multipart.MultipartResolver
-import org.springframework.web.multipart.commons.CommonsMultipartResolver
 import org.springframework.web.reactive.function.client.WebClient
 import reactor.netty.http.client.HttpClient
 
@@ -75,11 +73,6 @@ class Configuration {
             SslContextBuilder.forClient().trustManager(InsecureTrustManagerFactory.INSTANCE).build()
         val httpClient = HttpClient.create().secure { t -> t.sslContext(sslContext) }
         return webClientBuilder.clientConnector(ReactorClientHttpConnector(httpClient))
-    }
-
-    @Bean
-    fun multipartResolver(): MultipartResolver {
-        return CommonsMultipartResolver()
     }
 
     @Bean


### PR DESCRIPTION
After upgrading spring boot version, attachment uploads seem to fail.

- MissingServletRequestPartException: Required request part 'liite' is not present

Problem seems to happen due to multipartresolver bean from apache. Spring Boot should work with multipart files without any additional configuration beans.

Removing the mentioned bean seems to solve the upload issue at least locally.

## Type of change

- [x] Bug fix 
- [ ] New feature 
- [ ] Other

# Instructions for testing
Please describe tests how this change or new feature can be tested.

# Checklist:

- [ ] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 