### PR TITLE
HAI-1562 Fix auth for users with ad groups

### DIFF
--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/security/OAuth2ResourceServerSecurityConfiguration.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/security/OAuth2ResourceServerSecurityConfiguration.kt
@@ -41,7 +41,7 @@ class UserInfoOpaqueTokenIntrospector(private val userinfoUri: String) : OpaqueT
                 .uri(userinfoUri)
                 .headers { it.setBearerAuth(token) }
                 .retrieve()
-                .bodyToMono(object : ParameterizedTypeReference<Map<String, String>>() {})
+                .bodyToMono(object : ParameterizedTypeReference<Map<String, Any>>() {})
                 .block()
 
         return DefaultOAuth2User(listOf(), attributes, "sub")


### PR DESCRIPTION
# Description

The response from the userinfo query was read as a String -> String map, which broke down when the response contains `ad_groups`, which is an array.

Fix this by only reading a String -> Any map instead.

### Jira Issue:  https://helsinkisolutionoffice.atlassian.net/browse/HAI-1562

## Type of change

- [X] Bug fix 
- [ ] New feature 
- [ ] Other

# Other relevant info
Alternative to #313 