### PR TITLE
HAI-1562 Fix auth for users with ad groups

### DIFF
--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/security/OAuth2ResourceServerSecurityConfiguration.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/security/OAuth2ResourceServerSecurityConfiguration.kt
@@ -1,9 +1,9 @@
 package fi.hel.haitaton.hanke.security
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.core.ParameterizedTypeReference
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configurers.oauth2.server.resource.OAuth2ResourceServerConfigurer
 import org.springframework.security.oauth2.core.OAuth2AuthenticatedPrincipal
@@ -41,9 +41,11 @@ class UserInfoOpaqueTokenIntrospector(private val userinfoUri: String) : OpaqueT
                 .uri(userinfoUri)
                 .headers { it.setBearerAuth(token) }
                 .retrieve()
-                .bodyToMono(object : ParameterizedTypeReference<Map<String, String>>() {})
+                .bodyToMono(UserInfoResponse::class.java)
                 .block()
 
-        return DefaultOAuth2User(listOf(), attributes, "sub")
+        return DefaultOAuth2User(listOf(), mapOf("sub" to attributes?.sub), "sub")
     }
 }
+
+@JsonIgnoreProperties(ignoreUnknown = true) data class UserInfoResponse(val sub: String)


### PR DESCRIPTION
# Description

The response from the userinfo query was read as a String -> String map, which broke down when the response contains `ad_groups`, which is an array.

Fix this by only reading the `sub` field from the response, since it's the only one we care about.

### Jira Issue:  https://helsinkisolutionoffice.atlassian.net/browse/HAI-1562

## Type of change

- [X] Bug fix 
- [ ] New feature 
- [ ] Other

# Other relevant info
Alternative to #312