### PR TITLE
HAI-1626 Increase allowed size of uploaded attachment files.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,7 @@ services:
       - CLAMD_IP=clamd
       - APP_FORM_KEY=FILES
       - APP_PORT=3030
+      - APP_MAX_FILE_SIZE=104857600
     ports:
       - '3030:3030'
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       - CLAMD_IP=clamd
       - APP_FORM_KEY=FILES
       - APP_PORT=3030
-      - APP_MAX_FILE_SIZE=104857600
+      - APP_MAX_FILE_SIZE=105906176
     ports:
       - '3030:3030'
     networks:

--- a/scripts/nginx/nginx.conf
+++ b/scripts/nginx/nginx.conf
@@ -14,7 +14,7 @@ server {
     proxy_pass http://docker-frontend;
   }
 
-  client_max_body_size 100M;
+  client_max_body_size 101M;
 
   location /api/ {
     proxy_pass  http://docker-backend/;

--- a/scripts/nginx/nginx.conf
+++ b/scripts/nginx/nginx.conf
@@ -14,6 +14,8 @@ server {
     proxy_pass http://docker-frontend;
   }
 
+  client_max_body_size 100M;
+
   location /api/ {
     proxy_pass  http://docker-backend/;
     proxy_redirect  http://docker-backend/ /api/;

--- a/services/hanke-service/src/main/resources/application.properties
+++ b/services/hanke-service/src/main/resources/application.properties
@@ -25,6 +25,9 @@ spring.jpa.hibernate.naming.physical-strategy=org.hibernate.boot.model.naming.Ph
 # Don't log SQL queries. This is the default, but left here to make it easy to enable while developing.
 spring.jpa.show-sql=false
 
+spring.servlet.multipart.max-file-size=100MB
+spring.servlet.multipart.max-request-size=100MB
+
 # Spring Boot Actuator Management for Kubernetes (see https://docs.spring.io/spring-boot/docs/2.3.4.RELEASE/reference/html/production-ready-features.html#production-ready-kubernetes-probes)
 # Use separate HTTP port for probes
 management.server.port=8081

--- a/services/hanke-service/src/main/resources/application.properties
+++ b/services/hanke-service/src/main/resources/application.properties
@@ -25,8 +25,8 @@ spring.jpa.hibernate.naming.physical-strategy=org.hibernate.boot.model.naming.Ph
 # Don't log SQL queries. This is the default, but left here to make it easy to enable while developing.
 spring.jpa.show-sql=false
 
-spring.servlet.multipart.max-file-size=100MB
-spring.servlet.multipart.max-request-size=100MB
+spring.servlet.multipart.max-file-size=101MB
+spring.servlet.multipart.max-request-size=101MB
 
 # Spring Boot Actuator Management for Kubernetes (see https://docs.spring.io/spring-boot/docs/2.3.4.RELEASE/reference/html/production-ready-features.html#production-ready-kubernetes-probes)
 # Use separate HTTP port for probes


### PR DESCRIPTION
# Description

Increase allowed size of multipart files.

Changes:
1. Increase the allowed size for clamav rest api in docker-compose (local development).
2. Increase the allowed size for nginx (local development).
3. Increase the allowed size in application.properties (all envs.)


### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1626

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [x] Other

# Instructions for testing
Files of size up to 100MB can be uploaded.

# Checklist:
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 

# Other relevant info
Please describe here if there is e.g. some requirements for this change or
 other info that the tester/user needs to know.