### PR TITLE
HAI-1545 Send added attachment if application PENDING

### DIFF
--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationService.kt
@@ -216,10 +216,6 @@ open class ApplicationService(
         return applicationRepository.save(application).toApplication()
     }
 
-    open fun sendAttachment(alluId: Int, attachment: Attachment) {
-        cableReportService.addAttachment(alluId, attachment)
-    }
-
     @Transactional
     open fun handleApplicationUpdates(
         applicationHistories: List<ApplicationHistory>,

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationService.kt
@@ -14,7 +14,7 @@ import fi.hel.haitaton.hanke.allu.ApplicationStatusEvent
 import fi.hel.haitaton.hanke.allu.Attachment
 import fi.hel.haitaton.hanke.allu.AttachmentMetadata
 import fi.hel.haitaton.hanke.allu.CableReportService
-import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentEntity
+import fi.hel.haitaton.hanke.attachment.application.ApplicationAttachmentService
 import fi.hel.haitaton.hanke.email.EmailSenderService
 import fi.hel.haitaton.hanke.geometria.GeometriatDao
 import fi.hel.haitaton.hanke.logging.ApplicationLoggingService
@@ -43,6 +43,7 @@ open class ApplicationService(
     private val applicationLoggingService: ApplicationLoggingService,
     private val hankeKayttajaService: HankeKayttajaService,
     private val emailSenderService: EmailSenderService,
+    private val attachmentService: ApplicationAttachmentService,
     private val geometriatDao: GeometriatDao,
     private val permissionService: PermissionService,
     private val hankeRepository: HankeRepository,
@@ -446,18 +447,9 @@ open class ApplicationService(
                 is CableReportApplicationData -> createCableReportToAllu(applicationData)
             }
 
-        sendAllAttachments(alluId, application.attachments)
+        attachmentService.sendAllAttachments(alluId, application.attachments)
 
         return alluId
-    }
-
-    private fun sendAllAttachments(alluId: Int, attachments: List<ApplicationAttachmentEntity>) {
-        if (attachments.isEmpty()) {
-            logger.info { "No attachments to send for alluId $alluId" }
-            return
-        }
-        val alluAttachments = attachments.map { it.toAlluAttachment() }
-        cableReportService.addAttachments(alluId, alluAttachments)
     }
 
     private fun createCableReportToAllu(

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationService.kt
@@ -216,6 +216,10 @@ open class ApplicationService(
         return applicationRepository.save(application).toApplication()
     }
 
+    open fun sendAttachment(alluId: Int, attachment: Attachment) {
+        cableReportService.addAttachment(alluId, attachment)
+    }
+
     @Transactional
     open fun handleApplicationUpdates(
         applicationHistories: List<ApplicationHistory>,

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentController.kt
@@ -107,7 +107,7 @@ class ApplicationAttachmentController(
     @PostMapping
     @Operation(
         summary = "Upload attachment for application",
-        description = "File is available for downloading after successful virus scan."
+        description = "Upload. Attachment is sent to Allu if application has been sent there."
     )
     @ApiResponses(
         value =

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentController.kt
@@ -107,7 +107,8 @@ class ApplicationAttachmentController(
     @PostMapping
     @Operation(
         summary = "Upload attachment for application",
-        description = "Upload. Attachment is sent to Allu if application has been sent there."
+        description =
+            "Upload attachment. Sent to Allu if application has been sent but it is not yet in handling."
     )
     @ApiResponses(
         value =

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/configuration/Configuration.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/configuration/Configuration.kt
@@ -13,10 +13,6 @@ import fi.hel.haitaton.hanke.allu.CableReportServiceAllu
 import fi.hel.haitaton.hanke.application.ApplicationRepository
 import fi.hel.haitaton.hanke.application.ApplicationService
 import fi.hel.haitaton.hanke.attachment.application.ApplicationAttachmentService
-import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentRepository
-import fi.hel.haitaton.hanke.attachment.common.FileScanClient
-import fi.hel.haitaton.hanke.attachment.common.HankeAttachmentRepository
-import fi.hel.haitaton.hanke.attachment.hanke.HankeAttachmentService
 import fi.hel.haitaton.hanke.email.EmailSenderService
 import fi.hel.haitaton.hanke.geometria.GeometriatDao
 import fi.hel.haitaton.hanke.geometria.GeometriatDaoImpl
@@ -87,6 +83,7 @@ class Configuration {
         applicationLoggingService: ApplicationLoggingService,
         hankeKayttajaService: HankeKayttajaService,
         emailSenderService: EmailSenderService,
+        applicationAttachmentService: ApplicationAttachmentService,
         geometriatDao: GeometriatDao,
         permissionService: PermissionService,
         hankeRepository: HankeRepository,
@@ -99,6 +96,7 @@ class Configuration {
             applicationLoggingService,
             hankeKayttajaService,
             emailSenderService,
+            applicationAttachmentService,
             geometriatDao,
             permissionService,
             hankeRepository,
@@ -166,30 +164,6 @@ class Configuration {
             luokitteluRajaArvotService,
             perusIndeksiPainotService,
             tormaystarkasteluDao
-        )
-
-    @Bean
-    fun hankeAttachmentsService(
-        hankeRepository: HankeRepository,
-        hankeAttachmentRepository: HankeAttachmentRepository,
-        scanClient: FileScanClient,
-    ): HankeAttachmentService =
-        HankeAttachmentService(hankeRepository, hankeAttachmentRepository, scanClient)
-
-    @Bean
-    fun applicationAttachmentsService(
-        applicationService: ApplicationService,
-        cableReportService: CableReportService,
-        applicationRepository: ApplicationRepository,
-        applicationAttachmentRepository: ApplicationAttachmentRepository,
-        scanClient: FileScanClient,
-    ): ApplicationAttachmentService =
-        ApplicationAttachmentService(
-            applicationService,
-            cableReportService,
-            applicationRepository,
-            applicationAttachmentRepository,
-            scanClient,
         )
 
     companion object {

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/configuration/Configuration.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/configuration/Configuration.kt
@@ -179,12 +179,14 @@ class Configuration {
     @Bean
     fun applicationAttachmentsService(
         applicationService: ApplicationService,
+        cableReportService: CableReportService,
         applicationRepository: ApplicationRepository,
         applicationAttachmentRepository: ApplicationAttachmentRepository,
         scanClient: FileScanClient,
     ): ApplicationAttachmentService =
         ApplicationAttachmentService(
             applicationService,
+            cableReportService,
             applicationRepository,
             applicationAttachmentRepository,
             scanClient,

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/configuration/Configuration.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/configuration/Configuration.kt
@@ -178,14 +178,16 @@ class Configuration {
 
     @Bean
     fun applicationAttachmentsService(
+        applicationService: ApplicationService,
         applicationRepository: ApplicationRepository,
         applicationAttachmentRepository: ApplicationAttachmentRepository,
         scanClient: FileScanClient,
     ): ApplicationAttachmentService =
         ApplicationAttachmentService(
+            applicationService,
             applicationRepository,
             applicationAttachmentRepository,
-            scanClient
+            scanClient,
         )
 
     companion object {

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceTest.kt
@@ -18,6 +18,7 @@ import fi.hel.haitaton.hanke.allu.AlluStatusRepository
 import fi.hel.haitaton.hanke.allu.ApplicationStatus
 import fi.hel.haitaton.hanke.allu.CableReportService
 import fi.hel.haitaton.hanke.asJsonResource
+import fi.hel.haitaton.hanke.attachment.application.ApplicationAttachmentService
 import fi.hel.haitaton.hanke.email.EmailSenderService
 import fi.hel.haitaton.hanke.factory.AlluDataFactory
 import fi.hel.haitaton.hanke.factory.AlluDataFactory.Companion.withContacts
@@ -73,6 +74,7 @@ class ApplicationServiceTest {
     private val permissionService: PermissionService = mockk()
     private val emailSenderService: EmailSenderService = mockk()
     private val hankeKayttajaService: HankeKayttajaService = mockk(relaxUnitFun = true)
+    private val attachmentService: ApplicationAttachmentService = mockk()
 
     private val applicationService: ApplicationService =
         ApplicationService(
@@ -83,6 +85,7 @@ class ApplicationServiceTest {
             applicationLoggingService,
             hankeKayttajaService,
             emailSenderService,
+            attachmentService,
             geometriatDao,
             permissionService,
             hankeRepository,
@@ -265,6 +268,7 @@ class ApplicationServiceTest {
         every { geometriatDao.calculateCombinedArea(any()) } returns 100f
         every { geometriatDao.calculateArea(any()) } returns 100f
         every { geometriatDao.isInsideHankeAlueet(1, any()) } returns true
+        justRun { attachmentService.sendAllAttachments(42, any()) }
 
         applicationService.sendApplication(3, username)
 
@@ -278,6 +282,7 @@ class ApplicationServiceTest {
             cableReportService.create(any())
             disclosureLogService.saveDisclosureLogsForAllu(expectedApplication, Status.SUCCESS)
             cableReportService.addAttachment(42, any())
+            attachmentService.sendAllAttachments(42, any())
             cableReportService.getApplicationInformation(42)
             applicationRepo.save(any())
         }
@@ -370,6 +375,7 @@ class ApplicationServiceTest {
         justRun { cableReportService.addAttachment(852, any()) }
         every { cableReportService.getApplicationInformation(852) } returns
             AlluDataFactory.createAlluApplicationResponse(852)
+        justRun { attachmentService.sendAllAttachments(852, any()) }
 
         applicationService.sendApplication(3, username)
 


### PR DESCRIPTION
# Description

Part 2/3 of sending attachments to Allu. After initial sending, if another attachment is added, it should be sent to Allu if application status is PENDING.

Note: the prevention of adding / deleting attachments after handling has started in Allu will be implemented in the next pr.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1545

## Type of change

- [ ] Bug fix 
- [x] New feature 
- [ ] Other

# Instructions for testing
1. Create application, send to allu. Add attachment. Should be sent.
2. Create application, add attachments, should not send.


# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)