### PR TITLE
HAI-1303 Add endpoint for deleting personal information

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/IntegrationTestConfiguration.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/IntegrationTestConfiguration.kt
@@ -3,7 +3,7 @@ package fi.hel.haitaton.hanke
 import fi.hel.haitaton.hanke.application.ApplicationService
 import fi.hel.haitaton.hanke.attachment.application.ApplicationAttachmentService
 import fi.hel.haitaton.hanke.attachment.hanke.HankeAttachmentService
-import fi.hel.haitaton.hanke.gdpr.GdprJsonConverter
+import fi.hel.haitaton.hanke.gdpr.GdprService
 import fi.hel.haitaton.hanke.geometria.GeometriatDao
 import fi.hel.haitaton.hanke.geometria.GeometriatService
 import fi.hel.haitaton.hanke.logging.AuditLogRepository
@@ -44,7 +44,7 @@ class IntegrationTestConfiguration {
 
     @Bean fun applicationService(): ApplicationService = mockk()
 
-    @Bean fun gdprJsonConverter(): GdprJsonConverter = mockk()
+    @Bean fun gdprService(): GdprService = mockk(relaxUnitFun = true)
 
     @Bean fun permissionService(): PermissionService = mockk()
 

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/gdpr/GdprServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/gdpr/GdprServiceITest.kt
@@ -1,0 +1,194 @@
+package fi.hel.haitaton.hanke.gdpr
+
+import assertk.all
+import assertk.assertThat
+import assertk.assertions.containsExactlyInAnyOrder
+import assertk.assertions.each
+import assertk.assertions.extracting
+import assertk.assertions.hasSize
+import assertk.assertions.isEmpty
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNull
+import fi.hel.haitaton.hanke.DatabaseTest
+import fi.hel.haitaton.hanke.allu.ApplicationStatus
+import fi.hel.haitaton.hanke.application.Application
+import fi.hel.haitaton.hanke.application.ApplicationEntity
+import fi.hel.haitaton.hanke.application.ApplicationRepository
+import fi.hel.haitaton.hanke.factory.AlluDataFactory
+import fi.hel.haitaton.hanke.factory.AlluDataFactory.Companion.withContacts
+import fi.hel.haitaton.hanke.factory.AlluDataFactory.Companion.withCustomer
+import fi.hel.haitaton.hanke.factory.HankeFactory
+import fi.hel.haitaton.hanke.factory.TEPPO_TESTI
+import fi.hel.haitaton.hanke.hasSameElementsAs
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.test.context.ActiveProfiles
+import org.testcontainers.junit.jupiter.Testcontainers
+
+private const val USERID = "test-user"
+
+@Testcontainers
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("default")
+@WithMockUser(USERID)
+class GdprServiceITest : DatabaseTest() {
+
+    @Autowired lateinit var gdprService: GdprService
+    @Autowired lateinit var alluDataFactory: AlluDataFactory
+    @Autowired lateinit var hankeFactory: HankeFactory
+    @Autowired lateinit var applicationRepository: ApplicationRepository
+
+    @Nested
+    inner class FindGdprInfo {
+        @Test
+        fun `Returns null without applications`() {
+            val result = gdprService.findGdprInfo(USERID)
+
+            assertThat(result).isNull()
+        }
+
+        @Test
+        fun `Returns null when user has no applications`() {
+            val hanke = hankeFactory.saveEntity()
+            alluDataFactory.saveApplicationEntities(3, "Other User", hanke)
+            val result = gdprService.findGdprInfo(USERID)
+
+            assertThat(result).isNull()
+        }
+
+        @Test
+        fun `Returns information for user's applications`() {
+            val hanke = hankeFactory.saveEntity()
+            alluDataFactory.saveApplicationEntities(6, USERID, hanke) { i, application ->
+                if (i % 2 == 0) {
+                    application.userId = "Other User"
+                    application.setOrdererName("Other", "User")
+                } else {
+                    application.userId = USERID
+                    application.setOrdererName("Teppo", "Testihenkilö")
+                }
+            }
+
+            val result = gdprService.findGdprInfo(USERID)
+
+            val expected =
+                CollectionNode(
+                    "user",
+                    listOf(
+                        StringNode("id", USERID),
+                        StringNode("nimi", TEPPO_TESTI),
+                        StringNode("puhelinnumero", "04012345678"),
+                        StringNode("sahkoposti", "teppo@example.test"),
+                        CollectionNode(
+                            "organisaatio",
+                            listOf(
+                                StringNode("nimi", "DNA"),
+                                StringNode("tunnus", "3766028-0"),
+                            )
+                        ),
+                    )
+                )
+            assertThat(result).isEqualTo(expected)
+        }
+
+        private fun ApplicationEntity.setOrdererName(firstName: String, lastName: String) {
+            withCustomer(
+                AlluDataFactory.createCompanyCustomer()
+                    .withContacts(
+                        AlluDataFactory.createContact(firstName, lastName, orderer = true)
+                    )
+            )
+        }
+    }
+
+    @Nested
+    inner class FindApplicationsToDeletes {
+        @Test
+        fun `Returns empty list with no applications`() {
+            val result = gdprService.findApplicationsToDelete(USERID)
+
+            assertThat(result).isEmpty()
+        }
+
+        @Test
+        fun `Returns empty list with no matching applications`() {
+            val hanke = hankeFactory.saveEntity()
+            alluDataFactory.saveApplicationEntities(3, "Other user", hanke)
+
+            val result = gdprService.findApplicationsToDelete(USERID)
+
+            assertThat(result).isEmpty()
+        }
+
+        @Test
+        fun `Returns applications when only pending applications`() {
+            val hanke = hankeFactory.saveEntity()
+            val statuses = listOf(null, ApplicationStatus.PENDING, ApplicationStatus.PENDING_CLIENT)
+            val applications =
+                alluDataFactory.saveApplicationEntities(3, USERID, hanke) { i, application ->
+                    application.alluStatus = statuses[i]
+                }
+
+            val result = gdprService.findApplicationsToDelete(USERID)
+
+            assertThat(result).hasSize(3)
+            assertThat(result).extracting(Application::alluStatus).hasSameElementsAs(statuses)
+            assertThat(result)
+                .extracting(Application::id)
+                .hasSameElementsAs(applications.map { it.id })
+        }
+
+        @Test
+        fun `Throws exception when some applications are not pending`() {
+            val hanke = hankeFactory.saveEntity()
+            val statuses =
+                listOf(
+                    ApplicationStatus.HANDLING,
+                    ApplicationStatus.PENDING,
+                    ApplicationStatus.DECISION
+                )
+            alluDataFactory.saveApplicationEntities(3, USERID, hanke) { i, application ->
+                application.alluStatus = statuses[i]
+                application.applicationIdentifier = "HAI-00$i"
+            }
+
+            val exception =
+                assertThrows<DeleteForbiddenException> {
+                    gdprService.findApplicationsToDelete(USERID)
+                }
+
+            assertThat(exception.errors()).all {
+                hasSize(2)
+                extracting(GdprError::code).each { it.isEqualTo("HAI2003") }
+                extracting { it.message.fi }
+                    .containsExactlyInAnyOrder(
+                        "Keskeneräinen hakemus tunnuksella HAI-000. Ota yhteyttä alueidenkaytto@hel.fi hakemuksen poistamiseksi.",
+                        "Keskeneräinen hakemus tunnuksella HAI-002. Ota yhteyttä alueidenkaytto@hel.fi hakemuksen poistamiseksi.",
+                    )
+            }
+        }
+    }
+
+    @Nested
+    inner class DeleteApplications {
+        @Test
+        fun `Deletes all given applications`() {
+            val hanke = hankeFactory.saveEntity()
+            val applications =
+                alluDataFactory
+                    .saveApplicationEntities(6, USERID, hanke) { i, application ->
+                        if (i % 2 == 0) application.userId = "Other User"
+                    }
+                    .map { it.toApplication() }
+
+            gdprService.deleteApplications(applications, USERID)
+
+            val remainingApplications = applicationRepository.findAll()
+            assertThat(remainingApplications).isEmpty()
+        }
+    }
+}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/ApplicationPdfService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/ApplicationPdfService.kt
@@ -159,6 +159,17 @@ object ApplicationPdfService {
             }
         }
 
+        document.newPage()
+
+        document.section("Liitteet") { table ->
+            if (data.propertyDeveloperWithContacts != null) {
+                table.row("Rakennuttajat", data.propertyDeveloperWithContacts.format())
+            }
+            if (data.representativeWithContacts != null) {
+                table.row("Asianhoitajat", data.representativeWithContacts.format())
+            }
+        }
+
         document.close()
     }
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/gdpr/GdprController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/gdpr/GdprController.kt
@@ -1,6 +1,7 @@
 package fi.hel.haitaton.hanke.gdpr
 
-import fi.hel.haitaton.hanke.application.ApplicationService
+import fi.hel.haitaton.hanke.HankeError
+import fi.hel.haitaton.hanke.application.Application
 import fi.hel.haitaton.hanke.logging.DisclosureLogService
 import io.sentry.Sentry
 import io.swagger.v3.oas.annotations.Hidden
@@ -14,10 +15,12 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 
@@ -27,7 +30,7 @@ private val logger = KotlinLogging.logger {}
 @RequestMapping("/gdpr-api")
 @Validated
 class GdprController(
-    private val applicationService: ApplicationService,
+    private val gdprService: GdprService,
     private val disclosureLogService: DisclosureLogService,
 ) {
 
@@ -41,8 +44,9 @@ class GdprController(
                 "their personal information. We return all personal information we can link up " +
                 "with that user id. Information is returned if the person has created an " +
                 "application. We return the information they wrote down as their own info. " +
+                "\n\n" +
                 "The API has a specific format for the response, it's documented in " +
-                "https://helsinkisolutionoffice.atlassian.net/wiki/spaces/DD/pages/80969736/GDPR+API.",
+                "[Confluence](https://helsinkisolutionoffice.atlassian.net/wiki/spaces/DD/pages/80969736/GDPR+API).",
     )
     @ApiResponses(
         value =
@@ -58,7 +62,7 @@ class GdprController(
                 ),
                 ApiResponse(
                     description = "Profile’s data cannot be found with the given id",
-                    responseCode = "404",
+                    responseCode = "204",
                 ),
                 ApiResponse(
                     description = "There has been an unexpected error during the call",
@@ -69,22 +73,88 @@ class GdprController(
     )
     fun getByUserId(@PathVariable userId: String): ResponseEntity<CollectionNode> {
         if (gdprDisabled) {
-            throw NotImplementedError("/gdpr-api/$userId")
+            throw NotImplementedError("GET /gdpr-api/$userId")
         }
 
-        logger.info { "Finding GDPR information for user $userId" }
-        val applications = applicationService.getAllApplicationsCreatedByUser(userId)
-
-        val gdprInfo = GdprJsonConverter.createGdprJson(applications, userId)
+        val gdprInfo = gdprService.findGdprInfo(userId)
 
         if (gdprInfo == null) {
-            logger.warn { "No applications found for user $userId" }
-            return ResponseEntity.notFound().build()
+            logger.warn { "No GDPR information found for user $userId" }
+            return ResponseEntity.noContent().build()
         }
 
         disclosureLogService.saveDisclosureLogsForProfiili(userId, gdprInfo)
         logger.info { "Returning GDPR information for user $userId" }
         return ResponseEntity.ok().body(gdprInfo)
+    }
+
+    @DeleteMapping("/{userId}")
+    @Operation(
+        summary = "Deletes all personal information of the user",
+        description =
+            "Helsinki profiili calls this endpoint when a user makes a GDPR request to remove all " +
+                "their personal information. The only information we can associate with a user id is " +
+                "the information the creator of an application has entered as their own. We can't have " +
+                "applications without information about who has made them, so we have to delete the " +
+                "applications. If any of the user's applications have progressed to handling or " +
+                "beyond, we refuse to delete anything. " +
+                "\n\n" +
+                "Setting dry_run to true runs all the checks like we were deleting the information, " +
+                "but nothing is deleted. " +
+                "\n\n" +
+                "The API has a specific format for the response, it's documented in " +
+                "[Confluence](https://helsinkisolutionoffice.atlassian.net/wiki/spaces/DD/pages/80969736/GDPR+API).",
+    )
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @ApiResponses(
+        value =
+            [
+                ApiResponse(
+                    description =
+                        "The service allows and has done everything needed so that it no longer " +
+                            "contains personal data for the identified profile. This response is " +
+                            "also given in the case that the service does not contain any data " +
+                            "for the profile or is completely unaware of the identified profile.",
+                    responseCode = "204"
+                ),
+                ApiResponse(
+                    description = "Request’s parameters fail validation",
+                    responseCode = "400",
+                ),
+                ApiResponse(
+                    description = "Request’s credentials are missing or invalid",
+                    responseCode = "401",
+                ),
+                ApiResponse(
+                    description =
+                        "Service data related to the identified profile can't be removed " +
+                            "from the called service because of some legal reason. The reason(s) " +
+                            "for failure are detailed in the response.",
+                    responseCode = "403",
+                    content = [Content(schema = Schema(implementation = GdprErrorResponse::class))],
+                ),
+                ApiResponse(
+                    description = "There has been an unexpected error during the call",
+                    responseCode = "500",
+                    content = [Content(schema = Schema(implementation = GdprErrorResponse::class))],
+                ),
+            ],
+    )
+    fun deleteUserInformation(
+        @PathVariable userId: String,
+        @RequestParam("dry_run") dryRun: Boolean = false
+    ) {
+        if (gdprDisabled) {
+            throw NotImplementedError("DELETE /gdpr-api/$userId")
+        }
+
+        val applicationsToDelete = gdprService.findApplicationsToDelete(userId)
+
+        if (dryRun) {
+            logger.info { "Not deleting applications, GDPR request was a dry run." }
+        } else {
+            gdprService.deleteApplications(applicationsToDelete, userId)
+        }
     }
 
     class NotImplementedError(endpointName: String) :
@@ -98,6 +168,15 @@ class GdprController(
         Sentry.captureException(ex)
     }
 
+    @ExceptionHandler(DeleteForbiddenException::class)
+    @ResponseStatus(HttpStatus.FORBIDDEN)
+    @Hidden
+    fun deleteForbidden(ex: DeleteForbiddenException): GdprErrorResponse {
+        logger.info { "User has active applications, refusing GDPR delete request." }
+        Sentry.captureException(ex)
+        return GdprErrorResponse(ex.errors())
+    }
+
     @ExceptionHandler(Exception::class)
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     @Hidden
@@ -105,13 +184,38 @@ class GdprController(
         logger.error(ex) { "Error while retrieving GDPR info" }
         Sentry.captureException(ex)
         return GdprErrorResponse(
-            listOf(GdprError("HAI0002", LocalizedMessage("Tuntematon virhe", "Unknown error"))),
+            listOf(
+                GdprError(
+                    "HAI0002",
+                    LocalizedMessage(
+                        "Tapahtui virhe",
+                        "Det inträffade ett fel",
+                        "An error occurred"
+                    )
+                )
+            ),
         )
     }
 
     data class GdprErrorResponse(val errors: List<GdprError>)
-
-    data class GdprError(val code: String, val message: LocalizedMessage)
-
-    data class LocalizedMessage(val fi: String, val en: String)
 }
+
+data class DeleteForbiddenException(val applications: List<Application>) : RuntimeException() {
+    fun errors() = applications.map(Companion::toGdprError)
+
+    companion object {
+        private fun toGdprError(application: Application): GdprError =
+            GdprError(
+                HankeError.HAI2003.errorCode,
+                LocalizedMessage(
+                    "Keskeneräinen hakemus tunnuksella ${application.applicationIdentifier}. Ota yhteyttä alueidenkaytto@hel.fi hakemuksen poistamiseksi.",
+                    "sv: Keskeneräinen hakemus tunnuksella ${application.applicationIdentifier}. Ota yhteyttä alueidenkaytto@hel.fi hakemuksen poistamiseksi.",
+                    "en: Keskeneräinen hakemus tunnuksella ${application.applicationIdentifier}. Ota yhteyttä alueidenkaytto@hel.fi hakemuksen poistamiseksi."
+                )
+            )
+    }
+}
+
+data class GdprError(val code: String, val message: LocalizedMessage)
+
+data class LocalizedMessage(val fi: String, val sv: String, val en: String)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/gdpr/GdprService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/gdpr/GdprService.kt
@@ -1,0 +1,53 @@
+package fi.hel.haitaton.hanke.gdpr
+
+import fi.hel.haitaton.hanke.application.Application
+import fi.hel.haitaton.hanke.application.ApplicationService
+import mu.KotlinLogging
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+private val logger = KotlinLogging.logger {}
+
+@Service
+class GdprService(private val applicationService: ApplicationService) {
+
+    @Transactional(readOnly = true)
+    fun findGdprInfo(userId: String): CollectionNode? {
+        logger.info { "Finding GDPR information for user $userId" }
+        val applications = applicationService.getAllApplicationsCreatedByUser(userId)
+
+        return GdprJsonConverter.createGdprJson(applications, userId)
+    }
+
+    @Transactional(readOnly = true)
+    fun findApplicationsToDelete(userId: String): List<Application> {
+        logger.info { "Finding GDPR information to delete for user $userId" }
+
+        val (pendingApplications, activeApplications) =
+            applicationService.getAllApplicationsCreatedByUser(userId).partition {
+                applicationService.isStillPending(it)
+            }
+
+        if (activeApplications.isNotEmpty()) {
+            throw DeleteForbiddenException(activeApplications)
+        }
+
+        return pendingApplications
+    }
+
+    @Transactional
+    fun deleteApplications(applicationsToDelete: List<Application>, userId: String) {
+        if (applicationsToDelete.isEmpty()) {
+            logger.info { "No GDPR data found for user $userId" }
+            return
+        }
+        logger.info {
+            "In accordance with the GDPR request, deleting all ${applicationsToDelete.size} applications by user $userId"
+        }
+        applicationsToDelete.forEach {
+            // Application service will check the status of every application again.
+            // This is not optimal, but this is so rarely used, we can live with it.
+            applicationService.delete(it.id!!, userId)
+        }
+    }
+}

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/TestExtensions.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/TestExtensions.kt
@@ -1,5 +1,7 @@
 package fi.hel.haitaton.hanke
 
+import assertk.Assert
+import assertk.assertions.containsExactly
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.icegreen.greenmail.junit5.GreenMailExtension
 import fi.hel.haitaton.hanke.logging.AuditLogRepository
@@ -39,6 +41,9 @@ fun GreenMailExtension.firstReceivedMessage(): MimeMessage {
     Assertions.assertEquals(1, receivedMessages.size)
     return receivedMessages[0]
 }
+
+inline fun <reified T> Assert<List<T>>.hasSameElementsAs(elements: List<T>) =
+    containsExactly(*elements.toTypedArray<T>())
 
 /**
  * "Uses" a variable without doing anything with it. Used to avoid "Parameter is never used"

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceTest.kt
@@ -118,7 +118,6 @@ class ApplicationServiceTest {
 
     @Test
     fun create() {
-        val hankeTunnus = "HAI-1234"
         val dto =
             AlluDataFactory.createApplication(
                 id = null,
@@ -176,7 +175,6 @@ class ApplicationServiceTest {
 
     @Test
     fun `updateApplicationData saves disclosure logs when updating Allu data`() {
-        val hankeTunnus = "HAI-1234"
         val hanke = HankeEntity(id = 1, hankeTunnus = hankeTunnus)
         val applicationEntity =
             AlluDataFactory.createApplicationEntity(

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/AlluDataFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/AlluDataFactory.kt
@@ -19,8 +19,6 @@ import fi.hel.haitaton.hanke.application.CustomerWithContacts
 import fi.hel.haitaton.hanke.application.PostalAddress
 import fi.hel.haitaton.hanke.application.StreetAddress
 import fi.hel.haitaton.hanke.asJsonResource
-import fi.hel.haitaton.hanke.factory.AlluDataFactory.Companion.createApplication
-import fi.hel.haitaton.hanke.factory.AlluDataFactory.Companion.withContacts
 import java.time.ZonedDateTime
 import org.geojson.Polygon
 import org.springframework.http.MediaType.APPLICATION_PDF_VALUE

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeFactory.kt
@@ -20,6 +20,7 @@ class HankeFactory(
     private val hankeService: HankeService,
     private val hankeRepository: HankeRepository
 ) {
+
     /**
      * Create a new hanke and save it to database.
      *

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/gdpr/GdprServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/gdpr/GdprServiceTest.kt
@@ -1,0 +1,42 @@
+package fi.hel.haitaton.hanke.gdpr
+
+import fi.hel.haitaton.hanke.application.ApplicationService
+import fi.hel.haitaton.hanke.factory.AlluDataFactory
+import io.mockk.Called
+import io.mockk.mockk
+import io.mockk.verify
+import io.mockk.verifyAll
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+private const val USERID = "test-user"
+
+class GdprServiceTest {
+
+    private val applicationService: ApplicationService = mockk(relaxUnitFun = true)
+    private val gdprService = GdprService(applicationService)
+
+    @Nested
+    inner class DeleteApplications {
+        @Test
+        fun `Does nothing with an empty list`() {
+            gdprService.deleteApplications(listOf(), USERID)
+
+            verify { applicationService wasNot Called }
+        }
+
+        @Test
+        fun `Deletes all given applications`() {
+            val applications = AlluDataFactory.createApplications(4)
+
+            gdprService.deleteApplications(applications, USERID)
+
+            verifyAll {
+                applicationService.delete(1, USERID)
+                applicationService.delete(2, USERID)
+                applicationService.delete(3, USERID)
+                applicationService.delete(4, USERID)
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Description

If the user has created applications, we delete them if they're still pending. If they've been sent to Allu and have progressed to handling, we refuse to delete them.

Fixed GET endpoint to return 204 instead of 404 when there's no information for a user. Also refactor the GET endpoint to use the GdprService added here.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1303

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
1. Change haitaton.gdpr.disabled=true to haitaton.gdpr.disabled=false in application.properties.
2. Create some applications.
3. Use Postman or cURL to call http://localhost:3001/api/swagger-ui/index.html#/gdpr-controller/deleteUserInformation with your own userid.
4. It should return 204 No Content and remove the applications.
5. Create some applications.
6. Move one of the to handling in Allu.
7. Repeat step 3.
8. It should return 403 Forbidden with a reason why the personal information couldn't be deleted.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [X] I have made necessary changes to the documentation, link to confluence
 or other location: https://helsinkisolutionoffice.atlassian.net/wiki/spaces/HAI/pages/8075476993/GDPR+API

# Other relevant info
Translations are missing.