### PR TITLE
WIP: HAI-1603 Email allow list for non prod envs

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceITest.kt
@@ -26,15 +26,11 @@ import fi.hel.haitaton.hanke.allu.AlluCableReportApplicationData
 import fi.hel.haitaton.hanke.allu.AlluException
 import fi.hel.haitaton.hanke.allu.AlluStatusRepository
 import fi.hel.haitaton.hanke.allu.ApplicationStatus
-import fi.hel.haitaton.hanke.allu.Attachment
 import fi.hel.haitaton.hanke.allu.CableReportService
 import fi.hel.haitaton.hanke.asJsonResource
 import fi.hel.haitaton.hanke.asUtc
-import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType.MUU
-import fi.hel.haitaton.hanke.attachment.testFile
 import fi.hel.haitaton.hanke.domain.Hanke
 import fi.hel.haitaton.hanke.factory.AlluDataFactory
-import fi.hel.haitaton.hanke.factory.AlluDataFactory.Companion.createAttachmentMetadata
 import fi.hel.haitaton.hanke.factory.AlluDataFactory.Companion.teppoEmail
 import fi.hel.haitaton.hanke.factory.AlluDataFactory.Companion.withCustomer
 import fi.hel.haitaton.hanke.factory.ApplicationHistoryFactory
@@ -1443,14 +1439,6 @@ class ApplicationServiceITest : DatabaseTest() {
     private val havisAmanda: ApplicationArea =
         AlluDataFactory.createApplicationArea(
             geometry = "/fi/hel/haitaton/hanke/geometria/havis-amanda.json".asJsonResource()
-        )
-
-    private fun attachments(): List<Attachment> =
-        listOf(
-            Attachment(
-                metadata = createAttachmentMetadata(description = MUU.toString()),
-                file = testFile().bytes
-            )
         )
 
     private fun mockApplicationWithArea(

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/email/EmailSenderServiceFilteredImplTest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/email/EmailSenderServiceFilteredImplTest.kt
@@ -1,0 +1,52 @@
+package fi.hel.haitaton.hanke.email
+
+import com.ninjasquad.springmockk.MockkBean
+import fi.hel.haitaton.hanke.DatabaseTest
+import io.mockk.Called
+import io.mockk.justRun
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.testcontainers.junit.jupiter.Testcontainers
+
+@Testcontainers
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    properties = ["haitaton.email.filtering=true"]
+)
+@ActiveProfiles("default", "emailtest")
+class EmailSenderServiceFilteredImplTest : DatabaseTest() {
+
+    @Qualifier("emailSenderServiceFilteredImpl")
+    @Autowired
+    private lateinit var emailSenderService: EmailSenderService
+
+    @MockkBean private lateinit var emailClient: EmailClient
+
+    @Test
+    fun sendJohtoselvitysCompleteEmail() {
+        emailSenderService.sendJohtoselvitysCompleteEmail(
+            "test@test.test",
+            "HAI23-001",
+            "JS2300001"
+        )
+
+        verify { emailClient wasNot Called }
+    }
+
+    @Test
+    fun `sendJohtoselvitysCompleteEmail sends email with correct recipient`() {
+        val to = "haitaton@test.example"
+        val hankeTunnus = "HAI23-001"
+        val applicationId = "JS2300001"
+        justRun { emailClient.sendHybridEmail(to, hankeTunnus, applicationId) }
+
+        emailSenderService.sendJohtoselvitysCompleteEmail(to, hankeTunnus, applicationId)
+
+        verify { emailClient.sendHybridEmail(to, hankeTunnus, applicationId) }
+    }
+}

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/email/EmailSenderServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/email/EmailSenderServiceITest.kt
@@ -17,6 +17,7 @@ import javax.mail.internet.MimeMultipart
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
 import org.testcontainers.junit.jupiter.Testcontainers
@@ -26,13 +27,17 @@ import org.testcontainers.junit.jupiter.Testcontainers
 @ActiveProfiles("default", "emailtest")
 class EmailSenderServiceITest : DatabaseTest() {
 
-    @JvmField
-    @RegisterExtension
-    final val greenMail: GreenMailExtension =
-        GreenMailExtension(ServerSetupTest.SMTP)
-            .withConfiguration(GreenMailConfiguration.aConfig().withDisabledAuthentication())
+    @Qualifier("emailSenderServiceImpl")
+    @Autowired
+    private lateinit var emailSenderService: EmailSenderService
 
-    @Autowired lateinit var emailSenderService: EmailSenderService
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val greenMail: GreenMailExtension =
+            GreenMailExtension(ServerSetupTest.SMTP)
+                .withConfiguration(GreenMailConfiguration.aConfig().withDisabledAuthentication())
+    }
 
     @Test
     fun `sendJohtoselvitysCompleteEmail sends email with correct recipient`() {

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/email/EmailSenderService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/email/EmailSenderService.kt
@@ -5,54 +5,114 @@ import javax.mail.internet.MimeMessage
 import mu.KotlinLogging
 import net.pwall.mustache.Template
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.mail.javamail.JavaMailSender
 import org.springframework.mail.javamail.MimeMessageHelper
+import org.springframework.stereotype.Component
 import org.springframework.stereotype.Service
 
 private val logger = KotlinLogging.logger {}
 
+private const val JOHTOSELVITYS_VALMIS = "johtoselvitys-valmis"
+
+interface EmailSenderService {
+    fun sendJohtoselvitysCompleteEmail(to: String, hankeTunnus: String, applicationId: String)
+}
+
 @Service
-class EmailSenderService(
+@ConditionalOnProperty(value = ["haitaton.email.filtering"], havingValue = "false")
+class EmailSenderServiceImpl(private val emailClient: EmailClient) : EmailSenderService {
+
+    init {
+        logger.info { "Initialized EmailSender without recipient filtering. For production." }
+    }
+
+    override fun sendJohtoselvitysCompleteEmail(
+        to: String,
+        hankeTunnus: String,
+        applicationId: String
+    ) = emailClient.sendHybridEmail(to, hankeTunnus, applicationId)
+}
+
+/**
+ * Component used to filter sent emails. Will not send the mail if recipient is not in allow list.
+ * Can be used e.g. in environments other than production.
+ */
+@Service
+@ConditionalOnProperty(value = ["haitaton.email.filtering"], havingValue = "true")
+class EmailSenderServiceFilteredImpl(
+    private val emailClient: EmailClient,
+    @Value("\${haitaton.email.allow-list}") private val allowListRaw: String,
+) : EmailSenderService {
+
+    init {
+        logger.info {
+            "Initialized EmailSender with allow list recipient filtering. For non-prod environments."
+        }
+    }
+
+    private val allowList = allowListRaw.split(";").map { it.trim() }
+
+    override fun sendJohtoselvitysCompleteEmail(
+        to: String,
+        hankeTunnus: String,
+        applicationId: String
+    ) {
+        if (!allowList.contains(to)) {
+            logger.info { "Recipient not in allowed addresses, will not send." }
+            return
+        }
+        emailClient.sendHybridEmail(to, hankeTunnus, applicationId)
+    }
+}
+
+@Component
+class EmailClient(
     private val mailSender: JavaMailSender,
-    @Value("\${haitaton.email.enabled}") private val enabled: Boolean,
     @Value("\${haitaton.email.from}") private val from: String,
     @Value("\${haitaton.email.baseUrl}") private val baseUrl: String,
 ) {
+    fun sendHybridEmail(to: String, hankeTunnus: String, applicationId: String) {
+        logger.info { "Sending email for completed johtoselvitys $applicationId" }
 
-    fun sendJohtoselvitysCompleteEmail(
-        to: String,
-        hankeTunnus: String,
-        applicationIdentifier: String,
-    ) {
-        logger.info { "Sending email for completed johtoselvitys $applicationIdentifier" }
-        val templateData =
-            mapOf(
-                "baseUrl" to baseUrl,
-                "hankeTunnus" to hankeTunnus,
-                "applicationIdentifier" to applicationIdentifier,
-            )
-        sendHybridEmail(to, "johtoselvitys-valmis", templateData)
-    }
+        with(TemplateDataProvider) {
+            val templateData = createData(baseUrl, hankeTunnus, applicationId)
+            val textBody = textBody(JOHTOSELVITYS_VALMIS, templateData)
+            val htmlBody = htmlBody(JOHTOSELVITYS_VALMIS, templateData)
+            val subject = subject(JOHTOSELVITYS_VALMIS, templateData)
 
-    private fun sendHybridEmail(to: String, template: String, templateData: Map<String, String>) {
-        if (!enabled) {
-            logger.info { "Email sending not enabled, ignoring email" }
-            return
+            val mimeMessage: MimeMessage = mailSender.createMimeMessage()
+            val helper = MimeMessageHelper(mimeMessage, true, "utf-8")
+            helper.setText(textBody, htmlBody)
+
+            helper.setTo(to)
+            helper.setSubject(subject)
+            helper.setFrom(from)
+            mailSender.send(mimeMessage)
         }
-        val textBody = parseTemplate("/email/template/$template.text.mustache", templateData)
-        val htmlBody = parseTemplate("/email/template/$template.html.mustache", templateData)
-        val subject =
-            parseTemplate("/email/template/$template.subject.mustache", templateData).trimEnd()
-
-        val mimeMessage: MimeMessage = mailSender.createMimeMessage()
-        val helper = MimeMessageHelper(mimeMessage, true, "utf-8")
-        helper.setText(textBody, htmlBody)
-
-        helper.setTo(to)
-        helper.setSubject(subject)
-        helper.setFrom(from)
-        mailSender.send(mimeMessage)
     }
+}
+
+object TemplateDataProvider {
+    fun createData(
+        baseUrl: String,
+        hankeTunnus: String,
+        applicationIdentifier: String
+    ): Map<String, String> =
+        mapOf(
+            "baseUrl" to baseUrl,
+            "hankeTunnus" to hankeTunnus,
+            "applicationIdentifier" to applicationIdentifier,
+        )
+
+    fun textBody(template: String, data: Map<String, String>) =
+        parseTemplate("/email/template/$template.text.mustache", data)
+
+    fun htmlBody(template: String, data: Map<String, String>) =
+        parseTemplate("/email/template/$template.html.mustache", data)
+
+    fun subject(template: String, data: Map<String, String>) =
+        parseTemplate("/email/template/$template.subject.mustache", data).trimEnd()
 
     private fun parseTemplate(path: String, contextObject: Any): String =
         Template.parse(path.getResource().openStream()).processToString(contextObject)

--- a/services/hanke-service/src/main/resources/application.properties
+++ b/services/hanke-service/src/main/resources/application.properties
@@ -86,6 +86,8 @@ spring.mail.properties.mail.debug=${MAIL_SENDER_DEBUG:false}
 spring.mail.properties.mail.smtp.auth=${MAIL_SENDER_AUTH:false}
 spring.mail.properties.mail.smtp.starttls.enable=${MAIL_SENDER_STARTTLS_ENABLE:true}
 
-haitaton.email.enabled=${HAITATON_EMAIL_ENABLED:false}
+# Filtering / allow list to avoid actual sending e.g. in dev
+haitaton.email.filtering=${HAITATON_EMAIL_FILTERING:true}
+haitaton.email.allow-list=${HAITATON_EMAIL_ALLOW_LIST:haitaton@test.example}
 haitaton.email.from=${HAITATON_EMAIL_FROM:haitaton@test.example}
 haitaton.email.baseUrl=${HAITATON_EMAIL_BASEURL:http://localhost:3001}

--- a/services/hanke-service/src/test/resources/application-emailtest.properties
+++ b/services/hanke-service/src/test/resources/application-emailtest.properties
@@ -1,4 +1,4 @@
-haitaton.email.enabled=true
+haitaton.email.filtering=false
 haitaton.email.from=no-reply@hel.fi
 spring.mail.port=3025
 spring.mail.properties.mail.smtp.auth=false


### PR DESCRIPTION
# Description

Add a possibility to not actually send outgoing emails.

Introduce interface implemented by two conditional beans. One is for sending emails only for whitelisted emails, other is for sending every email without filtering.

application properties (and environment variables) can be used to control which bean is injected and to what addresses emails will be sent to.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1603

## Type of change

- [ ] Bug fix 
- [x] New feature 
- [ ] Other

# Instructions for testing
Please describe tests how this change or new feature can be tested.

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)