### PR TITLE
HAI-1633 Change randomness algorithm

### DIFF
--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/KayttajaTunniste.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/KayttajaTunniste.kt
@@ -25,21 +25,22 @@ class KayttajaTunnisteEntity(
     @Enumerated(EnumType.STRING) val role: Role,
     @OneToOne(mappedBy = "kayttajaTunniste") val hankeKayttaja: HankeKayttajaEntity?
 ) {
-    constructor() :
-        this(
-            tunniste = randomToken(),
-            createdAt = getCurrentTimeUTC().toOffsetDateTime(),
-            sentAt = null,
-            role = Role.KATSELUOIKEUS,
-            hankeKayttaja = null
-        )
 
     companion object {
         private const val tokenLength: Int = 24
         private val charPool: List<Char> = ('a'..'z') + ('A'..'Z') + ('0'..'9')
-        private val secureRandom: SecureRandom = SecureRandom.getInstanceStrong()
+        private val secureRandom: SecureRandom = SecureRandom()
 
-        fun randomToken(): String =
+        fun create() =
+            KayttajaTunnisteEntity(
+                tunniste = randomToken(),
+                createdAt = getCurrentTimeUTC().toOffsetDateTime(),
+                sentAt = null,
+                role = Role.KATSELUOIKEUS,
+                hankeKayttaja = null
+            )
+
+        private fun randomToken(): String =
             secureRandom
                 .ints(tokenLength.toLong(), 0, charPool.size)
                 .asSequence()

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceTest.kt
@@ -276,7 +276,7 @@ class ApplicationServiceTest {
         verifySequence {
             applicationRepo.findOneById(3)
             geometriatDao.isInsideHankeAlueet(1, any())
-            hankeKayttajaService.saveNewTokensFromApplication(applicationData, 1)
+            hankeKayttajaService.saveNewTokensFromApplication(applicationEntity, 1)
             geometriatDao.calculateCombinedArea(any())
             geometriatDao.calculateArea(any())
             cableReportService.create(any())
@@ -310,7 +310,7 @@ class ApplicationServiceTest {
         verifySequence {
             applicationRepo.findOneById(3)
             geometriatDao.isInsideHankeAlueet(1, any())
-            hankeKayttajaService.saveNewTokensFromApplication(applicationData, 1)
+            hankeKayttajaService.saveNewTokensFromApplication(applicationEntity, 1)
             geometriatDao.calculateCombinedArea(any())
             geometriatDao.calculateArea(any())
             cableReportService.create(any())
@@ -345,7 +345,7 @@ class ApplicationServiceTest {
             disclosureLogService wasNot called
             applicationRepo.findOneById(3)
             geometriatDao.isInsideHankeAlueet(any(), any())
-            hankeKayttajaService.saveNewTokensFromApplication(applicationData, 1)
+            hankeKayttajaService.saveNewTokensFromApplication(applicationEntity, 1)
             geometriatDao.calculateCombinedArea(any())
             geometriatDao.calculateArea(any())
             cableReportService.create(any())
@@ -426,7 +426,7 @@ class ApplicationServiceTest {
         verifySequence {
             applicationRepo.findOneById(3)
             geometriatDao.isInsideHankeAlueet(1, any())
-            hankeKayttajaService.saveNewTokensFromApplication(applicationData, 1)
+            hankeKayttajaService.saveNewTokensFromApplication(applicationEntity, 1)
             cableReportService wasNot Called
             disclosureLogService wasNot Called
             applicationLoggingService wasNot Called

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeFactory.kt
@@ -1,5 +1,7 @@
 package fi.hel.haitaton.hanke.factory
 
+import fi.hel.haitaton.hanke.HankeEntity
+import fi.hel.haitaton.hanke.HankeRepository
 import fi.hel.haitaton.hanke.HankeService
 import fi.hel.haitaton.hanke.HankeStatus
 import fi.hel.haitaton.hanke.SuunnitteluVaihe
@@ -14,8 +16,10 @@ import java.time.ZonedDateTime
 import org.springframework.stereotype.Component
 
 @Component
-class HankeFactory(private val hankeService: HankeService) {
-
+class HankeFactory(
+    private val hankeService: HankeService,
+    private val hankeRepository: HankeRepository
+) {
     /**
      * Create a new hanke and save it to database.
      *
@@ -33,6 +37,21 @@ class HankeFactory(private val hankeService: HankeService) {
                 suunnitteluVaihe = suunnitteluVaihe,
             )
         )
+
+    /**
+     * Save a new hanke using HankeService. Then get it as an entity.
+     *
+     * The service method creates a hankeTunnus and does other initialization, so we want to run it,
+     * even though we want to return the entity, not the domain object.
+     */
+    fun saveEntity(
+        nimi: String? = defaultNimi,
+        vaihe: Vaihe? = Vaihe.OHJELMOINTI,
+        suunnitteluVaihe: SuunnitteluVaihe? = null,
+    ): HankeEntity {
+        val hanke = save(nimi, vaihe, suunnitteluVaihe)
+        return hankeRepository.getReferenceById(hanke.id!!)
+    }
 
     fun save(hanke: Hanke) = hankeService.createHanke(hanke)
 


### PR DESCRIPTION
# Description

Change the algorithm used by SecureRandom to one that doesn't enforce the use of `/dev/random`. The default constructor creates an instance that uses the `NativePRNG` algorithm when `java.security.egd` has been set to `file:/dev/urandom`, like we have in the cloud environments.

Earlier, using `SecureRandom.getInstanceStrong()` and `NativePRNGBlocking` caused generating user tokens to hang for several minutes, while SecureRandom was waiting for more randomness from `/dev/random`.

Improve logging related to sending applications. The slowness was really hard to diagnose because of too little logging.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1633

## Type of change

- [X] Bug fix 
- [ ] New feature 
- [ ] Other

# Instructions for testing
This can only be tested after merging to dev. The new algorithm was tested already.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 