### PR TITLE
HAI-1621 Disable endpoints that are not yet ready for production

### DIFF
--- a/services/hanke-service/src/integrationTest/resources/application-test.properties
+++ b/services/hanke-service/src/integrationTest/resources/application-test.properties
@@ -1,2 +1,2 @@
 haitaton.clamav.baseUrl=http://localhost:6789
-haitaton.endpoint.disabled=true
+haitaton.feature.hanke-editing=false

--- a/services/hanke-service/src/integrationTest/resources/application-test.properties
+++ b/services/hanke-service/src/integrationTest/resources/application-test.properties
@@ -1,1 +1,2 @@
 haitaton.clamav.baseUrl=http://localhost:6789
+haitaton.endpoint.disabled=true

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/ControllerExceptionHandler.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/ControllerExceptionHandler.kt
@@ -22,6 +22,15 @@ private val logger = KotlinLogging.logger {}
 @RestControllerAdvice
 class ControllerExceptionHandler {
 
+    @ExceptionHandler(EndpointDisabledException::class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    @Hidden
+    fun endpointDisabled(ex: EndpointDisabledException): HankeError {
+        logger.warn { ex.message }
+        Sentry.captureException(ex)
+        return HankeError.HAI0004
+    }
+
     /** This is a horrible hack to get the 401 error to all endpoints in OpenAPI docs. */
     @ExceptionHandler(FakeAuthorizationException::class)
     @ResponseStatus(HttpStatus.UNAUTHORIZED)
@@ -158,3 +167,5 @@ class ControllerExceptionHandler {
 
     class FakeAuthorizationException : RuntimeException()
 }
+
+class EndpointDisabledException() : RuntimeException("Endpoint disabled in this environment.")

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeController.kt
@@ -12,6 +12,7 @@ import io.swagger.v3.oas.annotations.Operation
 import javax.validation.ConstraintViolationException
 import mu.KotlinLogging
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpStatus
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.DeleteMapping
@@ -35,6 +36,7 @@ class HankeController(
     @Autowired private val hankeService: HankeService,
     @Autowired private val permissionService: PermissionService,
     @Autowired private val disclosureLogService: DisclosureLogService,
+    @Value("\${haitaton.endpoint.disabled}") val endpointDisabled: Boolean = false,
 ) {
 
     @GetMapping("/{hankeTunnus}")
@@ -92,6 +94,10 @@ class HankeController(
     /** Add one hanke. This method will be called when we do not have id for hanke yet */
     @PostMapping
     fun createHanke(@ValidHanke @RequestBody hanke: Hanke?): Hanke {
+        if (endpointDisabled) {
+            throw EndpointDisabledException()
+        }
+
         if (hanke == null) {
             throw HankeArgumentException("No hanke given when creating hanke")
         }
@@ -117,6 +123,10 @@ class HankeController(
         @ValidHanke @RequestBody hanke: Hanke,
         @PathVariable hankeTunnus: String
     ): Hanke {
+        if (endpointDisabled) {
+            throw EndpointDisabledException()
+        }
+
         logger.info { "Updating Hanke: ${hanke.toLogString()}" }
 
         val existingHanke =
@@ -136,6 +146,10 @@ class HankeController(
     @DeleteMapping("/{hankeTunnus}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     fun deleteHanke(@PathVariable hankeTunnus: String) {
+        if (endpointDisabled) {
+            throw EndpointDisabledException()
+        }
+
         logger.info { "Deleting hanke: $hankeTunnus" }
 
         hankeService.getHankeWithApplications(hankeTunnus).let { (hanke, hakemukset) ->
@@ -172,10 +186,6 @@ class HankeController(
         }
     }
 
-    /**
-     * Verifies that hanke is updatable. Sets generated false as hanke to be updated is not
-     * considered generated anymore.
-     */
     private fun Hanke.validateUpdatable(updatedHanke: Hanke, hankeTunnusFromPath: String) {
         if (hankeTunnusFromPath != updatedHanke.hankeTunnus) {
             throw HankeArgumentException("Hanketunnus not given or doesn't match the hanke data")

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeController.kt
@@ -36,7 +36,7 @@ class HankeController(
     @Autowired private val hankeService: HankeService,
     @Autowired private val permissionService: PermissionService,
     @Autowired private val disclosureLogService: DisclosureLogService,
-    @Value("\${haitaton.endpoint.disabled}") val endpointDisabled: Boolean = false,
+    @Value("\${haitaton.feature.hanke-editing}") val enableEditFeature: Boolean = true,
 ) {
 
     @GetMapping("/{hankeTunnus}")
@@ -94,7 +94,7 @@ class HankeController(
     /** Add one hanke. This method will be called when we do not have id for hanke yet */
     @PostMapping
     fun createHanke(@ValidHanke @RequestBody hanke: Hanke?): Hanke {
-        if (endpointDisabled) {
+        if (!enableEditFeature) {
             throw EndpointDisabledException()
         }
 
@@ -123,7 +123,7 @@ class HankeController(
         @ValidHanke @RequestBody hanke: Hanke,
         @PathVariable hankeTunnus: String
     ): Hanke {
-        if (endpointDisabled) {
+        if (!enableEditFeature) {
             throw EndpointDisabledException()
         }
 
@@ -146,7 +146,7 @@ class HankeController(
     @DeleteMapping("/{hankeTunnus}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     fun deleteHanke(@PathVariable hankeTunnus: String) {
-        if (endpointDisabled) {
+        if (!enableEditFeature) {
             throw EndpointDisabledException()
         }
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeError.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeError.kt
@@ -8,6 +8,7 @@ enum class HankeError(val errorMessage: String) {
     HAI0001("Access denied"),
     HAI0002("Internal error"),
     HAI0003("Invalid data"),
+    HAI0004("Resource does not exist"),
     HAI1001("Hanke not found"),
     HAI1002("Invalid Hanke data"),
     HAI1003("Internal error while saving Hanke"),

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentController.kt
@@ -1,5 +1,6 @@
 package fi.hel.haitaton.hanke.attachment.hanke
 
+import fi.hel.haitaton.hanke.EndpointDisabledException
 import fi.hel.haitaton.hanke.HankeNotFoundException
 import fi.hel.haitaton.hanke.HankeService
 import fi.hel.haitaton.hanke.attachment.common.AttachmentInvalidException
@@ -18,6 +19,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import java.util.UUID
 import mu.KotlinLogging
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
@@ -36,6 +38,7 @@ class HankeAttachmentController(
     private val hankeAttachmentService: HankeAttachmentService,
     private val hankeService: HankeService,
     private val permissionService: PermissionService,
+    @Value("\${haitaton.endpoint.disabled}") val endpointDisabled: Boolean = false,
 ) {
 
     @GetMapping
@@ -120,6 +123,10 @@ class HankeAttachmentController(
         @PathVariable hankeTunnus: String,
         @RequestParam("liite") attachment: MultipartFile
     ): HankeAttachmentMetadata {
+        if (endpointDisabled) {
+            throw EndpointDisabledException()
+        }
+
         permissionOrThrow(hankeTunnus, EDIT)
         return hankeAttachmentService.addAttachment(hankeTunnus, attachment)
     }
@@ -142,6 +149,9 @@ class HankeAttachmentController(
             ]
     )
     fun deleteAttachment(@PathVariable hankeTunnus: String, @PathVariable attachmentId: UUID) {
+        if (endpointDisabled) {
+            throw EndpointDisabledException()
+        }
         permissionOrThrow(hankeTunnus, EDIT)
         return hankeAttachmentService.deleteAttachment(hankeTunnus, attachmentId)
     }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentController.kt
@@ -38,7 +38,7 @@ class HankeAttachmentController(
     private val hankeAttachmentService: HankeAttachmentService,
     private val hankeService: HankeService,
     private val permissionService: PermissionService,
-    @Value("\${haitaton.endpoint.disabled}") val endpointDisabled: Boolean = false,
+    @Value("\${haitaton.feature.hanke-editing}") val enableEditFeature: Boolean = true,
 ) {
 
     @GetMapping
@@ -123,7 +123,7 @@ class HankeAttachmentController(
         @PathVariable hankeTunnus: String,
         @RequestParam("liite") attachment: MultipartFile
     ): HankeAttachmentMetadata {
-        if (endpointDisabled) {
+        if (!enableEditFeature) {
             throw EndpointDisabledException()
         }
 
@@ -149,7 +149,7 @@ class HankeAttachmentController(
             ]
     )
     fun deleteAttachment(@PathVariable hankeTunnus: String, @PathVariable attachmentId: UUID) {
-        if (endpointDisabled) {
+        if (!enableEditFeature) {
             throw EndpointDisabledException()
         }
         permissionOrThrow(hankeTunnus, EDIT)

--- a/services/hanke-service/src/main/resources/application.properties
+++ b/services/hanke-service/src/main/resources/application.properties
@@ -21,7 +21,7 @@ haitaton.gdpr.delete-scope=${HAITATON_GDPR_DELETE_SCOPE:haitaton.gdprdelete}
 #logging.level.org.springframework.security=DEBUG
 
 # Disable endpoints that are e.g. in development and should not be in production.
-haitaton.endpoint.disabled=${HAITATON_ENDPOINT_DISABLE:false}
+haitaton.feature.hanke-editing=${HAITATON_FEATURE_HANKE_EDITING:true}
 
 spring.datasource.url=jdbc:postgresql://${HAITATON_HOST:localhost}:${HAITATON_PORT:5432}/${HAITATON_DATABASE:haitaton}
 spring.datasource.username=${HAITATON_USER:haitaton_user}

--- a/services/hanke-service/src/main/resources/application.properties
+++ b/services/hanke-service/src/main/resources/application.properties
@@ -20,6 +20,9 @@ haitaton.gdpr.query-scope=${HAITATON_GDPR_QUERY_SCOPE:haitaton.gdprquery}
 haitaton.gdpr.delete-scope=${HAITATON_GDPR_DELETE_SCOPE:haitaton.gdprdelete}
 #logging.level.org.springframework.security=DEBUG
 
+# Disable endpoints that are e.g. in development and should not be in production.
+haitaton.endpoint.disabled=${HAITATON_ENDPOINT_DISABLE:false}
+
 spring.datasource.url=jdbc:postgresql://${HAITATON_HOST:localhost}:${HAITATON_PORT:5432}/${HAITATON_DATABASE:haitaton}
 spring.datasource.username=${HAITATON_USER:haitaton_user}
 spring.datasource.password=${HAITATON_PASSWORD:haitaton}


### PR DESCRIPTION
# Description

Add a possibility to disable endpoints in certain environments.

Boolean environment variable HAITATON_FEATURE_HANKE_EDITING can be used to control this. The value should be false (disabled) in production and staging. Default value is true (enabled), so there is no need to set this elsewhere.

Related pr: https://dev.azure.com/City-of-Helsinki/haitaton/_git/haitaton-hanke-service-pipelines/pullrequest/4844

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1621

## Type of change

- [ ] Bug fix 
- [x] New feature 
- [ ] Other

# Instructions for testing
Endpoints described in the jira ticket should work in every environment except production and staging. In production and staging they should respond 404.

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 

# Other relevant info
Please describe here if there is e.g. some requirements for this change or
 other info that the tester/user needs to know.