### PR TITLE
HAI-1688 Add real hankeTunnus to allu cable report identificationNumber

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceITest.kt
@@ -561,7 +561,6 @@ class ApplicationServiceITest : DatabaseTest() {
         every { cableReportServiceAllu.getApplicationInformation(21) } returns
             AlluDataFactory.createAlluApplicationResponse(21)
         val expectedAlluRequest = newApplicationData.toAlluData(HANKE_TUNNUS)
-        assertEquals(application.hanke.hankeTunnus, expectedAlluRequest.identificationNumber)
         justRun { cableReportServiceAllu.update(21, expectedAlluRequest) }
         justRun { cableReportServiceAllu.addAttachment(21, any()) }
 
@@ -577,7 +576,7 @@ class ApplicationServiceITest : DatabaseTest() {
 
         verifyOrder {
             cableReportServiceAllu.getApplicationInformation(21)
-            cableReportServiceAllu.update(21, newApplicationData.toAlluData(HANKE_TUNNUS))
+            cableReportServiceAllu.update(21, expectedAlluRequest)
             cableReportServiceAllu.addAttachment(21, any())
         }
     }
@@ -925,7 +924,6 @@ class ApplicationServiceITest : DatabaseTest() {
         val applicationData = application.applicationData as CableReportApplicationData
         val pendingApplicationData = applicationData.copy(pendingOnClient = false)
         val expectedAlluRequest = pendingApplicationData.toAlluData(HANKE_TUNNUS)
-        assertEquals(application.hanke.hankeTunnus, expectedAlluRequest.identificationNumber)
         every { cableReportServiceAllu.create(expectedAlluRequest) } returns 26
         justRun { cableReportServiceAllu.addAttachment(26, any()) }
         justRun { cableReportServiceAllu.addAttachments(26, any()) }
@@ -947,7 +945,7 @@ class ApplicationServiceITest : DatabaseTest() {
         )
         assertEquals(ApplicationStatus.PENDING, savedApplication.alluStatus)
         verifyOrder {
-            cableReportServiceAllu.create(pendingApplicationData.toAlluData(HANKE_TUNNUS))
+            cableReportServiceAllu.create(expectedAlluRequest)
             cableReportServiceAllu.addAttachment(26, any())
             cableReportServiceAllu.addAttachments(26, any())
             cableReportServiceAllu.getApplicationInformation(26)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationData.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationData.kt
@@ -27,7 +27,7 @@ sealed interface ApplicationData {
     val areas: List<ApplicationArea>?
 
     fun copy(pendingOnClient: Boolean): ApplicationData
-    fun toAlluData(): AlluApplicationData?
+    fun toAlluData(hankeTunnus: String): AlluApplicationData
     fun customersWithContacts(): List<CustomerWithContacts>
 }
 
@@ -42,10 +42,8 @@ data class CableReportApplicationData(
     val startTime: ZonedDateTime?,
     val endTime: ZonedDateTime?,
     override val pendingOnClient: Boolean,
-    val identificationNumber: String,
 
     // CableReport specific, required
-    val clientApplicationKind: String,
     val workDescription: String,
     val contractorWithContacts: CustomerWithContacts, // työn suorittaja
     val rockExcavation: Boolean?,
@@ -67,8 +65,8 @@ data class CableReportApplicationData(
     override fun copy(pendingOnClient: Boolean): CableReportApplicationData =
         copy(applicationType = applicationType, pendingOnClient = pendingOnClient)
 
-    override fun toAlluData(): AlluCableReportApplicationData =
-        ApplicationDataMapper.toAlluData(this)
+    override fun toAlluData(hankeTunnus: String): AlluCableReportApplicationData =
+        ApplicationDataMapper.toAlluData(hankeTunnus, this)
 
     override fun customersWithContacts(): List<CustomerWithContacts> =
         listOfNotNull(

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationDataMapper.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationDataMapper.kt
@@ -2,57 +2,64 @@ package fi.hel.haitaton.hanke.application
 
 import fi.hel.haitaton.hanke.COORDINATE_SYSTEM_URN
 import fi.hel.haitaton.hanke.allu.AlluCableReportApplicationData
+import fi.hel.haitaton.hanke.application.AlluDataError.EMPTY_OR_NULL
+import fi.hel.haitaton.hanke.application.AlluDataError.NULL
 import fi.hel.haitaton.hanke.geometria.UnsupportedCoordinateSystemException
+import java.time.ZonedDateTime
 import org.geojson.GeometryCollection
 import org.geojson.Polygon
 
 object ApplicationDataMapper {
 
-    fun toAlluData(applicationData: CableReportApplicationData): AlluCableReportApplicationData =
-        AlluCableReportApplicationData(
-            applicationData.name,
-            applicationData.customerWithContacts.toAlluData("applicationData.customerWithContacts"),
-            getGeometry(applicationData),
-            applicationData.startTime
-                ?: throw AlluDataException("applicationData.startTime", AlluDataError.NULL),
-            applicationData.endTime
-                ?: throw AlluDataException("applicationData.endTime", AlluDataError.NULL),
-            applicationData.pendingOnClient,
-            applicationData.identificationNumber,
-            applicationData.clientApplicationKind,
-            getWorkDescription(applicationData),
-            applicationData.contractorWithContacts.toAlluData(
-                "applicationData.contractorWithContacts"
-            ),
-            applicationData.postalAddress?.toAlluData(),
-            applicationData.representativeWithContacts?.toAlluData(
-                "applicationData.representativeWithContacts"
-            ),
-            applicationData.invoicingCustomer?.toAlluData("applicationData.invoicingCustomer"),
-            applicationData.customerReference,
-            applicationData.area,
-            applicationData.propertyDeveloperWithContacts?.toAlluData(
-                "applicationData.propertyDeveloperWithContacts"
-            ),
-            applicationData.constructionWork,
-            applicationData.maintenanceWork,
-            applicationData.emergencyWork,
-            applicationData.propertyConnectivity
-        )
+    private const val BASE = "applicationData."
 
-    private fun getWorkDescription(applicationData: CableReportApplicationData): String {
-        val rockExcavation =
-            applicationData.rockExcavation
-                ?: throw AlluDataException("applicationData.rockExcavation", AlluDataError.NULL)
-        return applicationData.workDescription +
-            if (rockExcavation) "\nLouhitaan" else "\nEi louhita"
-    }
+    private const val AREAS = "areas"
+    private const val CONTRACTOR = "contractorWithContacts"
+    private const val CUSTOMER = "customerWithContacts"
+    private const val DEVELOPER = "propertyDeveloperWithContacts"
+    private const val EXCAVATION = "rockExcavation"
+    private const val INVOICING = "invoicingCustomer"
+    private const val REPRESENTATIVE = "representativeWithContacts"
+    private const val TIME_START = "startTime"
+    private const val TIME_END = "endTime"
+
+    fun toAlluData(
+        hankeTunnus: String,
+        applicationData: CableReportApplicationData
+    ): AlluCableReportApplicationData =
+        with(applicationData) {
+            val description = workDescription(cableReport = this)
+            AlluCableReportApplicationData(
+                name = name,
+                customerWithContacts = customerWithContacts.toAlluData(path(CUSTOMER)),
+                geometry = getGeometry(applicationData = this),
+                startTime = startTime.orThrow(path(TIME_START)),
+                endTime = endTime.orThrow(path(TIME_END)),
+                pendingOnClient = pendingOnClient,
+                identificationNumber = hankeTunnus,
+                clientApplicationKind = description, // intentional
+                workDescription = description,
+                contractorWithContacts = contractorWithContacts.toAlluData(path(CONTRACTOR)),
+                postalAddress = postalAddress?.toAlluData(),
+                representativeWithContacts =
+                    representativeWithContacts?.toAlluData(path(REPRESENTATIVE)),
+                invoicingCustomer = invoicingCustomer?.toAlluData(path(INVOICING)),
+                customerReference = customerReference,
+                area = area,
+                propertyDeveloperWithContacts =
+                    propertyDeveloperWithContacts?.toAlluData(path(DEVELOPER)),
+                constructionWork = constructionWork,
+                maintenanceWork = maintenanceWork,
+                emergencyWork = emergencyWork,
+                propertyConnectivity = propertyConnectivity
+            )
+        }
 
     /** If areas are missing, throw an exception. */
     internal fun getGeometry(applicationData: ApplicationData): GeometryCollection {
         val areas = applicationData.areas
         return if (areas.isNullOrEmpty()) {
-            throw AlluDataException("applicationData.areas", AlluDataError.EMPTY_OR_NULL)
+            throw AlluDataException(path(AREAS), EMPTY_OR_NULL)
         } else {
             // Check that all polygons have the coordinate reference system Haitaton understands
             areas
@@ -74,4 +81,16 @@ object ApplicationDataMapper {
             }
         }
     }
+
+    private fun path(vararg field: String) = field.joinToString(separator = ".", prefix = BASE)
+
+    private fun ZonedDateTime?.orThrow(path: String) = this ?: throw AlluDataException(path, NULL)
+
+    private fun workDescription(cableReport: CableReportApplicationData): String =
+        with(cableReport) {
+            val excavation = rockExcavation ?: throw AlluDataException(path(EXCAVATION), NULL)
+            return workDescription + excavation.description()
+        }
+
+    private fun Boolean.description(): String = if (this) "\nLouhitaan" else "\nEi louhita"
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationEntity.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationEntity.kt
@@ -50,4 +50,7 @@ data class ApplicationEntity(
             applicationData,
             hanke.hankeTunnus!!,
         )
+
+    /** An application must belong to a Hanke. Thus, hankeTunnus must be present. */
+    fun hankeTunnus(): String = hanke.hankeTunnus!!
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationService.kt
@@ -436,15 +436,13 @@ open class ApplicationService(
     }
 
     private fun updateApplicationInAllu(entity: ApplicationEntity): Int {
-        val application = entity.toApplication()
-        val alluId =
-            application.alluid ?: throw ApplicationArgumentException("AlluId null in update.")
+        val alluId = entity.alluid ?: throw ApplicationArgumentException("AlluId null in update.")
 
         logger.info { "Uploading updated application with alluId $alluId" }
 
-        when (val data = application.applicationData) {
+        when (val data = entity.applicationData) {
             is CableReportApplicationData ->
-                updateCableReportInAllu(alluId, application.hankeTunnus, data)
+                updateCableReportInAllu(alluId, entity.hankeTunnus(), data)
         }
 
         return alluId
@@ -452,13 +450,12 @@ open class ApplicationService(
 
     /** Creates new application in Allu. All attachments are sent after creation. */
     private fun createApplicationInAllu(entity: ApplicationEntity): Int {
-        val application = entity.toApplication()
-        val attachments = entity.attachments.map { it.toAlluAttachment() }
         val alluId =
-            when (val data = application.applicationData) {
-                is CableReportApplicationData ->
-                    createCableReportToAllu(application.hankeTunnus, data)
+            when (val data = entity.applicationData) {
+                is CableReportApplicationData -> createCableReportToAllu(entity.hankeTunnus(), data)
             }
+
+        val attachments = entity.attachments.map { it.toAlluAttachment() }
 
         attachmentService.sendAllAttachments(alluId, attachments)
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentService.kt
@@ -2,6 +2,7 @@ package fi.hel.haitaton.hanke.attachment.application
 
 import fi.hel.haitaton.hanke.allu.ApplicationStatus.PENDING
 import fi.hel.haitaton.hanke.allu.ApplicationStatus.PENDING_CLIENT
+import fi.hel.haitaton.hanke.allu.Attachment
 import fi.hel.haitaton.hanke.allu.CableReportService
 import fi.hel.haitaton.hanke.application.ApplicationAlreadyProcessingException
 import fi.hel.haitaton.hanke.application.ApplicationEntity
@@ -109,13 +110,13 @@ class ApplicationAttachmentService(
         logger.info { "Deleted application attachment ${attachment.id}" }
     }
 
-    fun sendAllAttachments(alluId: Int, attachments: List<ApplicationAttachmentEntity>) {
+    fun sendAllAttachments(alluId: Int, attachments: List<Attachment>) {
         if (attachments.isEmpty()) {
             logger.info { "No attachments to send for alluId $alluId" }
             return
         }
-        val alluAttachments = attachments.map { it.toAlluAttachment() }
-        cableReportService.addAttachments(alluId, alluAttachments)
+
+        cableReportService.addAttachments(alluId, attachments)
     }
 
     private fun findApplication(applicationId: Long): ApplicationEntity =

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/application/ApplicationDataMapperTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/application/ApplicationDataMapperTest.kt
@@ -1,9 +1,11 @@
 package fi.hel.haitaton.hanke.application
 
+import assertk.Assert
 import assertk.all
 import assertk.assertThat
 import assertk.assertions.containsExactly
 import assertk.assertions.containsExactlyInAnyOrder
+import assertk.assertions.each
 import assertk.assertions.endsWith
 import assertk.assertions.extracting
 import assertk.assertions.hasSize
@@ -11,6 +13,8 @@ import assertk.assertions.isEqualTo
 import assertk.assertions.isNotNull
 import assertk.assertions.isNull
 import fi.hel.haitaton.hanke.COORDINATE_SYSTEM_URN
+import fi.hel.haitaton.hanke.allu.Contact
+import fi.hel.haitaton.hanke.allu.CustomerWithContacts as AlluCustomerWithContacts
 import fi.hel.haitaton.hanke.asJsonResource
 import fi.hel.haitaton.hanke.factory.AlluDataFactory
 import fi.hel.haitaton.hanke.geometria.UnsupportedCoordinateSystemException
@@ -27,6 +31,35 @@ internal class ApplicationDataMapperTest {
 
     @Nested
     inner class ToAlluData {
+
+        @Test
+        fun `toAlluData when cable report should map fields correctly`() {
+            val input = AlluDataFactory.createCableReportApplicationData()
+
+            val result = ApplicationDataMapper.toAlluData(HANKE_TUNNUS, input)
+
+            assertThat(result.name).isEqualTo(input.name)
+            assertThat(result.customerWithContacts).isValid(input.customerWithContacts)
+            assertThat(result.geometry).isEqualTo(ApplicationDataMapper.getGeometry(input))
+            assertThat(result.startTime).isEqualTo(input.startTime)
+            assertThat(result.endTime).isEqualTo(input.endTime)
+            assertThat(result.pendingOnClient).isEqualTo(input.pendingOnClient)
+            assertThat(result.identificationNumber).isEqualTo(HANKE_TUNNUS)
+            assertThat(result.clientApplicationKind).isEqualTo(toDescription(input.workDescription))
+            assertThat(result.workDescription).isEqualTo(toDescription(input.workDescription))
+            assertThat(result.contractorWithContacts).isValid(input.contractorWithContacts)
+            assertThat(result.postalAddress).isEqualTo(input.postalAddress)
+            assertThat(result.representativeWithContacts).isNull()
+            assertThat(result.invoicingCustomer).isNull()
+            assertThat(result.customerReference).isEqualTo(input.customerReference)
+            assertThat(result.area).isEqualTo(input.area)
+            assertThat(result.propertyDeveloperWithContacts).isNull()
+            assertThat(result.constructionWork).isEqualTo(input.constructionWork)
+            assertThat(result.maintenanceWork).isEqualTo(input.maintenanceWork)
+            assertThat(result.emergencyWork).isEqualTo(input.emergencyWork)
+            assertThat(result.propertyConnectivity).isEqualTo(input.propertyConnectivity)
+        }
+
         @ParameterizedTest(name = "Adds rock excavation to work description, {argumentsWithNames}")
         @CsvSource("true,Louhitaan", "false,Ei louhita")
         fun `Adds rock excavation to work description`(
@@ -40,6 +73,30 @@ internal class ApplicationDataMapperTest {
 
             assertThat(alluData.workDescription).endsWith(expectedSuffix)
         }
+
+        private fun Assert<AlluCustomerWithContacts>.isValid(input: CustomerWithContacts) =
+            given { result ->
+                assertThat(result.customer.type).isEqualTo(input.customer.type)
+                assertThat(result.customer.country).isEqualTo(input.customer.country)
+                assertThat(result.customer.email).isEqualTo(input.customer.email)
+                assertThat(result.customer.phone).isEqualTo(input.customer.phone)
+                assertThat(result.customer.registryKey).isEqualTo(input.customer.registryKey)
+                assertThat(result.customer.ovt).isEqualTo(input.customer.ovt)
+                assertThat(result.customer.invoicingOperator)
+                    .isEqualTo(input.customer.invoicingOperator)
+                assertThat(result.customer.sapCustomerNumber)
+                    .isEqualTo(input.customer.sapCustomerNumber)
+                assertThat(result.contacts).areValid()
+            }
+
+        private fun Assert<List<Contact>>.areValid() = each { contact ->
+            contact.transform { it.name }.isNotNull()
+            contact.transform { it.email }.isNotNull()
+            contact.transform { it.phone }.isNotNull()
+            contact.transform { it.orderer }.isNotNull()
+        }
+
+        private fun toDescription(initial: String) = "$initial\nEi louhita"
     }
 
     @Nested

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/application/ApplicationDataMapperTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/application/ApplicationDataMapperTest.kt
@@ -21,6 +21,8 @@ import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
 
+private const val HANKE_TUNNUS = "HAI23-45"
+
 internal class ApplicationDataMapperTest {
 
     @Nested
@@ -34,7 +36,7 @@ internal class ApplicationDataMapperTest {
             val applicationData =
                 AlluDataFactory.createCableReportApplicationData(rockExcavation = rockExcavation)
 
-            val alluData = ApplicationDataMapper.toAlluData(applicationData)
+            val alluData = ApplicationDataMapper.toAlluData(HANKE_TUNNUS, applicationData)
 
             assertThat(alluData.workDescription).endsWith(expectedSuffix)
         }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/AlluDataFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/AlluDataFactory.kt
@@ -123,8 +123,6 @@ class AlluDataFactory(val applicationRepository: ApplicationRepository) {
             startTime: ZonedDateTime? = DateFactory.getStartDatetime(),
             endTime: ZonedDateTime? = DateFactory.getEndDatetime(),
             pendingOnClient: Boolean = false,
-            identificationNumber: String = "identification",
-            clientApplicationKind: String = "applicationKind",
             workDescription: String = "Work description.",
             customerWithContacts: CustomerWithContacts =
                 createCompanyCustomer().withContacts(createContact()),
@@ -142,8 +140,6 @@ class AlluDataFactory(val applicationRepository: ApplicationRepository) {
                 startTime = startTime,
                 endTime = endTime,
                 pendingOnClient = pendingOnClient,
-                identificationNumber = identificationNumber,
-                clientApplicationKind = clientApplicationKind,
                 workDescription = workDescription,
                 customerWithContacts = customerWithContacts,
                 contractorWithContacts = contractorWithContacts,


### PR DESCRIPTION
# Description

Remove identificationNumber from applicationdata used in application endpoints. Front-end does not need the value.

Value (hankeTunnus) is set when applicationdata is mapped to alludata.

Additional: similar thing is done with clientApplicationKind. The same value as workDescription field is used here as requested by Allu people (to sort incoming applications by description). 

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1688

## Type of change

- [x] Bug fix 
- [ ] New feature 
- [ ] Other

# Instructions for testing
Send application to Allu and check hanketunnus.

Haitaton:
![image](https://github.com/City-of-Helsinki/haitaton-backend/assets/78962935/42831128-1eea-4d27-8625-6e5f85edf730)

Allu:
![image](https://github.com/City-of-Helsinki/haitaton-backend/assets/78962935/9d8d2729-b9dc-4994-b684-ad74630e96de)

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 

# Other relevant info
Please describe here if there is e.g. some requirements for this change or
 other info that the tester/user needs to know.