### PR TITLE
HAI Remove email username and password

### DIFF
--- a/services/hanke-service/src/main/resources/application.properties
+++ b/services/hanke-service/src/main/resources/application.properties
@@ -84,8 +84,6 @@ springdoc.swagger-ui.config-url=${HAITATON_SWAGGER_PATH_PREFIX:/api/v3}/api-docs
 
 spring.mail.host=${MAIL_SENDER_HOST:localhost}
 spring.mail.port=${MAIL_SENDER_PORT:2525}
-spring.mail.username=${MAIL_SENDER_USERNAME}
-spring.mail.password=${MAIL_SENDER_PASSWORD}
 spring.mail.properties.mail.transport.protocol=${MAIL_SENDER_PROTOCOL:smtp}
 # Set to true to get detailed debug info from SMTP client
 spring.mail.properties.mail.debug=${MAIL_SENDER_DEBUG:false}


### PR DESCRIPTION
# Description

Remove username and password from email properties. In cloud environments, they caused the email client to use authentication even though we tell it not to do that.

No environment should use authentication for sending emails, so they are safe to remove.

## Type of change

- [X] Bug fix 
- [ ] New feature 
- [ ] Other