### PR TITLE
HAI-1679 Cancel application if initial attachment upload fails

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
@@ -8,6 +8,7 @@ import assertk.assertions.isNull
 import com.ninjasquad.springmockk.MockkBean
 import fi.hel.haitaton.hanke.allu.ApplicationStatus
 import fi.hel.haitaton.hanke.allu.CableReportService
+import fi.hel.haitaton.hanke.application.ALLU_USER_CANCELLATION_MSG
 import fi.hel.haitaton.hanke.application.Application
 import fi.hel.haitaton.hanke.application.ApplicationArea
 import fi.hel.haitaton.hanke.application.ApplicationEntity
@@ -1194,6 +1195,7 @@ class HankeServiceITests : DatabaseTest() {
         every { cableReportService.getApplicationInformation(hakemusAlluId) } returns
             AlluDataFactory.createAlluApplicationResponse(status = ApplicationStatus.PENDING)
         justRun { cableReportService.cancel(hakemusAlluId) }
+        every { cableReportService.sendSystemComment(hakemusAlluId, any()) } returns 1324
 
         hankeService.deleteHanke(hanke.toDomainObject(), hakemukset, USER_NAME)
 
@@ -1202,6 +1204,7 @@ class HankeServiceITests : DatabaseTest() {
             cableReportService.getApplicationInformation(hakemusAlluId)
             cableReportService.getApplicationInformation(hakemusAlluId)
             cableReportService.cancel(hakemusAlluId)
+            cableReportService.sendSystemComment(hakemusAlluId, ALLU_USER_CANCELLATION_MSG)
         }
     }
 

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/allu/CableReportServiceAlluITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/allu/CableReportServiceAlluITests.kt
@@ -204,7 +204,7 @@ class CableReportServiceAlluITests {
             val exception =
                 assertThrows<ApplicationDecisionNotFoundException> { service.getDecisionPdf(12) }
 
-            assertThat(exception).hasMessage("Decision not found in Allu. alluid=12")
+            assertThat(exception).hasMessage("Decision not found in Allu. alluApplicationId=12")
         }
 
         @Test

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/AlluCommonDomain.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/AlluCommonDomain.kt
@@ -56,3 +56,8 @@ data class AttachmentMetadata(
     val name: String,
     val description: String?,
 )
+
+data class Comment(
+    val commentator: String?,
+    val commentContent: String,
+)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/CableReportService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/CableReportService.kt
@@ -35,4 +35,6 @@ interface CableReportService {
     fun getApplicationInformation(applicationId: Int): AlluApplicationResponse
 
     fun cancel(applicationId: Int)
+
+    fun sendSystemComment(applicationId: Int, msg: String): Int
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/CableReportService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/CableReportService.kt
@@ -5,36 +5,36 @@ import java.time.ZonedDateTime
 interface CableReportService {
 
     fun getApplicationStatusHistories(
-        applicationIds: List<Int>,
+        alluApplicationIds: List<Int>,
         eventsAfter: ZonedDateTime
     ): List<ApplicationHistory>
 
     fun create(cableReport: AlluCableReportApplicationData): Int
 
-    fun update(applicationId: Int, cableReport: AlluCableReportApplicationData)
+    fun update(alluApplicationId: Int, cableReport: AlluCableReportApplicationData)
 
-    fun addAttachment(applicationId: Int, attachment: Attachment)
+    fun addAttachment(alluApplicationId: Int, attachment: Attachment)
 
-    fun addAttachments(alluId: Int, attachments: List<Attachment>)
+    fun addAttachments(alluApplicationId: Int, attachments: List<Attachment>)
 
-    fun getInformationRequests(applicationId: Int): List<InformationRequest>
+    fun getInformationRequests(alluApplicationId: Int): List<InformationRequest>
 
     fun respondToInformationRequest(
-        applicationId: Int,
+        alluApplicationId: Int,
         requestId: Int,
         cableReport: AlluCableReportApplicationData,
         updatedFields: List<InformationRequestFieldKey>
     )
 
-    fun getDecisionPdf(applicationId: Int): ByteArray
+    fun getDecisionPdf(alluApplicationId: Int): ByteArray
 
-    fun getDecisionAttachments(applicationId: Int): List<AttachmentMetadata>
+    fun getDecisionAttachments(alluApplicationId: Int): List<AttachmentMetadata>
 
-    fun getDecisionAttachmentData(applicationId: Int, attachmentId: Int): ByteArray
+    fun getDecisionAttachmentData(alluApplicationId: Int, attachmentId: Int): ByteArray
 
-    fun getApplicationInformation(applicationId: Int): AlluApplicationResponse
+    fun getApplicationInformation(alluApplicationId: Int): AlluApplicationResponse
 
-    fun cancel(applicationId: Int)
+    fun cancel(alluApplicationId: Int)
 
-    fun sendSystemComment(applicationId: Int, msg: String): Int
+    fun sendSystemComment(alluApplicationId: Int, msg: String): Int
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/CableReportServiceAllu.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/CableReportServiceAllu.kt
@@ -58,12 +58,12 @@ class CableReportServiceAllu(
         }
     }
 
-    override fun getApplicationInformation(applicationId: Int): AlluApplicationResponse {
-        logger.info { "Fetching application information for application: $applicationId" }
+    override fun getApplicationInformation(alluApplicationId: Int): AlluApplicationResponse {
+        logger.info { "Fetching application information for application: $alluApplicationId" }
         val token = login()
         return webClient
             .get()
-            .uri("$baseUrl/v2/applications/$applicationId")
+            .uri("$baseUrl/v2/applications/$alluApplicationId")
             .accept(MediaType.APPLICATION_JSON)
             .headers { it.setBearerAuth(token) }
             .retrieve()
@@ -83,12 +83,12 @@ class CableReportServiceAllu(
      * test instance is shared for all local, dev and test environments.
      */
     override fun getApplicationStatusHistories(
-        applicationIds: List<Int>,
+        alluApplicationIds: List<Int>,
         eventsAfter: ZonedDateTime,
     ): List<ApplicationHistory> {
         logger.info { "Fetching application status histories." }
         val token = login()
-        val search = ApplicationHistorySearch(applicationIds, eventsAfter)
+        val search = ApplicationHistorySearch(alluApplicationIds, eventsAfter)
         return webClient
             .post()
             .uri("$baseUrl/v2/applicationhistory")
@@ -128,12 +128,12 @@ class CableReportServiceAllu(
             .orElseThrow()
     }
 
-    override fun update(applicationId: Int, cableReport: AlluCableReportApplicationData) {
-        logger.info { "Updating application $applicationId." }
+    override fun update(alluApplicationId: Int, cableReport: AlluCableReportApplicationData) {
+        logger.info { "Updating application $alluApplicationId." }
         val token = login()
         webClient
             .put()
-            .uri("$baseUrl/v2/cablereports/$applicationId")
+            .uri("$baseUrl/v2/cablereports/$alluApplicationId")
             .contentType(MediaType.APPLICATION_JSON)
             .accept(MediaType.APPLICATION_JSON)
             .headers { it.setBearerAuth(token) }
@@ -148,12 +148,12 @@ class CableReportServiceAllu(
             .orElseThrow()
     }
 
-    override fun cancel(applicationId: Int) {
-        logger.info { "Cancelling application $applicationId." }
+    override fun cancel(alluApplicationId: Int) {
+        logger.info { "Cancelling application $alluApplicationId." }
         val token = login()
         webClient
             .put()
-            .uri("$baseUrl/v2/applications/$applicationId/cancelled")
+            .uri("$baseUrl/v2/applications/$alluApplicationId/cancelled")
             .contentType(MediaType.APPLICATION_JSON)
             .accept(MediaType.APPLICATION_JSON)
             .headers { it.setBearerAuth(token) }
@@ -167,25 +167,26 @@ class CableReportServiceAllu(
     }
 
     /** Send an individual attachment. */
-    override fun addAttachment(applicationId: Int, attachment: Attachment) {
+    override fun addAttachment(alluApplicationId: Int, attachment: Attachment) {
         val token = login()
-        postAttachment(applicationId, token, attachment)
+        postAttachment(alluApplicationId, token, attachment)
     }
 
     /** Send many attachments in parallel. */
-    override fun addAttachments(alluId: Int, attachments: List<Attachment>) = runBlocking {
-        withContext(ioDispatcher) {
-            val token = login()
-            attachments.forEach { launch { postAttachment(alluId, token, it) } }
+    override fun addAttachments(alluApplicationId: Int, attachments: List<Attachment>) =
+        runBlocking {
+            withContext(ioDispatcher) {
+                val token = login()
+                attachments.forEach { launch { postAttachment(alluApplicationId, token, it) } }
+            }
         }
-    }
 
-    override fun getInformationRequests(applicationId: Int): List<InformationRequest> {
-        logger.info { "Fetching information request for application $applicationId." }
+    override fun getInformationRequests(alluApplicationId: Int): List<InformationRequest> {
+        logger.info { "Fetching information request for application $alluApplicationId." }
         val token = login()
         return webClient
             .get()
-            .uri("$baseUrl/v2/applications/$applicationId/informationrequests")
+            .uri("$baseUrl/v2/applications/$alluApplicationId/informationrequests")
             .accept(MediaType.APPLICATION_JSON)
             .headers { it.setBearerAuth(token) }
             .retrieve()
@@ -200,7 +201,7 @@ class CableReportServiceAllu(
     }
 
     override fun respondToInformationRequest(
-        applicationId: Int,
+        alluApplicationId: Int,
         requestId: Int,
         cableReport: AlluCableReportApplicationData,
         updatedFields: List<InformationRequestFieldKey>,
@@ -209,7 +210,9 @@ class CableReportServiceAllu(
         val token = login()
         webClient
             .post()
-            .uri("$baseUrl/v2/cablereports/$applicationId/informationrequests/$requestId/response")
+            .uri(
+                "$baseUrl/v2/cablereports/$alluApplicationId/informationrequests/$requestId/response"
+            )
             .contentType(MediaType.APPLICATION_JSON)
             .accept(MediaType.APPLICATION_JSON)
             .headers { it.setBearerAuth(token) }
@@ -220,10 +223,10 @@ class CableReportServiceAllu(
             .block()
     }
 
-    override fun getDecisionPdf(applicationId: Int): ByteArray {
-        logger.info { "Fetching decision pdf for application $applicationId." }
+    override fun getDecisionPdf(alluApplicationId: Int): ByteArray {
+        logger.info { "Fetching decision pdf for application $alluApplicationId." }
         val token = login()
-        val requestUri = "$baseUrl/v2/cablereports/$applicationId/decision"
+        val requestUri = "$baseUrl/v2/cablereports/$alluApplicationId/decision"
         val response =
             webClient
                 .get()
@@ -236,7 +239,7 @@ class CableReportServiceAllu(
                     {
                         Mono.error(
                             ApplicationDecisionNotFoundException(
-                                "Decision not found in Allu. alluid=$applicationId"
+                                "Decision not found in Allu. alluApplicationId=$alluApplicationId"
                             )
                         )
                     }
@@ -260,12 +263,12 @@ class CableReportServiceAllu(
         return body.byteArray
     }
 
-    override fun getDecisionAttachments(applicationId: Int): List<AttachmentMetadata> {
-        logger.info { "Fetching decision attachments for application $applicationId." }
+    override fun getDecisionAttachments(alluApplicationId: Int): List<AttachmentMetadata> {
+        logger.info { "Fetching decision attachments for application $alluApplicationId." }
         val token = login()
         return webClient
             .get()
-            .uri("$baseUrl/v2/applications/$applicationId/attachments", applicationId)
+            .uri("$baseUrl/v2/applications/$alluApplicationId/attachments", alluApplicationId)
             .accept(MediaType.APPLICATION_JSON)
             .headers { it.setBearerAuth(token) }
             .retrieve()
@@ -279,12 +282,12 @@ class CableReportServiceAllu(
             .orElseThrow()
     }
 
-    override fun getDecisionAttachmentData(applicationId: Int, attachmentId: Int): ByteArray {
-        logger.info { "Fetching decision attachment for application: $applicationId." }
+    override fun getDecisionAttachmentData(alluApplicationId: Int, attachmentId: Int): ByteArray {
+        logger.info { "Fetching decision attachment for application: $alluApplicationId." }
         val token = login()
         return webClient
             .get()
-            .uri("$baseUrl/v2/applications/$applicationId/attachments/$attachmentId")
+            .uri("$baseUrl/v2/applications/$alluApplicationId/attachments/$attachmentId")
             .accept(MediaType.APPLICATION_PDF)
             .headers { it.setBearerAuth(token) }
             .retrieve()
@@ -298,20 +301,20 @@ class CableReportServiceAllu(
             .orElseThrow()
     }
 
-    override fun sendSystemComment(applicationId: Int, msg: String): Int =
-        sendComment(applicationId, Comment(HAITATON_SYSTEM, msg))
     /**
      * Send a comment to the application with Haitaton system as the sender.
      *
      * @return The id of the added comment in Allu
      */
+    override fun sendSystemComment(alluApplicationId: Int, msg: String): Int =
+        sendComment(alluApplicationId, Comment(HAITATON_SYSTEM, msg))
 
-    private fun sendComment(applicationId: Int, comment: Comment): Int {
-        logger.info { "Sending comment to application: $applicationId." }
+    private fun sendComment(alluApplicationId: Int, comment: Comment): Int {
+        logger.info { "Sending comment to application: $alluApplicationId." }
         val token = login()
         return webClient
             .post()
-            .uri("$baseUrl/v2/applications/$applicationId/comments")
+            .uri("$baseUrl/v2/applications/$alluApplicationId/comments")
             .contentType(MediaType.APPLICATION_JSON)
             .accept(MediaType.APPLICATION_JSON)
             .headers { it.setBearerAuth(token) }
@@ -326,8 +329,8 @@ class CableReportServiceAllu(
             .orElseThrow()
     }
 
-    private fun postAttachment(alluId: Int, token: String, attachment: Attachment) {
-        logger.info { "Sending attachment for application $alluId." }
+    private fun postAttachment(alluApplicationId: Int, token: String, attachment: Attachment) {
+        logger.info { "Sending attachment for application $alluApplicationId." }
 
         val builder = MultipartBodyBuilder()
         builder
@@ -344,7 +347,7 @@ class CableReportServiceAllu(
 
         webClient
             .post()
-            .uri("$baseUrl/v2/applications/$alluId/attachments")
+            .uri("$baseUrl/v2/applications/$alluApplicationId/attachments")
             .contentType(MediaType.MULTIPART_FORM_DATA)
             .accept(MediaType.APPLICATION_JSON)
             .headers { it.setBearerAuth(token) }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/CableReportServiceAllu.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/CableReportServiceAllu.kt
@@ -298,9 +298,13 @@ class CableReportServiceAllu(
             .orElseThrow()
     }
 
-    /** Send a comment to the application with Haitaton system as the sender. */
     override fun sendSystemComment(applicationId: Int, msg: String): Int =
         sendComment(applicationId, Comment(HAITATON_SYSTEM, msg))
+    /**
+     * Send a comment to the application with Haitaton system as the sender.
+     *
+     * @return The id of the added comment in Allu
+     */
 
     private fun sendComment(applicationId: Int, comment: Comment): Int {
         logger.info { "Sending comment to application: $applicationId." }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentService.kt
@@ -2,7 +2,6 @@ package fi.hel.haitaton.hanke.attachment.application
 
 import fi.hel.haitaton.hanke.allu.ApplicationStatus.PENDING
 import fi.hel.haitaton.hanke.allu.ApplicationStatus.PENDING_CLIENT
-import fi.hel.haitaton.hanke.allu.Attachment
 import fi.hel.haitaton.hanke.allu.CableReportService
 import fi.hel.haitaton.hanke.application.ApplicationAlreadyProcessingException
 import fi.hel.haitaton.hanke.application.ApplicationEntity
@@ -110,7 +109,9 @@ class ApplicationAttachmentService(
         logger.info { "Deleted application attachment ${attachment.id}" }
     }
 
-    fun sendAllAttachments(alluId: Int, attachments: List<Attachment>) {
+    fun sendInitialAttachments(alluId: Int, application: ApplicationEntity) {
+        logger.info { "Sending initial attachments for application, alluid=$alluId" }
+        val attachments = application.attachments.map { it.toAlluAttachment() }
         if (attachments.isEmpty()) {
             logger.info { "No attachments to send for alluId $alluId" }
             return

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceTest.kt
@@ -266,7 +266,7 @@ class ApplicationServiceTest {
         every { geometriatDao.calculateCombinedArea(any()) } returns 100f
         every { geometriatDao.calculateArea(any()) } returns 100f
         every { geometriatDao.isInsideHankeAlueet(1, any()) } returns true
-        justRun { attachmentService.sendAllAttachments(42, any()) }
+        justRun { attachmentService.sendInitialAttachments(42, any()) }
 
         applicationService.sendApplication(3, USERNAME)
 
@@ -280,7 +280,7 @@ class ApplicationServiceTest {
             cableReportService.create(any())
             disclosureLogService.saveDisclosureLogsForAllu(expectedApplication, Status.SUCCESS)
             cableReportService.addAttachment(42, any())
-            attachmentService.sendAllAttachments(42, any())
+            attachmentService.sendInitialAttachments(42, any())
             cableReportService.getApplicationInformation(42)
             applicationRepo.save(any())
         }
@@ -373,7 +373,7 @@ class ApplicationServiceTest {
         justRun { cableReportService.addAttachment(852, any()) }
         every { cableReportService.getApplicationInformation(852) } returns
             AlluDataFactory.createAlluApplicationResponse(852)
-        justRun { attachmentService.sendAllAttachments(852, any()) }
+        justRun { attachmentService.sendInitialAttachments(852, any()) }
 
         applicationService.sendApplication(3, USERNAME)
 


### PR DESCRIPTION
# Description

When sending an application to Allu for the first time, we need to send all attachments at the same time. But if one of the uploads fails, the upload fails from Haitaton perspective, so the application is not marked as sent.

From Allu perspective, however, the application was uploaded successfully, and the officer looking at it doesn't know there are attachments missing.

When the user resends the application from Haitaton, a duplicate is created in Allu.

The proper way to fix this would be:
1. Mark the uploaded application as sent to Allu, even if the attachments uploads fail. Set the status to PENDING_CLIENT in both Allu and Haitaton.
2. Mark the attachments that were sent successfully as sent.
3. Tell the user that the sending failed and ask them to retry.
4. When the user tries to resend the application, notice that the application is already in Allu, and update it instead of creating a new one.
5. Send only the applications that haven't been sent before.

This would be a big change, however. Among other things, we don't have a way to mark applications as sent at the moment.

So instead, cancel the application in Allu if uploading the attachments fail. The application will remain in Allu in the cancelled state for all eternity. Failing the attachment uploads should be rare enough that this is not a big problem.

Also, add a comment to Allu on behalf of the Haitaton system to say why the application was cancelled. While adding comments, also add a comment when a user cancels the application in Haitaton while it's pending in Allu.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1679

## Type of change

- [X] Bug fix 
- [ ] New feature 
- [ ] Other

# Instructions for testing
1. Add an attachment of over 20MB to an application draft.
2. Send it to Allu. The attachment upload should fail.
3. Check in Allu that Haitaton has cancelled the application and added a comment about why it was cancelled.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 
