### PR TITLE
HAI Add the correct sender to email properties

### DIFF
--- a/services/hanke-service/src/main/resources/application.properties
+++ b/services/hanke-service/src/main/resources/application.properties
@@ -97,5 +97,5 @@ spring.mail.properties.mail.smtp.starttls.enable=${MAIL_SENDER_STARTTLS_ENABLE:t
 haitaton.email.filter.use=${HAITATON_EMAIL_FILTER_USE:true}
 # List of allowed addresses, separated by ;
 haitaton.email.filter.allow-list=${HAITATON_EMAIL_FILTER_ALLOW_LIST:haitaton@test.com}
-haitaton.email.from=${HAITATON_EMAIL_FROM:haitaton@test.example}
+haitaton.email.from=${HAITATON_EMAIL_FROM:Haitaton <noreply.haitaton@hel.fi>}
 haitaton.email.baseUrl=${HAITATON_EMAIL_BASEURL:http://localhost:3001}


### PR DESCRIPTION
# Description

Add the correct sender to email properties.

This is the same in all environments, so it's easier to change the default than to set this to all environments separately.