### PR TITLE
HAI-1704 Add validation to prevent start time be after end time.

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationControllerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationControllerITest.kt
@@ -23,6 +23,7 @@ import io.mockk.confirmVerified
 import io.mockk.every
 import io.mockk.justRun
 import io.mockk.verify
+import java.time.ZonedDateTime
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
@@ -182,6 +183,24 @@ class ApplicationControllerITest(@Autowired override val mockMvc: MockMvc) : Con
 
     @Test
     @WithMockUser(USERNAME)
+    fun `create with endTime before start type returns 400`() {
+        val application =
+            AlluDataFactory.createApplication(
+                id = null,
+                applicationData =
+                    AlluDataFactory.createCableReportApplicationData(
+                        startTime = ZonedDateTime.now(),
+                        endTime = ZonedDateTime.now().minusDays(1)
+                    )
+            )
+
+        post(BASE_URL, application).andExpect(status().isBadRequest)
+
+        verify { applicationService wasNot Called }
+    }
+
+    @Test
+    @WithMockUser(USERNAME)
     fun `create with missing application type returns 400`() {
         val application = AlluDataFactory.createApplication(id = null)
         val content: ObjectNode = OBJECT_MAPPER.valueToTree(application)
@@ -239,6 +258,24 @@ class ApplicationControllerITest(@Autowired override val mockMvc: MockMvc) : Con
     @WithMockUser(USERNAME)
     fun `update without body returns 400`() {
         put("$BASE_URL/1234").andExpect(status().isBadRequest)
+
+        verify { applicationService wasNot Called }
+    }
+
+    @Test
+    @WithMockUser(USERNAME)
+    fun `update with endTime before start type returns 400`() {
+        val application =
+            AlluDataFactory.createApplication(
+                id = null,
+                applicationData =
+                    AlluDataFactory.createCableReportApplicationData(
+                        startTime = ZonedDateTime.now(),
+                        endTime = ZonedDateTime.now().minusDays(1)
+                    )
+            )
+
+        put("$BASE_URL/1234", application).andExpect(status().isBadRequest)
 
         verify { applicationService wasNot Called }
     }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationData.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationData.kt
@@ -68,6 +68,7 @@ data class CableReportApplicationData(
     override fun toAlluData(hankeTunnus: String): AlluCableReportApplicationData =
         ApplicationDataMapper.toAlluData(hankeTunnus, this)
 
+    /** Returns CustomerWithContacts fields that are not null. */
     override fun customersWithContacts(): List<CustomerWithContacts> =
         listOfNotNull(
             customerWithContacts,

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/CustomerWithContacts.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/CustomerWithContacts.kt
@@ -31,7 +31,7 @@ data class Contact(
     val orderer: Boolean = false,
 ) {
     /** Check if this contact is blank, i.e. it doesn't contain any actual contact information. */
-    @JsonIgnore fun isBlank() = listOf(firstName, lastName, email, phone).any { it.isNullOrBlank() }
+    @JsonIgnore fun isBlank() = listOf(firstName, lastName, email, phone).all { it.isNullOrBlank() }
 
     fun hasInformation() = !isBlank()
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/validation/ApplicationValidator.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/validation/ApplicationValidator.kt
@@ -29,10 +29,10 @@ class ApplicationValidator : ConstraintValidator<ValidApplication, Application> 
 
     private fun isValidCableReport(cableReportData: CableReportApplicationData): Boolean =
         listOf(
-                validStartAndEnd(cableReportData.startTime, cableReportData.endTime),
-                validCustomersWithContacts(cableReportData.customersWithContacts())
+                { validStartAndEnd(cableReportData.startTime, cableReportData.endTime) },
+                { validCustomersWithContacts(cableReportData.customersWithContacts()) }
             )
-            .all { it }
+            .all { it() }
 
     /**
      * Checks if the start is before or equal to the end.

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/validation/ApplicationValidator.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/validation/ApplicationValidator.kt
@@ -2,33 +2,87 @@ package fi.hel.haitaton.hanke.validation
 
 import fi.hel.haitaton.hanke.application.Application
 import fi.hel.haitaton.hanke.application.CableReportApplicationData
+import fi.hel.haitaton.hanke.application.Customer
+import fi.hel.haitaton.hanke.application.CustomerWithContacts
 import fi.hel.haitaton.hanke.isValidBusinessId
+import java.time.ZonedDateTime
 import javax.validation.ConstraintValidator
 import javax.validation.ConstraintValidatorContext
+import mu.KotlinLogging
+
+private val logger = KotlinLogging.logger {}
 
 class ApplicationValidator : ConstraintValidator<ValidApplication, Application> {
-    override fun isValid(application: Application?, context: ConstraintValidatorContext?): Boolean {
+    override fun isValid(application: Application, context: ConstraintValidatorContext?): Boolean {
 
-        val applicationData =
-            application?.applicationData
-                ?: throw InvalidApplicationDataException("Application data missing.")
-
-        return when (applicationData) {
-            is CableReportApplicationData ->
-                listOfNotNull(
-                        applicationData.customerWithContacts.customer,
-                        applicationData.contractorWithContacts.customer,
-                        applicationData.representativeWithContacts?.customer,
-                        applicationData.propertyDeveloperWithContacts?.customer,
-                    )
-                    .all {
-                        when {
-                            it.registryKey == null -> true
-                            it.registryKey.isValidBusinessId() -> true
-                            else -> throw InvalidApplicationDataException("Y-tunnus invalid.")
-                        }
-                    }
+        return when (application.applicationData) {
+            is CableReportApplicationData -> validOrThrow(application.applicationData)
         }
+    }
+
+    private fun validOrThrow(cableReportData: CableReportApplicationData): Boolean {
+        if (!isValidCableReport(cableReportData)) {
+            throw InvalidApplicationDataException("Received cable report contains invalid data.")
+        }
+        return true
+    }
+
+    private fun isValidCableReport(cableReportData: CableReportApplicationData): Boolean =
+        with(cableReportData) {
+            listOf(
+                    validStartAndEnd(startTime, endTime),
+                    validCustomerWithContactsNotNull(customerWithContacts),
+                    validCustomerWithContactsNullable(representativeWithContacts),
+                    validCustomerWithContactsNullable(contractorWithContacts),
+                    validCustomerWithContactsNullable(propertyDeveloperWithContacts)
+                )
+                .all { it }
+        }
+
+    /**
+     * Checks if the start is before or equal to the end.
+     *
+     * @param start the start time (nullable)
+     * @param end the end time (nullable)
+     * @return true if start is before or equal to end, false if either is null or if start is after
+     * end.
+     */
+    private fun validStartAndEnd(start: ZonedDateTime?, end: ZonedDateTime?): Boolean {
+        logger.info { "Application startDate: '$start', endDate: '$end'." }
+
+        if (start == null && end == null) {
+            return true
+        }
+
+        if (start == null || end == null) {
+            return false
+        }
+
+        return !start.isAfter(end)
+    }
+
+    /** Currently checks registryKey only. */
+    private fun validCustomer(customer: Customer?): Boolean {
+        if (customer == null) {
+            return true
+        }
+
+        return validRegistryKey(customer.registryKey)
+    }
+
+    private fun validRegistryKey(key: String?) = key?.isValidBusinessId() ?: true
+
+    /** Currently verifies customer only. */
+    private fun validCustomerWithContactsNotNull(contacts: CustomerWithContacts): Boolean =
+        validCustomer(contacts.customer)
+
+    /** Currently verifies customer only. */
+    private fun validCustomerWithContactsNullable(contacts: CustomerWithContacts?): Boolean {
+        if (contacts == null) {
+            return true
+        }
+
+        return validCustomer(contacts.customer)
     }
 }
 


### PR DESCRIPTION
# Description

Add validation to prevent start time be after end time. Application POST and PUT endpoints should not accept application startTime to be after endTime.

Additional: I refactored the whole application data validation. It is more than likely, that more validation will be implemented in the future, and I think this commit will make that work a bit easier.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1704

## Type of change

- [x] Bug fix 
- [ ] New feature 
- [ ] Other

# Instructions for testing
Set start time to be after end time. Endpoint should return 400.

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
