### PR TITLE
HAI-1723 Re-enable delete hanke endpoint

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/IntegrationTestConfiguration.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/IntegrationTestConfiguration.kt
@@ -3,6 +3,7 @@ package fi.hel.haitaton.hanke
 import fi.hel.haitaton.hanke.application.ApplicationService
 import fi.hel.haitaton.hanke.attachment.application.ApplicationAttachmentService
 import fi.hel.haitaton.hanke.attachment.hanke.HankeAttachmentService
+import fi.hel.haitaton.hanke.configuration.Features
 import fi.hel.haitaton.hanke.gdpr.GdprProperties
 import fi.hel.haitaton.hanke.gdpr.GdprService
 import fi.hel.haitaton.hanke.geometria.GeometriatDao
@@ -32,7 +33,7 @@ import org.springframework.security.web.SecurityFilterChain
 
 @TestConfiguration
 @Profile("itest")
-@EnableConfigurationProperties(GdprProperties::class)
+@EnableConfigurationProperties(GdprProperties::class, Features::class)
 class IntegrationTestConfiguration {
 
     @Bean fun jdbcOperations(): JdbcOperations = mockk()

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentControllerITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentControllerITests.kt
@@ -42,7 +42,6 @@ import org.springframework.security.test.context.support.WithAnonymousUser
 import org.springframework.security.test.context.support.WithMockUser
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf
 import org.springframework.test.context.ActiveProfiles
-import org.springframework.test.context.TestPropertySource
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.ResultActions
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart
@@ -193,16 +192,19 @@ class HankeAttachmentControllerITests(@Autowired override val mockMvc: MockMvc) 
     ): ResultActions = delete("/hankkeet/$hankeTunnus/liitteet/$attachmentId")
 }
 
-@WebMvcTest(HankeAttachmentController::class)
+@WebMvcTest(
+    HankeAttachmentController::class,
+    properties = ["haitaton.features.hanke-editing=false"]
+)
 @Import(IntegrationTestConfiguration::class)
 @ActiveProfiles("itest")
 @WithMockUser(USERNAME)
-@TestPropertySource(locations = ["classpath:application-test.properties"])
-class HankeAttachmentControllerEndpointDisabledITests(@Autowired override val mockMvc: MockMvc) :
-    ControllerTest {
+class HankeAttachmentControllerHankeEditingDisabledITests(
+    @Autowired override val mockMvc: MockMvc
+) : ControllerTest {
 
     @Test
-    fun `post attachment when endpoint is disabled should return 404`() {
+    fun `post attachment when hanke editing is disabled should return 404`() {
         val response =
             mockMvc
                 .perform(
@@ -216,7 +218,7 @@ class HankeAttachmentControllerEndpointDisabledITests(@Autowired override val mo
     }
 
     @Test
-    fun `delete attachment when endpoint is disabled should return 404`() {
+    fun `delete attachment when hanke editing is disabled should return 404`() {
         val response =
             delete("/hankkeet/$HANKE_TUNNUS/liitteet/${randomUUID()}").andReturn().response
 

--- a/services/hanke-service/src/integrationTest/resources/application-test.properties
+++ b/services/hanke-service/src/integrationTest/resources/application-test.properties
@@ -1,2 +1,1 @@
 haitaton.clamav.baseUrl=http://localhost:6789
-haitaton.feature.hanke-editing=false

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/ControllerExceptionHandler.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/ControllerExceptionHandler.kt
@@ -168,4 +168,4 @@ class ControllerExceptionHandler {
     class FakeAuthorizationException : RuntimeException()
 }
 
-class EndpointDisabledException() : RuntimeException("Endpoint disabled in this environment.")
+class EndpointDisabledException : RuntimeException("Endpoint disabled in this environment.")

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeController.kt
@@ -1,6 +1,8 @@
 package fi.hel.haitaton.hanke
 
 import fi.hel.haitaton.hanke.application.ApplicationsResponse
+import fi.hel.haitaton.hanke.configuration.Feature
+import fi.hel.haitaton.hanke.configuration.Features
 import fi.hel.haitaton.hanke.domain.Hanke
 import fi.hel.haitaton.hanke.logging.DisclosureLogService
 import fi.hel.haitaton.hanke.permissions.PermissionCode
@@ -12,7 +14,6 @@ import io.swagger.v3.oas.annotations.Operation
 import javax.validation.ConstraintViolationException
 import mu.KotlinLogging
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpStatus
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.DeleteMapping
@@ -36,7 +37,7 @@ class HankeController(
     @Autowired private val hankeService: HankeService,
     @Autowired private val permissionService: PermissionService,
     @Autowired private val disclosureLogService: DisclosureLogService,
-    @Value("\${haitaton.feature.hanke-editing}") val enableEditFeature: Boolean = true,
+    @Autowired private val features: Features,
 ) {
 
     @GetMapping("/{hankeTunnus}")
@@ -94,9 +95,7 @@ class HankeController(
     /** Add one hanke. This method will be called when we do not have id for hanke yet */
     @PostMapping
     fun createHanke(@ValidHanke @RequestBody hanke: Hanke?): Hanke {
-        if (!enableEditFeature) {
-            throw EndpointDisabledException()
-        }
+        features.check(Feature.HANKE_EDITING)
 
         if (hanke == null) {
             throw HankeArgumentException("No hanke given when creating hanke")
@@ -123,9 +122,7 @@ class HankeController(
         @ValidHanke @RequestBody hanke: Hanke,
         @PathVariable hankeTunnus: String
     ): Hanke {
-        if (!enableEditFeature) {
-            throw EndpointDisabledException()
-        }
+        features.check(Feature.HANKE_EDITING)
 
         logger.info { "Updating Hanke: ${hanke.toLogString()}" }
 
@@ -146,10 +143,6 @@ class HankeController(
     @DeleteMapping("/{hankeTunnus}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     fun deleteHanke(@PathVariable hankeTunnus: String) {
-        if (!enableEditFeature) {
-            throw EndpointDisabledException()
-        }
-
         logger.info { "Deleting hanke: $hankeTunnus" }
 
         hankeService.getHankeWithApplications(hankeTunnus).let { (hanke, hakemukset) ->

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/configuration/Configuration.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/configuration/Configuration.kt
@@ -48,7 +48,7 @@ import reactor.netty.http.client.HttpClient
 
 @Configuration
 @Profile("default")
-@EnableConfigurationProperties(GdprProperties::class)
+@EnableConfigurationProperties(GdprProperties::class, Features::class)
 class Configuration {
 
     @Value("\${haitaton.allu.baseUrl}") lateinit var alluBaseUrl: String

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/configuration/Features.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/configuration/Features.kt
@@ -1,0 +1,28 @@
+package fi.hel.haitaton.hanke.configuration
+
+import fi.hel.haitaton.hanke.EndpointDisabledException
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.ConstructorBinding
+
+@ConfigurationProperties(prefix = "haitaton")
+@ConstructorBinding
+data class Features(val features: Map<Feature, Boolean>) {
+
+    /** Disabled by default, if not in application.properties. */
+    private fun isEnabled(feature: Feature): Boolean = features.getOrDefault(feature, false)
+
+    /**
+     * Throws an exception if the feature is not enabled.
+     *
+     * Disabled by default, if not in application.properties.
+     */
+    fun check(feature: Feature) {
+        if (!isEnabled(feature)) {
+            throw EndpointDisabledException()
+        }
+    }
+}
+
+enum class Feature {
+    HANKE_EDITING,
+}

--- a/services/hanke-service/src/main/resources/application.properties
+++ b/services/hanke-service/src/main/resources/application.properties
@@ -21,7 +21,7 @@ haitaton.gdpr.delete-scope=${HAITATON_GDPR_DELETE_SCOPE:haitaton.gdprdelete}
 #logging.level.org.springframework.security=DEBUG
 
 # Disable endpoints that are e.g. in development and should not be in production.
-haitaton.feature.hanke-editing=${HAITATON_FEATURE_HANKE_EDITING:true}
+haitaton.features.hanke-editing=${HAITATON_FEATURE_HANKE_EDITING:true}
 
 spring.datasource.url=jdbc:postgresql://${HAITATON_HOST:localhost}:${HAITATON_PORT:5432}/${HAITATON_DATABASE:haitaton}
 spring.datasource.username=${HAITATON_USER:haitaton_user}

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/HankeControllerTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/HankeControllerTest.kt
@@ -1,5 +1,7 @@
 package fi.hel.haitaton.hanke
 
+import fi.hel.haitaton.hanke.configuration.Feature
+import fi.hel.haitaton.hanke.configuration.Features
 import fi.hel.haitaton.hanke.domain.Hanke
 import fi.hel.haitaton.hanke.domain.HankeYhteystieto
 import fi.hel.haitaton.hanke.domain.YhteystietoTyyppi.YKSITYISHENKILO
@@ -46,12 +48,15 @@ class HankeControllerTest {
 
         @Bean fun yhteystietoLoggingService(): DisclosureLogService = mockk(relaxUnitFun = true)
 
+        val features = Features(mapOf(Pair(Feature.HANKE_EDITING, true)))
+
         @Bean
         fun hankeController(
             hankeService: HankeService,
             permissionService: PermissionService,
             disclosureLogService: DisclosureLogService,
-        ): HankeController = HankeController(hankeService, permissionService, disclosureLogService)
+        ): HankeController =
+            HankeController(hankeService, permissionService, disclosureLogService, features)
     }
 
     private val mockedHankeTunnus = "AFC1234"


### PR DESCRIPTION
# Description

Delete hanke button is active in the UI in the first release, so the backend endpoint should be enabled as well.

I thought I needed to introduce a second feature flag, so I did some refactoring to the features. I introduced a centralized class for checking if an feature is enabled. In the end, it made a lot more sense to remove the feature-check from `DELETE /hanke/:id`, but I kept the refactoring since I think it will make handling feature flags easier in the future.

### Jira Issue:  https://helsinkisolutionoffice.atlassian.net/browse/HAI-1723

## Type of change

- [X] Bug fix 
- [ ] New feature 
- [ ] Other

# Instructions for testing
The feature flag should still prevent creating and updating a hanke if you add
```
      HAITATON_FEATURE_HANKE_EDITING: false
```
to docker-compose.yml.

The delete endpoint should not be affected by this change.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 