### PR TITLE
WIP: HAI-1758 Modify application attachment entities for performance

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/allu/CableReportServiceAlluITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/allu/CableReportServiceAlluITests.kt
@@ -102,27 +102,6 @@ class CableReportServiceAlluITests {
     }
 
     @Test
-    fun `addAttachments should upload attachments successfully`() {
-        addStubbedLoginResponse()
-        val alluId = 123
-        val metadata = AlluDataFactory.createAttachmentMetadata()
-        val file = "test file content".toByteArray()
-        val attachment = Attachment(metadata, file)
-        val mockResponse = MockResponse().setResponseCode(200)
-        (1..3).forEach { _ -> mockWebServer.enqueue(mockResponse) }
-        val attachments = listOf(attachment, attachment, attachment)
-
-        service.addAttachments(alluId, attachments)
-
-        assertThat(mockWebServer.takeRequest()).isValidLoginRequest()
-        attachments.forEach { _ ->
-            val request = mockWebServer.takeRequest()
-            assertThat(request.method).isEqualTo("POST")
-            assertThat(request.path).isEqualTo("/v2/applications/$alluId/attachments")
-        }
-    }
-
-    @Test
     fun testCreateErrorHandling() {
         val stubbedBearer = addStubbedLoginResponse()
         val applicationIdResponse =

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceITest.kt
@@ -35,7 +35,6 @@ import fi.hel.haitaton.hanke.factory.AlluDataFactory
 import fi.hel.haitaton.hanke.factory.AlluDataFactory.Companion.teppoEmail
 import fi.hel.haitaton.hanke.factory.AlluDataFactory.Companion.withCustomer
 import fi.hel.haitaton.hanke.factory.ApplicationHistoryFactory
-import fi.hel.haitaton.hanke.factory.AttachmentFactory.applicationAttachmentEntity
 import fi.hel.haitaton.hanke.factory.HankeFactory
 import fi.hel.haitaton.hanke.factory.HankeFactory.Companion.withHankealue
 import fi.hel.haitaton.hanke.findByType
@@ -914,23 +913,21 @@ class ApplicationServiceITest : DatabaseTest() {
         @Test
         @Sql("/sql/senaatintorin-hanke.sql")
         fun `Creates new application to Allu and saves ID and status to database`() {
+            val mockToken = "1234"
             val application =
-                alluDataFactory
-                    .saveApplicationEntity(
-                        USERNAME,
-                        hanke = initializedHanke(),
-                        application = mockApplicationWithArea()
-                    )
-                    .apply {
-                        attachments = mutableListOf(applicationAttachmentEntity(application = this))
-                        applicationRepository.save(this)
-                    }
+                alluDataFactory.saveApplicationEntity(
+                    USERNAME,
+                    hanke = initializedHanke(),
+                    application = mockApplicationWithArea()
+                )
+            alluDataFactory.saveAttachment(application.id!!)
             val applicationData = application.applicationData as CableReportApplicationData
             val pendingApplicationData = applicationData.copy(pendingOnClient = false)
             val expectedAlluRequest = pendingApplicationData.toAlluData(HANKE_TUNNUS)
             every { cableReportServiceAllu.create(expectedAlluRequest) } returns 26
             justRun { cableReportServiceAllu.addAttachment(26, any()) }
-            justRun { cableReportServiceAllu.addAttachments(26, any()) }
+            every { cableReportServiceAllu.login() } returns mockToken
+            justRun { cableReportServiceAllu.addAttachment(26, any(), mockToken) }
             every { cableReportServiceAllu.getApplicationInformation(26) } returns
                 AlluDataFactory.createAlluApplicationResponse(26)
 
@@ -954,7 +951,8 @@ class ApplicationServiceITest : DatabaseTest() {
             verifyOrder {
                 cableReportServiceAllu.create(expectedAlluRequest)
                 cableReportServiceAllu.addAttachment(26, any())
-                cableReportServiceAllu.addAttachments(26, any())
+                cableReportServiceAllu.login()
+                cableReportServiceAllu.addAttachment(26, any(), mockToken)
                 cableReportServiceAllu.getApplicationInformation(26)
             }
         }
@@ -1099,24 +1097,22 @@ class ApplicationServiceITest : DatabaseTest() {
         @Test
         @Sql("/sql/senaatintorin-hanke.sql")
         fun `Cancels the sent application before throwing if uploading initial attachments fails`() {
+            val mockToken = "1234"
             val application =
-                alluDataFactory
-                    .saveApplicationEntity(
-                        USERNAME,
-                        hanke = initializedHanke(),
-                        application = mockApplicationWithArea()
-                    )
-                    .apply {
-                        attachments = mutableListOf(applicationAttachmentEntity(application = this))
-                        applicationRepository.save(this)
-                    }
+                alluDataFactory.saveApplicationEntity(
+                    USERNAME,
+                    hanke = initializedHanke(),
+                    application = mockApplicationWithArea()
+                )
+            alluDataFactory.saveAttachment(application.id!!)
             val applicationData = application.applicationData as CableReportApplicationData
             val pendingApplicationData = applicationData.copy(pendingOnClient = false)
             val expectedAlluRequest = pendingApplicationData.toAlluData(HANKE_TUNNUS)
             val alluId = 236
             every { cableReportServiceAllu.create(expectedAlluRequest) } returns alluId
             justRun { cableReportServiceAllu.addAttachment(alluId, any()) }
-            every { cableReportServiceAllu.addAttachments(alluId, any()) } throws
+            every { cableReportServiceAllu.login() } returns mockToken
+            every { cableReportServiceAllu.addAttachment(alluId, any(), mockToken) } throws
                 AlluException(listOf())
             justRun { cableReportServiceAllu.cancel(alluId) }
             every { cableReportServiceAllu.sendSystemComment(alluId, any()) } returns 4141
@@ -1128,7 +1124,8 @@ class ApplicationServiceITest : DatabaseTest() {
             verifyOrder {
                 cableReportServiceAllu.create(expectedAlluRequest)
                 cableReportServiceAllu.addAttachment(alluId, any())
-                cableReportServiceAllu.addAttachments(alluId, any())
+                cableReportServiceAllu.login()
+                cableReportServiceAllu.addAttachment(alluId, any(), mockToken)
                 cableReportServiceAllu.cancel(alluId)
                 cableReportServiceAllu.sendSystemComment(
                     alluId,

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentServiceITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentServiceITests.kt
@@ -122,7 +122,7 @@ class HankeAttachmentServiceITests : DatabaseTest() {
                 hankeAttachmentService.getContent(firstHanke.hankeTunnus!!, secondAttachment.id!!)
             }
 
-        assertThat(exception.message).isEqualTo("Attachment ${secondAttachment.id} not found")
+        assertThat(exception.message).isEqualTo("Attachment '${secondAttachment.id}' not found")
     }
 
     @Test

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/CableReportService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/CableReportService.kt
@@ -4,6 +4,8 @@ import java.time.ZonedDateTime
 
 interface CableReportService {
 
+    fun login(): String
+
     fun getApplicationStatusHistories(
         alluApplicationIds: List<Int>,
         eventsAfter: ZonedDateTime
@@ -13,9 +15,7 @@ interface CableReportService {
 
     fun update(alluApplicationId: Int, cableReport: AlluCableReportApplicationData)
 
-    fun addAttachment(alluApplicationId: Int, attachment: Attachment)
-
-    fun addAttachments(alluApplicationId: Int, attachments: List<Attachment>)
+    fun addAttachment(alluApplicationId: Int, attachment: Attachment, loginToken: String? = null)
 
     fun getInformationRequests(alluApplicationId: Int): List<InformationRequest>
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationEntity.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationEntity.kt
@@ -3,19 +3,15 @@ package fi.hel.haitaton.hanke.application
 import com.vladmihalcea.hibernate.type.json.JsonType
 import fi.hel.haitaton.hanke.HankeEntity
 import fi.hel.haitaton.hanke.allu.ApplicationStatus
-import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentEntity
-import javax.persistence.CascadeType
 import javax.persistence.Column
 import javax.persistence.Entity
 import javax.persistence.EnumType
 import javax.persistence.Enumerated
-import javax.persistence.FetchType
 import javax.persistence.GeneratedValue
 import javax.persistence.GenerationType
 import javax.persistence.Id
 import javax.persistence.JoinColumn
 import javax.persistence.ManyToOne
-import javax.persistence.OneToMany
 import javax.persistence.Table
 import org.hibernate.annotations.Type
 import org.hibernate.annotations.TypeDef
@@ -32,13 +28,6 @@ data class ApplicationEntity(
     @Enumerated(EnumType.STRING) val applicationType: ApplicationType,
     @Type(type = "json") @Column(columnDefinition = "jsonb") var applicationData: ApplicationData,
     @ManyToOne @JoinColumn(updatable = false, nullable = false) var hanke: HankeEntity,
-    @OneToMany(
-        mappedBy = "application",
-        fetch = FetchType.LAZY,
-        cascade = [CascadeType.ALL],
-        orphanRemoval = true
-    )
-    var attachments: MutableList<ApplicationAttachmentEntity> = mutableListOf()
 ) {
     fun toApplication() =
         Application(

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationService.kt
@@ -252,7 +252,7 @@ open class ApplicationService(
             logger.info { "Application not sent to Allu yet, simply deleting it. id=$id" }
         } else {
             logger.info {
-                "Application sent to Allu yet, trying to cancel it before deleting. id=$id alluid=$alluid"
+                "Application is sent to Allu, trying to cancel it before deleting. id=$id alluid=$alluid"
             }
             cancelApplication(alluid, application.id)
         }
@@ -460,7 +460,7 @@ open class ApplicationService(
             }
 
         try {
-            attachmentService.sendInitialAttachments(alluId, entity)
+            attachmentService.sendInitialAttachments(alluId, entity.id!!)
         } catch (e: Exception) {
             logger.error(e) {
                 "Error while sending the initial attachments. Canceling the application. " +

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/common/Exceptions.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/common/Exceptions.kt
@@ -5,4 +5,4 @@ import java.util.UUID
 class AttachmentInvalidException(str: String) :
     RuntimeException("Attachment upload exception: $str")
 
-class AttachmentNotFoundException(id: UUID) : RuntimeException("Attachment $id not found")
+class AttachmentNotFoundException(id: UUID?) : RuntimeException("Attachment '$id' not found")

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/configuration/Configuration.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/configuration/Configuration.kt
@@ -36,6 +36,8 @@ import fi.hel.haitaton.hanke.tormaystarkastelu.TormaystarkasteluTormaysService
 import fi.hel.haitaton.hanke.tormaystarkastelu.TormaystarkasteluTormaysServicePG
 import io.netty.handler.ssl.SslContextBuilder
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
@@ -55,6 +57,8 @@ class Configuration {
     @Value("\${haitaton.allu.username}") lateinit var alluUsername: String
     @Value("\${haitaton.allu.password}") lateinit var alluPassword: String
     @Value("\${haitaton.allu.insecure}") var alluTrustInsecure: Boolean = false
+
+    @Bean fun ioDispatcher(): CoroutineDispatcher = Dispatchers.IO
 
     @Bean
     fun cableReportService(webClientBuilder: WebClient.Builder): CableReportService {

--- a/services/hanke-service/src/main/resources/db/changelog/changesets/036-add-delete-cascade-for-attachments.yml
+++ b/services/hanke-service/src/main/resources/db/changelog/changesets/036-add-delete-cascade-for-attachments.yml
@@ -1,0 +1,15 @@
+databaseChangeLog:
+  - changeSet:
+      id: 036-add-delete-cascade-for-application-attachments
+      author: Niko Pitkonen
+      changes:
+        - dropForeignKeyConstraint:
+            baseTableName: application_attachment
+            constraintName: fk_attachment_applications
+        - addForeignKeyConstraint:
+            baseTableName: application_attachment
+            baseColumnNames: application_id
+            constraintName: fk_attachment_applications
+            referencedTableName: applications
+            referencedColumnNames: id
+            onDelete: CASCADE

--- a/services/hanke-service/src/main/resources/db/changelog/changesets/037-add-delete-cascade-for-hanke-attachments.yml
+++ b/services/hanke-service/src/main/resources/db/changelog/changesets/037-add-delete-cascade-for-hanke-attachments.yml
@@ -1,0 +1,15 @@
+databaseChangeLog:
+  - changeSet:
+      id: 037-add-delete-cascade-for-hanke-attachments
+      author: Niko Pitkonen
+      changes:
+        - dropForeignKeyConstraint:
+            baseTableName: hanke_attachment
+            constraintName: fk_attachment_hanke
+        - addForeignKeyConstraint:
+            baseTableName: hanke_attachment
+            baseColumnNames: hanke_id
+            constraintName: fk_attachment_hanke
+            referencedTableName: hanke
+            referencedColumnNames: id
+            onDelete: CASCADE

--- a/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -99,3 +99,7 @@ databaseChangeLog:
       file: db/changelog/changesets/034-add-delete-cascade-to-hankekayttajat.yml
   - include:
       file: db/changelog/changesets/035-add-content-type-attachments.yml
+  - include:
+      file: db/changelog/changesets/036-add-delete-cascade-for-attachments.yml
+  - include:
+      file: db/changelog/changesets/037-add-delete-cascade-for-hanke-attachments.yml

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/AlluDataFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/AlluDataFactory.kt
@@ -19,6 +19,9 @@ import fi.hel.haitaton.hanke.application.CustomerWithContacts
 import fi.hel.haitaton.hanke.application.PostalAddress
 import fi.hel.haitaton.hanke.application.StreetAddress
 import fi.hel.haitaton.hanke.asJsonResource
+import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentContent
+import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentContentRepository
+import fi.hel.haitaton.hanke.factory.AttachmentFactory.applicationAttachmentContent
 import java.time.ZonedDateTime
 import org.geojson.Polygon
 import org.springframework.http.MediaType.APPLICATION_PDF_VALUE
@@ -27,7 +30,10 @@ import org.springframework.stereotype.Component
 const val TEPPO_TESTI = "Teppo Testihenkilö"
 
 @Component
-class AlluDataFactory(val applicationRepository: ApplicationRepository) {
+class AlluDataFactory(
+    val applicationRepository: ApplicationRepository,
+    val applicationAttachmentContentRepository: ApplicationAttachmentContentRepository
+) {
     companion object {
         const val defaultApplicationId: Long = 1
         const val defaultApplicationName: String = "Johtoselvityksen oletusnimi"
@@ -332,5 +338,10 @@ class AlluDataFactory(val applicationRepository: ApplicationRepository) {
             }
         entities.withIndex().forEach { (i, application) -> mutator(i, application) }
         return applicationRepository.saveAll(entities)
+    }
+
+    fun saveAttachment(applicationId: Long): ApplicationAttachmentContent {
+        val attachment = applicationAttachmentContent(applicationId = applicationId)
+        return applicationAttachmentContentRepository.save(attachment)
     }
 }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/AttachmentFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/AttachmentFactory.kt
@@ -1,8 +1,8 @@
 package fi.hel.haitaton.hanke.factory
 
-import fi.hel.haitaton.hanke.application.ApplicationEntity
-import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentEntity
+import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentContent
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentMetadata
+import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentSummary
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType.MUU
 import fi.hel.haitaton.hanke.attachment.common.AttachmentScanStatus
@@ -19,7 +19,28 @@ private const val FILE_NAME = "file.pdf"
 private val dummyData = "ABC".toByteArray()
 
 object AttachmentFactory {
-    fun applicationAttachmentEntity(
+    fun applicationAttachmentSummary(
+        id: UUID = randomUUID(),
+        fileName: String = FILE_NAME,
+        contentType: String = APPLICATION_PDF_VALUE,
+        createdByUserId: String = currentUserId(),
+        createdAt: OffsetDateTime = OffsetDateTime.now(),
+        scanStatus: AttachmentScanStatus = OK,
+        attachmentType: ApplicationAttachmentType = MUU,
+        applicationId: Long,
+    ): ApplicationAttachmentSummary =
+        ApplicationAttachmentSummary(
+            id = id,
+            fileName = fileName,
+            contentType = contentType,
+            createdByUserId = createdByUserId,
+            createdAt = createdAt,
+            scanStatus = scanStatus,
+            attachmentType = attachmentType,
+            applicationId = applicationId,
+        )
+
+    fun applicationAttachmentContent(
         id: UUID = randomUUID(),
         fileName: String = FILE_NAME,
         content: ByteArray = dummyData,
@@ -28,9 +49,9 @@ object AttachmentFactory {
         createdAt: OffsetDateTime = OffsetDateTime.now(),
         scanStatus: AttachmentScanStatus = OK,
         attachmentType: ApplicationAttachmentType = MUU,
-        application: ApplicationEntity,
-    ): ApplicationAttachmentEntity =
-        ApplicationAttachmentEntity(
+        applicationId: Long,
+    ): ApplicationAttachmentContent =
+        ApplicationAttachmentContent(
             id = id,
             fileName = fileName,
             content = content,
@@ -39,7 +60,7 @@ object AttachmentFactory {
             createdAt = createdAt,
             scanStatus = scanStatus,
             attachmentType = attachmentType,
-            application = application,
+            applicationId = applicationId,
         )
 
     fun hankeAttachmentMetadata(


### PR DESCRIPTION
# Description

- Remove oneToMany mapping of application and attachments.
  - Add on delete cascade to allow deletion of the owning entity of attachments.
- Divide application attachment entitites into summary and the actual data. Use fetching of actual files only when necessary to avoid memory consumption.
- Modify application attachment service to work with new entities.

Note: Does not include fix for hanke attachments. It will be done in a different task.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1758

## Type of change

- [x] Bug fix 
- [ ] New feature 
- [ ] Other

# Instructions for testing
As memory consumption is not that easily tested, every thing should at least work as previously.

# Checklist:

- [ ] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 

# Other relevant info
Please describe here if there is e.g. some requirements for this change or
 other info that the tester/user needs to know.