### PR TITLE
HAI-1748 Add more validation for application data

### DIFF
--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentService.kt
@@ -53,7 +53,7 @@ class HankeAttachmentService(
         val hanke = findHanke(hankeTunnus)
         validateAttachment(attachment)
 
-        val result =
+        val entity =
             HankeAttachmentEntity(
                 id = null,
                 fileName = attachment.originalFilename!!,
@@ -65,8 +65,10 @@ class HankeAttachmentService(
                 hanke = hanke,
             )
 
-        return attachmentRepository.save(result).toMetadata().also {
-            logger.info { "Added attachment ${it.id} to hanke $hankeTunnus" }
+        return attachmentRepository.save(entity).toMetadata().also {
+            logger.info {
+                "Added attachment ${it.id} to hanke $hankeTunnus with size ${entity.content.size}"
+            }
         }
     }
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/validation/ApplicationValidator.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/validation/ApplicationValidator.kt
@@ -2,67 +2,91 @@ package fi.hel.haitaton.hanke.validation
 
 import fi.hel.haitaton.hanke.application.Application
 import fi.hel.haitaton.hanke.application.CableReportApplicationData
+import fi.hel.haitaton.hanke.application.Contact
 import fi.hel.haitaton.hanke.application.Customer
 import fi.hel.haitaton.hanke.application.CustomerWithContacts
+import fi.hel.haitaton.hanke.application.PostalAddress
 import fi.hel.haitaton.hanke.isValidBusinessId
-import java.time.ZonedDateTime
+import fi.hel.haitaton.hanke.validation.Validators.isBeforeOrEqual
+import fi.hel.haitaton.hanke.validation.Validators.notJustWhitespace
+import fi.hel.haitaton.hanke.validation.Validators.validate
+import fi.hel.haitaton.hanke.validation.Validators.validateFalse
+import fi.hel.haitaton.hanke.validation.Validators.validateTrue
+import java.util.Locale
 import javax.validation.ConstraintValidator
 import javax.validation.ConstraintValidatorContext
-import mu.KotlinLogging
-
-private val logger = KotlinLogging.logger {}
 
 class ApplicationValidator : ConstraintValidator<ValidApplication, Application> {
     override fun isValid(application: Application, context: ConstraintValidatorContext?): Boolean {
 
-        return when (application.applicationData) {
-            is CableReportApplicationData -> validOrThrow(application.applicationData)
-        }
-    }
+        val result =
+            when (application.applicationData) {
+                is CableReportApplicationData -> application.applicationData.validate()
+            }
 
-    private fun validOrThrow(cableReportData: CableReportApplicationData): Boolean {
-        if (!isValidCableReport(cableReportData)) {
-            throw InvalidApplicationDataException("Received cable report contains invalid data.")
-        }
-        return true
-    }
-
-    private fun isValidCableReport(cableReportData: CableReportApplicationData): Boolean =
-        listOf(
-                { validStartAndEnd(cableReportData.startTime, cableReportData.endTime) },
-                { validCustomersWithContacts(cableReportData.customersWithContacts()) }
-            )
-            .all { it() }
-
-    /**
-     * Checks if the start is before or equal to the end.
-     *
-     * @param start the start time (nullable)
-     * @param end the end time (nullable)
-     * @return true if start is before or equal to end, false if either is null or if start is after
-     * end.
-     */
-    private fun validStartAndEnd(start: ZonedDateTime?, end: ZonedDateTime?): Boolean {
-        logger.info { "Application startDate: '$start', endDate: '$end'." }
-
-        if (start == null || end == null) {
+        if (result.isOk()) {
             return true
         }
 
-        return !start.isAfter(end)
+        throw InvalidApplicationDataException(result.errorPaths())
     }
 
-    /** Currently checks registryKey only. */
-    private fun validCustomer(customer: Customer): Boolean {
-        return validRegistryKey(customer.registryKey)
-    }
+    private fun CableReportApplicationData.validate(): ValidationResult =
+        validate { notJustWhitespace(name, "name") }
+            .and { notJustWhitespace(workDescription, "workDescription") }
+            .and { notJustWhitespace(customerReference, "customerReference") }
+            .and { atMostOneOrderer(customersWithContacts()) }
+            .andWhen(startTime != null && endTime != null) {
+                isBeforeOrEqual(startTime!!, endTime!!, "endTime")
+            }
+            .whenNotNull(postalAddress) { it.validate("postalAddress") }
+            .and { customerWithContacts.validate("customerWithContacts") }
+            .and { contractorWithContacts.validate("contractorWithContacts") }
+            .whenNotNull(representativeWithContacts) { it.validate("representativeWithContacts") }
+            .whenNotNull(propertyDeveloperWithContacts) {
+                it.validate("propertyDeveloperWithContacts")
+            }
+            .whenNotNull(invoicingCustomer) { it.validate("invoicingCustomer") }
 
-    private fun validRegistryKey(key: String?) = key?.isValidBusinessId() ?: true
+    private fun moreThanOneOrderer(customersWithContacts: List<CustomerWithContacts>): Boolean =
+        customersWithContacts.flatMap { it.contacts }.filter { it.orderer }.size > 1
 
-    /** Currently verifies customer only. */
-    private fun validCustomersWithContacts(
-        customerWithContacts: List<CustomerWithContacts>
-    ): Boolean = customerWithContacts.all { validCustomer(it.customer) }
+    private fun atMostOneOrderer(
+        customersWithContacts: List<CustomerWithContacts>
+    ): ValidationResult =
+        validateFalse(
+            moreThanOneOrderer(customersWithContacts),
+            "customersWithContacts[].contacts[].orderer"
+        )
+
+    private fun CustomerWithContacts.validate(path: String): ValidationResult =
+        customer.validate("$path.customer").andAllIn(contacts, "$path.contacts", ::validateContact)
+
+    private fun Customer.validate(path: String): ValidationResult =
+        validate { notJustWhitespace(name, "$path.name") }
+            .and { validateTrue(Locale.getISOCountries().contains(country), "country") }
+            .and { notJustWhitespace(email, "$path.email") }
+            .and { notJustWhitespace(phone, "$path.phone") }
+            .whenNotNull(registryKey) { validateTrue(it.isValidBusinessId(), "$path.registryKey") }
+            .and { notJustWhitespace(ovt, "$path.ovt") }
+            .and { notJustWhitespace(invoicingOperator, "$path.invoicingOperator") }
+            .and { notJustWhitespace(sapCustomerNumber, "$path.sapCustomerNumber") }
+
+    private fun Contact.validate(path: String): ValidationResult =
+        validate { notJustWhitespace(firstName, "$path.firstName") }
+            .and { notJustWhitespace(lastName, "$path.lastName") }
+            .and { notJustWhitespace(email, "$path.email") }
+            .and { notJustWhitespace(phone, "$path.phone") }
+
+    private fun validateContact(contact: Contact, path: String) = contact.validate(path)
+
+    private fun PostalAddress.validate(path: String) =
+        validate { notJustWhitespace(postalCode, "$path.postalCode") }
+            .and { notJustWhitespace(city, "$path.city") }
+            .and { notJustWhitespace(streetAddress.streetName, "$path.streetAddress.streetName") }
 }
 
-class InvalidApplicationDataException(message: String) : RuntimeException(message)
+class InvalidApplicationDataException(errorPaths: List<String>) :
+    RuntimeException(
+        "Received application contains invalid data. Errors at paths: ${errorPaths.joinToString()}"
+    )

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/validation/HankePublicValidator.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/validation/HankePublicValidator.kt
@@ -6,7 +6,6 @@ import fi.hel.haitaton.hanke.domain.Hanke
 import fi.hel.haitaton.hanke.domain.HankeYhteystieto
 import fi.hel.haitaton.hanke.domain.Hankealue
 import fi.hel.haitaton.hanke.validation.Validators.firstOf
-import fi.hel.haitaton.hanke.validation.Validators.given
 import fi.hel.haitaton.hanke.validation.Validators.notBlank
 import fi.hel.haitaton.hanke.validation.Validators.notEmpty
 import fi.hel.haitaton.hanke.validation.Validators.notNull
@@ -25,10 +24,8 @@ object HankePublicValidator {
             .and { notNullOrBlank(hanke.kuvaus, "kuvaus") }
             .and { notNullOrBlank(hanke.tyomaaKatuosoite, "tyomaaKatuosoite") }
             .and { notNull(hanke.vaihe, "vaihe") }
-            .and {
-                given(hanke.vaihe == Vaihe.SUUNNITTELU) {
-                    notNull(hanke.suunnitteluVaihe, "suunnitteluVaihe")
-                }
+            .andWhen(hanke.vaihe == Vaihe.SUUNNITTELU) {
+                notNull(hanke.suunnitteluVaihe, "suunnitteluVaihe")
             }
             .and { notEmpty(hanke.alueet, "alueet") }
             .andAllIn(hanke.alueet, "alueet", ::validateAlue)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/validation/Validators.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/validation/Validators.kt
@@ -1,8 +1,6 @@
 package fi.hel.haitaton.hanke.validation
 
-private typealias ValidationError = String
-
-private val ValidationSuccess: ValidationError? = null
+import java.time.ZonedDateTime
 
 /**
  * Validator helper methods for on-the-fly validation (not at the REST API-boundary or the database
@@ -11,67 +9,104 @@ private val ValidationSuccess: ValidationError? = null
  * Keeps track of the paths of validation failures, but not the errors that occurred.
  *
  * @see HankePublicValidator for examples on usage.
+ * @see ApplicationValidator for examples on usage.
  */
 object Validators {
 
     /**
      * Starts a validation chain. Further validations can be chained with [ValidationResult.and].
      */
-    fun validate(f: () -> ValidationError?): ValidationResult {
-        return ValidationResult().and(f)
+    fun validate(f: () -> ValidationResult): ValidationResult {
+        return ValidationResult.success().and(f)
     }
 
-    fun validateFalse(condition: Boolean, path: String): ValidationError? =
-        if (condition) path else ValidationSuccess
+    fun validateTrue(condition: Boolean, path: String): ValidationResult =
+        if (condition) ValidationResult.success() else ValidationResult.failure(path)
 
-    fun validateFalse(condition: Boolean?, path: String): ValidationError? =
-        if (condition == false) ValidationSuccess else path
+    fun validateFalse(condition: Boolean, path: String): ValidationResult =
+        if (!condition) ValidationResult.success() else ValidationResult.failure(path)
 
-    fun notNull(value: Any?, path: String): ValidationError? = validateFalse(value == null, path)
+    fun validateFalse(condition: Boolean?, path: String): ValidationResult =
+        if (condition == false) ValidationResult.success() else ValidationResult.failure(path)
 
-    fun notBlank(value: String, path: String): ValidationError? =
+    fun notNull(value: Any?, path: String): ValidationResult = validateFalse(value == null, path)
+
+    fun notBlank(value: String, path: String): ValidationResult =
         validateFalse(value.isBlank(), path)
 
-    fun notNullOrBlank(value: String?, path: String): ValidationError? =
+    /**
+     * Fails if the string is defined, non-empty and has nothing but whitespace characters.
+     * - null -> Ok
+     * - "" -> Ok
+     * - " " -> Fail
+     * - "*" -> Ok
+     * - "\t\n \t\n" -> Fail
+     * - " f " -> Ok
+     */
+    fun notJustWhitespace(value: String?, path: String): ValidationResult =
+        given(!value.isNullOrEmpty()) { notBlank(value!!, path) }
+
+    fun notNullOrBlank(value: String?, path: String): ValidationResult =
         validateFalse(value.isNullOrBlank(), path)
 
-    fun <T> notEmpty(value: Collection<T>, path: String): ValidationError? =
+    fun <T> notEmpty(value: Collection<T>, path: String): ValidationResult =
         validateFalse(value.isEmpty(), path)
 
-    fun <T> notNullOrEmpty(value: Collection<T>?, path: String): ValidationError? =
+    fun <T> notNullOrEmpty(value: Collection<T>?, path: String): ValidationResult =
         validateFalse(value?.isEmpty(), path)
 
-    /** Check run the validation lambda only if the pre-condition is true. */
-    fun given(condition: Boolean, f: () -> ValidationError?): ValidationError? =
-        if (condition) f() else ValidationSuccess
+    fun isBeforeOrEqual(start: ZonedDateTime, end: ZonedDateTime, path: String): ValidationResult =
+        validateFalse(start.isAfter(end), path)
+
+    /** Run the validation only if the pre-condition is true. */
+    fun given(condition: Boolean, f: () -> ValidationResult): ValidationResult =
+        if (condition) f() else ValidationResult.success()
 
     /**
      * Use only the first validation error from the ones supplied. Can be used to e.g. check for
      * null values somewhere along a path.
      */
-    fun firstOf(vararg fs: ValidationError?): ValidationError? =
-        fs.filterNotNull().firstOrNull() ?: ValidationSuccess
+    fun firstOf(vararg fs: ValidationResult): ValidationResult =
+        fs.toList().firstOrNull { !it.isOk() } ?: ValidationResult.success()
 }
 
-class ValidationResult {
-    private val errorPaths: MutableList<String> = mutableListOf()
+class ValidationResult
+private constructor(private val errorPaths: MutableList<String> = mutableListOf()) {
 
     fun errorPaths(): List<String> = errorPaths
     fun isOk() = errorPaths.isEmpty()
 
-    fun and(f: () -> ValidationError?): ValidationResult {
-        f()?.let { error -> this.errorPaths.add(error) }
+    fun and(f: () -> ValidationResult): ValidationResult {
+        this.errorPaths.addAll(f().errorPaths())
         return this
     }
+
+    /** Run the validation only when the value is not null. */
+    fun <T> whenNotNull(value: T?, f: (T) -> ValidationResult): ValidationResult {
+        if (value != null) {
+            and { f(value) }
+        }
+        return this
+    }
+
+    /** Check run the validation lambda only if the pre-condition is true. */
+    fun andWhen(condition: Boolean, f: () -> ValidationResult): ValidationResult =
+        if (condition) this.and(f) else this
 
     fun <T> andAllIn(
         values: Collection<T>,
         path: String,
-        f: (T, String) -> ValidationResult
+        f: (T, String) -> ValidationResult,
     ): ValidationResult {
         this.errorPaths.addAll(
             values.flatMapIndexed { index: Int, value: T -> f(value, "$path[$index]").errorPaths() }
         )
         return this
+    }
+
+    companion object {
+        fun success() = ValidationResult()
+
+        fun failure(errorPath: String) = ValidationResult(mutableListOf(errorPath))
     }
 }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/AlluDataFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/AlluDataFactory.kt
@@ -117,6 +117,40 @@ class AlluDataFactory(val applicationRepository: ApplicationRepository) {
                 "/fi/hel/haitaton/hanke/geometria/toinen_polygoni.json".asJsonResource(),
         ): ApplicationArea = ApplicationArea(name, geometry)
 
+        fun Application.withApplicationData(
+            name: String = defaultApplicationName,
+            areas: List<ApplicationArea>? = listOf(createApplicationArea()),
+            startTime: ZonedDateTime? = DateFactory.getStartDatetime(),
+            endTime: ZonedDateTime? = DateFactory.getEndDatetime(),
+            pendingOnClient: Boolean = false,
+            workDescription: String = "Work description.",
+            customerWithContacts: CustomerWithContacts =
+                createCompanyCustomer().withContacts(createContact()),
+            contractorWithContacts: CustomerWithContacts =
+                createCompanyCustomer().withContacts(createContact()),
+            representativeWithContacts: CustomerWithContacts? = null,
+            propertyDeveloperWithContacts: CustomerWithContacts? = null,
+            rockExcavation: Boolean = false,
+            postalAddress: PostalAddress? = null,
+        ): Application =
+            this.copy(
+                applicationData =
+                    createCableReportApplicationData(
+                        name,
+                        areas,
+                        startTime,
+                        endTime,
+                        pendingOnClient,
+                        workDescription,
+                        customerWithContacts,
+                        contractorWithContacts,
+                        representativeWithContacts,
+                        propertyDeveloperWithContacts,
+                        rockExcavation,
+                        postalAddress
+                    )
+            )
+
         fun createCableReportApplicationData(
             name: String = defaultApplicationName,
             areas: List<ApplicationArea>? = listOf(createApplicationArea()),
@@ -175,12 +209,18 @@ class AlluDataFactory(val applicationRepository: ApplicationRepository) {
                         customerWithContacts = customer
                     )
             )
-        fun Application.withCustomerContacts(contacts: List<Contact>): Application =
+        fun Application.withCustomerContacts(vararg contacts: Contact): Application =
             this.withCustomer(
                 (applicationData as CableReportApplicationData)
                     .customerWithContacts
-                    .copy(contacts = contacts)
+                    .copy(contacts = contacts.asList())
             )
+
+        fun CableReportApplicationData.withPostalAddress(
+            streetAddress: String = "Katu 1",
+            postalCode: String = "00100",
+            city: String = "Helsinki",
+        ) = this.copy(postalAddress = PostalAddress(StreetAddress(streetAddress), postalCode, city))
 
         fun cableReportWithoutHanke(): CableReportWithoutHanke =
             with(createApplication()) {

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/validation/ApplicationValidatorTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/validation/ApplicationValidatorTest.kt
@@ -1,0 +1,520 @@
+package fi.hel.haitaton.hanke.validation
+
+import assertk.assertThat
+import assertk.assertions.hasClass
+import assertk.assertions.isEmpty
+import assertk.assertions.isFailure
+import assertk.assertions.isFalse
+import assertk.assertions.isSuccess
+import assertk.assertions.isTrue
+import fi.hel.haitaton.hanke.application.CableReportApplicationData
+import fi.hel.haitaton.hanke.application.Contact
+import fi.hel.haitaton.hanke.application.Customer
+import fi.hel.haitaton.hanke.factory.AlluDataFactory
+import fi.hel.haitaton.hanke.factory.AlluDataFactory.Companion.withApplicationData
+import fi.hel.haitaton.hanke.factory.AlluDataFactory.Companion.withContacts
+import fi.hel.haitaton.hanke.factory.AlluDataFactory.Companion.withCustomer
+import fi.hel.haitaton.hanke.factory.AlluDataFactory.Companion.withCustomerContacts
+import fi.hel.haitaton.hanke.factory.AlluDataFactory.Companion.withPostalAddress
+import fi.hel.haitaton.hanke.isValidBusinessId
+import fi.hel.haitaton.hanke.touch
+import java.time.ZonedDateTime
+import java.util.stream.Stream
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.CsvSource
+import org.junit.jupiter.params.provider.MethodSource
+
+class ApplicationValidatorTest {
+
+    private val applicationValidator = ApplicationValidator()
+
+    @Test
+    fun `Correct application passes validation`() {
+        val application = AlluDataFactory.createApplication()
+
+        assertThat { applicationValidator.isValid(application, null) }.isSuccess().isTrue()
+    }
+
+    @Nested
+    inner class AtMostOneOrderer {
+        private val customerWithOneOrderer =
+            AlluDataFactory.createCompanyCustomer()
+                .withContacts(
+                    AlluDataFactory.createContact(orderer = true),
+                    AlluDataFactory.createContact(orderer = false),
+                )
+
+        private val customerWithTwoOrderers =
+            AlluDataFactory.createCompanyCustomer()
+                .withContacts(
+                    AlluDataFactory.createContact(orderer = true),
+                    AlluDataFactory.createContact(orderer = true),
+                )
+
+        private val customerWithNoOrderers =
+            AlluDataFactory.createCompanyCustomer()
+                .withContacts(
+                    AlluDataFactory.createContact(orderer = false),
+                    AlluDataFactory.createContact(orderer = false),
+                )
+
+        private val customerWithNoContacts = AlluDataFactory.createCompanyCustomer().withContacts()
+
+        @Test
+        fun `One orderer is allowed`() {
+            val application =
+                AlluDataFactory.createApplication()
+                    .withApplicationData(
+                        customerWithContacts = customerWithOneOrderer,
+                    )
+
+            assertThat { applicationValidator.isValid(application, null) }.isSuccess().isTrue()
+        }
+
+        @Test
+        fun `Zero orderers is allowed`() {
+            val application =
+                AlluDataFactory.createApplication()
+                    .withApplicationData(
+                        customerWithContacts = customerWithNoOrderers,
+                        contractorWithContacts = customerWithNoOrderers,
+                    )
+
+            assertThat { applicationValidator.isValid(application, null) }.isSuccess().isTrue()
+        }
+
+        @Test
+        fun `Two orderers throws exception`() {
+            val application =
+                AlluDataFactory.createApplication()
+                    .withApplicationData(
+                        customerWithContacts = customerWithTwoOrderers,
+                    )
+
+            assertThat { applicationValidator.isValid(application, null) }
+                .isFailure()
+                .hasClass(InvalidApplicationDataException::class)
+        }
+
+        @Test
+        fun `Two orderers across different roles throws exception`() {
+            val application =
+                AlluDataFactory.createApplication()
+                    .withApplicationData(
+                        customerWithContacts = customerWithOneOrderer,
+                        contractorWithContacts = customerWithOneOrderer,
+                    )
+
+            assertThat { applicationValidator.isValid(application, null) }
+                .isFailure()
+                .hasClass(InvalidApplicationDataException::class)
+        }
+
+        @Test
+        fun `No contacts at all is allowed`() {
+            val application =
+                AlluDataFactory.createApplication()
+                    .withApplicationData(
+                        customerWithContacts = customerWithNoContacts,
+                        contractorWithContacts = customerWithNoContacts,
+                    )
+            val contacts =
+                application.applicationData.customersWithContacts().flatMap { it.contacts }
+            assertThat(contacts).isEmpty()
+
+            assertThat { applicationValidator.isValid(application, null) }.isSuccess().isTrue()
+        }
+    }
+
+    @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    inner class CableReportApplicationDataValidate {
+
+        private val baseAppData = AlluDataFactory.createCableReportApplicationData()
+
+        private fun notJustWhitespaceCases(content: String): Stream<Arguments> =
+            Stream.of(
+                Arguments.of("name", baseAppData.copy(name = content)),
+                Arguments.of("workDescription", baseAppData.copy(workDescription = content)),
+                Arguments.of("customerReference", baseAppData.copy(customerReference = content)),
+                Arguments.of(
+                    "postalAddress.postalCode",
+                    baseAppData.withPostalAddress(postalCode = content)
+                ),
+                Arguments.of("postalAddress.city", baseAppData.withPostalAddress(city = content)),
+                Arguments.of(
+                    "postalAddress.streetAddress.streetName",
+                    baseAppData.withPostalAddress(streetAddress = content)
+                ),
+            )
+
+        private fun justWhitespaceCases(): Stream<Arguments> = notJustWhitespaceCases(" ")
+
+        private fun emptyCases(): Stream<Arguments> = notJustWhitespaceCases("")
+
+        private fun textCases(): Stream<Arguments> = notJustWhitespaceCases("Some Text")
+
+        @ParameterizedTest(name = "{0} should not be just whitespace")
+        @MethodSource("justWhitespaceCases")
+        fun `value should not be just whitespace`(
+            case: String,
+            applicationData: CableReportApplicationData
+        ) {
+            case.touch()
+            val application = AlluDataFactory.createApplication(applicationData = applicationData)
+
+            assertThat { applicationValidator.isValid(application, null) }
+                .isFailure()
+                .hasClass(InvalidApplicationDataException::class)
+        }
+
+        @ParameterizedTest(name = "{0} can be empty")
+        @MethodSource("emptyCases")
+        fun `value can be empty`(case: String, applicationData: CableReportApplicationData) {
+            case.touch()
+            val application = AlluDataFactory.createApplication(applicationData = applicationData)
+
+            assertThat { applicationValidator.isValid(application, null) }.isSuccess().isTrue()
+        }
+
+        @ParameterizedTest(name = "{0} can have text with whitespaces")
+        @MethodSource("textCases")
+        fun `value can have text with whitespaces`(
+            case: String,
+            applicationData: CableReportApplicationData
+        ) {
+            case.touch()
+            val application = AlluDataFactory.createApplication(applicationData = applicationData)
+
+            assertThat { applicationValidator.isValid(application, null) }.isSuccess().isTrue()
+        }
+
+        @Test
+        fun `customerWithContacts is validated`() {
+            val application =
+                AlluDataFactory.createApplication()
+                    .withApplicationData(
+                        customerWithContacts =
+                            AlluDataFactory.createCompanyCustomer(name = " ").withContacts()
+                    )
+
+            assertThat { applicationValidator.isValid(application, null) }
+                .isFailure()
+                .hasClass(InvalidApplicationDataException::class)
+        }
+        @Test
+        fun `contractorWithContacts is validated`() {
+            val application =
+                AlluDataFactory.createApplication()
+                    .withApplicationData(
+                        contractorWithContacts =
+                            AlluDataFactory.createCompanyCustomer(name = " ").withContacts()
+                    )
+
+            assertThat { applicationValidator.isValid(application, null) }
+                .isFailure()
+                .hasClass(InvalidApplicationDataException::class)
+        }
+
+        @Test
+        fun `representativeWithContacts is validated when not null`() {
+            val application =
+                AlluDataFactory.createApplication()
+                    .withApplicationData(
+                        representativeWithContacts =
+                            AlluDataFactory.createCompanyCustomer(name = " ").withContacts()
+                    )
+
+            assertThat { applicationValidator.isValid(application, null) }
+                .isFailure()
+                .hasClass(InvalidApplicationDataException::class)
+        }
+
+        @Test
+        fun `representativeWithContacts can be null`() {
+            val application =
+                AlluDataFactory.createApplication()
+                    .withApplicationData(representativeWithContacts = null)
+
+            assertThat { applicationValidator.isValid(application, null) }.isSuccess().isTrue()
+        }
+
+        @Test
+        fun `propertyDeveloperWithContacts is validated when not null`() {
+            val application =
+                AlluDataFactory.createApplication()
+                    .withApplicationData(
+                        propertyDeveloperWithContacts =
+                            AlluDataFactory.createCompanyCustomer(name = " ").withContacts()
+                    )
+
+            assertThat { applicationValidator.isValid(application, null) }
+                .isFailure()
+                .hasClass(InvalidApplicationDataException::class)
+        }
+
+        @Test
+        fun `propertyDeveloperWithContacts can be null`() {
+            val application =
+                AlluDataFactory.createApplication()
+                    .withApplicationData(propertyDeveloperWithContacts = null)
+
+            assertThat { applicationValidator.isValid(application, null) }.isSuccess().isTrue()
+        }
+
+        @Test
+        fun `invoicingCustomer is validated when not null`() {
+            val application =
+                AlluDataFactory.createApplication(
+                    applicationData =
+                        AlluDataFactory.createCableReportApplicationData()
+                            .copy(
+                                invoicingCustomer =
+                                    AlluDataFactory.createCompanyCustomer(name = " ")
+                            )
+                )
+
+            assertThat { applicationValidator.isValid(application, null) }
+                .isFailure()
+                .hasClass(InvalidApplicationDataException::class)
+        }
+
+        @Test
+        fun `invoicingCustomer can be null`() {
+            val application =
+                AlluDataFactory.createApplication(
+                    applicationData =
+                        AlluDataFactory.createCableReportApplicationData()
+                            .copy(invoicingCustomer = null)
+                )
+
+            assertThat { applicationValidator.isValid(application, null) }.isSuccess().isTrue()
+        }
+    }
+
+    @Nested
+    inner class StartBeforeEnd {
+        private val date: ZonedDateTime = ZonedDateTime.parse("2023-01-12T14:30:41Z")
+
+        @ParameterizedTest(name = "{displayName} {argumentsWithNames}")
+        @CsvSource(",", ",2023-01-12T14:30:41Z", "2023-01-12T14:30:41Z,")
+        fun `Null start and end dates are allowed`(
+            startTime: ZonedDateTime?,
+            endTime: ZonedDateTime?
+        ) {
+            val application =
+                AlluDataFactory.createApplication()
+                    .withApplicationData(
+                        startTime = startTime,
+                        endTime = endTime,
+                    )
+
+            assertThat { applicationValidator.isValid(application, null) }.isSuccess().isTrue()
+        }
+
+        @Test
+        fun `Start date before end date is allowed`() {
+            val application =
+                AlluDataFactory.createApplication()
+                    .withApplicationData(
+                        startTime = date,
+                        endTime = date.plusDays(1),
+                    )
+
+            assertThat { applicationValidator.isValid(application, null) }.isSuccess().isTrue()
+        }
+
+        @Test
+        fun `Start date after end date throws exception`() {
+            val application =
+                AlluDataFactory.createApplication()
+                    .withApplicationData(
+                        startTime = date.plusDays(1),
+                        endTime = date,
+                    )
+
+            assertThat { applicationValidator.isValid(application, null) }
+                .isFailure()
+                .hasClass(InvalidApplicationDataException::class)
+        }
+    }
+
+    @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    inner class CustomerValidate {
+        private val baseCustomer = AlluDataFactory.createCompanyCustomer()
+
+        private fun notJustWhitespaceCases(content: String): Stream<Arguments> =
+            Stream.of(
+                Arguments.of("name", baseCustomer.copy(name = content)),
+                Arguments.of("email", baseCustomer.copy(email = content)),
+                Arguments.of("phone", baseCustomer.copy(phone = content)),
+                Arguments.of("ovt", baseCustomer.copy(ovt = content)),
+                Arguments.of("invoicingOperator", baseCustomer.copy(invoicingOperator = content)),
+                Arguments.of("sapCustomerNumber", baseCustomer.copy(sapCustomerNumber = content)),
+            )
+
+        private fun justWhitespaceCases(): Stream<Arguments> = notJustWhitespaceCases(" ")
+
+        private fun emptyCases(): Stream<Arguments> = notJustWhitespaceCases("")
+
+        private fun textCases(): Stream<Arguments> = notJustWhitespaceCases("Some Text")
+
+        @ParameterizedTest(name = "{0} should not be just whitespace")
+        @MethodSource("justWhitespaceCases")
+        fun `value should not be just whitespace`(case: String, customer: Customer) {
+            case.touch()
+            val application =
+                AlluDataFactory.createApplication().withCustomer(customer.withContacts())
+
+            assertThat { applicationValidator.isValid(application, null) }
+                .isFailure()
+                .hasClass(InvalidApplicationDataException::class)
+        }
+
+        @ParameterizedTest(name = "{0} can be empty")
+        @MethodSource("emptyCases")
+        fun `value can be empty`(case: String, customer: Customer) {
+            case.touch()
+            val application =
+                AlluDataFactory.createApplication().withCustomer(customer.withContacts())
+
+            assertThat { applicationValidator.isValid(application, null) }.isSuccess().isTrue()
+        }
+
+        @ParameterizedTest(name = "{0} can have text with whitespaces")
+        @MethodSource("textCases")
+        fun `value can have text with whitespaces`(case: String, customer: Customer) {
+            case.touch()
+            val application =
+                AlluDataFactory.createApplication().withCustomer(customer.withContacts())
+
+            assertThat { applicationValidator.isValid(application, null) }.isSuccess().isTrue()
+        }
+
+        @Test
+        fun `country can't be free text`() {
+            val application =
+                AlluDataFactory.createApplication()
+                    .withCustomer(baseCustomer.copy(country = "Some country").withContacts())
+
+            assertThat { applicationValidator.isValid(application, null) }
+                .isFailure()
+                .hasClass(InvalidApplicationDataException::class)
+        }
+
+        @Test
+        fun `country can be two-letter country code`() {
+            val application =
+                AlluDataFactory.createApplication()
+                    .withCustomer(baseCustomer.copy(country = "FI").withContacts())
+
+            assertThat { applicationValidator.isValid(application, null) }.isSuccess().isTrue()
+        }
+
+        @Test
+        fun `country is case-sensitive`() {
+            val application =
+                AlluDataFactory.createApplication()
+                    .withCustomer(baseCustomer.copy(country = "fi").withContacts())
+
+            assertThat { applicationValidator.isValid(application, null) }
+                .isFailure()
+                .hasClass(InvalidApplicationDataException::class)
+        }
+
+        @Test
+        fun `country can't be three-letter country code`() {
+            val application =
+                AlluDataFactory.createApplication()
+                    .withCustomer(baseCustomer.copy(country = "FIN").withContacts())
+
+            assertThat { applicationValidator.isValid(application, null) }
+                .isFailure()
+                .hasClass(InvalidApplicationDataException::class)
+        }
+
+        @Test
+        fun `Valid business ID is allowed`() {
+            val validBusinessId = "2182805-0"
+            assertThat(validBusinessId.isValidBusinessId()).isTrue()
+            val application =
+                AlluDataFactory.createApplication()
+                    .withCustomer(
+                        AlluDataFactory.createCompanyCustomer(registryKey = validBusinessId)
+                            .withContacts()
+                    )
+
+            assertThat { applicationValidator.isValid(application, null) }.isSuccess().isTrue()
+        }
+
+        @Test
+        fun `Invalid business ID throws exception`() {
+            val invalidBusinessId = "2182805-3"
+            assertThat(invalidBusinessId.isValidBusinessId()).isFalse()
+            val application =
+                AlluDataFactory.createApplication()
+                    .withCustomer(
+                        AlluDataFactory.createCompanyCustomer(registryKey = invalidBusinessId)
+                            .withContacts()
+                    )
+
+            assertThat { applicationValidator.isValid(application, null) }
+                .isFailure()
+                .hasClass(InvalidApplicationDataException::class)
+        }
+    }
+
+    @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    inner class ContactValidate {
+        private val baseContact = AlluDataFactory.createContact()
+
+        private fun notJustWhitespaceCases(content: String): Stream<Arguments> =
+            Stream.of(
+                Arguments.of("firstName", baseContact.copy(firstName = content)),
+                Arguments.of("lastName", baseContact.copy(lastName = content)),
+                Arguments.of("email", baseContact.copy(email = content)),
+                Arguments.of("phone", baseContact.copy(phone = content)),
+            )
+
+        private fun justWhitespaceCases(): Stream<Arguments> = notJustWhitespaceCases(" ")
+
+        private fun emptyCases(): Stream<Arguments> = notJustWhitespaceCases("")
+
+        private fun textCases(): Stream<Arguments> = notJustWhitespaceCases("Some Text")
+
+        @ParameterizedTest(name = "{0} should not be just whitespace")
+        @MethodSource("justWhitespaceCases")
+        fun `value should not be just whitespace`(case: String, contact: Contact) {
+            case.touch()
+            val application = AlluDataFactory.createApplication().withCustomerContacts(contact)
+
+            assertThat { applicationValidator.isValid(application, null) }
+                .isFailure()
+                .hasClass(InvalidApplicationDataException::class)
+        }
+
+        @ParameterizedTest(name = "{0} can be empty")
+        @MethodSource("emptyCases")
+        fun `value can be empty`(case: String, contact: Contact) {
+            case.touch()
+            val application = AlluDataFactory.createApplication().withCustomerContacts(contact)
+
+            assertThat { applicationValidator.isValid(application, null) }.isSuccess().isTrue()
+        }
+
+        @ParameterizedTest(name = "{0} can have text with whitespaces")
+        @MethodSource("textCases")
+        fun `value can have text with whitespaces`(case: String, contact: Contact) {
+            case.touch()
+            val application = AlluDataFactory.createApplication().withCustomerContacts(contact)
+
+            assertThat { applicationValidator.isValid(application, null) }.isSuccess().isTrue()
+        }
+    }
+}


### PR DESCRIPTION
# Description

Validations added:
- There is at most one orderer
- Text fields don't have just blanks
- Country has a country code (UI uses constant FI here)

On top of the earlier:
- Registry key (business-id) is valid
- Start date is not after the end date

I ended up rewriting the validation using the same validators used in validating if a hanke is public or not. I refactored that quite a bit, though.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1748

## Type of change

- [X] Bug fix 
- [ ] New feature 
- [ ] Other

# Instructions for testing
This is easiest to verify with the UI before https://github.com/City-of-Helsinki/haitaton-ui/pull/323 is merged.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 