### PR TITLE
HAI-1758 Drop scan status from attachments

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentControllerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentControllerITest.kt
@@ -23,7 +23,6 @@ import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentMetadata
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType.MUU
 import fi.hel.haitaton.hanke.attachment.common.AttachmentContent
-import fi.hel.haitaton.hanke.attachment.common.AttachmentScanStatus
 import fi.hel.haitaton.hanke.attachment.dummyData
 import fi.hel.haitaton.hanke.attachment.testFile
 import fi.hel.haitaton.hanke.factory.AlluDataFactory.Companion.createApplication
@@ -104,7 +103,6 @@ class ApplicationAttachmentControllerITest(@Autowired override val mockMvc: Mock
             d.transform { it.fileName }.endsWith(FILE_NAME_PDF)
             d.transform { it.createdByUserId }.isEqualTo(USERNAME)
             d.transform { it.createdAt }.isNotNull()
-            d.transform { it.scanStatus }.isEqualTo(AttachmentScanStatus.OK)
             d.transform { it.applicationId }.isEqualTo(APPLICATION_ID)
             d.transform { it.attachmentType }.isEqualTo(MUU)
         }
@@ -157,7 +155,6 @@ class ApplicationAttachmentControllerITest(@Autowired override val mockMvc: Mock
             assertThat(fileName).isEqualTo(FILE_NAME_PDF)
             assertThat(createdByUserId).isEqualTo(USERNAME)
             assertThat(createdAt).isNotNull()
-            assertThat(scanStatus).isEqualTo(AttachmentScanStatus.OK)
             assertThat(applicationId).isEqualTo(APPLICATION_ID)
             assertThat(attachmentType).isEqualTo(MUU)
         }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentService.kt
@@ -14,7 +14,6 @@ import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType
 import fi.hel.haitaton.hanke.attachment.common.AttachmentContent
 import fi.hel.haitaton.hanke.attachment.common.AttachmentInvalidException
 import fi.hel.haitaton.hanke.attachment.common.AttachmentNotFoundException
-import fi.hel.haitaton.hanke.attachment.common.AttachmentScanStatus.OK
 import fi.hel.haitaton.hanke.attachment.common.AttachmentValidator
 import fi.hel.haitaton.hanke.attachment.common.FileScanClient
 import fi.hel.haitaton.hanke.attachment.common.FileScanInput
@@ -45,11 +44,6 @@ class ApplicationAttachmentService(
         val attachment = findApplication(applicationId).attachments.findOrThrow(attachmentId)
 
         with(attachment) {
-            if (scanStatus != OK) {
-                logger.warn { "Attachment $id with scan status: $scanStatus cannot be viewed." }
-                throw AttachmentNotFoundException(attachmentId)
-            }
-
             return AttachmentContent(fileName, contentType, content)
         }
     }
@@ -81,7 +75,6 @@ class ApplicationAttachmentService(
                 contentType = attachment.contentType!!,
                 createdByUserId = currentUserId(),
                 createdAt = now(),
-                scanStatus = OK,
                 attachmentType = attachmentType,
                 application = application,
             )

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/common/AttachmentEntity.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/common/AttachmentEntity.kt
@@ -49,11 +49,6 @@ abstract class AttachmentEntity(
 
     /** Creation timestamp. */
     @Column(name = "created_at", updatable = false, nullable = false) var createdAt: OffsetDateTime,
-
-    /** Virus scan status. Possible values: PENDING, FAILED, OK. */
-    @Column(name = "scan_status")
-    @Enumerated(EnumType.STRING)
-    var scanStatus: AttachmentScanStatus = AttachmentScanStatus.PENDING
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -65,7 +60,6 @@ abstract class AttachmentEntity(
             fileName != other.fileName -> false
             createdByUserId != other.createdByUserId -> false
             createdAt != other.createdAt -> false
-            scanStatus != other.scanStatus -> false
             else -> true
         }
     }
@@ -74,7 +68,6 @@ abstract class AttachmentEntity(
         var result = fileName.hashCode()
         result = 31 * result + createdByUserId.hashCode()
         result = 31 * result + createdAt.hashCode()
-        result = 31 * result + scanStatus.hashCode()
         return result
     }
 }
@@ -88,17 +81,15 @@ class HankeAttachmentEntity(
     contentType: String,
     createdByUserId: String,
     createdAt: OffsetDateTime,
-    scanStatus: AttachmentScanStatus,
 
     /** Hanke in which this attachment belongs to. */
     @ManyToOne(fetch = FetchType.LAZY) @JoinColumn(name = "hanke_id") var hanke: HankeEntity,
-) : AttachmentEntity(id, fileName, content, contentType, createdByUserId, createdAt, scanStatus) {
+) : AttachmentEntity(id, fileName, content, contentType, createdByUserId, createdAt) {
     fun toMetadata(): HankeAttachmentMetadata {
         return HankeAttachmentMetadata(
             id = id,
             fileName = fileName,
             createdAt = createdAt,
-            scanStatus = scanStatus,
             hankeTunnus = hanke.hankeTunnus!!,
             createdByUserId = createdByUserId,
         )
@@ -132,7 +123,6 @@ class ApplicationAttachmentEntity(
     contentType: String,
     createdByUserId: String,
     createdAt: OffsetDateTime,
-    scanStatus: AttachmentScanStatus,
 
     /** Attachment type: MUU, LIIKENNEJARJESTELY, VALTAKIRJA. */
     @Enumerated(EnumType.STRING)
@@ -143,13 +133,12 @@ class ApplicationAttachmentEntity(
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "application_id")
     var application: ApplicationEntity,
-) : AttachmentEntity(id, fileName, content, contentType, createdByUserId, createdAt, scanStatus) {
+) : AttachmentEntity(id, fileName, content, contentType, createdByUserId, createdAt) {
     fun toMetadata(): ApplicationAttachmentMetadata {
         return ApplicationAttachmentMetadata(
             id = id,
             fileName = fileName,
             createdAt = createdAt,
-            scanStatus = scanStatus,
             createdByUserId = createdByUserId,
             applicationId = application.id!!,
             attachmentType = attachmentType,
@@ -208,10 +197,4 @@ enum class ApplicationAttachmentType {
     MUU,
     LIIKENNEJARJESTELY,
     VALTAKIRJA,
-}
-
-enum class AttachmentScanStatus {
-    PENDING,
-    FAILED,
-    OK
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/common/AttachmentMetadata.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/common/AttachmentMetadata.kt
@@ -1,5 +1,6 @@
 package fi.hel.haitaton.hanke.attachment.common
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import java.time.OffsetDateTime
 import java.util.UUID
 
@@ -8,7 +9,6 @@ data class HankeAttachmentMetadata(
     val fileName: String,
     val createdByUserId: String,
     val createdAt: OffsetDateTime,
-    val scanStatus: AttachmentScanStatus,
     val hankeTunnus: String,
 )
 
@@ -17,7 +17,6 @@ data class ApplicationAttachmentMetadata(
     val fileName: String,
     val createdByUserId: String,
     val createdAt: OffsetDateTime,
-    val scanStatus: AttachmentScanStatus,
     val applicationId: Long,
     val attachmentType: ApplicationAttachmentType,
 )

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/common/AttachmentMetadata.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/common/AttachmentMetadata.kt
@@ -1,6 +1,5 @@
 package fi.hel.haitaton.hanke.attachment.common
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import java.time.OffsetDateTime
 import java.util.UUID
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentService.kt
@@ -5,7 +5,6 @@ import fi.hel.haitaton.hanke.HankeRepository
 import fi.hel.haitaton.hanke.attachment.common.AttachmentContent
 import fi.hel.haitaton.hanke.attachment.common.AttachmentInvalidException
 import fi.hel.haitaton.hanke.attachment.common.AttachmentNotFoundException
-import fi.hel.haitaton.hanke.attachment.common.AttachmentScanStatus.OK
 import fi.hel.haitaton.hanke.attachment.common.AttachmentValidator
 import fi.hel.haitaton.hanke.attachment.common.FileScanClient
 import fi.hel.haitaton.hanke.attachment.common.FileScanInput
@@ -39,11 +38,6 @@ class HankeAttachmentService(
         val attachment = findHanke(hankeTunnus).liitteet.findBy(attachmentId)
 
         with(attachment) {
-            if (scanStatus != OK) {
-                logger.warn { "Attachment $id with scan status: $scanStatus cannot be viewed." }
-                throw AttachmentNotFoundException(attachmentId)
-            }
-
             return AttachmentContent(fileName, contentType, content)
         }
     }
@@ -61,7 +55,6 @@ class HankeAttachmentService(
                 contentType = attachment.contentType!!,
                 createdAt = now(),
                 createdByUserId = currentUserId(),
-                scanStatus = OK,
                 hanke = hanke,
             )
 

--- a/services/hanke-service/src/main/resources/db/changelog/changesets/036-drop-scanstatus-from-attachments.yml
+++ b/services/hanke-service/src/main/resources/db/changelog/changesets/036-drop-scanstatus-from-attachments.yml
@@ -1,0 +1,11 @@
+databaseChangeLog:
+  - changeSet:
+      id: 036-drop-scanstatus-from-attachments
+      author: Topias Heinonen
+      changes:
+        - dropColumn:
+            tableName: application_attachment
+            columnName: scan_status
+        - dropColumn:
+            tableName: hanke_attachment
+            columnName: scan_status

--- a/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -99,3 +99,5 @@ databaseChangeLog:
       file: db/changelog/changesets/034-add-delete-cascade-to-hankekayttajat.yml
   - include:
       file: db/changelog/changesets/035-add-content-type-attachments.yml
+  - include:
+      file: db/changelog/changesets/036-drop-scanstatus-from-attachments.yml

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/AttachmentFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/AttachmentFactory.kt
@@ -5,8 +5,6 @@ import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentEntity
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentMetadata
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType.MUU
-import fi.hel.haitaton.hanke.attachment.common.AttachmentScanStatus
-import fi.hel.haitaton.hanke.attachment.common.AttachmentScanStatus.OK
 import fi.hel.haitaton.hanke.attachment.common.HankeAttachmentMetadata
 import fi.hel.haitaton.hanke.currentUserId
 import java.time.OffsetDateTime
@@ -26,7 +24,6 @@ object AttachmentFactory {
         contentType: String = APPLICATION_PDF_VALUE,
         createdByUserId: String = currentUserId(),
         createdAt: OffsetDateTime = OffsetDateTime.now(),
-        scanStatus: AttachmentScanStatus = OK,
         attachmentType: ApplicationAttachmentType = MUU,
         application: ApplicationEntity,
     ): ApplicationAttachmentEntity =
@@ -37,7 +34,6 @@ object AttachmentFactory {
             contentType = contentType,
             createdByUserId = createdByUserId,
             createdAt = createdAt,
-            scanStatus = scanStatus,
             attachmentType = attachmentType,
             application = application,
         )
@@ -47,7 +43,6 @@ object AttachmentFactory {
         fileName: String = FILE_NAME,
         createdByUser: String = currentUserId(),
         createdAt: OffsetDateTime = OffsetDateTime.now(),
-        scanStatus: AttachmentScanStatus = OK,
         hankeTunnus: String = "HAI-1234",
     ): HankeAttachmentMetadata =
         HankeAttachmentMetadata(
@@ -55,7 +50,6 @@ object AttachmentFactory {
             fileName = fileName,
             createdByUserId = createdByUser,
             createdAt = createdAt,
-            scanStatus = scanStatus,
             hankeTunnus = hankeTunnus,
         )
 
@@ -64,7 +58,6 @@ object AttachmentFactory {
         fileName: String = FILE_NAME,
         createdBy: String = currentUserId(),
         createdAt: OffsetDateTime = OffsetDateTime.now(),
-        scanStatus: AttachmentScanStatus = OK,
         applicationId: Long = 1L,
         attachmentType: ApplicationAttachmentType = MUU,
     ): ApplicationAttachmentMetadata =
@@ -73,7 +66,6 @@ object AttachmentFactory {
             fileName = fileName,
             createdByUserId = createdBy,
             createdAt = createdAt,
-            scanStatus = scanStatus,
             applicationId = applicationId,
             attachmentType = attachmentType
         )


### PR DESCRIPTION
# Description

Drop the unused scan status column from both attachment tables. Remove it from the entities and other places that use it.

The frontend seems to except the backend to return the scan status, even though it doesn't use it for anything. Add a constant `"scanStatus": "OK"` to each attachment object returned from the backend.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1758

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [X] Other

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 