### PR TITLE
HAI-1758 Split attachment content to separate tables

### DIFF
--- a/services/hanke-service/README.md
+++ b/services/hanke-service/README.md
@@ -103,7 +103,7 @@ without the need to install postgres locally.
 
 To run the postgres in localhost
 ```
- cd scripts/postgres-docker
+ cd scripts/docker-postgres
 ./build-postgres-docker.sh 
 ```
 You can change the port and data folder to your liking in configure-database

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentControllerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentControllerITest.kt
@@ -26,7 +26,7 @@ import fi.hel.haitaton.hanke.attachment.common.AttachmentContent
 import fi.hel.haitaton.hanke.attachment.dummyData
 import fi.hel.haitaton.hanke.attachment.testFile
 import fi.hel.haitaton.hanke.factory.AlluDataFactory.Companion.createApplication
-import fi.hel.haitaton.hanke.factory.AttachmentFactory.applicationAttachmentMetadata
+import fi.hel.haitaton.hanke.factory.AttachmentFactory
 import fi.hel.haitaton.hanke.permissions.PermissionCode.EDIT
 import fi.hel.haitaton.hanke.permissions.PermissionCode.VIEW
 import fi.hel.haitaton.hanke.permissions.PermissionService
@@ -89,7 +89,10 @@ class ApplicationAttachmentControllerITest(@Autowired override val mockMvc: Mock
 
     @Test
     fun `getMetadataList when valid request should return metadata list`() {
-        val data = (1..3).map { applicationAttachmentMetadata(fileName = "${it}file.pdf") }
+        val data =
+            (1..3).map {
+                AttachmentFactory.applicationAttachmentMetadata(fileName = "${it}file.pdf")
+            }
         every { applicationService.getApplicationById(APPLICATION_ID) } returns createApplication()
         every { hankeService.getHankeId(HANKE_TUNNUS) } returns HANKE_ID
         every { permissionService.hasPermission(HANKE_ID, USERNAME, VIEW) } returns true
@@ -145,7 +148,7 @@ class ApplicationAttachmentControllerITest(@Autowired override val mockMvc: Mock
         every { hankeService.getHankeId(HANKE_TUNNUS) } returns HANKE_ID
         every { permissionService.hasPermission(HANKE_ID, USERNAME, EDIT) } returns true
         every { applicationAttachmentService.addAttachment(APPLICATION_ID, MUU, file) } returns
-            applicationAttachmentMetadata()
+            AttachmentFactory.applicationAttachmentMetadata()
 
         val result: ApplicationAttachmentMetadata =
             postAttachment(file = file).andExpect(status().isOk).andReturnBody()

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentServiceITest.kt
@@ -168,7 +168,7 @@ class ApplicationAttachmentServiceITest : DatabaseTest() {
                 )
             }
 
-        assertThat(exception.message).isEqualTo("Attachment '${secondAttachment.id}' not found")
+        assertThat(exception.message).isEqualTo("Attachment not found, id=${secondAttachment.id}")
     }
 
     @EnumSource(ApplicationAttachmentType::class)

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentControllerITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentControllerITests.kt
@@ -15,7 +15,7 @@ import fi.hel.haitaton.hanke.attachment.andExpectError
 import fi.hel.haitaton.hanke.attachment.common.AttachmentContent
 import fi.hel.haitaton.hanke.attachment.dummyData
 import fi.hel.haitaton.hanke.attachment.testFile
-import fi.hel.haitaton.hanke.factory.AttachmentFactory.hankeAttachmentMetadata
+import fi.hel.haitaton.hanke.factory.AttachmentFactory
 import fi.hel.haitaton.hanke.permissions.PermissionCode.EDIT
 import fi.hel.haitaton.hanke.permissions.PermissionCode.VIEW
 import fi.hel.haitaton.hanke.permissions.PermissionService
@@ -72,7 +72,8 @@ class HankeAttachmentControllerITests(@Autowired override val mockMvc: MockMvc) 
 
     @Test
     fun `getMetadataList when valid request should return metadata list`() {
-        val data = (1..3).map { hankeAttachmentMetadata(fileName = "${it}file.pdf") }
+        val data =
+            (1..3).map { AttachmentFactory.hankeAttachmentMetadata(fileName = "${it}file.pdf") }
         every { hankeService.getHankeId(HANKE_TUNNUS) }.returns(HANKE_ID)
         every { permissionService.hasPermission(HANKE_ID, USERNAME, VIEW) } returns true
         every { hankeAttachmentService.getMetadataList(HANKE_TUNNUS) } returns data
@@ -113,7 +114,7 @@ class HankeAttachmentControllerITests(@Autowired override val mockMvc: MockMvc) 
         every { hankeService.getHankeId(HANKE_TUNNUS) } returns HANKE_ID
         every { permissionService.hasPermission(HANKE_ID, USERNAME, EDIT) } returns true
         every { hankeAttachmentService.addAttachment(HANKE_TUNNUS, file) } returns
-            hankeAttachmentMetadata(fileName = "text.txt")
+            AttachmentFactory.hankeAttachmentMetadata(fileName = "text.txt")
 
         postAttachment(file = file).andExpect(status().isOk)
 

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentServiceITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentServiceITests.kt
@@ -7,6 +7,7 @@ import assertk.assertions.hasSize
 import assertk.assertions.isEmpty
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNotNull
+import assertk.assertions.isPresent
 import fi.hel.haitaton.hanke.ALLOWED_ATTACHMENT_COUNT
 import fi.hel.haitaton.hanke.DatabaseTest
 import fi.hel.haitaton.hanke.HankeNotFoundException
@@ -23,7 +24,6 @@ import fi.hel.haitaton.hanke.attachment.successResult
 import fi.hel.haitaton.hanke.attachment.testFile
 import fi.hel.haitaton.hanke.factory.AttachmentFactory
 import fi.hel.haitaton.hanke.factory.HankeFactory
-import java.util.Optional
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
@@ -120,7 +120,7 @@ class HankeAttachmentServiceITests : DatabaseTest() {
                 hankeAttachmentService.getContent(firstHanke.hankeTunnus!!, secondAttachment.id!!)
             }
 
-        assertThat(exception.message).isEqualTo("Attachment ${secondAttachment.id} not found")
+        assertThat(exception.message).isEqualTo("Attachment '${secondAttachment.id}' not found")
     }
 
     @Test
@@ -204,12 +204,13 @@ class HankeAttachmentServiceITests : DatabaseTest() {
     fun `deleteAttachment when valid input should succeed`() {
         mockWebServer.enqueue(response(body(results = successResult())))
         val hanke = hankeService.createHanke(HankeFactory.create())
-        val result = hankeAttachmentService.addAttachment(hanke.hankeTunnus!!, testFile())
-        val attachmentId = result.id!!
-        assertThat(hankeAttachmentRepository.findById(attachmentId).orElseThrow()).isNotNull()
+        val attachment = hankeAttachmentService.addAttachment(hanke.hankeTunnus!!, testFile())
+        val attachmentId = attachment.id!!
+        assertThat(hankeAttachmentRepository.findById(attachmentId)).isPresent()
 
         hankeAttachmentService.deleteAttachment(hanke.hankeTunnus!!, attachmentId)
 
-        assertThat(hankeAttachmentRepository.findById(attachmentId)).isEqualTo(Optional.empty())
+        val remainingAttachment = hankeAttachmentRepository.findById(attachmentId)
+        assertThat(remainingAttachment).isEmpty()
     }
 }

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentServiceITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentServiceITests.kt
@@ -120,7 +120,7 @@ class HankeAttachmentServiceITests : DatabaseTest() {
                 hankeAttachmentService.getContent(firstHanke.hankeTunnus!!, secondAttachment.id!!)
             }
 
-        assertThat(exception.message).isEqualTo("Attachment '${secondAttachment.id}' not found")
+        assertThat(exception.message).isEqualTo("Attachment not found, id=${secondAttachment.id}")
     }
 
     @Test

--- a/services/hanke-service/src/integrationTest/resources/clear-db.sql
+++ b/services/hanke-service/src/integrationTest/resources/clear-db.sql
@@ -1,10 +1,12 @@
 TRUNCATE TABLE
     application_attachment,
+    application_attachment_content,
     applications,
     audit_logs,
     geometriat,
     hanke,
     hanke_attachment,
+    hanke_attachment_content,
     hanke_kayttaja,
     hankealue,
     hankegeometria,

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/CableReportService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/CableReportService.kt
@@ -1,6 +1,8 @@
 package fi.hel.haitaton.hanke.allu
 
+import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentEntity
 import java.time.ZonedDateTime
+import java.util.UUID
 
 interface CableReportService {
 
@@ -15,7 +17,11 @@ interface CableReportService {
 
     fun addAttachment(alluApplicationId: Int, attachment: Attachment)
 
-    fun addAttachments(alluApplicationId: Int, attachments: List<Attachment>)
+    fun addAttachments(
+        alluApplicationId: Int,
+        attachments: List<ApplicationAttachmentEntity>,
+        getContent: (UUID) -> ByteArray,
+    )
 
     fun getInformationRequests(alluApplicationId: Int): List<InformationRequest>
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationEntity.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationEntity.kt
@@ -3,19 +3,15 @@ package fi.hel.haitaton.hanke.application
 import com.vladmihalcea.hibernate.type.json.JsonType
 import fi.hel.haitaton.hanke.HankeEntity
 import fi.hel.haitaton.hanke.allu.ApplicationStatus
-import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentEntity
-import javax.persistence.CascadeType
 import javax.persistence.Column
 import javax.persistence.Entity
 import javax.persistence.EnumType
 import javax.persistence.Enumerated
-import javax.persistence.FetchType
 import javax.persistence.GeneratedValue
 import javax.persistence.GenerationType
 import javax.persistence.Id
 import javax.persistence.JoinColumn
 import javax.persistence.ManyToOne
-import javax.persistence.OneToMany
 import javax.persistence.Table
 import org.hibernate.annotations.Type
 import org.hibernate.annotations.TypeDef
@@ -32,13 +28,6 @@ data class ApplicationEntity(
     @Enumerated(EnumType.STRING) val applicationType: ApplicationType,
     @Type(type = "json") @Column(columnDefinition = "jsonb") var applicationData: ApplicationData,
     @ManyToOne @JoinColumn(updatable = false, nullable = false) var hanke: HankeEntity,
-    @OneToMany(
-        mappedBy = "application",
-        fetch = FetchType.LAZY,
-        cascade = [CascadeType.ALL],
-        orphanRemoval = true
-    )
-    var attachments: MutableList<ApplicationAttachmentEntity> = mutableListOf()
 ) {
     fun toApplication() =
         Application(

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationService.kt
@@ -252,7 +252,7 @@ open class ApplicationService(
             logger.info { "Application not sent to Allu yet, simply deleting it. id=$id" }
         } else {
             logger.info {
-                "Application sent to Allu yet, trying to cancel it before deleting. id=$id alluid=$alluid"
+                "Application is sent to Allu, trying to cancel it before deleting. id=$id alluid=$alluid"
             }
             cancelApplication(alluid, application.id)
         }
@@ -460,7 +460,7 @@ open class ApplicationService(
             }
 
         try {
-            attachmentService.sendInitialAttachments(alluId, entity)
+            attachmentService.sendInitialAttachments(alluId, entity.id!!)
         } catch (e: Exception) {
             logger.error(e) {
                 "Error while sending the initial attachments. Canceling the application. " +

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/common/AttachmentContentEntity.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/common/AttachmentContentEntity.kt
@@ -21,7 +21,6 @@ abstract class AttachmentContentEntity(
     /** Attachment data, i.e. the file itself. */
     @Lob
     @Type(type = "org.hibernate.type.BinaryType")
-    @Basic(fetch = FetchType.LAZY)
     @NotNull
     var content: ByteArray,
 )

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/common/AttachmentContentEntity.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/common/AttachmentContentEntity.kt
@@ -1,10 +1,8 @@
 package fi.hel.haitaton.hanke.attachment.common
 
 import java.util.UUID
-import javax.persistence.Basic
 import javax.persistence.Column
 import javax.persistence.Entity
-import javax.persistence.FetchType
 import javax.persistence.Id
 import javax.persistence.Lob
 import javax.persistence.MappedSuperclass
@@ -19,10 +17,7 @@ abstract class AttachmentContentEntity(
     @Id @Column(name = "attachment_id") var attachmentId: UUID,
 
     /** Attachment data, i.e. the file itself. */
-    @Lob
-    @Type(type = "org.hibernate.type.BinaryType")
-    @NotNull
-    var content: ByteArray,
+    @Lob @Type(type = "org.hibernate.type.BinaryType") @NotNull var content: ByteArray,
 )
 
 @Entity

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/common/AttachmentContentEntity.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/common/AttachmentContentEntity.kt
@@ -1,0 +1,48 @@
+package fi.hel.haitaton.hanke.attachment.common
+
+import java.util.UUID
+import javax.persistence.Basic
+import javax.persistence.Column
+import javax.persistence.Entity
+import javax.persistence.FetchType
+import javax.persistence.Id
+import javax.persistence.Lob
+import javax.persistence.MappedSuperclass
+import javax.persistence.Table
+import javax.validation.constraints.NotNull
+import org.hibernate.annotations.Type
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@MappedSuperclass
+abstract class AttachmentContentEntity(
+    @Id @Column(name = "attachment_id") var attachmentId: UUID,
+
+    /** Attachment data, i.e. the file itself. */
+    @Lob
+    @Type(type = "org.hibernate.type.BinaryType")
+    @Basic(fetch = FetchType.LAZY)
+    @NotNull
+    var content: ByteArray,
+)
+
+@Entity
+@Table(name = "hanke_attachment_content")
+class HankeAttachmentContentEntity(
+    attachmentId: UUID,
+    content: ByteArray,
+) : AttachmentContentEntity(attachmentId, content)
+
+@Entity
+@Table(name = "application_attachment_content")
+class ApplicationAttachmentContentEntity(
+    attachmentId: UUID,
+    content: ByteArray,
+) : AttachmentContentEntity(attachmentId, content)
+
+@Repository
+interface HankeAttachmentContentRepository : JpaRepository<HankeAttachmentContentEntity, UUID>
+
+@Repository
+interface ApplicationAttachmentContentRepository :
+    JpaRepository<ApplicationAttachmentContentEntity, UUID>

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/common/AttachmentContentService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/common/AttachmentContentService.kt
@@ -1,0 +1,42 @@
+package fi.hel.haitaton.hanke.attachment.common
+
+import java.util.UUID
+import mu.KotlinLogging
+import org.springframework.stereotype.Service
+
+private val logger = KotlinLogging.logger {}
+
+@Service
+class AttachmentContentService(
+    private val applicationAttachmentContentRepository: ApplicationAttachmentContentRepository,
+    private val hankeAttachmentContentRepository: HankeAttachmentContentRepository
+) {
+
+    fun saveApplicationContent(attachmentId: UUID, content: ByteArray) {
+        applicationAttachmentContentRepository.save(
+            ApplicationAttachmentContentEntity(attachmentId, content)
+        )
+    }
+
+    fun findApplicationContent(attachmentId: UUID): ByteArray =
+        applicationAttachmentContentRepository
+            .findById(attachmentId)
+            .map { it.content }
+            .orElseThrow {
+                logger.error { "Content not found for application attachment $attachmentId" }
+                AttachmentNotFoundException(attachmentId)
+            }
+
+    fun saveHankeContent(attachmentId: UUID, content: ByteArray) {
+        hankeAttachmentContentRepository.save(HankeAttachmentContentEntity(attachmentId, content))
+    }
+
+    fun findHankeContent(attachmentId: UUID): ByteArray =
+        hankeAttachmentContentRepository
+            .findById(attachmentId)
+            .map { it.content }
+            .orElseThrow {
+                logger.error { "Content not found for hanke attachment $attachmentId" }
+                AttachmentNotFoundException(attachmentId)
+            }
+}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/common/Exceptions.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/common/Exceptions.kt
@@ -5,4 +5,4 @@ import java.util.UUID
 class AttachmentInvalidException(str: String) :
     RuntimeException("Attachment upload exception: $str")
 
-class AttachmentNotFoundException(id: UUID) : RuntimeException("Attachment $id not found")
+class AttachmentNotFoundException(id: UUID?) : RuntimeException("Attachment '$id' not found")

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/common/Exceptions.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/common/Exceptions.kt
@@ -5,4 +5,4 @@ import java.util.UUID
 class AttachmentInvalidException(str: String) :
     RuntimeException("Attachment upload exception: $str")
 
-class AttachmentNotFoundException(id: UUID?) : RuntimeException("Attachment '$id' not found")
+class AttachmentNotFoundException(id: UUID) : RuntimeException("Attachment not found, id=$id")

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/configuration/Configuration.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/configuration/Configuration.kt
@@ -36,6 +36,9 @@ import fi.hel.haitaton.hanke.tormaystarkastelu.TormaystarkasteluTormaysService
 import fi.hel.haitaton.hanke.tormaystarkastelu.TormaystarkasteluTormaysServicePG
 import io.netty.handler.ssl.SslContextBuilder
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
@@ -48,13 +51,16 @@ import reactor.netty.http.client.HttpClient
 
 @Configuration
 @Profile("default")
-@EnableConfigurationProperties(GdprProperties::class, FeatureFlags::class)
+@EnableConfigurationProperties(
+    GdprProperties::class,
+    FeatureFlags::class,
+    AlluProperties::class,
+)
 class Configuration {
-
-    @Value("\${haitaton.allu.baseUrl}") lateinit var alluBaseUrl: String
-    @Value("\${haitaton.allu.username}") lateinit var alluUsername: String
-    @Value("\${haitaton.allu.password}") lateinit var alluPassword: String
     @Value("\${haitaton.allu.insecure}") var alluTrustInsecure: Boolean = false
+    @Autowired lateinit var alluProperties: AlluProperties
+
+    @Bean fun ioDispatcher(): CoroutineDispatcher = Dispatchers.IO
 
     @Bean
     fun cableReportService(webClientBuilder: WebClient.Builder): CableReportService {
@@ -63,9 +69,7 @@ class Configuration {
                 if (alluTrustInsecure) createInsecureTrustingWebClient(webClientBuilder)
                 else webClientBuilder
             )
-        val alluProps =
-            AlluProperties(baseUrl = alluBaseUrl, username = alluUsername, password = alluPassword)
-        return CableReportServiceAllu(webClient, alluProps)
+        return CableReportServiceAllu(webClient, alluProperties)
     }
 
     private fun createInsecureTrustingWebClient(

--- a/services/hanke-service/src/main/resources/application.properties
+++ b/services/hanke-service/src/main/resources/application.properties
@@ -4,6 +4,7 @@ haitaton.allu.baseUrl=${ALLU_BASEURL:/}
 haitaton.allu.username=${ALLU_USERNAME:fake_user}
 haitaton.allu.password=${ALLU_PASSWORD:fake_password}
 haitaton.allu.insecure=${ALLU_INSECURE:false}
+haitaton.allu.concurrentUploads=${ALLU_CONCURRENT_UPLOADS:3}
 haitaton.allu.updateIntervalMilliSeconds=${ALLU_UPDATE_INTERVAL:60000}
 haitaton.allu.updateInitialDelayMilliSeconds=${ALLU_UPDATE_INITIAL_DELAY:60000}
 

--- a/services/hanke-service/src/main/resources/db/changelog/changesets/037-add-delete-cascade-for-attachments.yml
+++ b/services/hanke-service/src/main/resources/db/changelog/changesets/037-add-delete-cascade-for-attachments.yml
@@ -1,0 +1,25 @@
+databaseChangeLog:
+  - changeSet:
+      id: 037-add-delete-cascade-for-attachments
+      author: Niko Pitkonen
+      changes:
+        - dropForeignKeyConstraint:
+            baseTableName: application_attachment
+            constraintName: fk_attachment_applications
+        - addForeignKeyConstraint:
+            baseTableName: application_attachment
+            baseColumnNames: application_id
+            constraintName: fk_attachment_applications
+            referencedTableName: applications
+            referencedColumnNames: id
+            onDelete: CASCADE
+        - dropForeignKeyConstraint:
+            baseTableName: hanke_attachment
+            constraintName: fk_attachment_hanke
+        - addForeignKeyConstraint:
+            baseTableName: hanke_attachment
+            baseColumnNames: hanke_id
+            constraintName: fk_attachment_hanke
+            referencedTableName: hanke
+            referencedColumnNames: id
+            onDelete: CASCADE

--- a/services/hanke-service/src/main/resources/db/changelog/changesets/038-add-attachment-content-tables.sql
+++ b/services/hanke-service/src/main/resources/db/changelog/changesets/038-add-attachment-content-tables.sql
@@ -1,0 +1,44 @@
+--liquibase formatted sql
+--changeset Topias Heinonen:038-add-attachment-content-tables
+--comment: Add separate tables for storing attachment file content
+
+CREATE TABLE hanke_attachment_content
+(
+    attachment_id uuid PRIMARY KEY NOT NULL,
+    content       bytea            NOT NULL,
+    CONSTRAINT fk_hanke_attachment
+        FOREIGN KEY (attachment_id)
+            REFERENCES hanke_attachment (id) ON DELETE CASCADE
+);
+
+COMMENT ON TABLE hanke_attachment_content IS 'Separate table for holding just the binary content of the attachment file. Separated so JPA does not load the binaries unexpectedly.';
+COMMENT ON COLUMN hanke_attachment_content.attachment_id IS 'ID of the attachment this binary data belongs to. Also the primary key, since this is a strict one-to-one relationship.';
+COMMENT ON COLUMN hanke_attachment_content.content IS 'The file content as a binary BLOB.';
+
+INSERT INTO hanke_attachment_content
+SELECT id, content
+FROM hanke_attachment;
+
+ALTER TABLE hanke_attachment
+    DROP COLUMN content;
+
+CREATE TABLE application_attachment_content
+(
+    attachment_id uuid PRIMARY KEY NOT NULL,
+    content       bytea            NOT NULL,
+    CONSTRAINT fk_application_attachment
+        FOREIGN KEY (attachment_id)
+            REFERENCES application_attachment (id) ON DELETE CASCADE
+);
+
+COMMENT ON TABLE application_attachment_content IS 'Separate table for holding just the binary content of the attachment file. Separated so JPA does not load the binaries unexpectedly.';
+COMMENT ON COLUMN application_attachment_content.attachment_id IS 'ID of the attachment this binary data belongs to. Also the primary key, since this is a strict one-to-one relationship.';
+COMMENT ON COLUMN application_attachment_content.content IS 'The file content as a binary BLOB.';
+
+
+INSERT INTO application_attachment_content
+SELECT id, content
+FROM application_attachment;
+
+ALTER TABLE application_attachment
+    DROP COLUMN content;

--- a/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -101,3 +101,7 @@ databaseChangeLog:
       file: db/changelog/changesets/035-add-content-type-attachments.yml
   - include:
       file: db/changelog/changesets/036-drop-scanstatus-from-attachments.yml
+  - include:
+      file: db/changelog/changesets/037-add-delete-cascade-for-attachments.yml
+  - include:
+      file: db/changelog/changesets/038-add-attachment-content-tables.sql

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/AlluDataFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/AlluDataFactory.kt
@@ -27,7 +27,9 @@ import org.springframework.stereotype.Component
 const val TEPPO_TESTI = "Teppo Testihenkilö"
 
 @Component
-class AlluDataFactory(val applicationRepository: ApplicationRepository) {
+class AlluDataFactory(
+    private val applicationRepository: ApplicationRepository,
+) {
     companion object {
         const val defaultApplicationId: Long = 1
         const val defaultApplicationName: String = "Johtoselvityksen oletusnimi"

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/AttachmentFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/AttachmentFactory.kt
@@ -1,11 +1,12 @@
 package fi.hel.haitaton.hanke.factory
 
 import fi.hel.haitaton.hanke.HankeEntity
-import fi.hel.haitaton.hanke.application.ApplicationEntity
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentEntity
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentMetadata
+import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentRepository
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType.MUU
+import fi.hel.haitaton.hanke.attachment.common.AttachmentContentService
 import fi.hel.haitaton.hanke.attachment.common.HankeAttachmentEntity
 import fi.hel.haitaton.hanke.attachment.common.HankeAttachmentMetadata
 import fi.hel.haitaton.hanke.currentUserId
@@ -13,81 +14,94 @@ import java.time.OffsetDateTime
 import java.util.UUID
 import java.util.UUID.randomUUID
 import org.springframework.http.MediaType.APPLICATION_PDF_VALUE
+import org.springframework.stereotype.Component
 
 private const val FILE_NAME = "file.pdf"
 
 private val dummyData = "ABC".toByteArray()
 
-object AttachmentFactory {
-    fun applicationAttachmentEntity(
-        id: UUID = randomUUID(),
-        fileName: String = FILE_NAME,
-        content: ByteArray = dummyData,
-        contentType: String = APPLICATION_PDF_VALUE,
-        createdByUserId: String = currentUserId(),
-        createdAt: OffsetDateTime = OffsetDateTime.now(),
-        attachmentType: ApplicationAttachmentType = MUU,
-        application: ApplicationEntity,
-    ): ApplicationAttachmentEntity =
-        ApplicationAttachmentEntity(
-            id = id,
-            fileName = fileName,
-            content = content,
-            contentType = contentType,
-            createdByUserId = createdByUserId,
-            createdAt = createdAt,
-            attachmentType = attachmentType,
-            application = application,
-        )
+@Component
+class AttachmentFactory(
+    private val applicationAttachmentRepository: ApplicationAttachmentRepository,
+    private val attachmentContentService: AttachmentContentService,
+) {
+    fun saveAttachment(applicationId: Long): ApplicationAttachmentEntity {
+        val attachment =
+            applicationAttachmentRepository.save(
+                applicationAttachmentEntity(applicationId = applicationId)
+            )
+        attachmentContentService.saveApplicationContent(attachment.id!!, dummyData)
+        return attachment
+    }
 
-    fun hankeAttachmentEntity(
-        id: UUID = randomUUID(),
-        fileName: String = FILE_NAME,
-        content: ByteArray = dummyData,
-        contentType: String = APPLICATION_PDF_VALUE,
-        createdByUser: String = currentUserId(),
-        createdAt: OffsetDateTime = OffsetDateTime.now(),
-        hanke: HankeEntity,
-    ): HankeAttachmentEntity =
-        HankeAttachmentEntity(
-            id = id,
-            fileName = fileName,
-            content = content,
-            contentType = contentType,
-            createdByUserId = createdByUser,
-            createdAt = createdAt,
-            hanke = hanke,
-        )
+    companion object {
 
-    fun hankeAttachmentMetadata(
-        attachmentId: UUID = randomUUID(),
-        fileName: String = FILE_NAME,
-        createdByUser: String = currentUserId(),
-        createdAt: OffsetDateTime = OffsetDateTime.now(),
-        hankeTunnus: String = "HAI-1234",
-    ): HankeAttachmentMetadata =
-        HankeAttachmentMetadata(
-            id = attachmentId,
-            fileName = fileName,
-            createdByUserId = createdByUser,
-            createdAt = createdAt,
-            hankeTunnus = hankeTunnus,
-        )
+        fun applicationAttachmentEntity(
+            id: UUID = randomUUID(),
+            fileName: String = FILE_NAME,
+            contentType: String = APPLICATION_PDF_VALUE,
+            createdByUserId: String = "currentUserId",
+            createdAt: OffsetDateTime = OffsetDateTime.now(),
+            attachmentType: ApplicationAttachmentType = MUU,
+            applicationId: Long,
+        ): ApplicationAttachmentEntity =
+            ApplicationAttachmentEntity(
+                id = id,
+                fileName = fileName,
+                contentType = contentType,
+                createdByUserId = createdByUserId,
+                createdAt = createdAt,
+                attachmentType = attachmentType,
+                applicationId = applicationId,
+            )
 
-    fun applicationAttachmentMetadata(
-        attachmentId: UUID = randomUUID(),
-        fileName: String = FILE_NAME,
-        createdBy: String = currentUserId(),
-        createdAt: OffsetDateTime = OffsetDateTime.now(),
-        applicationId: Long = 1L,
-        attachmentType: ApplicationAttachmentType = MUU,
-    ): ApplicationAttachmentMetadata =
-        ApplicationAttachmentMetadata(
-            id = attachmentId,
-            fileName = fileName,
-            createdByUserId = createdBy,
-            createdAt = createdAt,
-            applicationId = applicationId,
-            attachmentType = attachmentType
-        )
+        fun hankeAttachmentEntity(
+            id: UUID = randomUUID(),
+            fileName: String = FILE_NAME,
+            contentType: String = APPLICATION_PDF_VALUE,
+            createdByUser: String = currentUserId(),
+            createdAt: OffsetDateTime = OffsetDateTime.now(),
+            hanke: HankeEntity,
+        ): HankeAttachmentEntity =
+            HankeAttachmentEntity(
+                id = id,
+                fileName = fileName,
+                contentType = contentType,
+                createdByUserId = createdByUser,
+                createdAt = createdAt,
+                hanke = hanke,
+            )
+
+        fun hankeAttachmentMetadata(
+            attachmentId: UUID = randomUUID(),
+            fileName: String = FILE_NAME,
+            createdByUser: String = currentUserId(),
+            createdAt: OffsetDateTime = OffsetDateTime.now(),
+            hankeTunnus: String = "HAI-1234",
+        ): HankeAttachmentMetadata =
+            HankeAttachmentMetadata(
+                id = attachmentId,
+                fileName = fileName,
+                createdByUserId = createdByUser,
+                createdAt = createdAt,
+                hankeTunnus = hankeTunnus,
+            )
+
+        fun applicationAttachmentMetadata(
+            attachmentId: UUID = randomUUID(),
+            fileName: String = FILE_NAME,
+            createdBy: String = currentUserId(),
+            createdAt: OffsetDateTime = OffsetDateTime.now(),
+            applicationId: Long = 1L,
+            attachmentType: ApplicationAttachmentType = MUU,
+        ): ApplicationAttachmentMetadata =
+            ApplicationAttachmentMetadata(
+                id = attachmentId,
+                fileName = fileName,
+                createdByUserId = createdBy,
+                createdAt = createdAt,
+                applicationId = applicationId,
+                attachmentType = attachmentType
+            )
+    }
 }


### PR DESCRIPTION
# Description

Improve the memory use around attachments by separating the binary
content of the attachment files into separate tables and entities. Make
sure to only load the attachment content only when needed, and
separately for each attachment.

Also, remove oneToMany mapping of application and attachments. Add on
delete cascade to allow deletion of the owning entity of attachments.

Limit the concurrency on sending all attachments to Allu. Send at most 4
attachments cconcurrently, hopefully meaning only those 4 need their
content to be loaded into memory.

When testing locally, Allu didn't accept files fast enough when the
concurrency was set at four. Or maybe my connection couldn't transfer
the files fast enough.

There are possibly any number of environment-specific things that affect
how many files can be and should be uploaded concurrently. Make the
concurrency configurable by an environment variable, so we can tweak
this as necessary.

Set the default at three which seemed like a safe value when testing
locally.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1758

## Type of change

- [X] Bug fix 
- [ ] New feature 
- [ ] Other

# Instructions for testing
Check that adding, sending and removing attachments works like before.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 