### PR TITLE
HAI Fix hanketunnus generation on Postgresql 14

### DIFF
--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Persistence.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Persistence.kt
@@ -271,7 +271,7 @@ interface IdCounterRepository : JpaRepository<IdCounter, CounterType> {
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query(
         """
-            WITH currentyear AS (SELECT EXTRACT(YEAR FROM now() AT TIME ZONE 'UTC'))
+            WITH currentyear AS (SELECT EXTRACT(YEAR FROM now() AT TIME ZONE 'UTC') AS date_part)
             UPDATE 
                 idcounter
             SET


### PR DESCRIPTION
# Description

The EXTRACT function seems to work slightly differently in PostgreSQL
14. The name of the result column is `extract` instead of the `date_part` it was in PostgreSQL 13. Given an alias to the column to make the query work like it did before.

## Type of change

- [X] Bug fix 
- [ ] New feature 
- [ ] Other