### PR TITLE
HAI-1792 Add validation to hakemus hanke generation endpoint

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationControllerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationControllerITest.kt
@@ -10,7 +10,7 @@ import fi.hel.haitaton.hanke.andReturnBody
 import fi.hel.haitaton.hanke.domain.HankeWithApplications
 import fi.hel.haitaton.hanke.factory.AlluDataFactory
 import fi.hel.haitaton.hanke.factory.AlluDataFactory.Companion.withContacts
-import fi.hel.haitaton.hanke.factory.AlluDataFactory.Companion.withCustomer
+import fi.hel.haitaton.hanke.factory.AlluDataFactory.Companion.withCustomerContacts
 import fi.hel.haitaton.hanke.factory.HankeFactory
 import fi.hel.haitaton.hanke.getResourceAsBytes
 import fi.hel.haitaton.hanke.permissions.PermissionCode.EDIT_APPLICATIONS
@@ -252,13 +252,9 @@ class ApplicationControllerITest(@Autowired override val mockMvc: MockMvc) : Con
     fun `create with hanke generation calls validation fails with invalid data and returns 400`() {
         val applicationInput =
             AlluDataFactory.createApplication()
-                .withCustomer(
-                    customer =
-                        AlluDataFactory.createCompanyCustomer()
-                            .withContacts(
-                                AlluDataFactory.createContact(orderer = true),
-                                AlluDataFactory.createContact(orderer = true)
-                            )
+                .withCustomerContacts(
+                    AlluDataFactory.createContact(orderer = true),
+                    AlluDataFactory.createContact(orderer = true)
                 )
                 .toCableReportWithoutHanke()
 

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationControllerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationControllerITest.kt
@@ -10,6 +10,7 @@ import fi.hel.haitaton.hanke.andReturnBody
 import fi.hel.haitaton.hanke.domain.HankeWithApplications
 import fi.hel.haitaton.hanke.factory.AlluDataFactory
 import fi.hel.haitaton.hanke.factory.AlluDataFactory.Companion.withContacts
+import fi.hel.haitaton.hanke.factory.AlluDataFactory.Companion.withCustomer
 import fi.hel.haitaton.hanke.factory.HankeFactory
 import fi.hel.haitaton.hanke.getResourceAsBytes
 import fi.hel.haitaton.hanke.permissions.PermissionCode.EDIT_APPLICATIONS
@@ -244,6 +245,26 @@ class ApplicationControllerITest(@Autowired override val mockMvc: MockMvc) : Con
 
         assertEquals(response, mockCreatedApplication)
         verify { hankeService.generateHankeWithApplication(applicationInput, USERNAME) }
+    }
+
+    @Test
+    @WithMockUser(USERNAME)
+    fun `create with hanke generation calls validation fails with invalid data and returns 400`() {
+        val applicationInput =
+            AlluDataFactory.createApplication()
+                .withCustomer(
+                    customer =
+                        AlluDataFactory.createCompanyCustomer()
+                            .withContacts(
+                                AlluDataFactory.createContact(orderer = true),
+                                AlluDataFactory.createContact(orderer = true)
+                            )
+                )
+                .toCableReportWithoutHanke()
+
+        post("/hakemukset/johtoselvitys", applicationInput).andExpect(status().isBadRequest)
+
+        verify { hankeService wasNot Called }
     }
 
     @Test
@@ -710,4 +731,10 @@ class ApplicationControllerITest(@Autowired override val mockMvc: MockMvc) : Con
 
         verify { permissionService.hasPermission(42, USERNAME, EDIT_APPLICATIONS) }
     }
+
+    private fun Application.toCableReportWithoutHanke(): CableReportWithoutHanke =
+        CableReportWithoutHanke(
+            applicationType = applicationType,
+            applicationData = applicationData as CableReportApplicationData
+        )
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeServiceImpl.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeServiceImpl.kt
@@ -7,7 +7,6 @@ import fi.hel.haitaton.hanke.ContactType.TOTEUTTAJA
 import fi.hel.haitaton.hanke.application.Application
 import fi.hel.haitaton.hanke.application.ApplicationService
 import fi.hel.haitaton.hanke.application.CableReportWithoutHanke
-import fi.hel.haitaton.hanke.application.toNewApplication
 import fi.hel.haitaton.hanke.domain.Hanke
 import fi.hel.haitaton.hanke.domain.HankeWithApplications
 import fi.hel.haitaton.hanke.domain.HankeYhteystieto

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/Application.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/Application.kt
@@ -7,29 +7,35 @@ enum class ApplicationType {
     CABLE_REPORT,
 }
 
+/** Interface to enable Application and CableReportWithoutHanke handling equivalently. */
+interface HaitatonApplication {
+    val applicationType: ApplicationType
+    val applicationData: ApplicationData
+}
+
 data class Application(
     override val id: Long?,
     val alluid: Int?,
     val alluStatus: ApplicationStatus?,
     val applicationIdentifier: String?,
-    val applicationType: ApplicationType,
-    val applicationData: ApplicationData,
+    override val applicationType: ApplicationType,
+    override val applicationData: ApplicationData,
     val hankeTunnus: String,
-) : HasId<Long>
+) : HasId<Long>, HaitatonApplication
 
 /** Creation of an application without hanke is enabled for cable reports. */
 data class CableReportWithoutHanke(
-    val applicationType: ApplicationType,
-    val applicationData: CableReportApplicationData,
-)
-
-fun CableReportWithoutHanke.toNewApplication(hankeTunnus: String) =
-    Application(
-        id = null,
-        alluid = null,
-        alluStatus = null,
-        applicationIdentifier = null,
-        applicationType = applicationType,
-        applicationData = applicationData,
-        hankeTunnus = hankeTunnus,
-    )
+    override val applicationType: ApplicationType,
+    override val applicationData: CableReportApplicationData,
+) : HaitatonApplication {
+    fun toNewApplication(hankeTunnus: String) =
+        Application(
+            id = null,
+            alluid = null,
+            alluStatus = null,
+            applicationIdentifier = null,
+            applicationType = applicationType,
+            applicationData = applicationData,
+            hankeTunnus = hankeTunnus,
+        )
+}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/Application.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/Application.kt
@@ -8,7 +8,7 @@ enum class ApplicationType {
 }
 
 /** Interface to enable Application and CableReportWithoutHanke handling equivalently. */
-interface HaitatonApplication {
+interface BaseApplication {
     val applicationType: ApplicationType
     val applicationData: ApplicationData
 }
@@ -21,13 +21,13 @@ data class Application(
     override val applicationType: ApplicationType,
     override val applicationData: ApplicationData,
     val hankeTunnus: String,
-) : HasId<Long>, HaitatonApplication
+) : HasId<Long>, BaseApplication
 
 /** Creation of an application without hanke is enabled for cable reports. */
 data class CableReportWithoutHanke(
     override val applicationType: ApplicationType,
     override val applicationData: CableReportApplicationData,
-) : HaitatonApplication {
+) : BaseApplication {
     fun toNewApplication(hankeTunnus: String) =
         Application(
             id = null,

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationController.kt
@@ -132,7 +132,9 @@ class ApplicationController(
                 ),
             ]
     )
-    fun createWithGeneratedHanke(@RequestBody cableReport: CableReportWithoutHanke): Application {
+    fun createWithGeneratedHanke(
+        @ValidApplication @RequestBody cableReport: CableReportWithoutHanke
+    ): Application {
         val userId = currentUserId()
         return hankeService
             .generateHankeWithApplication(cableReport, userId)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/validation/ApplicationValidator.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/validation/ApplicationValidator.kt
@@ -1,10 +1,10 @@
 package fi.hel.haitaton.hanke.validation
 
-import fi.hel.haitaton.hanke.application.Application
 import fi.hel.haitaton.hanke.application.CableReportApplicationData
 import fi.hel.haitaton.hanke.application.Contact
 import fi.hel.haitaton.hanke.application.Customer
 import fi.hel.haitaton.hanke.application.CustomerWithContacts
+import fi.hel.haitaton.hanke.application.HaitatonApplication
 import fi.hel.haitaton.hanke.application.PostalAddress
 import fi.hel.haitaton.hanke.isValidBusinessId
 import fi.hel.haitaton.hanke.validation.Validators.isBeforeOrEqual
@@ -16,12 +16,15 @@ import java.util.Locale
 import javax.validation.ConstraintValidator
 import javax.validation.ConstraintValidatorContext
 
-class ApplicationValidator : ConstraintValidator<ValidApplication, Application> {
-    override fun isValid(application: Application, context: ConstraintValidatorContext?): Boolean {
+class ApplicationValidator : ConstraintValidator<ValidApplication, HaitatonApplication> {
+    override fun isValid(
+        application: HaitatonApplication,
+        context: ConstraintValidatorContext?
+    ): Boolean {
 
         val result =
-            when (application.applicationData) {
-                is CableReportApplicationData -> application.applicationData.validate()
+            when (val applicationData = application.applicationData) {
+                is CableReportApplicationData -> applicationData.validate()
             }
 
         if (result.isOk()) {

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/validation/ApplicationValidator.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/validation/ApplicationValidator.kt
@@ -1,10 +1,10 @@
 package fi.hel.haitaton.hanke.validation
 
+import fi.hel.haitaton.hanke.application.BaseApplication
 import fi.hel.haitaton.hanke.application.CableReportApplicationData
 import fi.hel.haitaton.hanke.application.Contact
 import fi.hel.haitaton.hanke.application.Customer
 import fi.hel.haitaton.hanke.application.CustomerWithContacts
-import fi.hel.haitaton.hanke.application.HaitatonApplication
 import fi.hel.haitaton.hanke.application.PostalAddress
 import fi.hel.haitaton.hanke.isValidBusinessId
 import fi.hel.haitaton.hanke.validation.Validators.isBeforeOrEqual
@@ -16,9 +16,9 @@ import java.util.Locale
 import javax.validation.ConstraintValidator
 import javax.validation.ConstraintValidatorContext
 
-class ApplicationValidator : ConstraintValidator<ValidApplication, HaitatonApplication> {
+class ApplicationValidator : ConstraintValidator<ValidApplication, BaseApplication> {
     override fun isValid(
-        application: HaitatonApplication,
+        application: BaseApplication,
         context: ConstraintValidatorContext?
     ): Boolean {
 


### PR DESCRIPTION
# Description

Add missing validation to hakemushankegeneration endpoint. We have a pretty decent and thorough validation in place for Application instances so I did not want to copypaste the same validation for this special case of hanke generation. Instead, I added an interface HaitatonApplication which is implemented by Application and CableReportWithoutHanke. This way we can use the validator to hanke HaitatonApplications and validate both types of applications.

Additional: replaced toNewApplication extension function as a normal class function. There was no need to use extension function.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1792

## Type of change

- [x] Bug fix 
- [ ] New feature 
- [ ] Other

# Instructions for testing
POST http://localhost:3001/api/hakemukset/johtoselvitys
```
{
    "id": 148,
    "alluid": null,
    "alluStatus": null,
    "applicationIdentifier": null,
    "applicationType": "CABLE_REPORT",
    "applicationData": {
        "applicationType": "CABLE_REPORT",
        "name": "Merikadun vj",
        "customerWithContacts": {
            "customer": {
                "type": null,
                "name": "",
                "country": "FI",
                "email": "",
                "phone": "",
                "registryKey": null,
                "ovt": null,
                "invoicingOperator": null,
                "sapCustomerNumber": null
            },
            "contacts": [
                {
                    "firstName": "Suvi",
                    "lastName": "Kupari",
                    "email": "foo@bar.com",
                    "phone": "05000000",
                    "orderer": true
                },
                {
                    "firstName": "Suvi",
                    "lastName": "Kupari",
                    "email": "foo@bar.com",
                    "phone": "",
                    "orderer": true
                }
            ]
        },
        "areas": [],
        "startTime": null,
        "endTime": null,
        "pendingOnClient": true,
        "workDescription": "Vesijohdon saneeraus",
        "contractorWithContacts": {
            "customer": {
                "type": null,
                "name": "",
                "country": "FI",
                "email": "",
                "phone": "",
                "registryKey": null,
                "ovt": null,
                "invoicingOperator": null,
                "sapCustomerNumber": null
            },
            "contacts": [
                {
                    "firstName": "",
                    "lastName": "",
                    "email": "",
                    "phone": "",
                    "orderer": false
                }
            ]
        },
        "rockExcavation": false,
        "postalAddress": {
            "streetAddress": {
                "streetName": "Merikatu 3"
            },
            "postalCode": "",
            "city": ""
        },
        "representativeWithContacts": null,
        "invoicingCustomer": null,
        "customerReference": null,
        "area": null,
        "propertyDeveloperWithContacts": null,
        "constructionWork": false,
        "maintenanceWork": true,
        "emergencyWork": false,
        "propertyConnectivity": true
    },
    "hankeTunnus": "HAI23-116"
}
```
Application has two orderers, and thus should fail validation.

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)