### PR TITLE
HAI-1710 Sanitize special chars in attachment filenames

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/AttachmentTestUtil.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/AttachmentTestUtil.kt
@@ -24,12 +24,13 @@ const val APPLICATION_ID = 1L
 const val CONTENT_TYPE = "Content-Type"
 
 val dummyData = "ABC".toByteArray()
+val defaultData = "/fi/hel/haitaton/hanke/decision/fake-decision.pdf".getResourceAsBytes()
 
 fun testFile(
     fileParam: String = FILE_PARAM,
     fileName: String = FILE_NAME_PDF,
-    contentType: String = APPLICATION_PDF_VALUE,
-    data: ByteArray = "/fi/hel/haitaton/hanke/decision/fake-decision.pdf".getResourceAsBytes(),
+    contentType: String? = APPLICATION_PDF_VALUE,
+    data: ByteArray = defaultData,
 ) = MockMultipartFile(fileParam, fileName, contentType, data)
 
 fun ResultActions.andExpectError(error: HankeError): ResultActions =

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/ControllerExceptionHandler.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/ControllerExceptionHandler.kt
@@ -4,6 +4,7 @@ import fi.hel.haitaton.hanke.application.ApplicationAlreadyProcessingException
 import fi.hel.haitaton.hanke.application.ApplicationNotFoundException
 import fi.hel.haitaton.hanke.attachment.application.ApplicationInAlluException
 import fi.hel.haitaton.hanke.attachment.common.AttachmentInvalidException
+import fi.hel.haitaton.hanke.attachment.common.AttachmentLimitReachedException
 import fi.hel.haitaton.hanke.attachment.common.AttachmentNotFoundException
 import fi.hel.haitaton.hanke.geometria.GeometriaValidationException
 import fi.hel.haitaton.hanke.geometria.UnsupportedCoordinateSystemException
@@ -160,6 +161,15 @@ class ControllerExceptionHandler {
         logger.warn { ex.message }
         Sentry.captureException(ex)
         return HankeError.HAI3001
+    }
+
+    @ExceptionHandler(AttachmentLimitReachedException::class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @Hidden
+    fun attachmentLimitReached(ex: AttachmentLimitReachedException): HankeError {
+        logger.warn { ex.message }
+        Sentry.captureException(ex)
+        return HankeError.HAI3003
     }
 
     @ExceptionHandler(Throwable::class)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeError.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeError.kt
@@ -38,6 +38,7 @@ enum class HankeError(val errorMessage: String) {
     HAI2009("Application is already sent to Allu, operation prohibited."),
     HAI3001("Attachment upload failed"),
     HAI3002("Loading attachment failed"),
+    HAI3003("Attachment limit reached"),
     ;
 
     val errorCode: String

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/common/AttachmentEntity.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/common/AttachmentEntity.kt
@@ -64,7 +64,7 @@ class HankeAttachmentEntity(
 ) : AttachmentEntity(id, fileName, contentType, createdByUserId, createdAt) {
     fun toMetadata(): HankeAttachmentMetadata {
         return HankeAttachmentMetadata(
-            id = id,
+            id = id!!,
             fileName = fileName,
             createdAt = createdAt,
             hankeTunnus = hanke.hankeTunnus!!,
@@ -104,7 +104,7 @@ class ApplicationAttachmentEntity(
 ) : AttachmentEntity(id, fileName, contentType, createdByUserId, createdAt) {
     fun toDto(): ApplicationAttachmentMetadata {
         return ApplicationAttachmentMetadata(
-            id = id,
+            id = id!!,
             fileName = fileName,
             createdAt = createdAt,
             createdByUserId = createdByUserId,

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/common/AttachmentMetadata.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/common/AttachmentMetadata.kt
@@ -4,7 +4,7 @@ import java.time.OffsetDateTime
 import java.util.UUID
 
 data class HankeAttachmentMetadata(
-    val id: UUID?,
+    val id: UUID,
     val fileName: String,
     val createdByUserId: String,
     val createdAt: OffsetDateTime,
@@ -12,7 +12,7 @@ data class HankeAttachmentMetadata(
 )
 
 data class ApplicationAttachmentMetadata(
-    val id: UUID?,
+    val id: UUID,
     val fileName: String,
     val createdByUserId: String,
     val createdAt: OffsetDateTime,

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/common/Exceptions.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/common/Exceptions.kt
@@ -2,6 +2,9 @@ package fi.hel.haitaton.hanke.attachment.common
 
 import java.util.UUID
 
+class AttachmentLimitReachedException(applicationId: Long, limit: Int) :
+    RuntimeException("Attachment amount limit reached, limit=$limit, applicationId=$applicationId")
+
 class AttachmentInvalidException(str: String) :
     RuntimeException("Attachment upload exception: $str")
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentService.kt
@@ -47,16 +47,17 @@ class HankeAttachmentService(
 
     @Transactional
     fun addAttachment(hankeTunnus: String, attachment: MultipartFile): HankeAttachmentMetadata {
+        val filename = AttachmentValidator.validFilename(attachment.originalFilename)
         val hanke =
             findHanke(hankeTunnus).also { hanke ->
                 ensureRoomForAttachment(hanke.id!!)
-                ensureValidFile(attachment)
+                scanAttachment(filename, attachment.bytes)
             }
 
         val entity =
             HankeAttachmentEntity(
                 id = null,
-                fileName = attachment.originalFilename!!,
+                fileName = filename,
                 contentType = attachment.contentType!!,
                 createdAt = now(),
                 createdByUserId = currentUserId(),
@@ -99,12 +100,10 @@ class HankeAttachmentService(
         return attachmentCount >= ALLOWED_ATTACHMENT_COUNT
     }
 
-    private fun ensureValidFile(attachment: MultipartFile) =
-        with(attachment) {
-            AttachmentValidator.validate(this)
-            val scanResult = scanClient.scan(listOf(FileScanInput(originalFilename!!, bytes)))
-            if (scanResult.hasInfected()) {
-                throw AttachmentInvalidException("Infected file detected, see previous logs.")
-            }
+    fun scanAttachment(filename: String, content: ByteArray) {
+        val scanResult = scanClient.scan(listOf(FileScanInput(filename, content)))
+        if (scanResult.hasInfected()) {
+            throw AttachmentInvalidException("Infected file detected, see previous logs.")
         }
+    }
 }


### PR DESCRIPTION
# Description

Sanitize any special characters (`\/:*?"<>|`) in attachment file names. The special characters are replaced with underscores (`_`).

Change id field in attachment metadata classes to non-nullable. There's no reason to create a metadata presentation of an attachment if it's not saved to database.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1710

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
1. I created a file with all sorts of special characters, separated by marking characters.
    ```shell
     echo "Hassuja merkkejä" > 'p%a&c:a*q?s b\q"s l<g>p|.txt'
    ```
2. Then I added it to an application as an attachment through frontend.
3. The summary page shows the sanitized filename: ![image](https://github.com/City-of-Helsinki/haitaton-backend/assets/604238/6221c7f1-ad5c-4112-a1dd-d4e229319a5c)


# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 