### PR TITLE
HAI-1756 Add validation for missing data when sending application

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationControllerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationControllerITest.kt
@@ -1,8 +1,12 @@
 package fi.hel.haitaton.hanke.application
 
+import assertk.assertThat
+import assertk.assertions.isEqualTo
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.node.ObjectNode
 import fi.hel.haitaton.hanke.ControllerTest
+import fi.hel.haitaton.hanke.HankeError
+import fi.hel.haitaton.hanke.HankeErrorDetail
 import fi.hel.haitaton.hanke.HankeService
 import fi.hel.haitaton.hanke.IntegrationTestConfiguration
 import fi.hel.haitaton.hanke.OBJECT_MAPPER
@@ -17,6 +21,7 @@ import fi.hel.haitaton.hanke.permissions.PermissionCode.EDIT_APPLICATIONS
 import fi.hel.haitaton.hanke.permissions.PermissionCode.VIEW
 import fi.hel.haitaton.hanke.permissions.PermissionService
 import fi.hel.haitaton.hanke.toJsonString
+import fi.hel.haitaton.hanke.validation.InvalidApplicationDataException
 import io.mockk.Called
 import io.mockk.checkUnnecessaryStub
 import io.mockk.clearAllMocks
@@ -258,8 +263,19 @@ class ApplicationControllerITest(@Autowired override val mockMvc: MockMvc) : Con
                 )
                 .toCableReportWithoutHanke()
 
-        post("/hakemukset/johtoselvitys", applicationInput).andExpect(status().isBadRequest)
+        val result =
+            post("/hakemukset/johtoselvitys", applicationInput)
+                .andExpect(status().isBadRequest)
+                .andReturn()
 
+        assertThat(result.response.contentAsString)
+            .isEqualTo(
+                HankeErrorDetail(
+                        HankeError.HAI2008,
+                        listOf("customersWithContacts[].contacts[].orderer")
+                    )
+                    .toJsonString()
+            )
         verify { hankeService wasNot Called }
     }
 
@@ -292,8 +308,10 @@ class ApplicationControllerITest(@Autowired override val mockMvc: MockMvc) : Con
                     )
             )
 
-        put("$BASE_URL/1234", application).andExpect(status().isBadRequest)
+        val result = put("$BASE_URL/1234", application).andExpect(status().isBadRequest).andReturn()
 
+        assertThat(result.response.contentAsString)
+            .isEqualTo(HankeErrorDetail(HankeError.HAI2008, listOf("endTime")).toJsonString())
         verify { applicationService wasNot Called }
     }
 
@@ -517,6 +535,28 @@ class ApplicationControllerITest(@Autowired override val mockMvc: MockMvc) : Con
 
         post("$BASE_URL/$id/send-application").andExpect(status().isConflict)
 
+        verify { permissionService.hasPermission(42, USERNAME, EDIT_APPLICATIONS) }
+        verify { applicationService.getApplicationById(id) }
+        verify { applicationService.sendApplication(id, USERNAME) }
+    }
+
+    @Test
+    @WithMockUser(USERNAME)
+    fun `sendApplication with missing data in application returns 400 with details`() {
+        val id = 1234L
+        val mockErrorPaths = listOf("startTime", "customerWithContacts.customer.type")
+        every { hankeService.getHankeId(HANKE_TUNNUS) } returns 42
+        every { permissionService.hasPermission(42, USERNAME, EDIT_APPLICATIONS) } returns true
+        every { applicationService.getApplicationById(id) } returns
+            AlluDataFactory.createApplication(id = id, hankeTunnus = HANKE_TUNNUS)
+        every { applicationService.sendApplication(id, USERNAME) } throws
+            InvalidApplicationDataException(mockErrorPaths)
+
+        val response =
+            post("$BASE_URL/$id/send-application").andExpect(status().isBadRequest).andReturn()
+
+        assertThat(response.response.contentAsString)
+            .isEqualTo(HankeErrorDetail(HankeError.HAI2008, mockErrorPaths).toJsonString())
         verify { permissionService.hasPermission(42, USERNAME, EDIT_APPLICATIONS) }
         verify { applicationService.getApplicationById(id) }
         verify { applicationService.sendApplication(id, USERNAME) }

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceITest.kt
@@ -1562,7 +1562,7 @@ class ApplicationServiceITest : DatabaseTest() {
             AlluDataFactory.createCableReportApplicationData(areas = listOf(aleksanterinpatsas))
     ): Application = AlluDataFactory.createApplication(applicationData = applicationData)
 
-    val customerWithContactsJson =
+    private fun customerWithContactsJson(orderer: Boolean) =
         """
            "customer": {
              "type": "COMPANY",
@@ -1581,7 +1581,7 @@ class ApplicationServiceITest : DatabaseTest() {
                "lastName": "Testihenkilö",
                "email": "teppo@example.test",
                "phone": "04012345678",
-               "orderer": false
+               "orderer": $orderer
              }
            ]
         """
@@ -1603,7 +1603,7 @@ class ApplicationServiceITest : DatabaseTest() {
               "applicationData": {
                 "name": "$name",
                 "customerWithContacts": {
-                  $customerWithContactsJson
+                  ${customerWithContactsJson(orderer = true)}
                 },
                 "areas": [],
                 "startTime": "${nextYear()}-02-20T23:45:56Z",
@@ -1612,7 +1612,7 @@ class ApplicationServiceITest : DatabaseTest() {
                 "workDescription": "Work description.",
                 "rockExcavation": false,
                 "contractorWithContacts": {
-                  $customerWithContactsJson
+                  ${customerWithContactsJson(orderer = false)}
                 },
                 "postalAddress": null,
                 "representativeWithContacts": null,

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceITest.kt
@@ -53,6 +53,7 @@ import fi.hel.haitaton.hanke.permissions.kayttajaTunnistePattern
 import fi.hel.haitaton.hanke.test.Asserts.isRecent
 import fi.hel.haitaton.hanke.test.TestUtils
 import fi.hel.haitaton.hanke.test.TestUtils.nextYear
+import fi.hel.haitaton.hanke.validation.InvalidApplicationDataException
 import io.mockk.Called
 import io.mockk.checkUnnecessaryStub
 import io.mockk.clearAllMocks
@@ -686,7 +687,7 @@ class ApplicationServiceITest : DatabaseTest() {
             AlluDataFactory.createAlluApplicationResponse(21)
 
         val exception =
-            assertThrows<AlluDataException> {
+            assertThrows<InvalidApplicationDataException> {
                 applicationService.updateApplicationData(
                     application.id!!,
                     newApplicationData,
@@ -695,7 +696,7 @@ class ApplicationServiceITest : DatabaseTest() {
             }
 
         assertEquals(
-            "Application data failed validation at applicationData.startTime: Can't be null",
+            "Application contains invalid data. Errors at paths: applicationData.startTime",
             exception.message
         )
         val savedApplications = applicationRepository.findAll()

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeError.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeError.kt
@@ -1,6 +1,7 @@
 package fi.hel.haitaton.hanke
 
 import com.fasterxml.jackson.annotation.JsonFormat
+import com.fasterxml.jackson.annotation.JsonUnwrapped
 import javax.validation.ConstraintViolation
 
 @JsonFormat(shape = JsonFormat.Shape.OBJECT)
@@ -56,6 +57,11 @@ enum class HankeError(val errorMessage: String) {
         return "$name - $errorMessage"
     }
 }
+
+data class HankeErrorDetail(
+    @JsonUnwrapped val hankeError: HankeError,
+    val errorPaths: List<String>
+)
 
 class HankeNotFoundException(val hankeTunnus: String?) :
     RuntimeException("Hanke $hankeTunnus not found")

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Utils.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Utils.kt
@@ -1,5 +1,6 @@
 package fi.hel.haitaton.hanke
 
+import fi.hel.haitaton.hanke.application.CustomerWithContacts
 import fi.hel.haitaton.hanke.domain.BusinessId
 import java.time.LocalDateTime
 import java.time.ZonedDateTime
@@ -68,3 +69,5 @@ fun BusinessId.isValidBusinessId(): Boolean {
         false
     }
 }
+
+fun List<CustomerWithContacts>.ordererCount() = flatMap { it.contacts }.count { it.orderer }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationController.kt
@@ -1,6 +1,7 @@
 package fi.hel.haitaton.hanke.application
 
 import fi.hel.haitaton.hanke.HankeError
+import fi.hel.haitaton.hanke.HankeErrorDetail
 import fi.hel.haitaton.hanke.HankeNotFoundException
 import fi.hel.haitaton.hanke.HankeService
 import fi.hel.haitaton.hanke.currentUserId
@@ -341,8 +342,8 @@ class ApplicationController(
     @ExceptionHandler(InvalidApplicationDataException::class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     @Hidden
-    fun invalidApplicationDataException(ex: InvalidApplicationDataException): HankeError {
+    fun invalidApplicationDataException(ex: InvalidApplicationDataException): HankeErrorDetail {
         logger.warn(ex) { ex.message }
-        return HankeError.HAI2008
+        return HankeErrorDetail(hankeError = HankeError.HAI2008, errorPaths = ex.errorPaths)
     }
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationController.kt
@@ -161,9 +161,9 @@ class ApplicationController(
             [
                 ApiResponse(description = "The updated application", responseCode = "200"),
                 ApiResponse(
-                    description = "The request body was invalid",
+                    description = "Application contains invalid data",
                     responseCode = "400",
-                    content = [Content(schema = Schema(implementation = HankeError::class))]
+                    content = [Content(schema = Schema(implementation = HankeErrorDetail::class))]
                 ),
                 ApiResponse(
                     description = "An application was not found with the given id",
@@ -237,6 +237,11 @@ class ApplicationController(
         value =
             [
                 ApiResponse(description = "The sent application", responseCode = "200"),
+                ApiResponse(
+                    description = "Application contains invalid data",
+                    responseCode = "400",
+                    content = [Content(schema = Schema(implementation = HankeErrorDetail::class))]
+                ),
                 ApiResponse(
                     description = "An application was not found with the given id",
                     responseCode = "404",

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationService.kt
@@ -24,6 +24,7 @@ import fi.hel.haitaton.hanke.permissions.HankeKayttajaService
 import fi.hel.haitaton.hanke.permissions.PermissionCode
 import fi.hel.haitaton.hanke.permissions.PermissionService
 import fi.hel.haitaton.hanke.toJsonString
+import fi.hel.haitaton.hanke.validation.ApplicationDataValidator.ensureValidForSend
 import java.time.LocalDateTime
 import java.time.OffsetDateTime
 import kotlin.reflect.KClass
@@ -432,6 +433,8 @@ open class ApplicationService(
     }
 
     private fun sendApplicationToAllu(entity: ApplicationEntity): Int {
+        ensureValidForSend(entity.applicationData)
+
         return if (entity.alluid == null) {
             createApplicationInAllu(entity)
         } else {

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationService.kt
@@ -433,8 +433,6 @@ open class ApplicationService(
     }
 
     private fun sendApplicationToAllu(entity: ApplicationEntity): Int {
-        ensureValidForSend(entity.applicationData)
-
         return if (entity.alluid == null) {
             createApplicationInAllu(entity)
         } else {
@@ -443,6 +441,7 @@ open class ApplicationService(
     }
 
     private fun updateApplicationInAllu(entity: ApplicationEntity): Int {
+        ensureValidForSend(entity.applicationData)
         val alluId = entity.alluid ?: throw ApplicationArgumentException("AlluId null in update.")
 
         logger.info { "Uploading updated application with alluId $alluId" }
@@ -457,6 +456,7 @@ open class ApplicationService(
 
     /** Creates new application in Allu. All attachments are sent after creation. */
     private fun createApplicationInAllu(entity: ApplicationEntity): Int {
+        ensureValidForSend(entity.applicationData)
         val alluId =
             when (val data = entity.applicationData) {
                 is CableReportApplicationData -> createCableReportToAllu(entity.hankeTunnus(), data)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/validation/CableReportErrorValidation.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/validation/CableReportErrorValidation.kt
@@ -1,0 +1,70 @@
+package fi.hel.haitaton.hanke.application.validation
+
+import fi.hel.haitaton.hanke.application.CableReportApplicationData
+import fi.hel.haitaton.hanke.application.Contact
+import fi.hel.haitaton.hanke.application.Customer
+import fi.hel.haitaton.hanke.application.CustomerWithContacts
+import fi.hel.haitaton.hanke.application.PostalAddress
+import fi.hel.haitaton.hanke.isValidBusinessId
+import fi.hel.haitaton.hanke.ordererCount
+import fi.hel.haitaton.hanke.validation.ValidationResult
+import fi.hel.haitaton.hanke.validation.Validators.isBeforeOrEqual
+import fi.hel.haitaton.hanke.validation.Validators.notJustWhitespace
+import fi.hel.haitaton.hanke.validation.Validators.validate
+import fi.hel.haitaton.hanke.validation.Validators.validateFalse
+import fi.hel.haitaton.hanke.validation.Validators.validateTrue
+import java.util.Locale
+
+/** Validate draft application. Checks only fields that have some actual data. */
+fun CableReportApplicationData.validateForErrors(): ValidationResult =
+    validate { notJustWhitespace(name, "name") }
+        .and { notJustWhitespace(workDescription, "workDescription") }
+        .and { notJustWhitespace(customerReference, "customerReference") }
+        .and { atMostOneOrderer(customersWithContacts()) }
+        .andWhen(startTime != null && endTime != null) {
+            isBeforeOrEqual(startTime!!, endTime!!, "endTime")
+        }
+        .whenNotNull(postalAddress) { it.validateForErrors("postalAddress") }
+        .and { customerWithContacts.validateForErrors("customerWithContacts") }
+        .and { contractorWithContacts.validateForErrors("contractorWithContacts") }
+        .whenNotNull(representativeWithContacts) {
+            it.validateForErrors("representativeWithContacts")
+        }
+        .whenNotNull(propertyDeveloperWithContacts) {
+            it.validateForErrors("propertyDeveloperWithContacts")
+        }
+        .whenNotNull(invoicingCustomer) { it.validateForErrors("invoicingCustomer") }
+
+private fun CustomerWithContacts.validateForErrors(path: String): ValidationResult =
+    customer
+        .validateForErrors("$path.customer")
+        .andAllIn(contacts, "$path.contacts", ::validateContactForErrors)
+
+private fun Customer.validateForErrors(path: String): ValidationResult =
+    validate { notJustWhitespace(name, "$path.name") }
+        .and { validateTrue(Locale.getISOCountries().contains(country), "$path.country") }
+        .and { notJustWhitespace(email, "$path.email") }
+        .and { notJustWhitespace(phone, "$path.phone") }
+        .whenNotNull(registryKey) { validateTrue(it.isValidBusinessId(), "$path.registryKey") }
+        .and { notJustWhitespace(ovt, "$path.ovt") }
+        .and { notJustWhitespace(invoicingOperator, "$path.invoicingOperator") }
+        .and { notJustWhitespace(sapCustomerNumber, "$path.sapCustomerNumber") }
+
+private fun validateContactForErrors(contact: Contact, path: String) =
+    with(contact) {
+        validate { notJustWhitespace(firstName, "$path.firstName") }
+            .and { notJustWhitespace(lastName, "$path.lastName") }
+            .and { notJustWhitespace(email, "$path.email") }
+            .and { notJustWhitespace(phone, "$path.phone") }
+    }
+
+private fun PostalAddress.validateForErrors(path: String) =
+    validate { notJustWhitespace(postalCode, "$path.postalCode") }
+        .and { notJustWhitespace(city, "$path.city") }
+        .and { notJustWhitespace(streetAddress.streetName, "$path.streetAddress.streetName") }
+
+private fun atMostOneOrderer(customersWithContacts: List<CustomerWithContacts>): ValidationResult =
+    validateFalse(
+        customersWithContacts.ordererCount() > 1,
+        "customersWithContacts[].contacts[].orderer"
+    )

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/validation/CableReportMissingValidation.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/validation/CableReportMissingValidation.kt
@@ -1,0 +1,52 @@
+package fi.hel.haitaton.hanke.application.validation
+
+import fi.hel.haitaton.hanke.application.CableReportApplicationData
+import fi.hel.haitaton.hanke.application.Contact
+import fi.hel.haitaton.hanke.application.Customer
+import fi.hel.haitaton.hanke.application.CustomerWithContacts
+import fi.hel.haitaton.hanke.ordererCount
+import fi.hel.haitaton.hanke.validation.ValidationResult
+import fi.hel.haitaton.hanke.validation.Validators.notBlank
+import fi.hel.haitaton.hanke.validation.Validators.notNull
+import fi.hel.haitaton.hanke.validation.Validators.notNullOrBlank
+import fi.hel.haitaton.hanke.validation.Validators.validate
+import fi.hel.haitaton.hanke.validation.Validators.validateTrue
+
+/**
+ * Validate required field are set. When application is a draft, it is ok to have fields that are
+ * not yet defined. But e.g. when sending, they must be present.
+ */
+fun CableReportApplicationData.validateForMissing(): ValidationResult =
+    validate { notBlank(name, "name") }
+        .and { notBlank(workDescription, "workDescription") }
+        .and { notNull(startTime, "startTime") }
+        .and { notNull(endTime, "endTime") }
+        .and { notNull(areas, "areas") }
+        .and { notNull(rockExcavation, "rockExcavation") }
+        .and { exactlyOneOrderer(customersWithContacts()) }
+        .and { customerWithContacts.validateForMissing("customerWithContacts") }
+        .and { contractorWithContacts.validateForMissing("contractorWithContacts") }
+        .whenNotNull(representativeWithContacts) {
+            it.validateForMissing("representativeWithContacts")
+        }
+        .whenNotNull(propertyDeveloperWithContacts) {
+            it.validateForMissing("propertyDeveloperWithContacts")
+        }
+
+private fun CustomerWithContacts.validateForMissing(path: String): ValidationResult =
+    customer
+        .validateForMissing("$path.customer")
+        .andAllIn(contacts, "$path.contacts", ::validateForMissing)
+
+private fun Customer.validateForMissing(path: String): ValidationResult =
+    validate { notNull(type, "$path.type") }.and { notBlank(name, "$path.name") }
+
+private fun validateForMissing(contact: Contact, path: String) = validate {
+    notNullOrBlank(contact.fullName(), "$path.firstName")
+}
+
+private fun exactlyOneOrderer(customersWithContacts: List<CustomerWithContacts>): ValidationResult =
+    validateTrue(
+        customersWithContacts.ordererCount() == 1,
+        "customersWithContacts[].contacts[].orderer"
+    )

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/validation/ApplicationValidator.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/validation/ApplicationValidator.kt
@@ -1,18 +1,11 @@
 package fi.hel.haitaton.hanke.validation
 
+import fi.hel.haitaton.hanke.application.ApplicationData
 import fi.hel.haitaton.hanke.application.BaseApplication
 import fi.hel.haitaton.hanke.application.CableReportApplicationData
-import fi.hel.haitaton.hanke.application.Contact
-import fi.hel.haitaton.hanke.application.Customer
-import fi.hel.haitaton.hanke.application.CustomerWithContacts
-import fi.hel.haitaton.hanke.application.PostalAddress
-import fi.hel.haitaton.hanke.isValidBusinessId
-import fi.hel.haitaton.hanke.validation.Validators.isBeforeOrEqual
-import fi.hel.haitaton.hanke.validation.Validators.notJustWhitespace
+import fi.hel.haitaton.hanke.application.validation.validateForErrors
+import fi.hel.haitaton.hanke.application.validation.validateForMissing
 import fi.hel.haitaton.hanke.validation.Validators.validate
-import fi.hel.haitaton.hanke.validation.Validators.validateFalse
-import fi.hel.haitaton.hanke.validation.Validators.validateTrue
-import java.util.Locale
 import javax.validation.ConstraintValidator
 import javax.validation.ConstraintValidatorContext
 
@@ -23,73 +16,35 @@ class ApplicationValidator : ConstraintValidator<ValidApplication, BaseApplicati
     ): Boolean {
 
         val result =
-            when (val applicationData = application.applicationData) {
-                is CableReportApplicationData -> applicationData.validate()
+            when (val data = application.applicationData) {
+                is CableReportApplicationData -> validate { data.validateForErrors() }
             }
 
-        if (result.isOk()) {
-            return true
-        }
-
-        throw InvalidApplicationDataException(result.errorPaths())
+        return result.okOrThrow()
     }
-
-    private fun CableReportApplicationData.validate(): ValidationResult =
-        validate { notJustWhitespace(name, "name") }
-            .and { notJustWhitespace(workDescription, "workDescription") }
-            .and { notJustWhitespace(customerReference, "customerReference") }
-            .and { atMostOneOrderer(customersWithContacts()) }
-            .andWhen(startTime != null && endTime != null) {
-                isBeforeOrEqual(startTime!!, endTime!!, "endTime")
-            }
-            .whenNotNull(postalAddress) { it.validate("postalAddress") }
-            .and { customerWithContacts.validate("customerWithContacts") }
-            .and { contractorWithContacts.validate("contractorWithContacts") }
-            .whenNotNull(representativeWithContacts) { it.validate("representativeWithContacts") }
-            .whenNotNull(propertyDeveloperWithContacts) {
-                it.validate("propertyDeveloperWithContacts")
-            }
-            .whenNotNull(invoicingCustomer) { it.validate("invoicingCustomer") }
-
-    private fun moreThanOneOrderer(customersWithContacts: List<CustomerWithContacts>): Boolean =
-        customersWithContacts.flatMap { it.contacts }.filter { it.orderer }.size > 1
-
-    private fun atMostOneOrderer(
-        customersWithContacts: List<CustomerWithContacts>
-    ): ValidationResult =
-        validateFalse(
-            moreThanOneOrderer(customersWithContacts),
-            "customersWithContacts[].contacts[].orderer"
-        )
-
-    private fun CustomerWithContacts.validate(path: String): ValidationResult =
-        customer.validate("$path.customer").andAllIn(contacts, "$path.contacts", ::validateContact)
-
-    private fun Customer.validate(path: String): ValidationResult =
-        validate { notJustWhitespace(name, "$path.name") }
-            .and { validateTrue(Locale.getISOCountries().contains(country), "country") }
-            .and { notJustWhitespace(email, "$path.email") }
-            .and { notJustWhitespace(phone, "$path.phone") }
-            .whenNotNull(registryKey) { validateTrue(it.isValidBusinessId(), "$path.registryKey") }
-            .and { notJustWhitespace(ovt, "$path.ovt") }
-            .and { notJustWhitespace(invoicingOperator, "$path.invoicingOperator") }
-            .and { notJustWhitespace(sapCustomerNumber, "$path.sapCustomerNumber") }
-
-    private fun Contact.validate(path: String): ValidationResult =
-        validate { notJustWhitespace(firstName, "$path.firstName") }
-            .and { notJustWhitespace(lastName, "$path.lastName") }
-            .and { notJustWhitespace(email, "$path.email") }
-            .and { notJustWhitespace(phone, "$path.phone") }
-
-    private fun validateContact(contact: Contact, path: String) = contact.validate(path)
-
-    private fun PostalAddress.validate(path: String) =
-        validate { notJustWhitespace(postalCode, "$path.postalCode") }
-            .and { notJustWhitespace(city, "$path.city") }
-            .and { notJustWhitespace(streetAddress.streetName, "$path.streetAddress.streetName") }
 }
 
-class InvalidApplicationDataException(errorPaths: List<String>) :
+object ApplicationDataValidator {
+
+    fun ensureValidForSend(data: ApplicationData): Boolean {
+        val result =
+            when (data) {
+                is CableReportApplicationData ->
+                    validate { data.validateForErrors() }.and { data.validateForMissing() }
+            }
+
+        return result.okOrThrow()
+    }
+}
+
+private fun ValidationResult.okOrThrow(): Boolean {
+    if (isOk()) {
+        return true
+    }
+    throw InvalidApplicationDataException(errorPaths())
+}
+
+class InvalidApplicationDataException(val errorPaths: List<String>) :
     RuntimeException(
-        "Received application contains invalid data. Errors at paths: ${errorPaths.joinToString()}"
+        "Application contains invalid data. Errors at paths: ${errorPaths.joinToString { "applicationData.$it" }}"
     )

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceTest.kt
@@ -31,6 +31,7 @@ import fi.hel.haitaton.hanke.logging.DisclosureLogService
 import fi.hel.haitaton.hanke.logging.Status
 import fi.hel.haitaton.hanke.permissions.HankeKayttajaService
 import fi.hel.haitaton.hanke.permissions.PermissionService
+import fi.hel.haitaton.hanke.validation.InvalidApplicationDataException
 import io.mockk.Called
 import io.mockk.called
 import io.mockk.checkUnnecessaryStub
@@ -417,8 +418,8 @@ class ApplicationServiceTest {
         assertThat { applicationService.sendApplication(3, USERNAME) }
             .isFailure()
             .all {
-                this.hasClass(AlluDataException::class)
-                this.hasMessage("Application data failed validation at $path: Can't be null")
+                hasClass(InvalidApplicationDataException::class)
+                hasMessage("Application contains invalid data. Errors at paths: $path")
             }
 
         verifySequence {

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/AlluDataFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/AlluDataFactory.kt
@@ -127,7 +127,7 @@ class AlluDataFactory(
             pendingOnClient: Boolean = false,
             workDescription: String = "Work description.",
             customerWithContacts: CustomerWithContacts =
-                createCompanyCustomer().withContacts(createContact()),
+                createCompanyCustomer().withContacts(createContact(orderer = true)),
             contractorWithContacts: CustomerWithContacts =
                 createCompanyCustomer().withContacts(createContact()),
             representativeWithContacts: CustomerWithContacts? = null,
@@ -161,7 +161,7 @@ class AlluDataFactory(
             pendingOnClient: Boolean = false,
             workDescription: String = "Work description.",
             customerWithContacts: CustomerWithContacts =
-                createCompanyCustomer().withContacts(createContact()),
+                createCompanyCustomer().withContacts(createContact(orderer = true)),
             contractorWithContacts: CustomerWithContacts =
                 createCompanyCustomer().withContacts(createContact()),
             representativeWithContacts: CustomerWithContacts? = null,

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/gdpr/GdprJsonConverterTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/gdpr/GdprJsonConverterTest.kt
@@ -69,11 +69,7 @@ class GdprJsonConverterTest {
         val sahkopostit = getCollectionNodeFromChildren(result, "sahkopostit").children
         assertThat(sahkopostit.map { it.key }).each { it.isEqualTo("sahkoposti") }
         assertThat(sahkopostit.map { (it as StringNode).value })
-            .containsExactlyInAnyOrder(
-                "teppo@yhteystieto.test",
-                "teppo@example.test",
-                "teppo@dna.test"
-            )
+            .containsExactlyInAnyOrder("teppo@yhteystieto.test", "teppo@dna.test")
         val organisaatiot = getCollectionNodeFromChildren(result, "organisaatiot").children
         assertThat(organisaatiot.map { it.key }).each { it.isEqualTo("organisaatio") }
         assertThat(organisaatiot.map { (it as CollectionNode).children })
@@ -182,7 +178,7 @@ class GdprJsonConverterTest {
 
         val result = GdprJsonConverter.getCreatorInfoFromApplication(applicationData)
 
-        assertThat(result).hasSize(2)
+        assertThat(result).hasSize(1)
         val expectedInfos =
             arrayOf(
                 GdprInfo(
@@ -190,12 +186,6 @@ class GdprJsonConverterTest {
                     phone = "04012345678",
                     email = "teppo@dna.test",
                     organisation = GdprOrganisation(name = "Dna", registryKey = "3766028-0"),
-                ),
-                GdprInfo(
-                    name = TEPPO_TESTI,
-                    phone = "04012345678",
-                    email = "teppo@example.test",
-                    organisation = null,
                 ),
             )
         assertThat(result).containsExactlyInAnyOrder(*expectedInfos)

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/logging/DisclosureLogServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/logging/DisclosureLogServiceTest.kt
@@ -272,8 +272,12 @@ internal class DisclosureLogServiceTest {
     @Test
     fun `saveDisclosureLogsForApplication with contacts logs contacts`() {
         val cableReportApplication = AlluDataFactory.createCableReportApplicationData()
-        val contact = cableReportApplication.customerWithContacts.contacts[0]
-        val expectedLogs = listOf(AuditLogEntryFactory.createReadEntryForContact(contact))
+        val firstContact = cableReportApplication.customerWithContacts.contacts[0]
+        val secondContact = cableReportApplication.contractorWithContacts.contacts[0]
+        val expectedLogs =
+            listOf(firstContact, secondContact).map {
+                AuditLogEntryFactory.createReadEntryForContact(it)
+            }
         val application =
             AlluDataFactory.createApplication(
                 applicationData = cableReportApplication,
@@ -289,16 +293,17 @@ internal class DisclosureLogServiceTest {
     @EnumSource(Status::class)
     fun `saveDisclosureLogsForAllu saves logs with the given status`(expectedStatus: Status) {
         val cableReportApplication = AlluDataFactory.createCableReportApplicationData()
-        val contact = cableReportApplication.customerWithContacts.contacts[0]
+        val firstContact = cableReportApplication.customerWithContacts.contacts[0]
+        val secondContact = cableReportApplication.contractorWithContacts.contacts[0]
         val expectedLogs =
-            listOf(
-                AuditLogEntryFactory.createReadEntryForContact(contact)
+            listOf(firstContact, secondContact).map {
+                AuditLogEntryFactory.createReadEntryForContact(it)
                     .copy(
                         status = expectedStatus,
                         userId = ALLU_AUDIT_LOG_USERID,
                         userRole = UserRole.SERVICE,
                     )
-            )
+            }
 
         disclosureLogService.saveDisclosureLogsForAllu(cableReportApplication, expectedStatus)
 

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/validation/ApplicationDataValidatorTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/validation/ApplicationDataValidatorTest.kt
@@ -1,0 +1,213 @@
+package fi.hel.haitaton.hanke.validation
+
+import assertk.assertThat
+import assertk.assertions.hasClass
+import assertk.assertions.isEmpty
+import assertk.assertions.isFailure
+import assertk.assertions.isSuccess
+import assertk.assertions.isTrue
+import fi.hel.haitaton.hanke.application.CableReportApplicationData
+import fi.hel.haitaton.hanke.application.CustomerWithContacts
+import fi.hel.haitaton.hanke.application.validation.validateForErrors
+import fi.hel.haitaton.hanke.factory.AlluDataFactory.Companion.createApplication
+import fi.hel.haitaton.hanke.factory.AlluDataFactory.Companion.createCableReportApplicationData
+import fi.hel.haitaton.hanke.factory.AlluDataFactory.Companion.createCompanyCustomer
+import fi.hel.haitaton.hanke.factory.AlluDataFactory.Companion.createContact
+import fi.hel.haitaton.hanke.factory.AlluDataFactory.Companion.withApplicationData
+import fi.hel.haitaton.hanke.factory.AlluDataFactory.Companion.withContacts
+import fi.hel.haitaton.hanke.touch
+import fi.hel.haitaton.hanke.validation.ApplicationDataValidator.ensureValidForSend
+import java.util.stream.Stream
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.Arguments.of
+import org.junit.jupiter.params.provider.MethodSource
+
+class ApplicationDataValidatorTest {
+    private val applicationValidator = ApplicationValidator()
+
+    private val customerWithNoOrderers =
+        createCompanyCustomer()
+            .withContacts(
+                createContact(orderer = false),
+                createContact(orderer = false),
+            )
+
+    private val customerWithNoContacts = createCompanyCustomer().withContacts()
+
+    @Test
+    fun `Correct application passes validation`() {
+        val applicationData = createCableReportApplicationData()
+
+        assertThat { ensureValidForSend(applicationData) }.isSuccess().isTrue()
+    }
+
+    @ParameterizedTest(name = "{displayName}: missingField: {0}")
+    @MethodSource("missingDataInput")
+    fun `Missing fields ok as draft but not as non-draft`(
+        missingField: String,
+        cableReportApplicationData: CableReportApplicationData
+    ) {
+        missingField.touch()
+        assertThat { cableReportApplicationData.validateForErrors().isOk() }.isSuccess().isTrue()
+
+        assertThat { ensureValidForSend(cableReportApplicationData) }
+            .isFailure()
+            .hasClass(InvalidApplicationDataException::class)
+    }
+
+    @Test
+    fun `No orderers ok as draft but not as final`() {
+        val application =
+            createApplication()
+                .withApplicationData(
+                    customerWithContacts = customerWithNoOrderers,
+                    contractorWithContacts = customerWithNoOrderers,
+                )
+        val applicationData = application.applicationData as CableReportApplicationData
+        assertThat { applicationData.validateForErrors().isOk() }.isSuccess().isTrue()
+
+        assertThat { ensureValidForSend(applicationData) }
+            .isFailure()
+            .hasClass(InvalidApplicationDataException::class)
+    }
+
+    @Test
+    fun `No contacts ok as draft but not as final`() {
+        val application =
+            createApplication()
+                .withApplicationData(
+                    customerWithContacts = customerWithNoContacts,
+                    contractorWithContacts = customerWithNoContacts,
+                )
+        val applicationData = application.applicationData as CableReportApplicationData
+        val contacts = applicationData.customersWithContacts().flatMap { it.contacts }
+        assertThat(contacts).isEmpty()
+        assertThat { applicationData.validateForErrors().isOk() }.isSuccess().isTrue()
+
+        assertThat { ensureValidForSend(applicationData) }
+            .isFailure()
+            .hasClass(InvalidApplicationDataException::class)
+    }
+
+    @ParameterizedTest(name = "{displayName}: missingField: {0}")
+    @MethodSource("missingCustomerWithContactsInput")
+    fun `CustomerWithContacts missing fields ok as draft but not as non-draft`(
+        missingField: String,
+        customerWithContacts: CustomerWithContacts
+    ) {
+        missingField.touch()
+        val application =
+            createApplication().withApplicationData(customerWithContacts = customerWithContacts)
+        val applicationData = application.applicationData as CableReportApplicationData
+        assertThat { applicationData.validateForErrors().isOk() }.isSuccess().isTrue()
+
+        assertThat { ensureValidForSend(applicationData) }
+            .isFailure()
+            .hasClass(InvalidApplicationDataException::class)
+    }
+
+    @ParameterizedTest(name = "{displayName}: missingField: {0}")
+    @MethodSource("missingCustomerWithContactsInput")
+    fun `ContractorWithContacts missing fields ok as draft but not as non-draft`(
+        missingField: String,
+        customerWithContacts: CustomerWithContacts
+    ) {
+        missingField.touch()
+        val application =
+            createApplication().withApplicationData(contractorWithContacts = customerWithContacts)
+        val applicationData = application.applicationData as CableReportApplicationData
+        assertThat { applicationData.validateForErrors().isOk() }.isSuccess().isTrue()
+
+        assertThat { ensureValidForSend(applicationData) }
+            .isFailure()
+            .hasClass(InvalidApplicationDataException::class)
+    }
+
+    @ParameterizedTest(name = "{displayName}: missingField: {0}")
+    @MethodSource("missingCustomerWithContactsInput")
+    fun `RepresentativeWithContacts missing fields ok as draft but not as non-draft`(
+        missingField: String,
+        customerWithContacts: CustomerWithContacts
+    ) {
+        missingField.touch()
+        val application =
+            createApplication()
+                .withApplicationData(representativeWithContacts = customerWithContacts)
+        val applicationData = application.applicationData as CableReportApplicationData
+        assertThat { applicationData.validateForErrors().isOk() }.isSuccess().isTrue()
+
+        assertThat { ensureValidForSend(applicationData) }
+            .isFailure()
+            .hasClass(InvalidApplicationDataException::class)
+    }
+
+    @Test
+    fun `RepresentativeWithContacts can be null`() {
+        val application =
+            createApplication()
+                .withApplicationData(representativeWithContacts = null)
+                .applicationData
+
+        assertThat { ensureValidForSend(application) }.isSuccess().isTrue()
+    }
+
+    @ParameterizedTest(name = "{displayName}: missingField: {0}")
+    @MethodSource("missingCustomerWithContactsInput")
+    fun `PropertyDeveloperWithContacts missing fields ok as draft but not as non-draft`(
+        missingField: String,
+        customerWithContacts: CustomerWithContacts
+    ) {
+        missingField.touch()
+        val application =
+            createApplication()
+                .withApplicationData(propertyDeveloperWithContacts = customerWithContacts)
+        val applicationData = application.applicationData as CableReportApplicationData
+        assertThat { applicationData.validateForErrors().isOk() }.isSuccess().isTrue()
+
+        assertThat { ensureValidForSend(applicationData) }
+            .isFailure()
+            .hasClass(InvalidApplicationDataException::class)
+    }
+
+    @Test
+    fun `PropertyDeveloperWithContacts can be null`() {
+        val application =
+            createApplication().withApplicationData(propertyDeveloperWithContacts = null)
+
+        assertThat { applicationValidator.isValid(application, null) }.isSuccess().isTrue()
+    }
+
+    companion object {
+        @JvmStatic
+        private fun missingDataInput(): Stream<Arguments> =
+            Stream.of(
+                of("Empty name", createCableReportApplicationData(name = "")),
+                of(
+                    "Empty work description",
+                    createCableReportApplicationData(workDescription = "")
+                ),
+                of("Null start time", createCableReportApplicationData(startTime = null)),
+                of("Null end time", createCableReportApplicationData(endTime = null)),
+                of("Null areas", createCableReportApplicationData(areas = null)),
+                of(
+                    "Null rock excavation",
+                    createCableReportApplicationData().copy(rockExcavation = null)
+                )
+            )
+
+        @JvmStatic
+        private fun missingCustomerWithContactsInput(): Stream<Arguments> =
+            Stream.of(
+                of("Customer null type", createCompanyCustomer(type = null).withContacts()),
+                of("Customer empty name", createCompanyCustomer(name = "").withContacts()),
+                of(
+                    "Contact empty name",
+                    createCompanyCustomer(name = "")
+                        .withContacts(createContact(firstName = "", lastName = ""))
+                )
+            )
+    }
+}

--- a/services/hanke-service/src/test/resources/fi/hel/haitaton/hanke/application/applicationData.json
+++ b/services/hanke-service/src/test/resources/fi/hel/haitaton/hanke/application/applicationData.json
@@ -56,31 +56,6 @@
       {
         "firstName": "Teppo",
         "lastName": "Testihenkilö",
-        "email": "teppo@example.test",
-        "phone": "04012345678",
-        "orderer": true
-      }
-    ],
-    "customer": {
-      "ovt": null,
-      "name": "Teppo Testihenkilö",
-      "type": "PERSON",
-      "email": "teppo@example.test",
-      "phone": "04012345678",
-      "country": "FI",
-      "registryKey": "281192-937W",
-      "invoicingOperator": null,
-      "sapCustomerNumber": null
-    }
-  },
-  "identificationNumber": "HAI-123",
-  "propertyConnectivity": false,
-  "clientApplicationKind": "HAITATON",
-  "contractorWithContacts": {
-    "contacts": [
-      {
-        "firstName": "Teppo",
-        "lastName": "Testihenkilö",
         "email": "teppo@dna.test",
         "phone": "04012345678",
         "orderer": true
@@ -94,6 +69,29 @@
       "phone": "+3581012345678",
       "country": "FI",
       "registryKey": "3766028-0",
+      "invoicingOperator": null,
+      "sapCustomerNumber": null
+    }
+  },
+  "identificationNumber": "HAI-123",
+  "propertyConnectivity": false,
+  "clientApplicationKind": "HAITATON",
+  "contractorWithContacts": {
+    "contacts": [
+      {
+        "firstName": "Teppo",
+        "lastName": "Testihenkilö",
+        "email": "teppo@example.test",
+        "phone": "04012345678"
+      }
+    ],
+    "customer": {
+      "ovt": null,
+      "name": "Teppo Testihenkilö",
+      "type": "PERSON",
+      "email": "teppo@example.test",
+      "phone": "04012345678",
+      "country": "FI",
       "invoicingOperator": null,
       "sapCustomerNumber": null
     }


### PR DESCRIPTION
It is ok for a draft application to have missing data that is not yet set.

However, when sending the application, all required fields must be present. This commit adds validation to be performed on application creation and update before sending the data to Allu.

# Description

Please include definition of what was done. 

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1756

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [x] Other

# Instructions for testing
1. Create johtoselvitys, fill for example just the first page. 
2. Save and quit. Take note of the application id.
3. For example with postman: POST http://localhost:3001/api/hakemukset/{application_id}/send-application
4. Expected response from the backend should be similar to (status 400):
```
{
    "errorMessage": "Application contains invalid data",
    "errorCode": "HAI2008",
    "errorPaths": [
        "startTime",
        "endTime",
        "customerWithContacts.customer.type",
        "customerWithContacts.customer.name",
        "contractorWithContacts.customer.type",
        "contractorWithContacts.customer.name",
        "contractorWithContacts.contacts[0].firstName"
    ]
}
```

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 
