### PR TITLE
HAI Increase attachment upload timeout and disable concurrency

### DIFF
--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/CableReportServiceAllu.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/CableReportServiceAllu.kt
@@ -38,6 +38,7 @@ class CableReportServiceAllu(
 
     private val baseUrl = properties.baseUrl
     private val defaultTimeout = ofSeconds(30)
+    private val attachmentUploadTimeout = ofSeconds(55)
 
     private fun login(): String {
         try {
@@ -371,7 +372,7 @@ class CableReportServiceAllu(
             .body(BodyInserters.fromMultipartData(multipartData))
             .retrieve()
             .bodyToMono<Void>()
-            .timeout(defaultTimeout)
+            .timeout(attachmentUploadTimeout)
             .doOnError(WebClientResponseException::class.java) {
                 logError("Error uploading attachment to Allu", it)
             }

--- a/services/hanke-service/src/main/resources/application.properties
+++ b/services/hanke-service/src/main/resources/application.properties
@@ -4,7 +4,7 @@ haitaton.allu.baseUrl=${ALLU_BASEURL:/}
 haitaton.allu.username=${ALLU_USERNAME:fake_user}
 haitaton.allu.password=${ALLU_PASSWORD:fake_password}
 haitaton.allu.insecure=${ALLU_INSECURE:false}
-haitaton.allu.concurrentUploads=${ALLU_CONCURRENT_UPLOADS:3}
+haitaton.allu.concurrentUploads=${ALLU_CONCURRENT_UPLOADS:1}
 haitaton.allu.updateIntervalMilliSeconds=${ALLU_UPDATE_INTERVAL:60000}
 haitaton.allu.updateInitialDelayMilliSeconds=${ALLU_UPDATE_INITIAL_DELAY:60000}
 


### PR DESCRIPTION
# Description

Allu has trouble accepting attachments in a reasonable amount of time. Let's try to mitigate the issue by disabling concurrency and setting a slightly higher timeout value.

### Jira Issue: -

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [X] Other

# Instructions for testing
Can't be tested, since the problem is with Allu's production environment.

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 