### PR TITLE
HAI-1221 Upgrade Java and Kotlin

### DIFF
--- a/.github/workflows/hanke-service-dev.yml
+++ b/.github/workflows/hanke-service-dev.yml
@@ -22,10 +22,10 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v1
         with:
-          java-version: 11
+          java-version: 17
       - name: Cache Gradle packages
         uses: actions/cache@v2
         with:

--- a/.github/workflows/hanke-service-feature.yml
+++ b/.github/workflows/hanke-service-feature.yml
@@ -20,10 +20,10 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v1
         with:
-          java-version: 11
+          java-version: 17
       - name: Cache Gradle packages
         uses: actions/cache@v2
         with:

--- a/.github/workflows/hanke-service-main.yml
+++ b/.github/workflows/hanke-service-main.yml
@@ -22,10 +22,10 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v1
         with:
-          java-version: 11
+          java-version: 17
       - name: Cache Gradle packages
         uses: actions/cache@v2
         with:

--- a/README.md
+++ b/README.md
@@ -3,22 +3,15 @@ Haitaton 2.0 backend project.
 
 ## Requirements
 
-TODO: IntelliJ Idea, with the initialized project dependencies, has things built-in or fetches almost
-everything automatically, except separate OpenJDK (for manual running). But would be nice to test
-and document what is needed for a fully manual command line build from these sources. (And needed for
-CI, too).
-
 TODO: document versions (once we settle with them).
 
 Using Idea:
 * IntelliJ Idea
    * it contains its own JDK, kotlinc, gradle, etc.
-* OpenJDK (version 11+) - for running things after they have been built
+* OpenJDK (version 17+) - for running things after they have been built
 
 Manual build
-* OpenJDK (version 11+)
-* Kotlin compiler
-* Gradle
+* OpenJDK (version 17+)
 
 ## Modules
 

--- a/services/hanke-service/Dockerfile
+++ b/services/hanke-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/openjdk/openjdk-11-rhel7
+FROM registry.redhat.io/ubi8/openjdk-17:latest
 WORKDIR /app
 EXPOSE 8080 8081
 VOLUME /tmp

--- a/services/hanke-service/Dockerfile-local
+++ b/services/hanke-service/Dockerfile-local
@@ -1,4 +1,4 @@
-FROM openjdk:11 as builder
+FROM eclipse-temurin:17 as builder
 USER root
 
 # Copy gradle to avoid redownloading it
@@ -13,7 +13,7 @@ WORKDIR /builder
 # Add GRADLE_OPTS to prevent JVM forking while building
 RUN GRADLE_OPTS="-XX:MaxMetaspaceSize=256m -XX:+HeapDumpOnOutOfMemoryError -Xms256m -Xmx512m" ./gradlew assemble --no-daemon
 
-FROM openjdk:11
+FROM eclipse-temurin:17
 WORKDIR /app
 EXPOSE 8080 8081
 COPY --from=builder /builder/services/hanke-service/build/libs/hanke-service-*.jar /app/haitaton.jar

--- a/services/hanke-service/README.md
+++ b/services/hanke-service/README.md
@@ -6,12 +6,11 @@ Haitaton 2.0 project API for "hanke" data.
 Using IDEA:
 * IntelliJ IDEA
    * it contains its own JDK, gradle, etc.
-* OpenJDK (version 11+) - for running things after they have been built
+* OpenJDK (version 17+) - for running things after they have been built
 * Docker
 
 Manual build
-* OpenJDK (version 11+)
-* Gradle
+* OpenJDK (version 17+)
 * Docker
 
 ## How to compile, build and run
@@ -222,24 +221,6 @@ Compose setup. Rebuilding is not necessary.
 
 You should now be able to call GDPR API with the API tester's `query`, `delete` and `delete dryrun`
 commands.
-
-## Info
-There is a Spring Boot Actuator endpoint for general info:
-> http://localhost:8081/actuator/info
-```
-{
-    "java-name": "Java Platform API Specification",
-    "java-version": "11",
-    "java-vendor": "Oracle Corporation",
-    "build": {
-        "artifact": "hanke-service",
-        "name": "hanke-service",
-        "time": "2020-11-02T07:00:31.071Z",
-        "version": "0.0.1-SNAPSHOT",
-        "group": "fi.hel.haitaton"
-    }
-}
-```
 
 ## Probes
 There are following Spring Boot Actuator probes (https://docs.spring.io/spring-boot/docs/2.3.4.RELEASE/reference/html/production-ready-features.html#production-ready-kubernetes-probes) for Kubernetes (these must be configured in Kuberneters/OpenShift):

--- a/services/hanke-service/build.gradle.kts
+++ b/services/hanke-service/build.gradle.kts
@@ -4,7 +4,6 @@ import org.springframework.boot.gradle.tasks.run.BootRun
 
 group = "fi.hel.haitaton"
 version = "0.0.1-SNAPSHOT"
-java.sourceCompatibility = JavaVersion.VERSION_11
 val springDocVersion = "1.7.0"
 val geoJsonJacksonVersion = "1.14"
 val mockkVersion = "1.13.5"
@@ -57,11 +56,11 @@ plugins {
 	id("org.springframework.boot") version "2.7.11"
 	id("io.spring.dependency-management") version "1.1.0"
 	id("com.diffplug.spotless") version "6.18.0"
-	kotlin("jvm") version "1.6.21"
+	kotlin("jvm") version "1.8.22"
 	// Gives kotlin-allopen, which auto-opens classes with certain annotations
-	kotlin("plugin.spring") version "1.6.21"
+	kotlin("plugin.spring") version "1.8.22"
 	// Gives kotlin-noarg for @Entity, @Embeddable
-	kotlin("plugin.jpa") version "1.6.21"
+	kotlin("plugin.jpa") version "1.8.22"
 	idea
 	id("com.github.ben-manes.versions") version "0.42.0"
 }
@@ -123,7 +122,12 @@ dependencies {
 tasks.withType<KotlinCompile> {
 	kotlinOptions {
 		freeCompilerArgs = listOf("-Xjsr305=strict")
-		jvmTarget = "11"
+	}
+}
+
+kotlin {
+	jvmToolchain {
+		languageVersion.set(JavaLanguageVersion.of(17))
 	}
 }
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Utils.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Utils.kt
@@ -3,6 +3,7 @@ package fi.hel.haitaton.hanke
 import fi.hel.haitaton.hanke.domain.BusinessId
 import java.time.LocalDateTime
 import java.time.ZonedDateTime
+import java.time.temporal.ChronoUnit
 import mu.KotlinLogging
 import org.springframework.security.core.context.SecurityContextHolder
 
@@ -11,15 +12,19 @@ private val logger = KotlinLogging.logger {}
 private val businessIdRegex = "^(\\d{7})-(\\d)\$".toRegex()
 private val businessIdMultipliers = listOf(7, 9, 10, 5, 8, 4, 2)
 
-/** Returns the current time in UTC, with time zone info. */
-fun getCurrentTimeUTC(): ZonedDateTime {
-    return ZonedDateTime.now(TZ_UTC)
-}
+/**
+ * Returns the current time in UTC, with time zone info.
+ *
+ * Truncated to microseconds, since that's the database precision.
+ */
+fun getCurrentTimeUTC(): ZonedDateTime = ZonedDateTime.now(TZ_UTC).truncatedTo(ChronoUnit.MICROS)
 
-/** Returns the current time in UTC, without time zone info (i.e. LocalTime instance). */
-fun getCurrentTimeUTCAsLocalTime(): LocalDateTime {
-    return ZonedDateTime.now(TZ_UTC).toLocalDateTime()
-}
+/**
+ * Returns the current time in UTC, without time zone info (i.e. LocalTime instance).
+ *
+ * Truncated to microseconds, since that's the database precision.
+ */
+fun getCurrentTimeUTCAsLocalTime(): LocalDateTime = getCurrentTimeUTC().toLocalDateTime()
 
 fun currentUserId(): String = SecurityContextHolder.getContext().authentication.name
 


### PR DESCRIPTION
# Description

Upgrade Java to latest LTS release 17 and Kotlin to the latest release.

Use eclipse-temurin as the base image for the build environment, since the openjdk-images have been deprecated.

There's no OpenJDK 17 base image for RHEL7, so using the next release of Red Hat for the runtime base image.

Java 17 uses more precise timestamps than earlier versions, more precise than the database. This causes the timestamps to be modified when saving. This is fixed by truncating the created timestamps to the same microsecond-precision the database uses, but only where it would break tests. It causes no other issues.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1221

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [X] Other