### PR TITLE
HAI-1560 Prepare for Spring upgrade

### DIFF
--- a/services/hanke-service/build.gradle.kts
+++ b/services/hanke-service/build.gradle.kts
@@ -5,10 +5,9 @@ import org.springframework.boot.gradle.tasks.run.BootRun
 group = "fi.hel.haitaton"
 version = "0.0.1-SNAPSHOT"
 val springDocVersion = "1.7.0"
-val geoJsonJacksonVersion = "1.14"
-val mockkVersion = "1.13.5"
-val springmockkVersion = "3.1.2"
-val assertkVersion = "0.25"
+val sentryVersion = "6.18.1"
+
+ext["spring-security.version"]="5.8.4"
 
 repositories {
 	mavenCentral()
@@ -53,7 +52,7 @@ spotless {
 }
 
 plugins {
-	id("org.springframework.boot") version "2.7.11"
+	id("org.springframework.boot") version "2.7.13"
 	id("io.spring.dependency-management") version "1.1.0"
 	id("com.diffplug.spotless") version "6.18.0"
 	kotlin("jvm") version "1.8.22"
@@ -76,17 +75,17 @@ dependencies {
 	implementation("com.fasterxml.jackson.module:jackson-module-jaxb-annotations")
 	implementation("io.github.microutils:kotlin-logging:3.0.5")
 	implementation("ch.qos.logback:logback-access")
-	implementation("net.logstash.logback:logstash-logback-encoder:7.3")
+	implementation("net.logstash.logback:logstash-logback-encoder:7.3") // Can be updated to 7.4 after Spring Boot 3.0
 	implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
-	implementation("de.grundid.opendatalab:geojson-jackson:$geoJsonJacksonVersion")
+    implementation("de.grundid.opendatalab:geojson-jackson:1.14")
 	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
 	implementation("org.liquibase:liquibase-core")
 	implementation("com.github.blagerweij:liquibase-sessionlock:1.6.2")
-	implementation("com.vladmihalcea:hibernate-types-52:2.21.1")
-	implementation("commons-io:commons-io:2.11.0")
+	implementation("com.vladmihalcea:hibernate-types-52:2.21.1") // use io.hypersistence:hypersistence-utils-hibernate-60:3.5.0 after Spring Boot 3.0
+	implementation("commons-io:commons-io:2.13.0")
 	implementation("com.github.librepdf:openpdf:1.3.30")
 	implementation("net.pwall.mustache:kotlin-mustache:0.10")
-	implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.1")
+	implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.2")
 
 	implementation("org.postgresql:postgresql")
 	implementation("org.springdoc:springdoc-openapi-kotlin:$springDocVersion")
@@ -95,14 +94,14 @@ dependencies {
 	testImplementation("org.springframework.boot:spring-boot-starter-test") {
 		exclude(group = "org.junit.vintage", module = "junit-vintage-engine")
 	}
-	testImplementation("io.mockk:mockk:$mockkVersion")
-	testImplementation("com.ninja-squad:springmockk:$springmockkVersion")
-	testImplementation("com.willowtreeapps.assertk:assertk-jvm:$assertkVersion")
+	testImplementation("io.mockk:mockk:1.13.5")
+	testImplementation("com.ninja-squad:springmockk:3.1.2") // Needs upgrade to 4.0.2 for Spring 3.0
+    testImplementation("com.willowtreeapps.assertk:assertk-jvm:0.26.1")
 	testImplementation("com.squareup.okhttp3:mockwebserver")
-	testImplementation("com.icegreen:greenmail-junit5:1.6.14")
+	testImplementation("com.icegreen:greenmail-junit5:1.6.14") // Can be updated to 2.0.0 after Spring 3.0
 
 	// Testcontainers
-	implementation(platform("org.testcontainers:testcontainers-bom:1.18.0"))
+	implementation(platform("org.testcontainers:testcontainers-bom:1.18.3"))
 	testImplementation("org.testcontainers:junit-jupiter")
 	testImplementation("org.testcontainers:postgresql")
 
@@ -113,8 +112,8 @@ dependencies {
 	testImplementation("org.springframework.security:spring-security-test")
 
 	// Sentry
-	implementation("io.sentry:sentry-spring-boot-starter:6.18.1")
-	implementation("io.sentry:sentry-logback:6.18.1")
+	implementation("io.sentry:sentry-spring-boot-starter:$sentryVersion") // For Spring 3.0, replace with io.sentry:sentry-spring-boot-starter-jakarta:6.23.0
+	implementation("io.sentry:sentry-logback:$sentryVersion") // Upgrade this to 6.23.0 at the same time
 
 	annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
 }

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/allu/CableReportServiceAlluITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/allu/CableReportServiceAlluITests.kt
@@ -1,12 +1,12 @@
 package fi.hel.haitaton.hanke.allu
 
 import assertk.Assert
+import assertk.assertFailure
 import assertk.assertThat
 import assertk.assertions.containsExactly
 import assertk.assertions.hasClass
 import assertk.assertions.hasMessage
 import assertk.assertions.isEqualTo
-import assertk.assertions.isFailure
 import assertk.assertions.isNull
 import assertk.assertions.prop
 import fi.hel.haitaton.hanke.OBJECT_MAPPER
@@ -301,8 +301,7 @@ class CableReportServiceAlluITests {
                     .setBody("Error message")
             )
 
-            assertThat { service.getApplicationStatusHistories(alluids, eventsAfter) }
-                .isFailure()
+            assertFailure { service.getApplicationStatusHistories(alluids, eventsAfter) }
                 .hasClass(WebClientResponseException.NotFound::class)
         }
     }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/configuration/SchedulingConfig.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/configuration/SchedulingConfig.kt
@@ -3,4 +3,4 @@ package fi.hel.haitaton.hanke.configuration
 import org.springframework.context.annotation.Configuration
 import org.springframework.scheduling.annotation.EnableScheduling
 
-@Configuration @EnableScheduling class SchedulingConfig {}
+@Configuration @EnableScheduling class SchedulingConfig

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/security/AccessRules.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/security/AccessRules.kt
@@ -13,8 +13,8 @@ private val logger = KotlinLogging.logger {}
 object AccessRules {
     fun configureHttpAccessRules(http: HttpSecurity) {
         http
-            .authorizeRequests()
-            .mvcMatchers(
+            .authorizeHttpRequests()
+            .requestMatchers(
                 HttpMethod.GET,
                 "/actuator/health",
                 "/actuator/health/liveness",
@@ -27,7 +27,7 @@ object AccessRules {
             )
             .permitAll()
             .and()
-            .authorizeRequests()
+            .authorizeHttpRequests()
             .anyRequest()
             .authenticated()
             .and()

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceTest.kt
@@ -1,12 +1,12 @@
 package fi.hel.haitaton.hanke.application
 
 import assertk.all
+import assertk.assertFailure
 import assertk.assertThat
 import assertk.assertions.contains
 import assertk.assertions.hasClass
 import assertk.assertions.hasMessage
 import assertk.assertions.isEqualTo
-import assertk.assertions.isFailure
 import assertk.assertions.isNotEmpty
 import assertk.assertions.isNotNull
 import fi.hel.haitaton.hanke.HankeEntity
@@ -415,8 +415,7 @@ class ApplicationServiceTest {
         every { applicationRepo.findOneById(3) } returns applicationEntity
         every { geometriatDao.isInsideHankeAlueet(1, any()) } returns true
 
-        assertThat { applicationService.sendApplication(3, USERNAME) }
-            .isFailure()
+        assertFailure { applicationService.sendApplication(3, USERNAME) }
             .all {
                 hasClass(InvalidApplicationDataException::class)
                 hasMessage("Application contains invalid data. Errors at paths: $path")

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/validation/ApplicationDataValidatorTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/validation/ApplicationDataValidatorTest.kt
@@ -1,10 +1,9 @@
 package fi.hel.haitaton.hanke.validation
 
+import assertk.assertFailure
 import assertk.assertThat
 import assertk.assertions.hasClass
 import assertk.assertions.isEmpty
-import assertk.assertions.isFailure
-import assertk.assertions.isSuccess
 import assertk.assertions.isTrue
 import fi.hel.haitaton.hanke.application.CableReportApplicationData
 import fi.hel.haitaton.hanke.application.CustomerWithContacts
@@ -41,7 +40,7 @@ class ApplicationDataValidatorTest {
     fun `Correct application passes validation`() {
         val applicationData = createCableReportApplicationData()
 
-        assertThat { ensureValidForSend(applicationData) }.isSuccess().isTrue()
+        assertThat(ensureValidForSend(applicationData)).isTrue()
     }
 
     @ParameterizedTest(name = "{displayName}: missingField: {0}")
@@ -51,10 +50,9 @@ class ApplicationDataValidatorTest {
         cableReportApplicationData: CableReportApplicationData
     ) {
         missingField.touch()
-        assertThat { cableReportApplicationData.validateForErrors().isOk() }.isSuccess().isTrue()
+        assertThat(cableReportApplicationData.validateForErrors().isOk()).isTrue()
 
-        assertThat { ensureValidForSend(cableReportApplicationData) }
-            .isFailure()
+        assertFailure { ensureValidForSend(cableReportApplicationData) }
             .hasClass(InvalidApplicationDataException::class)
     }
 
@@ -67,10 +65,9 @@ class ApplicationDataValidatorTest {
                     contractorWithContacts = customerWithNoOrderers,
                 )
         val applicationData = application.applicationData as CableReportApplicationData
-        assertThat { applicationData.validateForErrors().isOk() }.isSuccess().isTrue()
+        assertThat(applicationData.validateForErrors().isOk()).isTrue()
 
-        assertThat { ensureValidForSend(applicationData) }
-            .isFailure()
+        assertFailure { ensureValidForSend(applicationData) }
             .hasClass(InvalidApplicationDataException::class)
     }
 
@@ -85,10 +82,9 @@ class ApplicationDataValidatorTest {
         val applicationData = application.applicationData as CableReportApplicationData
         val contacts = applicationData.customersWithContacts().flatMap { it.contacts }
         assertThat(contacts).isEmpty()
-        assertThat { applicationData.validateForErrors().isOk() }.isSuccess().isTrue()
+        assertThat(applicationData.validateForErrors().isOk()).isTrue()
 
-        assertThat { ensureValidForSend(applicationData) }
-            .isFailure()
+        assertFailure { ensureValidForSend(applicationData) }
             .hasClass(InvalidApplicationDataException::class)
     }
 
@@ -102,10 +98,9 @@ class ApplicationDataValidatorTest {
         val application =
             createApplication().withApplicationData(customerWithContacts = customerWithContacts)
         val applicationData = application.applicationData as CableReportApplicationData
-        assertThat { applicationData.validateForErrors().isOk() }.isSuccess().isTrue()
+        assertThat(applicationData.validateForErrors().isOk()).isTrue()
 
-        assertThat { ensureValidForSend(applicationData) }
-            .isFailure()
+        assertFailure { ensureValidForSend(applicationData) }
             .hasClass(InvalidApplicationDataException::class)
     }
 
@@ -119,10 +114,9 @@ class ApplicationDataValidatorTest {
         val application =
             createApplication().withApplicationData(contractorWithContacts = customerWithContacts)
         val applicationData = application.applicationData as CableReportApplicationData
-        assertThat { applicationData.validateForErrors().isOk() }.isSuccess().isTrue()
+        assertThat(applicationData.validateForErrors().isOk()).isTrue()
 
-        assertThat { ensureValidForSend(applicationData) }
-            .isFailure()
+        assertFailure { ensureValidForSend(applicationData) }
             .hasClass(InvalidApplicationDataException::class)
     }
 
@@ -137,10 +131,9 @@ class ApplicationDataValidatorTest {
             createApplication()
                 .withApplicationData(representativeWithContacts = customerWithContacts)
         val applicationData = application.applicationData as CableReportApplicationData
-        assertThat { applicationData.validateForErrors().isOk() }.isSuccess().isTrue()
+        assertThat(applicationData.validateForErrors().isOk()).isTrue()
 
-        assertThat { ensureValidForSend(applicationData) }
-            .isFailure()
+        assertFailure { ensureValidForSend(applicationData) }
             .hasClass(InvalidApplicationDataException::class)
     }
 
@@ -151,7 +144,7 @@ class ApplicationDataValidatorTest {
                 .withApplicationData(representativeWithContacts = null)
                 .applicationData
 
-        assertThat { ensureValidForSend(application) }.isSuccess().isTrue()
+        assertThat(ensureValidForSend(application)).isTrue()
     }
 
     @ParameterizedTest(name = "{displayName}: missingField: {0}")
@@ -165,10 +158,9 @@ class ApplicationDataValidatorTest {
             createApplication()
                 .withApplicationData(propertyDeveloperWithContacts = customerWithContacts)
         val applicationData = application.applicationData as CableReportApplicationData
-        assertThat { applicationData.validateForErrors().isOk() }.isSuccess().isTrue()
+        assertThat(applicationData.validateForErrors().isOk()).isTrue()
 
-        assertThat { ensureValidForSend(applicationData) }
-            .isFailure()
+        assertFailure { ensureValidForSend(applicationData) }
             .hasClass(InvalidApplicationDataException::class)
     }
 
@@ -177,7 +169,7 @@ class ApplicationDataValidatorTest {
         val application =
             createApplication().withApplicationData(propertyDeveloperWithContacts = null)
 
-        assertThat { applicationValidator.isValid(application, null) }.isSuccess().isTrue()
+        assertThat(applicationValidator.isValid(application, null)).isTrue()
     }
 
     companion object {

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/validation/ApplicationValidatorTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/validation/ApplicationValidatorTest.kt
@@ -1,11 +1,10 @@
 package fi.hel.haitaton.hanke.validation
 
+import assertk.assertFailure
 import assertk.assertThat
 import assertk.assertions.hasClass
 import assertk.assertions.isEmpty
-import assertk.assertions.isFailure
 import assertk.assertions.isFalse
-import assertk.assertions.isSuccess
 import assertk.assertions.isTrue
 import fi.hel.haitaton.hanke.application.CableReportApplicationData
 import fi.hel.haitaton.hanke.application.Contact
@@ -36,7 +35,7 @@ class ApplicationValidatorTest {
     fun `Correct application passes validation`() {
         val application = AlluDataFactory.createApplication()
 
-        assertThat { applicationValidator.isValid(application, null) }.isSuccess().isTrue()
+        assertThat(applicationValidator.isValid(application, null)).isTrue()
     }
 
     @Nested
@@ -72,7 +71,7 @@ class ApplicationValidatorTest {
                         customerWithContacts = customerWithOneOrderer,
                     )
 
-            assertThat { applicationValidator.isValid(application, null) }.isSuccess().isTrue()
+            assertThat(applicationValidator.isValid(application, null)).isTrue()
         }
 
         @Test
@@ -84,7 +83,7 @@ class ApplicationValidatorTest {
                         contractorWithContacts = customerWithNoOrderers,
                     )
 
-            assertThat { applicationValidator.isValid(application, null) }.isSuccess().isTrue()
+            assertThat(applicationValidator.isValid(application, null)).isTrue()
         }
 
         @Test
@@ -95,8 +94,7 @@ class ApplicationValidatorTest {
                         customerWithContacts = customerWithTwoOrderers,
                     )
 
-            assertThat { applicationValidator.isValid(application, null) }
-                .isFailure()
+            assertFailure { applicationValidator.isValid(application, null) }
                 .hasClass(InvalidApplicationDataException::class)
         }
 
@@ -109,8 +107,7 @@ class ApplicationValidatorTest {
                         contractorWithContacts = customerWithOneOrderer,
                     )
 
-            assertThat { applicationValidator.isValid(application, null) }
-                .isFailure()
+            assertFailure { applicationValidator.isValid(application, null) }
                 .hasClass(InvalidApplicationDataException::class)
         }
 
@@ -126,7 +123,7 @@ class ApplicationValidatorTest {
                 application.applicationData.customersWithContacts().flatMap { it.contacts }
             assertThat(contacts).isEmpty()
 
-            assertThat { applicationValidator.isValid(application, null) }.isSuccess().isTrue()
+            assertThat(applicationValidator.isValid(application, null)).isTrue()
         }
     }
 
@@ -167,8 +164,7 @@ class ApplicationValidatorTest {
             case.touch()
             val application = AlluDataFactory.createApplication(applicationData = applicationData)
 
-            assertThat { applicationValidator.isValid(application, null) }
-                .isFailure()
+            assertFailure { applicationValidator.isValid(application, null) }
                 .hasClass(InvalidApplicationDataException::class)
         }
 
@@ -178,7 +174,7 @@ class ApplicationValidatorTest {
             case.touch()
             val application = AlluDataFactory.createApplication(applicationData = applicationData)
 
-            assertThat { applicationValidator.isValid(application, null) }.isSuccess().isTrue()
+            assertThat(applicationValidator.isValid(application, null)).isTrue()
         }
 
         @ParameterizedTest(name = "{0} can have text with whitespaces")
@@ -190,7 +186,7 @@ class ApplicationValidatorTest {
             case.touch()
             val application = AlluDataFactory.createApplication(applicationData = applicationData)
 
-            assertThat { applicationValidator.isValid(application, null) }.isSuccess().isTrue()
+            assertThat(applicationValidator.isValid(application, null)).isTrue()
         }
 
         @Test
@@ -202,8 +198,7 @@ class ApplicationValidatorTest {
                             AlluDataFactory.createCompanyCustomer(name = " ").withContacts()
                     )
 
-            assertThat { applicationValidator.isValid(application, null) }
-                .isFailure()
+            assertFailure { applicationValidator.isValid(application, null) }
                 .hasClass(InvalidApplicationDataException::class)
         }
         @Test
@@ -215,8 +210,7 @@ class ApplicationValidatorTest {
                             AlluDataFactory.createCompanyCustomer(name = " ").withContacts()
                     )
 
-            assertThat { applicationValidator.isValid(application, null) }
-                .isFailure()
+            assertFailure { applicationValidator.isValid(application, null) }
                 .hasClass(InvalidApplicationDataException::class)
         }
 
@@ -229,8 +223,7 @@ class ApplicationValidatorTest {
                             AlluDataFactory.createCompanyCustomer(name = " ").withContacts()
                     )
 
-            assertThat { applicationValidator.isValid(application, null) }
-                .isFailure()
+            assertFailure { applicationValidator.isValid(application, null) }
                 .hasClass(InvalidApplicationDataException::class)
         }
 
@@ -240,7 +233,7 @@ class ApplicationValidatorTest {
                 AlluDataFactory.createApplication()
                     .withApplicationData(representativeWithContacts = null)
 
-            assertThat { applicationValidator.isValid(application, null) }.isSuccess().isTrue()
+            assertThat(applicationValidator.isValid(application, null)).isTrue()
         }
 
         @Test
@@ -252,8 +245,7 @@ class ApplicationValidatorTest {
                             AlluDataFactory.createCompanyCustomer(name = " ").withContacts()
                     )
 
-            assertThat { applicationValidator.isValid(application, null) }
-                .isFailure()
+            assertFailure { applicationValidator.isValid(application, null) }
                 .hasClass(InvalidApplicationDataException::class)
         }
 
@@ -263,7 +255,7 @@ class ApplicationValidatorTest {
                 AlluDataFactory.createApplication()
                     .withApplicationData(propertyDeveloperWithContacts = null)
 
-            assertThat { applicationValidator.isValid(application, null) }.isSuccess().isTrue()
+            assertThat(applicationValidator.isValid(application, null)).isTrue()
         }
 
         @Test
@@ -278,8 +270,7 @@ class ApplicationValidatorTest {
                             )
                 )
 
-            assertThat { applicationValidator.isValid(application, null) }
-                .isFailure()
+            assertFailure { applicationValidator.isValid(application, null) }
                 .hasClass(InvalidApplicationDataException::class)
         }
 
@@ -292,7 +283,7 @@ class ApplicationValidatorTest {
                             .copy(invoicingCustomer = null)
                 )
 
-            assertThat { applicationValidator.isValid(application, null) }.isSuccess().isTrue()
+            assertThat(applicationValidator.isValid(application, null)).isTrue()
         }
     }
 
@@ -313,7 +304,7 @@ class ApplicationValidatorTest {
                         endTime = endTime,
                     )
 
-            assertThat { applicationValidator.isValid(application, null) }.isSuccess().isTrue()
+            assertThat(applicationValidator.isValid(application, null)).isTrue()
         }
 
         @Test
@@ -325,7 +316,7 @@ class ApplicationValidatorTest {
                         endTime = date.plusDays(1),
                     )
 
-            assertThat { applicationValidator.isValid(application, null) }.isSuccess().isTrue()
+            assertThat(applicationValidator.isValid(application, null)).isTrue()
         }
 
         @Test
@@ -337,8 +328,7 @@ class ApplicationValidatorTest {
                         endTime = date,
                     )
 
-            assertThat { applicationValidator.isValid(application, null) }
-                .isFailure()
+            assertFailure { applicationValidator.isValid(application, null) }
                 .hasClass(InvalidApplicationDataException::class)
         }
     }
@@ -371,8 +361,7 @@ class ApplicationValidatorTest {
             val application =
                 AlluDataFactory.createApplication().withCustomer(customer.withContacts())
 
-            assertThat { applicationValidator.isValid(application, null) }
-                .isFailure()
+            assertFailure { applicationValidator.isValid(application, null) }
                 .hasClass(InvalidApplicationDataException::class)
         }
 
@@ -383,7 +372,7 @@ class ApplicationValidatorTest {
             val application =
                 AlluDataFactory.createApplication().withCustomer(customer.withContacts())
 
-            assertThat { applicationValidator.isValid(application, null) }.isSuccess().isTrue()
+            assertThat(applicationValidator.isValid(application, null)).isTrue()
         }
 
         @ParameterizedTest(name = "{0} can have text with whitespaces")
@@ -393,7 +382,7 @@ class ApplicationValidatorTest {
             val application =
                 AlluDataFactory.createApplication().withCustomer(customer.withContacts())
 
-            assertThat { applicationValidator.isValid(application, null) }.isSuccess().isTrue()
+            assertThat(applicationValidator.isValid(application, null)).isTrue()
         }
 
         @Test
@@ -402,8 +391,7 @@ class ApplicationValidatorTest {
                 AlluDataFactory.createApplication()
                     .withCustomer(baseCustomer.copy(country = "Some country").withContacts())
 
-            assertThat { applicationValidator.isValid(application, null) }
-                .isFailure()
+            assertFailure { applicationValidator.isValid(application, null) }
                 .hasClass(InvalidApplicationDataException::class)
         }
 
@@ -413,7 +401,7 @@ class ApplicationValidatorTest {
                 AlluDataFactory.createApplication()
                     .withCustomer(baseCustomer.copy(country = "FI").withContacts())
 
-            assertThat { applicationValidator.isValid(application, null) }.isSuccess().isTrue()
+            assertThat(applicationValidator.isValid(application, null)).isTrue()
         }
 
         @Test
@@ -422,8 +410,7 @@ class ApplicationValidatorTest {
                 AlluDataFactory.createApplication()
                     .withCustomer(baseCustomer.copy(country = "fi").withContacts())
 
-            assertThat { applicationValidator.isValid(application, null) }
-                .isFailure()
+            assertFailure { applicationValidator.isValid(application, null) }
                 .hasClass(InvalidApplicationDataException::class)
         }
 
@@ -433,8 +420,7 @@ class ApplicationValidatorTest {
                 AlluDataFactory.createApplication()
                     .withCustomer(baseCustomer.copy(country = "FIN").withContacts())
 
-            assertThat { applicationValidator.isValid(application, null) }
-                .isFailure()
+            assertFailure { applicationValidator.isValid(application, null) }
                 .hasClass(InvalidApplicationDataException::class)
         }
 
@@ -449,7 +435,7 @@ class ApplicationValidatorTest {
                             .withContacts()
                     )
 
-            assertThat { applicationValidator.isValid(application, null) }.isSuccess().isTrue()
+            assertThat(applicationValidator.isValid(application, null)).isTrue()
         }
 
         @Test
@@ -463,8 +449,7 @@ class ApplicationValidatorTest {
                             .withContacts()
                     )
 
-            assertThat { applicationValidator.isValid(application, null) }
-                .isFailure()
+            assertFailure { applicationValidator.isValid(application, null) }
                 .hasClass(InvalidApplicationDataException::class)
         }
     }
@@ -494,8 +479,7 @@ class ApplicationValidatorTest {
             case.touch()
             val application = AlluDataFactory.createApplication().withCustomerContacts(contact)
 
-            assertThat { applicationValidator.isValid(application, null) }
-                .isFailure()
+            assertFailure { applicationValidator.isValid(application, null) }
                 .hasClass(InvalidApplicationDataException::class)
         }
 
@@ -505,7 +489,7 @@ class ApplicationValidatorTest {
             case.touch()
             val application = AlluDataFactory.createApplication().withCustomerContacts(contact)
 
-            assertThat { applicationValidator.isValid(application, null) }.isSuccess().isTrue()
+            assertThat(applicationValidator.isValid(application, null)).isTrue()
         }
 
         @ParameterizedTest(name = "{0} can have text with whitespaces")
@@ -514,7 +498,7 @@ class ApplicationValidatorTest {
             case.touch()
             val application = AlluDataFactory.createApplication().withCustomerContacts(contact)
 
-            assertThat { applicationValidator.isValid(application, null) }.isSuccess().isTrue()
+            assertThat(applicationValidator.isValid(application, null)).isTrue()
         }
     }
 }


### PR DESCRIPTION
# Description

Update Spring Security to 5.8, which is a transitional version, making the jump to Spring Security 6.0 easier. Update Spring Boot to the latest version in the latest 2.7-branch. Update misc packages that can be updated now, and mark packages that can or need to be updated while upgrading to Spring Boot 3.0.

Assertk has deprecated the `assertThat {}` method that takes a function parameter. It has been replaced with the usual `assertThat()` for success cases and with `assertFailure {}` for cases that throw an exception.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1560

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [X] Other