### PR TITLE
HAI-1832 Add unique indexes to database

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentServiceITest.kt
@@ -13,7 +13,6 @@ import com.ninjasquad.springmockk.MockkBean
 import fi.hel.haitaton.hanke.ALLOWED_ATTACHMENT_COUNT
 import fi.hel.haitaton.hanke.DatabaseTest
 import fi.hel.haitaton.hanke.HankeEntity
-import fi.hel.haitaton.hanke.HankeRepository
 import fi.hel.haitaton.hanke.allu.ApplicationStatus
 import fi.hel.haitaton.hanke.allu.ApplicationStatus.HANDLING
 import fi.hel.haitaton.hanke.allu.ApplicationStatus.PENDING
@@ -22,7 +21,6 @@ import fi.hel.haitaton.hanke.application.ApplicationAlreadyProcessingException
 import fi.hel.haitaton.hanke.application.ApplicationEntity
 import fi.hel.haitaton.hanke.application.ApplicationNotFoundException
 import fi.hel.haitaton.hanke.attachment.FILE_NAME_PDF
-import fi.hel.haitaton.hanke.attachment.HANKE_TUNNUS
 import fi.hel.haitaton.hanke.attachment.USERNAME
 import fi.hel.haitaton.hanke.attachment.body
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentRepository
@@ -42,6 +40,7 @@ import fi.hel.haitaton.hanke.attachment.testFile
 import fi.hel.haitaton.hanke.factory.AlluDataFactory
 import fi.hel.haitaton.hanke.factory.AlluDataFactory.Companion.createAlluApplicationResponse
 import fi.hel.haitaton.hanke.factory.AttachmentFactory
+import fi.hel.haitaton.hanke.factory.HankeFactory
 import fi.hel.haitaton.hanke.test.Asserts.isRecent
 import io.mockk.Called
 import io.mockk.checkUnnecessaryStub
@@ -80,7 +79,7 @@ class ApplicationAttachmentServiceITest : DatabaseTest() {
     @Autowired private lateinit var applicationAttachmentRepository: ApplicationAttachmentRepository
     @Autowired private lateinit var alluDataFactory: AlluDataFactory
     @Autowired private lateinit var attachmentFactory: AttachmentFactory
-    @Autowired private lateinit var hankeRepository: HankeRepository
+    @Autowired private lateinit var hankeFactory: HankeFactory
 
     private lateinit var mockWebServer: MockWebServer
 
@@ -425,6 +424,5 @@ class ApplicationAttachmentServiceITest : DatabaseTest() {
             mutator = mutator
         )
 
-    private fun hankeEntity(): HankeEntity =
-        hankeRepository.save(HankeEntity(hankeTunnus = HANKE_TUNNUS))
+    private fun hankeEntity(): HankeEntity = hankeFactory.saveEntity()
 }

--- a/services/hanke-service/src/main/resources/db/changelog/changesets/039-add-indexes.yml
+++ b/services/hanke-service/src/main/resources/db/changelog/changesets/039-add-indexes.yml
@@ -1,0 +1,32 @@
+databaseChangeLog:
+  - changeSet:
+      id: 039-add-unique-indexes-for-allu-keys
+      author: Topias Heinonen
+      comment: The only way to get duplicates is an Allu malfunction, so we should safeguard against those.
+      changes:
+        - createIndex:
+            tableName: applications
+            indexName: uk_applications_alluid
+            unique: true
+            columns:
+              - column:
+                  name: alluid
+        - createIndex:
+            tableName: applications
+            indexName: uk_applications_applicationidentifier
+            unique: true
+            columns:
+              - column:
+                  name: applicationidentifier
+  - changeSet:
+      id: 039-add-index-for-hanketunnus
+      author: Topias Heinonen
+      comment: This is on of the most common ways to find a hanke, so it should be indexed.
+      changes:
+        - createIndex:
+            tableName: hanke
+            indexName: uk_hanke_hanketunnus
+            unique: true
+            columns:
+              - column:
+                  name: hanketunnus

--- a/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -105,3 +105,5 @@ databaseChangeLog:
       file: db/changelog/changesets/037-add-delete-cascade-for-attachments.yml
   - include:
       file: db/changelog/changesets/038-add-attachment-content-tables.sql
+  - include:
+      file: db/changelog/changesets/039-add-indexes.yml


### PR DESCRIPTION
# Description

Add unique indexes to application Allu keys. The only way to get duplicates is an Allu malfunction, so we should safeguard against those.

Also add a unique index for hanketunnus in hanke. This is on of the most common ways to find a hanke, so it should be indexed. The uniqueness quarantee is a bonus.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1832

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [X] Other