### PR TITLE
HAI-1409 Add missing openapi documentation

### DIFF
--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeController.kt
@@ -205,7 +205,13 @@ class HankeController(
     @Operation(
         summary = "Update hanke",
         description =
-            "Update an existing hanke. An updated hanke must comply with the restrictions defined in HankeValidator."
+            """
+               Update an existing hanke. Data must comply with the restrictions defined in Hanke schema definition. 
+               
+               On update following will happen automatically:
+               1. Status is updated. PUBLIC if required fields are filled. Else DRAFT.
+               2. Tormaystarkastelu (project nuisance) is re-calculated.
+            """
     )
     @ApiResponses(
         value =
@@ -251,7 +257,11 @@ class HankeController(
 
     @DeleteMapping("/{hankeTunnus}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    @Operation(summary = "Delete hanke", description = "Delete an existing hanke.")
+    @Operation(
+        summary = "Delete hanke",
+        description =
+            "Delete an existing hanke. Deletion is not possible if Hanke contains active applications."
+    )
     @ApiResponses(
         value =
             [
@@ -259,6 +269,11 @@ class HankeController(
                 ApiResponse(
                     description = "Hanke by requested hankeTunnus not found",
                     responseCode = "404",
+                    content = [Content(schema = Schema(implementation = HankeError::class))]
+                ),
+                ApiResponse(
+                    description = "Hanke has active application(s) in Allu, will not delete.",
+                    responseCode = "409",
                     content = [Content(schema = Schema(implementation = HankeError::class))]
                 )
             ]

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeController.kt
@@ -145,7 +145,6 @@ class HankeController(
         }
     }
 
-    /** Add one hanke. This method will be called when we do not have id for hanke yet */
     @PostMapping(consumes = [APPLICATION_JSON_VALUE], produces = [APPLICATION_JSON_VALUE])
     @Operation(
         summary = "Create new hanke",
@@ -189,7 +188,6 @@ class HankeController(
         return createdHanke
     }
 
-    /** Update one hanke. */
     @PutMapping(
         "/{hankeTunnus}",
         consumes = [APPLICATION_JSON_VALUE],

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeController.kt
@@ -150,7 +150,7 @@ class HankeController(
     @Operation(
         summary = "Create new hanke",
         description =
-            "Create a new hanke. A valid new hanke must comply with the restrictions defined in HankeValidator."
+            "Create a new hanke. A valid new hanke must comply with the restrictions in Hanke schema definition."
     )
     @ApiResponses(
         value =

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeController.kt
@@ -101,7 +101,7 @@ class HankeController(
             description =
                 """Boolean flag indicating whether endpoint should return geometry data for alueet. 
                     Geometriat fields will be null if false.""",
-            schema = Schema(type = "boolean"),
+            schema = Schema(type = "boolean", defaultValue = "false"),
             required = false,
             example = "false",
         )

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeController.kt
@@ -79,7 +79,9 @@ class HankeController(
     @GetMapping(produces = [APPLICATION_JSON_VALUE])
     @Operation(
         summary = "Get hanke list",
-        description = "Get list of hanke to which the user has permission to."
+        description =
+            """Get Hanke list to which the user has permission to. 
+            Contains e.g. personal contact information, which is not available in a public Hanke."""
     )
     @ApiResponses(
         value =

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeController.kt
@@ -149,7 +149,14 @@ class HankeController(
     @Operation(
         summary = "Create new hanke",
         description =
-            "Create a new hanke. A valid new hanke must comply with the restrictions in Hanke schema definition."
+            """
+              A valid new hanke must comply with the restrictions in Hanke schema definition.
+              When Hanke is created:
+              1. A unique Hanke tunnus is created.
+              2. The status of the created hanke is set automatically:
+                  - PUBLIC (i.e. visible to everyone) if all mandatory fields are filled. 
+                  - DRAFT if all mandatory fields are not filled.
+        """
     )
     @ApiResponses(
         value =

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeYhteystietoEntity.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeYhteystietoEntity.kt
@@ -3,6 +3,7 @@ package fi.hel.haitaton.hanke
 import com.fasterxml.jackson.annotation.JsonView
 import fi.hel.haitaton.hanke.domain.YhteystietoTyyppi
 import io.hypersistence.utils.hibernate.type.json.JsonType
+import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType.STRING
@@ -110,11 +111,12 @@ class HankeYhteystietoEntity(
         )
 }
 
+@Schema(description = "Contact person")
 data class Yhteyshenkilo(
-    val etunimi: String,
-    val sukunimi: String,
-    val email: String,
-    val puhelinnumero: String,
+    @field:Schema(description = "First name") val etunimi: String,
+    @field:Schema(description = "Last name") val sukunimi: String,
+    @field:Schema(description = "Email address") val email: String,
+    @field:Schema(description = "Phone number") val puhelinnumero: String,
 ) {
     fun fullName(): String = listOf(etunimi, sukunimi).filter { it.isNotBlank() }.joinToString(" ")
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/PublicHankeController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/PublicHankeController.kt
@@ -2,16 +2,40 @@ package fi.hel.haitaton.hanke
 
 import fi.hel.haitaton.hanke.domain.PublicHanke
 import fi.hel.haitaton.hanke.domain.hankeToPublic
-import org.springframework.beans.factory.annotation.Autowired
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.ArraySchema
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/public-hankkeet")
-class PublicHankeController(
-    @Autowired private val hankeService: HankeService,
-) {
-    @GetMapping
+class PublicHankeController(private val hankeService: HankeService) {
+
+    @GetMapping(produces = [APPLICATION_JSON_VALUE])
+    @Operation(summary = "Get list of public hanke")
+    @ApiResponses(
+        value =
+            [
+                ApiResponse(
+                    description = "Success",
+                    responseCode = "200",
+                    content =
+                        [
+                            Content(
+                                array =
+                                    ArraySchema(
+                                        schema = Schema(implementation = PublicHanke::class)
+                                    )
+                            )
+                        ]
+                )
+            ]
+    )
     fun getAll(): List<PublicHanke> = hankeService.loadPublicHanke().map { hankeToPublic(it) }
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/PublicHankeController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/PublicHankeController.kt
@@ -18,7 +18,11 @@ import org.springframework.web.bind.annotation.RestController
 class PublicHankeController(private val hankeService: HankeService) {
 
     @GetMapping(produces = [APPLICATION_JSON_VALUE])
-    @Operation(summary = "Get list of public hanke")
+    @Operation(
+        summary = "Get list of public hanke",
+        description =
+            "A public hanke contains data that is visible to everyone. It does not contain private information."
+    )
     @ApiResponses(
         value =
             [

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/StatusController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/StatusController.kt
@@ -1,5 +1,8 @@
 package fi.hel.haitaton.hanke
 
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
 import mu.KotlinLogging
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpStatus
@@ -20,6 +23,17 @@ class StatusController(@Autowired private val jdbcOperations: JdbcOperations) {
     }
 
     @GetMapping
+    @Operation(
+        summary = "Check application status",
+        description = "Health check to verify application status."
+    )
+    @ApiResponses(
+        value =
+            [
+                ApiResponse(description = "Success", responseCode = "200"),
+                ApiResponse(description = "Internal server error", responseCode = "500")
+            ]
+    )
     fun getStatus(): ResponseEntity<Void> {
         return if (canConnectToDatabase()) {
             ResponseEntity.ok().build()

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/StatusController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/StatusController.kt
@@ -25,7 +25,8 @@ class StatusController(@Autowired private val jdbcOperations: JdbcOperations) {
     @GetMapping
     @Operation(
         summary = "Check application status",
-        description = "Health check to verify application status."
+        description =
+            "Health check to verify application status. Checks that the database connection is working."
     )
     @ApiResponses(
         value =

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationController.kt
@@ -211,7 +211,7 @@ class ApplicationController(
                 ),
                 ApiResponse(
                     description =
-                        "The application is already processing in Allu and can't be deleted.",
+                        "The application is already processing in Allu and can't be deleted",
                     responseCode = "409",
                     content = [Content(schema = Schema(implementation = HankeError::class))]
                 ),

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentController.kt
@@ -1,13 +1,11 @@
 package fi.hel.haitaton.hanke.attachment.application
 
+import fi.hel.haitaton.hanke.HankeError
 import fi.hel.haitaton.hanke.HankeService
-import fi.hel.haitaton.hanke.application.ApplicationAlreadyProcessingException
 import fi.hel.haitaton.hanke.application.ApplicationNotFoundException
 import fi.hel.haitaton.hanke.application.ApplicationService
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentMetadata
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType
-import fi.hel.haitaton.hanke.attachment.common.AttachmentInvalidException
-import fi.hel.haitaton.hanke.attachment.common.AttachmentNotFoundException
 import fi.hel.haitaton.hanke.attachment.common.HeadersBuilder.buildHeaders
 import fi.hel.haitaton.hanke.currentUserId
 import fi.hel.haitaton.hanke.permissions.PermissionCode
@@ -41,22 +39,16 @@ class ApplicationAttachmentController(
 
     @GetMapping
     @Operation(
-        summary = "Get metadata from application attachments.",
+        summary = "Get metadata from application attachments",
     )
     @ApiResponses(
         value =
             [
-                ApiResponse(description = "Application attachments.", responseCode = "200"),
+                ApiResponse(description = "Application attachments", responseCode = "200"),
                 ApiResponse(
-                    description = "Application not found.",
+                    description = "Application not found",
                     responseCode = "404",
-                    content =
-                        [
-                            Content(
-                                schema =
-                                    Schema(implementation = ApplicationNotFoundException::class)
-                            )
-                        ]
+                    content = [Content(schema = Schema(implementation = HankeError::class))]
                 ),
             ]
     )
@@ -68,20 +60,15 @@ class ApplicationAttachmentController(
     }
 
     @GetMapping("/{attachmentId}/content")
-    @Operation(summary = "Download attachment file.")
+    @Operation(summary = "Download attachment file")
     @ApiResponses(
         value =
             [
-                ApiResponse(description = "Attachment file.", responseCode = "200"),
+                ApiResponse(description = "Attachment file", responseCode = "200"),
                 ApiResponse(
-                    description = "Attachment not found.",
+                    description = "Attachment not found",
                     responseCode = "404",
-                    content =
-                        [
-                            Content(
-                                schema = Schema(implementation = AttachmentNotFoundException::class)
-                            )
-                        ]
+                    content = [Content(schema = Schema(implementation = HankeError::class))]
                 ),
             ]
     )
@@ -106,41 +93,21 @@ class ApplicationAttachmentController(
     @ApiResponses(
         value =
             [
-                ApiResponse(description = "Success.", responseCode = "200"),
+                ApiResponse(description = "Success", responseCode = "200"),
                 ApiResponse(
-                    description = "Application not found.",
+                    description = "Application not found",
                     responseCode = "404",
-                    content =
-                        [
-                            Content(
-                                schema =
-                                    Schema(implementation = ApplicationNotFoundException::class)
-                            )
-                        ]
+                    content = [Content(schema = Schema(implementation = HankeError::class))]
                 ),
                 ApiResponse(
-                    description = "Attachment invalid.",
+                    description = "Attachment invalid",
                     responseCode = "400",
-                    content =
-                        [
-                            Content(
-                                schema = Schema(implementation = AttachmentInvalidException::class)
-                            )
-                        ]
+                    content = [Content(schema = Schema(implementation = HankeError::class))]
                 ),
                 ApiResponse(
-                    description = "Application already processing.",
+                    description = "Application already processing",
                     responseCode = "409",
-                    content =
-                        [
-                            Content(
-                                schema =
-                                    Schema(
-                                        implementation =
-                                            ApplicationAlreadyProcessingException::class
-                                    )
-                            )
-                        ]
+                    content = [Content(schema = Schema(implementation = HankeError::class))]
                 ),
             ]
     )
@@ -155,33 +122,23 @@ class ApplicationAttachmentController(
 
     @DeleteMapping("/{attachmentId}")
     @Operation(
-        summary = "Delete attachment from application.",
+        summary = "Delete attachment from application",
         description =
             "Can be deleted if application has not been sent to Allu. Don't delete if application has alluId."
     )
     @ApiResponses(
         value =
             [
-                ApiResponse(description = "Delete attachment.", responseCode = "200"),
+                ApiResponse(description = "Delete attachment", responseCode = "200"),
                 ApiResponse(
-                    description = "Attachment not found.",
+                    description = "Attachment not found",
                     responseCode = "404",
-                    content =
-                        [
-                            Content(
-                                schema = Schema(implementation = AttachmentNotFoundException::class)
-                            )
-                        ]
+                    content = [Content(schema = Schema(implementation = HankeError::class))]
                 ),
                 ApiResponse(
-                    description = "Application already in Allu.",
+                    description = "Application already in Allu",
                     responseCode = "409",
-                    content =
-                        [
-                            Content(
-                                schema = Schema(implementation = ApplicationInAlluException::class)
-                            )
-                        ]
+                    content = [Content(schema = Schema(implementation = HankeError::class))]
                 ),
             ]
     )

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentController.kt
@@ -1,9 +1,8 @@
 package fi.hel.haitaton.hanke.attachment.hanke
 
+import fi.hel.haitaton.hanke.HankeError
 import fi.hel.haitaton.hanke.HankeNotFoundException
 import fi.hel.haitaton.hanke.HankeService
-import fi.hel.haitaton.hanke.attachment.common.AttachmentInvalidException
-import fi.hel.haitaton.hanke.attachment.common.AttachmentNotFoundException
 import fi.hel.haitaton.hanke.attachment.common.HankeAttachmentMetadata
 import fi.hel.haitaton.hanke.attachment.common.HeadersBuilder.buildHeaders
 import fi.hel.haitaton.hanke.configuration.Feature
@@ -43,16 +42,15 @@ class HankeAttachmentController(
 ) {
 
     @GetMapping
-    @Operation(summary = "Get metadata from hanke attachments.")
+    @Operation(summary = "Get metadata from hanke attachments")
     @ApiResponses(
         value =
             [
-                ApiResponse(description = "Metadata of hanke attachments.", responseCode = "200"),
+                ApiResponse(description = "Metadata of hanke attachments", responseCode = "200"),
                 ApiResponse(
                     description = "Hanke not found",
                     responseCode = "404",
-                    content =
-                        [Content(schema = Schema(implementation = HankeNotFoundException::class))]
+                    content = [Content(schema = Schema(implementation = HankeError::class))]
                 ),
             ]
     )
@@ -70,12 +68,7 @@ class HankeAttachmentController(
                 ApiResponse(
                     description = "Attachment not found.",
                     responseCode = "404",
-                    content =
-                        [
-                            Content(
-                                schema = Schema(implementation = AttachmentNotFoundException::class)
-                            )
-                        ]
+                    content = [Content(schema = Schema(implementation = HankeError::class))]
                 ),
             ]
     )
@@ -97,26 +90,19 @@ class HankeAttachmentController(
         value =
             [
                 ApiResponse(
-                    description = "Success.",
+                    description = "Success",
                     responseCode = "200",
-                    content =
-                        [Content(schema = Schema(implementation = HankeAttachmentMetadata::class))]
+                    content = [Content(schema = Schema(implementation = HankeError::class))]
                 ),
                 ApiResponse(
-                    description = "Hanke not found.",
+                    description = "Hanke not found",
                     responseCode = "404",
-                    content =
-                        [Content(schema = Schema(implementation = HankeNotFoundException::class))]
+                    content = [Content(schema = Schema(implementation = HankeError::class))]
                 ),
                 ApiResponse(
-                    description = "Invalid attachment.",
+                    description = "Invalid attachment",
                     responseCode = "400",
-                    content =
-                        [
-                            Content(
-                                schema = Schema(implementation = AttachmentInvalidException::class)
-                            )
-                        ]
+                    content = [Content(schema = Schema(implementation = HankeError::class))]
                 ),
             ]
     )
@@ -131,20 +117,16 @@ class HankeAttachmentController(
     }
 
     @DeleteMapping("/{attachmentId}")
+    @Operation(summary = "Delete attachment from hanke")
     @ApiResponses(
         value =
             [
-                ApiResponse(description = "Removes the attachment.", responseCode = "200"),
+                ApiResponse(description = "Success", responseCode = "200"),
                 ApiResponse(
-                    description = "Attachment was not found by id",
+                    description = "Attachment not found",
                     responseCode = "404",
-                    content =
-                        [
-                            Content(
-                                schema = Schema(implementation = AttachmentNotFoundException::class)
-                            )
-                        ]
-                ),
+                    content = [Content(schema = Schema(implementation = HankeError::class))]
+                )
             ]
     )
     fun deleteAttachment(@PathVariable hankeTunnus: String, @PathVariable attachmentId: UUID) {

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/Hanke.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/Hanke.kt
@@ -15,36 +15,103 @@ import fi.hel.haitaton.hanke.geometria.Geometriat
 import fi.hel.haitaton.hanke.permissions.PermissionCode
 import fi.hel.haitaton.hanke.tormaystarkastelu.LiikennehaittaIndeksiType
 import fi.hel.haitaton.hanke.tormaystarkastelu.TormaystarkasteluTulos
+import io.swagger.v3.oas.annotations.media.Schema
 import java.time.ZonedDateTime
 import java.time.temporal.ChronoUnit
 
+@Schema(description = "The project within which applications are processed")
 data class Hanke(
-    @JsonView(ChangeLogView::class) override var id: Int?,
-    @JsonView(ChangeLogView::class) var hankeTunnus: String?,
-    @JsonView(ChangeLogView::class) var onYKTHanke: Boolean?,
-    @JsonView(ChangeLogView::class) var nimi: String?,
-    @JsonView(ChangeLogView::class) var kuvaus: String?,
-    @JsonView(ChangeLogView::class) var vaihe: Vaihe?,
-    @JsonView(ChangeLogView::class) var suunnitteluVaihe: SuunnitteluVaihe?,
-    @JsonView(ChangeLogView::class) var version: Int?,
-    @JsonView(NotInChangeLogView::class) val createdBy: String?,
-    @JsonView(NotInChangeLogView::class) val createdAt: ZonedDateTime?,
-    @JsonView(NotInChangeLogView::class) var modifiedBy: String?,
-    @JsonView(NotInChangeLogView::class) var modifiedAt: ZonedDateTime?,
-    @JsonView(ChangeLogView::class) var status: HankeStatus? = HankeStatus.DRAFT,
-    @JsonView(ChangeLogView::class) var perustaja: Perustaja? = null,
-    @JsonView(ChangeLogView::class) var generated: Boolean = false,
+    @JsonView(ChangeLogView::class)
+    @field:Schema(description = "Id, set by the service")
+    override var id: Int?,
+    //
+    @JsonView(ChangeLogView::class)
+    @field:Schema(
+        description = "Hanke identity for external purposes, set by the service",
+        example = "HAI24-123"
+    )
+    var hankeTunnus: String?,
+    //
+    @JsonView(ChangeLogView::class)
+    @field:Schema(description = "Yhteinen kunnallistekninen työmaa")
+    var onYKTHanke: Boolean?,
+    //
+    @JsonView(ChangeLogView::class)
+    @field:Schema(description = "Name of the Hanke, must not be blank")
+    var nimi: String?,
+    //
+    @JsonView(ChangeLogView::class)
+    @field:Schema(description = "Description of the Hanke contents ")
+    var kuvaus: String?,
+    //
+    @JsonView(ChangeLogView::class)
+    @field:Schema(description = "Hanke current stage", required = true)
+    var vaihe: Vaihe?,
+    //
+    @JsonView(ChangeLogView::class)
+    @field:Schema(
+        description = "Hanke current planning stage, must be defined if vaihe = SUUNNITTELU"
+    )
+    var suunnitteluVaihe: SuunnitteluVaihe?,
+    //
+    @JsonView(ChangeLogView::class)
+    @field:Schema(description = "Version, set by the service")
+    var version: Int?,
+    //
+    @JsonView(NotInChangeLogView::class)
+    @field:Schema(description = "User id of the Hanke creator, set by the service")
+    val createdBy: String?,
+    //
+    @JsonView(NotInChangeLogView::class)
+    @field:Schema(description = "Timestamp of creation, set by the service")
+    val createdAt: ZonedDateTime?,
+    //
+    @JsonView(NotInChangeLogView::class)
+    @field:Schema(description = "User id of the last modifier, set by the service")
+    var modifiedBy: String?,
+    //
+    @JsonView(NotInChangeLogView::class)
+    @field:Schema(description = "Timestamp of last modification, set by the service")
+    var modifiedAt: ZonedDateTime?,
+    //
+    @JsonView(ChangeLogView::class)
+    @field:Schema(description = "Hanke current status, set by the service")
+    var status: HankeStatus? = HankeStatus.DRAFT,
+    //
+    @JsonView(ChangeLogView::class)
+    @field:Schema(description = "Hanke founder contact information")
+    var perustaja: Perustaja? = null,
+    //
+    @JsonView(ChangeLogView::class)
+    @field:Schema(description = "Indicates whether the Hanke data is generated, set by the service")
+    var generated: Boolean = false,
 ) : HasId<Int> {
 
     // --------------- Yhteystiedot -----------------
-    @JsonView(NotInChangeLogView::class) var omistajat = mutableListOf<HankeYhteystieto>()
-    @JsonView(NotInChangeLogView::class) var rakennuttajat = mutableListOf<HankeYhteystieto>()
-    @JsonView(NotInChangeLogView::class) var toteuttajat = mutableListOf<HankeYhteystieto>()
-    @JsonView(NotInChangeLogView::class) var muut = mutableListOf<HankeYhteystieto>()
+    @JsonView(NotInChangeLogView::class)
+    @field:Schema(description = "Project owners, contact information")
+    var omistajat = mutableListOf<HankeYhteystieto>()
+    //
+    @JsonView(NotInChangeLogView::class)
+    @field:Schema(description = "Property developers, contact information")
+    var rakennuttajat = mutableListOf<HankeYhteystieto>()
+    //
+    @JsonView(NotInChangeLogView::class)
+    @field:Schema(description = "Executor of the work")
+    var toteuttajat = mutableListOf<HankeYhteystieto>()
+    //
+    @JsonView(NotInChangeLogView::class)
+    @field:Schema(description = "Other contacts")
+    var muut = mutableListOf<HankeYhteystieto>()
 
     // --------------- Hankkeen lisätiedot / Työmaan tiedot -------------------
-    @JsonView(ChangeLogView::class) var tyomaaKatuosoite: String? = null
-    @JsonView(ChangeLogView::class) var tyomaaTyyppi = mutableSetOf<TyomaaTyyppi>()
+    @JsonView(ChangeLogView::class)
+    @field:Schema(description = "Work site street address", maxLength = 2000)
+    var tyomaaKatuosoite: String? = null
+    //
+    @JsonView(ChangeLogView::class)
+    @field:Schema(description = "Work site types")
+    var tyomaaTyyppi = mutableSetOf<TyomaaTyyppi>()
 
     // --------------- Hankkeen haitat -------------------
     fun kaistaHaitat(): Set<TodennakoinenHaittaPaaAjoRatojenKaistajarjestelyihin> {
@@ -75,9 +142,13 @@ data class Hanke(
         @JsonView(ChangeLogView::class)
         get(): ZonedDateTime? = alueet.mapNotNull { it.haittaLoppuPvm }.maxOfOrNull { it }
 
-    @JsonView(ChangeLogView::class) var alueet = mutableListOf<Hankealue>()
+    @JsonView(ChangeLogView::class)
+    @field:Schema(description = "Hanke areas data")
+    var alueet = mutableListOf<Hankealue>()
 
-    @JsonView(NotInChangeLogView::class) var permissions: List<PermissionCode>? = null
+    @JsonView(NotInChangeLogView::class)
+    @field:Schema(description = "Permission codes to this Hanke project")
+    var permissions: List<PermissionCode>? = null
 
     /** Number of days between haittaAlkuPvm and haittaLoppuPvm (incl. both days) */
     val haittaAjanKestoDays: Int?
@@ -93,7 +164,9 @@ data class Hanke(
     fun getLiikennehaittaindeksi(): LiikennehaittaIndeksiType? =
         tormaystarkasteluTulos?.liikennehaittaIndeksi
 
-    @JsonView(ChangeLogView::class) var tormaystarkasteluTulos: TormaystarkasteluTulos? = null
+    @JsonView(ChangeLogView::class)
+    @field:Schema(description = "")
+    var tormaystarkasteluTulos: TormaystarkasteluTulos? = null
 
     fun toLogString(): String {
         return toString()

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/HankeYhteystieto.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/HankeYhteystieto.kt
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonView
 import fi.hel.haitaton.hanke.ChangeLogView
 import fi.hel.haitaton.hanke.NotInChangeLogView
 import fi.hel.haitaton.hanke.Yhteyshenkilo
+import io.swagger.v3.oas.annotations.media.Schema
 import java.time.ZonedDateTime
 
 enum class YhteystietoTyyppi {
@@ -13,28 +14,63 @@ enum class YhteystietoTyyppi {
     YHTEISO,
 }
 
+@Schema(description = "Hanke contact")
 data class HankeYhteystieto(
-    @JsonView(ChangeLogView::class) override var id: Int?,
+    @JsonView(ChangeLogView::class)
+    @field:Schema(description = "Id, set by the service")
+    override var id: Int?,
 
     // Mandatory info (person or juridical person):
-    @JsonView(ChangeLogView::class) var nimi: String,
-    @JsonView(ChangeLogView::class) var email: String,
+    @JsonView(ChangeLogView::class)
+    @field:Schema(description = "Contact name. Full name if an actual person.")
+    var nimi: String,
+    //
+    @JsonView(ChangeLogView::class)
+    @field:Schema(description = "Contact email address")
+    var email: String,
 
     // Optional subcontacts (person)
-    @JsonView(ChangeLogView::class) var alikontaktit: List<Yhteyshenkilo> = emptyList(),
+    @JsonView(ChangeLogView::class)
+    @field:Schema(description = "Sub-contacts, i.e. contacts of this contact")
+    var alikontaktit: List<Yhteyshenkilo> = emptyList(),
 
     // Optional
-    @JsonView(ChangeLogView::class) var puhelinnumero: String?,
-    @JsonView(ChangeLogView::class) var organisaatioNimi: String?,
-    @JsonView(ChangeLogView::class) var osasto: String?,
-    @JsonView(ChangeLogView::class) var rooli: String?,
-    @JsonView(ChangeLogView::class) var tyyppi: YhteystietoTyyppi? = null,
+    @JsonView(ChangeLogView::class)
+    @field:Schema(description = "Phone number")
+    var puhelinnumero: String?,
+    //
+    @JsonView(ChangeLogView::class)
+    @field:Schema(description = "Organisation name")
+    var organisaatioNimi: String?,
+    //
+    @JsonView(ChangeLogView::class)
+    @field:Schema(description = "Contact department")
+    var osasto: String?,
+    //
+    @JsonView(ChangeLogView::class)
+    @field:Schema(description = "Role of the contact")
+    var rooli: String?,
+    //
+    @JsonView(ChangeLogView::class)
+    @field:Schema(description = "Contact type")
+    var tyyppi: YhteystietoTyyppi? = null,
 
     // Metadata
-    @JsonView(NotInChangeLogView::class) var createdBy: String? = null,
-    @JsonView(NotInChangeLogView::class) var createdAt: ZonedDateTime? = null,
-    @JsonView(NotInChangeLogView::class) var modifiedBy: String? = null,
-    @JsonView(NotInChangeLogView::class) var modifiedAt: ZonedDateTime? = null
+    @JsonView(NotInChangeLogView::class)
+    @field:Schema(description = "User id of the creator, set by the service")
+    var createdBy: String? = null,
+    //
+    @JsonView(NotInChangeLogView::class)
+    @field:Schema(description = "Timestamp of creation, set by the service")
+    var createdAt: ZonedDateTime? = null,
+    //
+    @JsonView(NotInChangeLogView::class)
+    @field:Schema(description = "User id of the last modifier, set by the service")
+    var modifiedBy: String? = null,
+    //
+    @JsonView(NotInChangeLogView::class)
+    @field:Schema(description = "Timestamp of last modification, set by the service")
+    var modifiedAt: ZonedDateTime? = null
 ) : HasId<Int> {
 
     /**

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/Hankealue.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/Hankealue.kt
@@ -6,20 +6,42 @@ import fi.hel.haitaton.hanke.Haitta13
 import fi.hel.haitaton.hanke.KaistajarjestelynPituus
 import fi.hel.haitaton.hanke.TodennakoinenHaittaPaaAjoRatojenKaistajarjestelyihin
 import fi.hel.haitaton.hanke.geometria.Geometriat
+import io.swagger.v3.oas.annotations.media.Schema
 import java.time.ZonedDateTime
 
 /** NOTE Remember to update PublicHankealue after changes */
 @JsonView(ChangeLogView::class)
+@Schema(description = "Area data of a Hanke")
 data class Hankealue(
-    override var id: Int? = null,
-    var hankeId: Int? = null,
+    @field:Schema(description = "Area identity, set by the service") override var id: Int? = null,
+    //
+    @field:Schema(description = "Hanke identity of this area") var hankeId: Int? = null,
+    //
+    @field:Schema(
+        description = "Nuisance start date, must not be null",
+        maximum = "2099-12-31T23:59:59.99Z"
+    )
     var haittaAlkuPvm: ZonedDateTime? = null,
+    //
+    @field:Schema(
+        description = "Nuisance end date, must not be before haittaAlkuPvm",
+        maximum = "2099-12-31T23:59:59.99Z"
+    )
     var haittaLoppuPvm: ZonedDateTime? = null,
-    var geometriat: Geometriat? = null,
+    //
+    @field:Schema(description = "Geometry data") var geometriat: Geometriat? = null,
+    //
+    @field:Schema(description = "Street lane nuisance value and explanation")
     var kaistaHaitta: TodennakoinenHaittaPaaAjoRatojenKaistajarjestelyihin? = null,
+    //
+    @field:Schema(description = "Street lane nuisance length")
     var kaistaPituusHaitta: KaistajarjestelynPituus? = null,
-    var meluHaitta: Haitta13? = null,
-    var polyHaitta: Haitta13? = null,
-    var tarinaHaitta: Haitta13? = null,
-    var nimi: String? = null,
+    //
+    @field:Schema(description = "Noise nuisance") var meluHaitta: Haitta13? = null,
+    //
+    @field:Schema(description = "Dust nuisance") var polyHaitta: Haitta13? = null,
+    //
+    @field:Schema(description = "Vibration nuisance") var tarinaHaitta: Haitta13? = null,
+    //
+    @field:Schema(description = "Area name") var nimi: String? = null,
 ) : HasId<Int>

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/Perustaja.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/Perustaja.kt
@@ -1,7 +1,12 @@
 package fi.hel.haitaton.hanke.domain
 
 import fi.hel.haitaton.hanke.PerustajaEntity
+import io.swagger.v3.oas.annotations.media.Schema
 
-data class Perustaja(val nimi: String?, val email: String)
+@Schema(description = "Founder information")
+data class Perustaja(
+    @field:Schema(description = "Name") val nimi: String?,
+    @field:Schema(description = "Email address") val email: String
+)
 
 fun Perustaja.toEntity(): PerustajaEntity = PerustajaEntity(nimi, email)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/geometria/Geometriat.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/geometria/Geometriat.kt
@@ -5,17 +5,39 @@ import fi.hel.haitaton.hanke.ChangeLogView
 import fi.hel.haitaton.hanke.NotInChangeLogView
 import fi.hel.haitaton.hanke.domain.Hanke
 import fi.hel.haitaton.hanke.domain.HasId
+import io.swagger.v3.oas.annotations.media.Schema
 import java.time.ZonedDateTime
 import org.geojson.FeatureCollection
 
+@Schema(description = "Geometry data")
 data class Geometriat(
-    @JsonView(ChangeLogView::class) override var id: Int? = null,
-    @JsonView(ChangeLogView::class) var featureCollection: FeatureCollection? = null,
-    @JsonView(ChangeLogView::class) var version: Int? = null,
-    @JsonView(NotInChangeLogView::class) var createdByUserId: String? = null,
-    @JsonView(NotInChangeLogView::class) var createdAt: ZonedDateTime? = null,
-    @JsonView(NotInChangeLogView::class) var modifiedByUserId: String? = null,
-    @JsonView(NotInChangeLogView::class) var modifiedAt: ZonedDateTime? = null
+    @JsonView(ChangeLogView::class)
+    @field:Schema(description = "Id, set by the service")
+    override var id: Int? = null,
+    //
+    @JsonView(ChangeLogView::class)
+    @field:Schema(description = "The geometry data")
+    var featureCollection: FeatureCollection? = null,
+    //
+    @field:Schema(description = "Version, set by the service")
+    @JsonView(ChangeLogView::class)
+    var version: Int? = null,
+    //
+    @field:Schema(description = "User id of the geometry data creator, set by the service")
+    @JsonView(NotInChangeLogView::class)
+    var createdByUserId: String? = null,
+    //
+    @field:Schema(description = "Timestamp of last modification, set by the service")
+    @JsonView(NotInChangeLogView::class)
+    var createdAt: ZonedDateTime? = null,
+    //
+    @field:Schema(description = "User id of the last modifier, set by the service")
+    @JsonView(NotInChangeLogView::class)
+    var modifiedByUserId: String? = null,
+    //
+    @field:Schema(description = "Timestamp of last modification, set by the service")
+    @JsonView(NotInChangeLogView::class)
+    var modifiedAt: ZonedDateTime? = null
 ) : HasId<Int> {
     fun withFeatureCollection(featureCollection: FeatureCollection): Geometriat {
         this.featureCollection = featureCollection

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluTulos.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluTulos.kt
@@ -3,7 +3,7 @@ package fi.hel.haitaton.hanke.tormaystarkastelu
 import com.fasterxml.jackson.annotation.JsonView
 import fi.hel.haitaton.hanke.ChangeLogView
 import fi.hel.haitaton.hanke.HankeEntity
-<<<<<<< HEAD
+import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.persistence.Entity
 import jakarta.persistence.FetchType
 import jakarta.persistence.GeneratedValue
@@ -12,17 +12,6 @@ import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
-=======
-import io.swagger.v3.oas.annotations.media.Schema
-import javax.persistence.Entity
-import javax.persistence.FetchType
-import javax.persistence.GeneratedValue
-import javax.persistence.GenerationType
-import javax.persistence.Id
-import javax.persistence.JoinColumn
-import javax.persistence.ManyToOne
-import javax.persistence.Table
->>>>>>> e187ab90 (HAI-1409 Add schema annotations for hanke fields)
 
 @Schema(description = "Collision review result")
 data class TormaystarkasteluTulos(

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluTulos.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluTulos.kt
@@ -3,6 +3,7 @@ package fi.hel.haitaton.hanke.tormaystarkastelu
 import com.fasterxml.jackson.annotation.JsonView
 import fi.hel.haitaton.hanke.ChangeLogView
 import fi.hel.haitaton.hanke.HankeEntity
+<<<<<<< HEAD
 import jakarta.persistence.Entity
 import jakarta.persistence.FetchType
 import jakarta.persistence.GeneratedValue
@@ -11,11 +12,31 @@ import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
+=======
+import io.swagger.v3.oas.annotations.media.Schema
+import javax.persistence.Entity
+import javax.persistence.FetchType
+import javax.persistence.GeneratedValue
+import javax.persistence.GenerationType
+import javax.persistence.Id
+import javax.persistence.JoinColumn
+import javax.persistence.ManyToOne
+import javax.persistence.Table
+>>>>>>> e187ab90 (HAI-1409 Add schema annotations for hanke fields)
 
+@Schema(description = "Collision review result")
 data class TormaystarkasteluTulos(
-    @JsonView(ChangeLogView::class) val perusIndeksi: Float,
-    @JsonView(ChangeLogView::class) val pyorailyIndeksi: Float,
-    @JsonView(ChangeLogView::class) val joukkoliikenneIndeksi: Float
+    @JsonView(ChangeLogView::class)
+    @field:Schema(description = "Basic index result")
+    val perusIndeksi: Float,
+    //
+    @field:Schema(description = "Cycling index result")
+    @JsonView(ChangeLogView::class)
+    val pyorailyIndeksi: Float,
+    //
+    @field:Schema(description = "Public transport index result")
+    @JsonView(ChangeLogView::class)
+    val joukkoliikenneIndeksi: Float
 ) {
 
     @get:JsonView(ChangeLogView::class)
@@ -29,6 +50,7 @@ data class TormaystarkasteluTulos(
     }
 }
 
+@Schema(description = "Traffic nuisance index type")
 data class LiikennehaittaIndeksiType(
     @JsonView(ChangeLogView::class) val indeksi: Float,
     @JsonView(ChangeLogView::class) val tyyppi: IndeksiType


### PR DESCRIPTION
# Description

Documentation added where it was missing. Furthermore, did some fixes on documented error responses. Endpoints will not return the thrown error. They return the error code returned by exceptionhandlers.

Did not implement documentation for organisations and geometry controllers as they are soon deleted.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1409

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [x] Other

# Instructions for testing
Run with docker compose and verify openapi: http://localhost:3001/api/swagger-ui/index.html

# Checklist:

- [ ] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [x] I have made necessary changes to the documentation, link to confluence
 or other location: 