### PR TITLE
HAI-1509 Add endpoint to get hanke kayttaja data

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/IntegrationTestConfiguration.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/IntegrationTestConfiguration.kt
@@ -10,6 +10,7 @@ import fi.hel.haitaton.hanke.geometria.GeometriatDao
 import fi.hel.haitaton.hanke.geometria.GeometriatService
 import fi.hel.haitaton.hanke.logging.AuditLogRepository
 import fi.hel.haitaton.hanke.logging.DisclosureLogService
+import fi.hel.haitaton.hanke.permissions.HankeKayttajaService
 import fi.hel.haitaton.hanke.permissions.PermissionService
 import fi.hel.haitaton.hanke.security.AccessRules
 import fi.hel.haitaton.hanke.tormaystarkastelu.TormaystarkasteluLaskentaService
@@ -68,6 +69,8 @@ class IntegrationTestConfiguration {
     @Bean fun hankeAttachmentService(): HankeAttachmentService = mockk()
 
     @Bean fun applicationAttachmentService(): ApplicationAttachmentService = mockk()
+
+    @Bean fun hankeKayttajaService(): HankeKayttajaService = mockk()
 
     @EventListener
     fun onApplicationEvent(event: ContextRefreshedEvent) {

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaControllerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaControllerITest.kt
@@ -1,0 +1,124 @@
+package fi.hel.haitaton.hanke.permissions
+
+import assertk.assertThat
+import assertk.assertions.hasSize
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotNull
+import fi.hel.haitaton.hanke.ControllerTest
+import fi.hel.haitaton.hanke.HankeNotFoundException
+import fi.hel.haitaton.hanke.HankeService
+import fi.hel.haitaton.hanke.IntegrationTestConfiguration
+import fi.hel.haitaton.hanke.andReturnBody
+import fi.hel.haitaton.hanke.factory.HankeFactory
+import fi.hel.haitaton.hanke.hasSameElementsAs
+import fi.hel.haitaton.hanke.logging.DisclosureLogService
+import fi.hel.haitaton.hanke.permissions.PermissionCode.VIEW
+import io.mockk.Called
+import io.mockk.checkUnnecessaryStub
+import io.mockk.clearAllMocks
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.justRun
+import io.mockk.verify
+import io.mockk.verifyOrder
+import java.util.UUID
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.context.annotation.Import
+import org.springframework.security.test.context.support.WithAnonymousUser
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.ResultActions
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+private const val USERNAME = "testUser"
+private const val HANKE_TUNNUS = HankeFactory.defaultHankeTunnus
+
+@WebMvcTest(HankeKayttajaController::class)
+@Import(IntegrationTestConfiguration::class)
+@ActiveProfiles("itest")
+@WithMockUser(USERNAME)
+class HankeKayttajaControllerITest(@Autowired override val mockMvc: MockMvc) : ControllerTest {
+
+    @Autowired private lateinit var hankeKayttajaService: HankeKayttajaService
+    @Autowired private lateinit var hankeService: HankeService
+    @Autowired private lateinit var permissionService: PermissionService
+    @Autowired private lateinit var disclosureLogService: DisclosureLogService
+
+    @BeforeEach
+    fun clearMocks() {
+        clearAllMocks()
+    }
+
+    @AfterEach
+    fun checkMocks() {
+        checkUnnecessaryStub()
+        confirmVerified(hankeKayttajaService, hankeService, permissionService)
+    }
+
+    @Test
+    fun `getHankeKayttajat when valid request returns users of given hanke and logs audit`() {
+        val hanke = HankeFactory.create()
+        val testData = generateContacts()
+        every { hankeService.findHankeOrThrow(HANKE_TUNNUS) } returns hanke
+        justRun { permissionService.verifyHankeUserAuthorization(USERNAME, hanke, VIEW) }
+        every { hankeKayttajaService.getKayttajatByHankeId(hanke.id!!) } returns testData
+
+        val response: HankeKayttajaResponse =
+            getHankeKayttajat().andExpect(status().isOk).andReturnBody()
+
+        assertThat(response.kayttajat).hasSize(3)
+        with(response.kayttajat.first()) {
+            assertThat(id).isNotNull()
+            assertThat(nimi).isEqualTo("test name1")
+            assertThat(sahkoposti).isEqualTo("email.1.address.com")
+            assertThat(tunnistautunut).isEqualTo(false)
+        }
+        assertThat(response.kayttajat).hasSameElementsAs(testData)
+        verifyOrder {
+            hankeService.findHankeOrThrow(HANKE_TUNNUS)
+            permissionService.verifyHankeUserAuthorization(USERNAME, hanke, VIEW)
+            hankeKayttajaService.getKayttajatByHankeId(hanke.id!!)
+            disclosureLogService.saveDisclosureLogsForHankeKayttajat(response.kayttajat, USERNAME)
+        }
+    }
+
+    @Test
+    fun `getHankeKayttajat when no permission for hanke returns not found`() {
+        val hanke = HankeFactory.create()
+        every { hankeService.findHankeOrThrow(HANKE_TUNNUS) } returns hanke
+        every { permissionService.verifyHankeUserAuthorization(USERNAME, hanke, VIEW) } throws
+            HankeNotFoundException(HANKE_TUNNUS)
+
+        getHankeKayttajat().andExpect(status().isNotFound)
+
+        verifyOrder {
+            hankeService.findHankeOrThrow(HANKE_TUNNUS)
+            permissionService.verifyHankeUserAuthorization(USERNAME, hanke, VIEW)
+        }
+        verify { hankeKayttajaService wasNot Called }
+    }
+
+    @Test
+    @WithAnonymousUser
+    fun `getHankeKayttajat when unauthorized token returns 401 `() {
+        getHankeKayttajat().andExpect(status().isUnauthorized)
+    }
+
+    private fun generateContacts(amount: Int = 3): List<HankeKayttajaDto> =
+        (1..amount).map {
+            HankeKayttajaDto(
+                id = UUID.randomUUID(),
+                sahkoposti = "email.$it.address.com",
+                nimi = "test name$it",
+                rooli = Role.KATSELUOIKEUS,
+                tunnistautunut = it % 2 == 0
+            )
+        }
+
+    private fun getHankeKayttajat(): ResultActions = get("/hankkeet/$HANKE_TUNNUS/kayttajat")
+}

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaControllerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaControllerITest.kt
@@ -10,6 +10,7 @@ import fi.hel.haitaton.hanke.HankeService
 import fi.hel.haitaton.hanke.IntegrationTestConfiguration
 import fi.hel.haitaton.hanke.andReturnBody
 import fi.hel.haitaton.hanke.factory.HankeFactory
+import fi.hel.haitaton.hanke.factory.HankeKayttajaFactory
 import fi.hel.haitaton.hanke.hasSameElementsAs
 import fi.hel.haitaton.hanke.logging.DisclosureLogService
 import fi.hel.haitaton.hanke.permissions.PermissionCode.VIEW
@@ -21,7 +22,6 @@ import io.mockk.every
 import io.mockk.justRun
 import io.mockk.verify
 import io.mockk.verifyOrder
-import java.util.UUID
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -63,7 +63,7 @@ class HankeKayttajaControllerITest(@Autowired override val mockMvc: MockMvc) : C
     @Test
     fun `getHankeKayttajat when valid request returns users of given hanke and logs audit`() {
         val hanke = HankeFactory.create()
-        val testData = generateContacts()
+        val testData = HankeKayttajaFactory.generateHankeKayttajat()
         every { hankeService.findHankeOrThrow(HANKE_TUNNUS) } returns hanke
         justRun { permissionService.verifyHankeUserAuthorization(USERNAME, hanke, VIEW) }
         every { hankeKayttajaService.getKayttajatByHankeId(hanke.id!!) } returns testData
@@ -108,17 +108,6 @@ class HankeKayttajaControllerITest(@Autowired override val mockMvc: MockMvc) : C
     fun `getHankeKayttajat when unauthorized token returns 401 `() {
         getHankeKayttajat().andExpect(status().isUnauthorized)
     }
-
-    private fun generateContacts(amount: Int = 3): List<HankeKayttajaDto> =
-        (1..amount).map {
-            HankeKayttajaDto(
-                id = UUID.randomUUID(),
-                sahkoposti = "email.$it.address.com",
-                nimi = "test name$it",
-                rooli = Role.KATSELUOIKEUS,
-                tunnistautunut = it % 2 == 0
-            )
-        }
 
     private fun getHankeKayttajat(): ResultActions = get("/hankkeet/$HANKE_TUNNUS/kayttajat")
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeService.kt
@@ -8,8 +8,9 @@ import org.springframework.transaction.annotation.Transactional
 
 interface HankeService {
 
-    /** Fetch hanke with hankeTunnus. Returns null if there is no hanke with the given tunnus. */
     fun loadHanke(hankeTunnus: String): Hanke?
+
+    fun findHankeOrThrow(hankeTunnus: String): Hanke
 
     fun getHankeId(hankeTunnus: String): Int?
 
@@ -27,11 +28,7 @@ interface HankeService {
 
     @Transactional fun deleteHanke(hanke: Hanke, hakemukset: List<Application>, userId: String)
 
-    fun loadAllHanke(): List<Hanke>
-
     fun loadPublicHanke(): List<Hanke>
 
     fun loadHankkeetByIds(ids: List<Int>): List<Hanke>
-
-    fun loadHankkeetByUserId(userId: String): List<Hanke>
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeServiceImpl.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeServiceImpl.kt
@@ -98,8 +98,8 @@ open class HankeServiceImpl(
         }
 
     @Transactional(readOnly = true)
-    override fun loadAllHanke() =
-        hankeRepository.findAll().map { createHankeDomainObjectFromEntity(it) }
+    override fun findHankeOrThrow(hankeTunnus: String) =
+        loadHanke(hankeTunnus) ?: throw HankeNotFoundException(hankeTunnus)
 
     @Transactional(readOnly = true)
     override fun loadPublicHanke() =
@@ -110,12 +110,6 @@ open class HankeServiceImpl(
     @Transactional(readOnly = true)
     override fun loadHankkeetByIds(ids: List<Int>) =
         hankeRepository.findAllById(ids).map { createHankeDomainObjectFromEntity(it) }
-
-    @Transactional(readOnly = true)
-    override fun loadHankkeetByUserId(userId: String) =
-        hankeRepository.findAllByCreatedByUserIdOrModifiedByUserId(userId, userId).map {
-            createHankeDomainObjectFromEntity(it)
-        }
 
     /** @return a new Hanke instance with the added and possibly modified values. */
     @Transactional

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Persistence.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Persistence.kt
@@ -238,11 +238,6 @@ interface HankeRepository : JpaRepository<HankeEntity, Int> {
     override fun findAll(): List<HankeEntity>
 
     fun findAllByStatus(status: HankeStatus): List<HankeEntity>
-
-    fun findAllByCreatedByUserIdOrModifiedByUserId(
-        createdByUserId: String,
-        modifiedByUserId: String
-    ): List<HankeEntity>
 }
 
 enum class CounterType {

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/AuditLogEntry.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/AuditLogEntry.kt
@@ -48,6 +48,7 @@ enum class ObjectType {
     ALLU_CONTACT,
     GDPR_RESPONSE,
     HANKE,
+    HANKE_KAYTTAJA,
     APPLICATION,
 }
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/DisclosureLogService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/DisclosureLogService.kt
@@ -9,6 +9,7 @@ import fi.hel.haitaton.hanke.application.Customer
 import fi.hel.haitaton.hanke.domain.Hanke
 import fi.hel.haitaton.hanke.domain.HankeYhteystieto
 import fi.hel.haitaton.hanke.gdpr.CollectionNode
+import fi.hel.haitaton.hanke.permissions.HankeKayttajaDto
 import fi.hel.haitaton.hanke.toJsonString
 import org.springframework.stereotype.Service
 
@@ -89,6 +90,18 @@ class DisclosureLogService(private val auditLogService: AuditLogService) {
             UserRole.USER,
             auditLogEntriesForYhteystiedot(hankkeet.flatMap { it.extractYhteystiedot() })
         )
+    }
+
+    fun saveDisclosureLogsForHankeKayttajat(
+        hankeKayttajat: List<HankeKayttajaDto>,
+        userId: String
+    ) {
+        val entries: List<AuditLogEntry> =
+            hankeKayttajat.map {
+                disclosureLogEntry(ObjectType.HANKE_KAYTTAJA, it.id, it, Status.SUCCESS)
+            }
+
+        saveDisclosureLogs(userId, UserRole.USER, entries)
     }
 
     private fun auditLogEntriesForCustomers(

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttaja.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttaja.kt
@@ -1,5 +1,6 @@
 package fi.hel.haitaton.hanke.permissions
 
+import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.Id
@@ -9,6 +10,20 @@ import jakarta.persistence.Table
 import java.util.UUID
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
+
+@Schema(description = "Api response of user data of given Hanke")
+data class HankeKayttajaResponse(
+    @field:Schema(description = "Hanke users") val kayttajat: List<HankeKayttajaDto>
+)
+
+@Schema(description = "Hanke user")
+data class HankeKayttajaDto(
+    @field:Schema(description = "Id, set by the service") val id: UUID,
+    @field:Schema(description = "Email address") val sahkoposti: String,
+    @field:Schema(description = "Full name") val nimi: String,
+    @field:Schema(description = "Role in Hanke, null for Hanke creator") val rooli: Role?,
+    @field:Schema(description = "Has user logged in to view Hanke") val tunnistautunut: Boolean,
+)
 
 @Entity
 @Table(name = "hanke_kayttaja")
@@ -23,10 +38,29 @@ class HankeKayttajaEntity(
     @OneToOne
     @JoinColumn(name = "tunniste_id", updatable = true, nullable = true)
     val kayttajaTunniste: KayttajaTunnisteEntity?,
-)
+) {
+    fun toDto(): HankeKayttajaDto =
+        HankeKayttajaDto(
+            id = id,
+            sahkoposti = sahkoposti,
+            nimi = nimi,
+            rooli = deriveRole(),
+            tunnistautunut = permission != null,
+        )
+
+    /**
+     * [KayttajaTunnisteEntity] stores role temporarily until user has signed in. After that,
+     * [PermissionEntity] is used.
+     *
+     * Thus, role is read primarily from [PermissionEntity] if the relation exists.
+     */
+    private fun deriveRole(): Role? = permission?.role?.role ?: kayttajaTunniste?.role
+}
 
 @Repository
 interface HankeKayttajaRepository : JpaRepository<HankeKayttajaEntity, UUID> {
+    fun findByHankeId(hankeId: Int): List<HankeKayttajaEntity>
+
     fun findByHankeIdAndSahkopostiIn(
         hankeId: Int,
         sahkopostit: List<String>

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttaja.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttaja.kt
@@ -21,7 +21,7 @@ data class HankeKayttajaDto(
     @field:Schema(description = "Id, set by the service") val id: UUID,
     @field:Schema(description = "Email address") val sahkoposti: String,
     @field:Schema(description = "Full name") val nimi: String,
-    @field:Schema(description = "Role in Hanke, null for Hanke creator") val rooli: Role?,
+    @field:Schema(description = "Role in Hanke") val rooli: Role?,
     @field:Schema(description = "Has user logged in to view Hanke") val tunnistautunut: Boolean,
 )
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaController.kt
@@ -53,22 +53,22 @@ class HankeKayttajaController(
 
         val userId = currentUserId()
 
-        val hanke =
-            hankeService.findHankeOrThrow(hankeTunnus).also {
-                permissionService.verifyHankeUserAuthorization(
-                    userId = userId,
-                    hanke = it,
-                    permissionCode = PermissionCode.VIEW
-                )
-            }
+        val hanke = hankeService.findHankeOrThrow(hankeTunnus)
+
+        permissionService.verifyHankeUserAuthorization(
+            userId = userId,
+            hanke = hanke,
+            permissionCode = PermissionCode.VIEW
+        )
 
         val users = hankeKayttajaService.getKayttajatByHankeId(hanke.id!!)
 
-        return HankeKayttajaResponse(users).also {
-            disclosureLogService.saveDisclosureLogsForHankeKayttajat(users, userId)
-            logger.info {
-                "Found ${it.kayttajat.size} kayttajat for hanke(id=${hanke.id}, hankeTunnus=$hankeTunnus)"
-            }
+        disclosureLogService.saveDisclosureLogsForHankeKayttajat(users, userId)
+
+        logger.info {
+            "Found ${users.size} kayttajat for hanke(id=${hanke.id}, hankeTunnus=$hankeTunnus)"
         }
+
+        return HankeKayttajaResponse(users)
     }
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaController.kt
@@ -1,0 +1,74 @@
+package fi.hel.haitaton.hanke.permissions
+
+import fi.hel.haitaton.hanke.HankeError
+import fi.hel.haitaton.hanke.HankeService
+import fi.hel.haitaton.hanke.currentUserId
+import fi.hel.haitaton.hanke.logging.DisclosureLogService
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import mu.KotlinLogging
+import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+private val logger = KotlinLogging.logger {}
+
+@RestController
+@RequestMapping("/hankkeet/{hankeTunnus}/kayttajat")
+class HankeKayttajaController(
+    private val hankeService: HankeService,
+    private val hankeKayttajaService: HankeKayttajaService,
+    private val permissionService: PermissionService,
+    private val disclosureLogService: DisclosureLogService,
+) {
+
+    @GetMapping(produces = [APPLICATION_JSON_VALUE])
+    @Operation(
+        summary = "Get Hanke users",
+        description = "Returns a list of users and their Hanke  related information."
+    )
+    @ApiResponses(
+        value =
+            [
+                ApiResponse(
+                    description = "Users in Hanke",
+                    responseCode = "200",
+                    content =
+                        [Content(schema = Schema(implementation = HankeKayttajaResponse::class))]
+                ),
+                ApiResponse(
+                    description = "Hanke not found",
+                    responseCode = "404",
+                    content = [Content(schema = Schema(implementation = HankeError::class))]
+                ),
+            ]
+    )
+    fun getHankeKayttajat(@PathVariable hankeTunnus: String): HankeKayttajaResponse {
+        logger.info { "Finding kayttajat for hanke $hankeTunnus" }
+
+        val userId = currentUserId()
+
+        val hanke =
+            hankeService.findHankeOrThrow(hankeTunnus).also {
+                permissionService.verifyHankeUserAuthorization(
+                    userId = userId,
+                    hanke = it,
+                    permissionCode = PermissionCode.VIEW
+                )
+            }
+
+        val users = hankeKayttajaService.getKayttajatByHankeId(hanke.id!!)
+
+        return HankeKayttajaResponse(users).also {
+            disclosureLogService.saveDisclosureLogsForHankeKayttajat(users, userId)
+            logger.info {
+                "Found ${it.kayttajat.size} kayttajat for hanke(id=${hanke.id}, hankeTunnus=$hankeTunnus)"
+            }
+        }
+    }
+}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaService.kt
@@ -15,6 +15,10 @@ class HankeKayttajaService(
     private val kayttajaTunnisteRepository: KayttajaTunnisteRepository,
 ) {
 
+    @Transactional(readOnly = true)
+    fun getKayttajatByHankeId(hankeId: Int): List<HankeKayttajaDto> =
+        hankeKayttajaRepository.findByHankeId(hankeId).map { it.toDto() }
+
     @Transactional
     fun saveNewTokensFromApplication(application: ApplicationEntity, hankeId: Int) {
         logger.info {

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/PermissionService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/PermissionService.kt
@@ -1,5 +1,7 @@
 package fi.hel.haitaton.hanke.permissions
 
+import fi.hel.haitaton.hanke.HankeNotFoundException
+import fi.hel.haitaton.hanke.domain.Hanke
 import org.springframework.stereotype.Service
 
 @Service
@@ -25,6 +27,13 @@ class PermissionService(
             }
                 ?: PermissionEntity(userId = userId, hankeId = hankeId, role = roleEntity)
         permissionRepository.save(entity)
+    }
+
+    fun verifyHankeUserAuthorization(userId: String, hanke: Hanke, permissionCode: PermissionCode) {
+        val hankeId = hanke.id
+        if (hankeId == null || !hasPermission(hankeId, userId, permissionCode)) {
+            throw HankeNotFoundException(hanke.hankeTunnus)
+        }
     }
 
     companion object {

--- a/services/hanke-service/src/main/resources/db/changelog/changesets/042-add-indices-to-hanke-kayttaja.yml
+++ b/services/hanke-service/src/main/resources/db/changelog/changesets/042-add-indices-to-hanke-kayttaja.yml
@@ -1,0 +1,15 @@
+databaseChangeLog:
+  - changeSet:
+      id: 041-add-indices-to-hanke-kayttaja
+      author: Niko Pitkonen
+      comment: Indices for columns to improve search performance
+      changes:
+        - createIndex:
+            tableName: hanke_kayttaja
+            indexName: hanke_kayttaja_hanke_id_sahkoposti_idx
+            unique: true
+            columns:
+              - column:
+                  name: hanke_id
+              - column:
+                  name: sahkoposti

--- a/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -111,3 +111,5 @@ databaseChangeLog:
       file: db/changelog/changesets/040-drop-table-organisaatio.sql
   - include:
       file: db/changelog/changesets/041-drop-column-organisaatioid-from-yhteystiedot.yml
+  - include:
+      file: db/changelog/changesets/042-add-indices-to-hanke-kayttaja.yml

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/AuditLogEntryFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/AuditLogEntryFactory.kt
@@ -8,6 +8,7 @@ import fi.hel.haitaton.hanke.logging.ObjectType
 import fi.hel.haitaton.hanke.logging.Operation
 import fi.hel.haitaton.hanke.logging.Status
 import fi.hel.haitaton.hanke.logging.UserRole
+import fi.hel.haitaton.hanke.permissions.HankeKayttajaDto
 import fi.hel.haitaton.hanke.toJsonString
 
 object AuditLogEntryFactory {
@@ -49,4 +50,13 @@ object AuditLogEntryFactory {
             objectType = ObjectType.ALLU_CUSTOMER,
             objectBefore = customer.toJsonString()
         )
+
+    fun createReadEntryForHankeKayttajat(kayttajat: List<HankeKayttajaDto>): List<AuditLogEntry> =
+        kayttajat.map {
+            createReadEntry(
+                objectId = it.id,
+                objectType = ObjectType.HANKE_KAYTTAJA,
+                objectBefore = it.toJsonString()
+            )
+        }
 }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeKayttajaFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeKayttajaFactory.kt
@@ -1,0 +1,19 @@
+package fi.hel.haitaton.hanke.factory
+
+import fi.hel.haitaton.hanke.permissions.HankeKayttajaDto
+import fi.hel.haitaton.hanke.permissions.Role
+import java.util.UUID
+
+object HankeKayttajaFactory {
+
+    fun generateHankeKayttajat(amount: Int = 3): List<HankeKayttajaDto> =
+        (1..amount).map {
+            HankeKayttajaDto(
+                id = UUID.randomUUID(),
+                sahkoposti = "email.$it.address.com",
+                nimi = "test name$it",
+                rooli = Role.KATSELUOIKEUS,
+                tunnistautunut = it % 2 == 0
+            )
+        }
+}

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/logging/DisclosureLogServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/logging/DisclosureLogServiceTest.kt
@@ -15,6 +15,8 @@ import fi.hel.haitaton.hanke.factory.HankeFactory.Companion.withYhteystiedot
 import fi.hel.haitaton.hanke.factory.HankeYhteystietoFactory
 import fi.hel.haitaton.hanke.gdpr.CollectionNode
 import fi.hel.haitaton.hanke.gdpr.StringNode
+import fi.hel.haitaton.hanke.permissions.HankeKayttajaDto
+import fi.hel.haitaton.hanke.permissions.Role
 import fi.hel.haitaton.hanke.toJsonString
 import io.mockk.Called
 import io.mockk.checkUnnecessaryStub
@@ -22,6 +24,7 @@ import io.mockk.clearAllMocks
 import io.mockk.confirmVerified
 import io.mockk.mockk
 import io.mockk.verify
+import java.util.*
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
@@ -168,6 +171,16 @@ internal class DisclosureLogServiceTest {
         val expectedLogs = AuditLogEntryFactory.createReadEntriesForHanke(hankkeet[0])
 
         disclosureLogService.saveDisclosureLogsForHankkeet(hankkeet, userId)
+
+        verify { auditLogService.createAll(match(containsAll(expectedLogs))) }
+    }
+
+    @Test
+    fun `saveDisclosureLogsForHankeKayttajat saves audit logs`() {
+        val hankeKayttajat = createMockHankeKayttajat(amount = 2)
+        val expectedLogs = AuditLogEntryFactory.createReadEntryForHankeKayttajat(hankeKayttajat)
+
+        disclosureLogService.saveDisclosureLogsForHankeKayttajat(hankeKayttajat, userId)
 
         verify { auditLogService.createAll(match(containsAll(expectedLogs))) }
     }
@@ -355,6 +368,17 @@ internal class DisclosureLogServiceTest {
 
         verify { auditLogService wasNot Called }
     }
+
+    private fun createMockHankeKayttajat(amount: Int): List<HankeKayttajaDto> =
+        (1..amount).map {
+            HankeKayttajaDto(
+                id = UUID.randomUUID(),
+                sahkoposti = "test.$it@email.com",
+                nimi = "test person $it",
+                rooli = Role.KATSELUOIKEUS,
+                tunnistautunut = false
+            )
+        }
 
     private fun containsAll(
         expectedLogs: List<AuditLogEntry>,

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/logging/DisclosureLogServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/logging/DisclosureLogServiceTest.kt
@@ -24,7 +24,7 @@ import io.mockk.clearAllMocks
 import io.mockk.confirmVerified
 import io.mockk.mockk
 import io.mockk.verify
-import java.util.*
+import java.util.UUID
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/logging/DisclosureLogServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/logging/DisclosureLogServiceTest.kt
@@ -12,11 +12,10 @@ import fi.hel.haitaton.hanke.factory.HankeFactory.Companion.withGeneratedOmistaj
 import fi.hel.haitaton.hanke.factory.HankeFactory.Companion.withGeneratedRakennuttaja
 import fi.hel.haitaton.hanke.factory.HankeFactory.Companion.withGeneratedToteuttaja
 import fi.hel.haitaton.hanke.factory.HankeFactory.Companion.withYhteystiedot
+import fi.hel.haitaton.hanke.factory.HankeKayttajaFactory
 import fi.hel.haitaton.hanke.factory.HankeYhteystietoFactory
 import fi.hel.haitaton.hanke.gdpr.CollectionNode
 import fi.hel.haitaton.hanke.gdpr.StringNode
-import fi.hel.haitaton.hanke.permissions.HankeKayttajaDto
-import fi.hel.haitaton.hanke.permissions.Role
 import fi.hel.haitaton.hanke.toJsonString
 import io.mockk.Called
 import io.mockk.checkUnnecessaryStub
@@ -24,7 +23,6 @@ import io.mockk.clearAllMocks
 import io.mockk.confirmVerified
 import io.mockk.mockk
 import io.mockk.verify
-import java.util.UUID
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
@@ -177,7 +175,7 @@ internal class DisclosureLogServiceTest {
 
     @Test
     fun `saveDisclosureLogsForHankeKayttajat saves audit logs`() {
-        val hankeKayttajat = createMockHankeKayttajat(amount = 2)
+        val hankeKayttajat = HankeKayttajaFactory.generateHankeKayttajat(amount = 2)
         val expectedLogs = AuditLogEntryFactory.createReadEntryForHankeKayttajat(hankeKayttajat)
 
         disclosureLogService.saveDisclosureLogsForHankeKayttajat(hankeKayttajat, userId)
@@ -368,17 +366,6 @@ internal class DisclosureLogServiceTest {
 
         verify { auditLogService wasNot Called }
     }
-
-    private fun createMockHankeKayttajat(amount: Int): List<HankeKayttajaDto> =
-        (1..amount).map {
-            HankeKayttajaDto(
-                id = UUID.randomUUID(),
-                sahkoposti = "test.$it@email.com",
-                nimi = "test person $it",
-                rooli = Role.KATSELUOIKEUS,
-                tunnistautunut = false
-            )
-        }
 
     private fun containsAll(
         expectedLogs: List<AuditLogEntry>,

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/validation/ApplicationDataValidatorTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/validation/ApplicationDataValidatorTest.kt
@@ -17,7 +17,6 @@ import fi.hel.haitaton.hanke.factory.AlluDataFactory.Companion.withContacts
 import fi.hel.haitaton.hanke.touch
 import fi.hel.haitaton.hanke.validation.ApplicationDataValidator.ensureValidForSend
 import java.util.stream.Stream
-import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments


### PR DESCRIPTION
# Description

Add endpoint to view hanke kayttajas and their privileges on hanke.

Additional: removed a couple functions from HankeService as they were not used.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1509

## Type of change

- [ ] Bug fix 
- [x] New feature 
- [ ] Other

# Instructions for testing
Create an application with contact persons and send it to Allu. After that:
- GET http://localhost:3001/api/hankkeet/{createdHanke}/kayttajat

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 

# Other relevant info
Please describe here if there is e.g. some requirements for this change or
 other info that the tester/user needs to know.