### PR TITLE
HAI-1842 Add endpoint for unlinking applications from Allu in dev and test

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,6 +87,7 @@ services:
       MAIL_SENDER_PORT: 25
       HAITATON_EMAIL_FILTER_USE: false
       CLAMAV_BASE_URL: http://clamav-api:3030
+      HAITATON_TESTDATA_ENABLED: true
     depends_on:
       - db
       - clamav-api

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/IntegrationTestConfiguration.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/IntegrationTestConfiguration.kt
@@ -12,6 +12,7 @@ import fi.hel.haitaton.hanke.logging.AuditLogRepository
 import fi.hel.haitaton.hanke.logging.DisclosureLogService
 import fi.hel.haitaton.hanke.permissions.PermissionService
 import fi.hel.haitaton.hanke.security.AccessRules
+import fi.hel.haitaton.hanke.testdata.TestDataService
 import fi.hel.haitaton.hanke.tormaystarkastelu.TormaystarkasteluLaskentaService
 import fi.hel.haitaton.hanke.tormaystarkastelu.TormaystarkasteluTormaysService
 import fi.hel.haitaton.hanke.tormaystarkastelu.TormaystarkasteluTormaysServicePG
@@ -48,6 +49,8 @@ class IntegrationTestConfiguration {
     @Bean fun applicationService(): ApplicationService = mockk()
 
     @Bean fun gdprService(): GdprService = mockk(relaxUnitFun = true)
+
+    @Bean fun testDataService(): TestDataService = mockk(relaxUnitFun = true)
 
     @Bean fun permissionService(): PermissionService = mockk()
 

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/testdata/TestDataControllerDisabledITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/testdata/TestDataControllerDisabledITest.kt
@@ -1,0 +1,67 @@
+package fi.hel.haitaton.hanke.testdata
+
+import fi.hel.haitaton.hanke.ControllerTest
+import fi.hel.haitaton.hanke.IntegrationTestConfiguration
+import io.mockk.Called
+import io.mockk.checkUnnecessaryStub
+import io.mockk.clearAllMocks
+import io.mockk.confirmVerified
+import io.mockk.verify
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.context.annotation.Import
+import org.springframework.security.test.context.support.WithAnonymousUser
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers
+
+private const val USERNAME = "testUser"
+private const val BASE_URL = "/testdata"
+
+@WebMvcTest(
+    controllers = [TestDataController::class],
+    properties = ["haitaton.testdata.enabled=false"],
+)
+@Import(IntegrationTestConfiguration::class)
+@ActiveProfiles("itest")
+@WithMockUser(USERNAME)
+class TestDataControllerDisabledITest(@Autowired override val mockMvc: MockMvc) : ControllerTest {
+
+    @Autowired private lateinit var testDataService: TestDataService
+
+    @BeforeEach
+    fun clearMocks() {
+        clearAllMocks()
+    }
+
+    @AfterEach
+    fun checkMocks() {
+        checkUnnecessaryStub()
+        confirmVerified(testDataService)
+    }
+
+    @Nested
+    inner class UnlinkApplicationsFromAllu {
+        private val url = "$BASE_URL/unlink-applications"
+
+        @Test
+        @WithAnonymousUser
+        fun `Without user ID returns 404`() {
+            post(url).andExpect(MockMvcResultMatchers.status().isNotFound)
+
+            verify { testDataService wasNot Called }
+        }
+
+        @Test
+        fun `With valid user returns 404`() {
+            post(url).andExpect(MockMvcResultMatchers.status().isNotFound)
+
+            verify { testDataService wasNot Called }
+        }
+    }
+}

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/testdata/TestDataControllerEnabledITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/testdata/TestDataControllerEnabledITest.kt
@@ -1,0 +1,67 @@
+package fi.hel.haitaton.hanke.testdata
+
+import fi.hel.haitaton.hanke.ControllerTest
+import fi.hel.haitaton.hanke.IntegrationTestConfiguration
+import io.mockk.checkUnnecessaryStub
+import io.mockk.clearAllMocks
+import io.mockk.confirmVerified
+import io.mockk.verifyAll
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.context.annotation.Import
+import org.springframework.security.test.context.support.WithAnonymousUser
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers
+
+private const val USERNAME = "testUser"
+private const val BASE_URL = "/testdata"
+
+@WebMvcTest(
+    controllers = [TestDataController::class],
+    properties = ["haitaton.testdata.enabled=true"],
+)
+@Import(IntegrationTestConfiguration::class)
+@ActiveProfiles("itest")
+@WithMockUser(USERNAME)
+class TestDataControllerEnabledITest(@Autowired override val mockMvc: MockMvc) : ControllerTest {
+
+    @Autowired private lateinit var testDataService: TestDataService
+    @Value("\${haitaton.testdata.enabled}") private lateinit var enabled: String
+
+    @BeforeEach
+    fun clearMocks() {
+        clearAllMocks()
+    }
+
+    @AfterEach
+    fun checkMocks() {
+        checkUnnecessaryStub()
+        confirmVerified(testDataService)
+    }
+
+    @Nested
+    inner class UnlinkApplicationsFromAllu {
+        private val url = "$BASE_URL/unlink-applications"
+        @Test
+        @WithAnonymousUser
+        fun `Without user ID calls service normally`() {
+            post(url).andExpect(MockMvcResultMatchers.status().isOk)
+
+            verifyAll { testDataService.unlinkApplicationsFromAllu() }
+        }
+
+        @Test
+        fun `With valid user calls service`() {
+            post(url).andExpect(MockMvcResultMatchers.status().isOk)
+
+            verifyAll { testDataService.unlinkApplicationsFromAllu() }
+        }
+    }
+}

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/testdata/TestDataServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/testdata/TestDataServiceITest.kt
@@ -1,0 +1,77 @@
+package fi.hel.haitaton.hanke.testdata
+
+import assertk.assertThat
+import assertk.assertions.each
+import assertk.assertions.hasSize
+import assertk.assertions.isNull
+import assertk.assertions.isTrue
+import fi.hel.haitaton.hanke.DatabaseTest
+import fi.hel.haitaton.hanke.allu.ApplicationStatus
+import fi.hel.haitaton.hanke.application.ApplicationRepository
+import fi.hel.haitaton.hanke.factory.AlluDataFactory
+import fi.hel.haitaton.hanke.factory.HankeFactory
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.test.context.ActiveProfiles
+import org.testcontainers.junit.jupiter.Testcontainers
+
+private const val USERNAME = "testUser"
+
+@Testcontainers
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    properties = ["haitaton.testdata.enabled=true"],
+)
+@ActiveProfiles("default")
+@WithMockUser(USERNAME)
+class TestDataServiceITest : DatabaseTest() {
+
+    @Autowired private lateinit var testDataService: TestDataService
+    @Autowired private lateinit var applicationRepository: ApplicationRepository
+    @Autowired private lateinit var alluDataFactory: AlluDataFactory
+    @Autowired private lateinit var hankeFactory: HankeFactory
+
+    @Nested
+    inner class UnlinkApplicationsFromAllu {
+        @Test
+        fun `Without applications does nothing`() {
+            testDataService.unlinkApplicationsFromAllu()
+        }
+
+        @Test
+        fun `With applications resets their allu fields`() {
+            for (i in 1..4) {
+                val hanke = hankeFactory.saveEntity()
+                alluDataFactory.saveApplicationEntity(USERNAME, hanke) { application ->
+                    application.alluStatus = ApplicationStatus.values()[i + 4]
+                    application.alluid = i
+                    application.applicationIdentifier = "JS00$i"
+                    application.applicationData =
+                        application.applicationData.copy(pendingOnClient = false)
+                }
+
+                alluDataFactory.saveApplicationEntity(USERNAME, hanke) { application ->
+                    application.alluStatus = null
+                    application.alluid = null
+                    application.applicationIdentifier = null
+                    application.applicationData =
+                        application.applicationData.copy(pendingOnClient = true)
+                }
+            }
+
+            testDataService.unlinkApplicationsFromAllu()
+
+            val applications = applicationRepository.findAll()
+            assertThat(applications).hasSize(8)
+            assertThat(applications).each { application ->
+                application.transform { it.alluid }.isNull()
+                application.transform { it.applicationIdentifier }.isNull()
+                application.transform { it.alluStatus }.isNull()
+                application.transform { it.applicationData.pendingOnClient }.isTrue()
+            }
+        }
+    }
+}

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/testdata/TestDataServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/testdata/TestDataServiceITest.kt
@@ -37,7 +37,7 @@ class TestDataServiceITest : DatabaseTest() {
     @Nested
     inner class UnlinkApplicationsFromAllu {
         @Test
-        fun `Without applications does nothing`() {
+        fun `Doesn't throw an exception without applications`() {
             testDataService.unlinkApplicationsFromAllu()
         }
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/configuration/OpenApiConfiguration.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/configuration/OpenApiConfiguration.kt
@@ -1,4 +1,4 @@
-package fi.hel.haitaton.hanke
+package fi.hel.haitaton.hanke.configuration
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition
 import io.swagger.v3.oas.annotations.info.Info
@@ -11,6 +11,6 @@ import io.swagger.v3.oas.annotations.servers.Server
             description = "API for Haitaton internal use. Can change without warning.",
             version = "1"
         ),
-    servers = [Server(url = "/")]
+    servers = [Server(url = "/api/")],
 )
 internal class OpenAPIConfiguration

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/security/AccessRules.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/security/AccessRules.kt
@@ -26,6 +26,11 @@ object AccessRules {
                 "/v3/api-docs/**",
             )
             .permitAll()
+            .mvcMatchers(HttpMethod.POST, "/testdata/unlink-applications")
+            .permitAll()
+            .and()
+            .csrf()
+            .ignoringAntMatchers("/testdata/unlink-applications")
             .and()
             .authorizeRequests()
             .anyRequest()

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/testdata/TestDataController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/testdata/TestDataController.kt
@@ -1,0 +1,41 @@
+package fi.hel.haitaton.hanke.testdata
+
+import io.swagger.v3.oas.annotations.Operation
+import mu.KotlinLogging
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.boot.context.event.ApplicationReadyEvent
+import org.springframework.context.event.EventListener
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+private val logger = KotlinLogging.logger {} // ASDF
+
+@RestController
+@RequestMapping("/testdata")
+@ConditionalOnProperty(name = ["haitaton.testdata.enabled"], havingValue = "true")
+class TestDataController(
+    private val testDataService: TestDataService,
+) {
+
+    @EventListener(ApplicationReadyEvent::class)
+    fun logWarning() {
+        logger.warn { "Test data endpoint enabled." }
+    }
+
+    @Operation(
+        summary = "Unlink applications from allu",
+        description =
+            "Removes the Allu IDs and statuses from all applications, effectively " +
+                "unlinking them from Allu and returning them to drafts. The applications " +
+                "can be re-sent to allu whenever. This endpoint can be used to unlink all " +
+                "applications from Allu after Allu wipes all of it's data during test " +
+                "environment update. Allu will re-issue the same IDs, causing collisions " +
+                "in Haitaton."
+    )
+    @PostMapping("/unlink-applications")
+    fun unlinkApplicationsFromAllu() {
+        testDataService.unlinkApplicationsFromAllu()
+        logger.warn { "Unlinked all applications from Allu." }
+    }
+}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/testdata/TestDataService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/testdata/TestDataService.kt
@@ -1,0 +1,30 @@
+package fi.hel.haitaton.hanke.testdata
+
+import fi.hel.haitaton.hanke.application.ApplicationRepository
+import mu.KotlinLogging
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+private val logger = KotlinLogging.logger {}
+
+@Service
+@ConditionalOnProperty(name = ["haitaton.testdata.enabled"], havingValue = "true")
+class TestDataService(
+    private val applicationRepository: ApplicationRepository,
+) {
+    @Transactional
+    fun unlinkApplicationsFromAllu() {
+        logger.warn { "Unlinking all applications from Allu." }
+        applicationRepository.findAll().forEach {
+            logger.warn {
+                "Unlinking application from Allu id=${it.id} alluid=${it.alluid} " +
+                    "applicationIdentifier=${it.applicationIdentifier}."
+            }
+            it.alluid = null
+            it.alluStatus = null
+            it.applicationIdentifier = null
+            it.applicationData = it.applicationData.copy(pendingOnClient = true)
+        }
+    }
+}

--- a/services/hanke-service/src/main/resources/application.properties
+++ b/services/hanke-service/src/main/resources/application.properties
@@ -24,6 +24,9 @@ haitaton.gdpr.delete-scope=${HAITATON_GDPR_DELETE_SCOPE:haitaton.gdprdelete}
 # Disable endpoints that are e.g. in development and should not be in production.
 haitaton.features.hanke-editing=${HAITATON_FEATURE_HANKE_EDITING:true}
 
+# For dev and test environments, enable the testdata controller for resetting data
+haitaton.testdata.enabled=${HAITATON_TESTDATA_ENABLED:false}
+
 spring.datasource.url=jdbc:postgresql://${HAITATON_HOST:localhost}:${HAITATON_PORT:5432}/${HAITATON_DATABASE:haitaton}
 spring.datasource.username=${HAITATON_USER:haitaton_user}
 spring.datasource.password=${HAITATON_PASSWORD:haitaton}

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/application/ApplicationControllerTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/application/ApplicationControllerTest.kt
@@ -35,7 +35,7 @@ class ApplicationControllerTest {
             applicationService,
             hankeService,
             disclosureLogService,
-            permissionService
+            permissionService,
         )
 
     @BeforeEach


### PR DESCRIPTION
# Description

Allu removes all of its data in the test environment when it's updated. To mitigate problems this causes to Haitaton dev and test environments, add an endpoint that removes the linking between Haitaton applications and Allu. The links are non-functional after an Allu update anyway.

Make the endpoint callable directly from Swagger UI, so it calling it doesn't require a developer.

The endpoint is only visible and accessible from specific environments, namely dev and test environments. This is accomplished with environment variables.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1842

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [X] Other

# Instructions for testing
Create an application and then call the endpoint to unlink it.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: TODO