### PR TITLE
HAI-1527 API for changing permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,21 @@ See docker-compose.yml for details.
 
 ### Swagger UI
 
-Swagger UI (see https://springdoc.org/) and OpenAPI v3 description (JSON). Note though that the swagger
-setup can not currently support authentication, so can not test the actions with it.
+Swagger UI (see https://springdoc.org/) and OpenAPI v3 description (JSON). You
+can use the Swagger UI to send requests, if you copy your bearer token over from
+the browser. So,
+1. Log in to Haitaton.
+2. Open the Network tab from developer tools.
+3. Open e.g. Omat Hankkeet in Haitaton.
+4. From the backend request, copy the content of the Authorization header, that
+   comes after the Bearer keyword.
+5. In the Swagger UI of the same environment, open the Authorize dialog.
+6. Paste the bearer token.
+7. Send a request as a logged-in user.
+
+Authentication for the GDPR API is different from the other application, and
+it's not configured for the Swagger UI. GDPR API can be tested using the
+specialized tester, as detailed in [GDPR API section](#gdpr-api).
 
 Locally without Docker:
 

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaControllerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaControllerITest.kt
@@ -5,12 +5,15 @@ import assertk.assertions.hasSize
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNotNull
 import fi.hel.haitaton.hanke.ControllerTest
+import fi.hel.haitaton.hanke.HankeError
 import fi.hel.haitaton.hanke.HankeNotFoundException
 import fi.hel.haitaton.hanke.HankeService
 import fi.hel.haitaton.hanke.IntegrationTestConfiguration
 import fi.hel.haitaton.hanke.andReturnBody
+import fi.hel.haitaton.hanke.domain.Hanke
 import fi.hel.haitaton.hanke.factory.HankeFactory
 import fi.hel.haitaton.hanke.factory.HankeKayttajaFactory
+import fi.hel.haitaton.hanke.hankeError
 import fi.hel.haitaton.hanke.hasSameElementsAs
 import fi.hel.haitaton.hanke.logging.DisclosureLogService
 import fi.hel.haitaton.hanke.permissions.PermissionCode.VIEW
@@ -22,8 +25,11 @@ import io.mockk.every
 import io.mockk.justRun
 import io.mockk.verify
 import io.mockk.verifyOrder
+import io.mockk.verifySequence
+import java.util.UUID
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
@@ -33,12 +39,16 @@ import org.springframework.security.test.context.support.WithMockUser
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.ResultActions
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
 private const val USERNAME = "testUser"
 private const val HANKE_TUNNUS = HankeFactory.defaultHankeTunnus
 
-@WebMvcTest(HankeKayttajaController::class)
+@WebMvcTest(
+    HankeKayttajaController::class,
+    properties = ["haitaton.features.user-management=true"],
+)
 @Import(IntegrationTestConfiguration::class)
 @ActiveProfiles("itest")
 @WithMockUser(USERNAME)
@@ -60,54 +70,291 @@ class HankeKayttajaControllerITest(@Autowired override val mockMvc: MockMvc) : C
         confirmVerified(hankeKayttajaService, hankeService, permissionService)
     }
 
-    @Test
-    fun `getHankeKayttajat when valid request returns users of given hanke and logs audit`() {
-        val hanke = HankeFactory.create()
-        val testData = HankeKayttajaFactory.generateHankeKayttajat()
-        every { hankeService.findHankeOrThrow(HANKE_TUNNUS) } returns hanke
-        justRun { permissionService.verifyHankeUserAuthorization(USERNAME, hanke, VIEW) }
-        every { hankeKayttajaService.getKayttajatByHankeId(hanke.id!!) } returns testData
+    @Nested
+    inner class GetHankeKayttajat {
 
-        val response: HankeKayttajaResponse =
-            getHankeKayttajat().andExpect(status().isOk).andReturnBody()
+        @Test
+        fun `With valid request returns users of given hanke and logs audit`() {
+            val hanke = HankeFactory.create()
+            val testData = HankeKayttajaFactory.generateHankeKayttajat()
+            every { hankeService.findHankeOrThrow(HANKE_TUNNUS) } returns hanke
+            justRun { permissionService.verifyHankeUserAuthorization(USERNAME, hanke, VIEW) }
+            every { hankeKayttajaService.getKayttajatByHankeId(hanke.id!!) } returns testData
 
-        assertThat(response.kayttajat).hasSize(3)
-        with(response.kayttajat.first()) {
-            assertThat(id).isNotNull()
-            assertThat(nimi).isEqualTo("test name1")
-            assertThat(sahkoposti).isEqualTo("email.1.address.com")
-            assertThat(tunnistautunut).isEqualTo(false)
+            val response: HankeKayttajaResponse =
+                getHankeKayttajat().andExpect(status().isOk).andReturnBody()
+
+            assertThat(response.kayttajat).hasSize(3)
+            with(response.kayttajat.first()) {
+                assertThat(id).isNotNull()
+                assertThat(nimi).isEqualTo("test name1")
+                assertThat(sahkoposti).isEqualTo("email.1.address.com")
+                assertThat(tunnistautunut).isEqualTo(false)
+            }
+            assertThat(response.kayttajat).hasSameElementsAs(testData)
+            verifyOrder {
+                hankeService.findHankeOrThrow(HANKE_TUNNUS)
+                permissionService.verifyHankeUserAuthorization(USERNAME, hanke, VIEW)
+                hankeKayttajaService.getKayttajatByHankeId(hanke.id!!)
+                disclosureLogService.saveDisclosureLogsForHankeKayttajat(
+                    response.kayttajat,
+                    USERNAME
+                )
+            }
         }
-        assertThat(response.kayttajat).hasSameElementsAs(testData)
-        verifyOrder {
-            hankeService.findHankeOrThrow(HANKE_TUNNUS)
-            permissionService.verifyHankeUserAuthorization(USERNAME, hanke, VIEW)
-            hankeKayttajaService.getKayttajatByHankeId(hanke.id!!)
-            disclosureLogService.saveDisclosureLogsForHankeKayttajat(response.kayttajat, USERNAME)
+
+        @Test
+        fun `getHankeKayttajat when no permission for hanke returns not found`() {
+            val hanke = HankeFactory.create()
+            every { hankeService.findHankeOrThrow(HANKE_TUNNUS) } returns hanke
+            every { permissionService.verifyHankeUserAuthorization(USERNAME, hanke, VIEW) } throws
+                HankeNotFoundException(HANKE_TUNNUS)
+
+            getHankeKayttajat().andExpect(status().isNotFound)
+
+            verifyOrder {
+                hankeService.findHankeOrThrow(HANKE_TUNNUS)
+                permissionService.verifyHankeUserAuthorization(USERNAME, hanke, VIEW)
+            }
+            verify { hankeKayttajaService wasNot Called }
         }
+
+        @Test
+        @WithAnonymousUser
+        fun `When unauthorized token returns 401 `() {
+            getHankeKayttajat().andExpect(status().isUnauthorized)
+        }
+
+        private fun getHankeKayttajat(): ResultActions = get("/hankkeet/$HANKE_TUNNUS/kayttajat")
     }
 
-    @Test
-    fun `getHankeKayttajat when no permission for hanke returns not found`() {
-        val hanke = HankeFactory.create()
-        every { hankeService.findHankeOrThrow(HANKE_TUNNUS) } returns hanke
-        every { permissionService.verifyHankeUserAuthorization(USERNAME, hanke, VIEW) } throws
-            HankeNotFoundException(HANKE_TUNNUS)
+    @Nested
+    inner class UpdatePermissions {
+        private val url = "/hankkeet/$HANKE_TUNNUS/kayttajat"
+        private val hankeKayttajaId = UUID.fromString("5d67712f-ea0b-490c-957f-9b30bddb848c")
 
-        getHankeKayttajat().andExpect(status().isNotFound)
-
-        verifyOrder {
-            hankeService.findHankeOrThrow(HANKE_TUNNUS)
-            permissionService.verifyHankeUserAuthorization(USERNAME, hanke, VIEW)
+        @Test
+        @WithAnonymousUser
+        fun `Returns 401 when unauthorized token`() {
+            put(url).andExpect(status().isUnauthorized)
         }
-        verify { hankeKayttajaService wasNot Called }
-    }
 
-    @Test
-    @WithAnonymousUser
-    fun `getHankeKayttajat when unauthorized token returns 401 `() {
-        getHankeKayttajat().andExpect(status().isUnauthorized)
-    }
+        @Test
+        fun `Returns not found when no permission for hanke`() {
+            val hanke = HankeFactory.create()
+            every { hankeService.findHankeOrThrow(HANKE_TUNNUS) } returns hanke
+            every {
+                permissionService.verifyHankeUserAuthorization(
+                    USERNAME,
+                    hanke,
+                    PermissionCode.MODIFY_EDIT_PERMISSIONS
+                )
+            } throws HankeNotFoundException(HANKE_TUNNUS)
 
-    private fun getHankeKayttajat(): ResultActions = get("/hankkeet/$HANKE_TUNNUS/kayttajat")
+            put(url, PermissionUpdate(listOf(PermissionDto(hankeKayttajaId, Role.HANKEMUOKKAUS))))
+                .andExpect(status().isNotFound)
+
+            verifySequence {
+                hankeService.findHankeOrThrow(HANKE_TUNNUS)
+                permissionService.verifyHankeUserAuthorization(
+                    USERNAME,
+                    hanke,
+                    PermissionCode.MODIFY_EDIT_PERMISSIONS
+                )
+            }
+            verify { hankeKayttajaService wasNot Called }
+        }
+
+        @Test
+        fun `Returns 204 on success`() {
+            val hanke = HankeFactory.create()
+            every { hankeService.findHankeOrThrow(HANKE_TUNNUS) } returns hanke
+            justRun {
+                permissionService.verifyHankeUserAuthorization(
+                    USERNAME,
+                    hanke,
+                    PermissionCode.MODIFY_EDIT_PERMISSIONS
+                )
+            }
+            every {
+                permissionService.hasPermission(
+                    hanke.id!!,
+                    USERNAME,
+                    PermissionCode.MODIFY_DELETE_PERMISSIONS
+                )
+            } returns false
+            val updates = mapOf(hankeKayttajaId to Role.HANKEMUOKKAUS)
+            justRun { hankeKayttajaService.updatePermissions(hanke, updates, false, USERNAME) }
+
+            put(url, PermissionUpdate(listOf(PermissionDto(hankeKayttajaId, Role.HANKEMUOKKAUS))))
+                .andExpect(status().isNoContent)
+                .andExpect(content().string(""))
+
+            verifyCalls(hanke, updates)
+        }
+
+        @Test
+        fun `Calls service with admin permission when user has them`() {
+            val hanke = HankeFactory.create()
+            every { hankeService.findHankeOrThrow(HANKE_TUNNUS) } returns hanke
+            justRun {
+                permissionService.verifyHankeUserAuthorization(
+                    USERNAME,
+                    hanke,
+                    PermissionCode.MODIFY_EDIT_PERMISSIONS
+                )
+            }
+            every {
+                permissionService.hasPermission(
+                    hanke.id!!,
+                    USERNAME,
+                    PermissionCode.MODIFY_DELETE_PERMISSIONS
+                )
+            } returns true
+            val updates = mapOf(hankeKayttajaId to Role.HANKEMUOKKAUS)
+            justRun { hankeKayttajaService.updatePermissions(hanke, updates, true, USERNAME) }
+
+            put(url, PermissionUpdate(listOf(PermissionDto(hankeKayttajaId, Role.HANKEMUOKKAUS))))
+                .andExpect(status().isNoContent)
+
+            verifyCalls(hanke, updates, deleteAdminPermission = true)
+        }
+
+        @Test
+        fun `Returns forbidden when missing admin permissions`() {
+            val (hanke, updates) = setupForException(MissingAdminPermissionException(USERNAME))
+
+            put(url, PermissionUpdate(listOf(PermissionDto(hankeKayttajaId, Role.HANKEMUOKKAUS))))
+                .andExpect(status().isForbidden)
+                .andExpect(hankeError(HankeError.HAI0005))
+
+            verifyCalls(hanke, updates)
+        }
+
+        @Test
+        fun `Returns forbidden when changing own permissions`() {
+            val (hanke, updates) = setupForException(ChangingOwnPermissionException(USERNAME))
+
+            put(url, PermissionUpdate(listOf(PermissionDto(hankeKayttajaId, Role.HANKEMUOKKAUS))))
+                .andExpect(status().isForbidden)
+                .andExpect(hankeError(HankeError.HAI4002))
+
+            verifyCalls(hanke, updates)
+        }
+
+        @Test
+        fun `Returns internal server error if there are users without either permission or tunniste`() {
+            val (hanke, updates) =
+                setupForException(UsersWithoutRolesException(missingIds = listOf(hankeKayttajaId)))
+
+            put(url, PermissionUpdate(listOf(PermissionDto(hankeKayttajaId, Role.HANKEMUOKKAUS))))
+                .andExpect(status().isInternalServerError)
+                .andExpect(hankeError(HankeError.HAI4003))
+
+            verifyCalls(hanke, updates)
+        }
+
+        @Test
+        fun `Returns conflict if there would be no admins remaining`() {
+            val (hanke, updates) = setupForException { hanke -> NoAdminRemainingException(hanke) }
+
+            put(url, PermissionUpdate(listOf(PermissionDto(hankeKayttajaId, Role.HANKEMUOKKAUS))))
+                .andExpect(status().isConflict)
+                .andExpect(hankeError(HankeError.HAI4003))
+
+            verifyCalls(hanke, updates)
+        }
+
+        @Test
+        fun `Returns bad request if there would be no admins remaining`() {
+            val (hanke, updates) =
+                setupForException { hanke ->
+                    HankeKayttajatNotFoundException(listOf(hankeKayttajaId), hanke)
+                }
+
+            put(url, PermissionUpdate(listOf(PermissionDto(hankeKayttajaId, Role.HANKEMUOKKAUS))))
+                .andExpect(status().isBadRequest)
+                .andExpect(hankeError(HankeError.HAI4001))
+
+            verifyCalls(hanke, updates)
+        }
+
+        private fun verifyCalls(
+            hanke: Hanke,
+            updates: Map<UUID, Role>,
+            deleteAdminPermission: Boolean = false,
+        ) {
+            verifySequence {
+                hankeService.findHankeOrThrow(HANKE_TUNNUS)
+                permissionService.verifyHankeUserAuthorization(
+                    USERNAME,
+                    hanke,
+                    PermissionCode.MODIFY_EDIT_PERMISSIONS
+                )
+                permissionService.hasPermission(
+                    hanke.id!!,
+                    USERNAME,
+                    PermissionCode.MODIFY_DELETE_PERMISSIONS
+                )
+                hankeKayttajaService.updatePermissions(
+                    hanke,
+                    updates,
+                    deleteAdminPermission,
+                    USERNAME
+                )
+            }
+        }
+
+        private fun setupForException(ex: Throwable): Pair<Hanke, Map<UUID, Role>> =
+            setupForException {
+                ex
+            }
+
+        private fun setupForException(ex: (Hanke) -> Throwable): Pair<Hanke, Map<UUID, Role>> {
+            val hanke = HankeFactory.create()
+            every { hankeService.findHankeOrThrow(HANKE_TUNNUS) } returns hanke
+            justRun {
+                permissionService.verifyHankeUserAuthorization(
+                    USERNAME,
+                    hanke,
+                    PermissionCode.MODIFY_EDIT_PERMISSIONS
+                )
+            }
+            every {
+                permissionService.hasPermission(
+                    hanke.id!!,
+                    USERNAME,
+                    PermissionCode.MODIFY_DELETE_PERMISSIONS
+                )
+            } returns false
+            val updates = mapOf(hankeKayttajaId to Role.HANKEMUOKKAUS)
+            every { hankeKayttajaService.updatePermissions(hanke, updates, false, USERNAME) } throws
+                ex(hanke)
+
+            return Pair(hanke, updates)
+        }
+    }
+}
+
+@WebMvcTest(
+    HankeKayttajaController::class,
+    properties = ["haitaton.features.user-management=false"],
+)
+@Import(IntegrationTestConfiguration::class)
+@ActiveProfiles("itest")
+@WithMockUser(USERNAME)
+class HankeKayttajaControllerFeatureDisabledITest(@Autowired override val mockMvc: MockMvc) :
+    ControllerTest {
+    private val url = "/hankkeet/$HANKE_TUNNUS/kayttajat"
+    private val hankeKayttajaId = UUID.fromString("5d67712f-ea0b-490c-957f-9b30bddb848c")
+
+    @Nested
+    inner class UpdatePermissions {
+        @Test
+        fun `Returns not found when feature disabled`() {
+            put(url, PermissionUpdate(listOf(PermissionDto(hankeKayttajaId, Role.HANKEMUOKKAUS))))
+                .andExpect(status().isNotFound)
+                .andExpect(hankeError(HankeError.HAI0004))
+        }
+    }
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeController.kt
@@ -16,6 +16,7 @@ import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import jakarta.validation.ConstraintViolationException
 import mu.KotlinLogging
 import org.springframework.beans.factory.annotation.Autowired
@@ -39,6 +40,7 @@ private val logger = KotlinLogging.logger {}
 @RestController
 @RequestMapping("/hankkeet")
 @Validated
+@SecurityRequirement(name = "bearerAuth")
 class HankeController(
     @Autowired private val hankeService: HankeService,
     @Autowired private val permissionService: PermissionService,
@@ -151,13 +153,14 @@ class HankeController(
         summary = "Create new hanke",
         description =
             """
-              A valid new hanke must comply with the restrictions in Hanke schema definition.
-              When Hanke is created:
-              1. A unique Hanke tunnus is created.
-              2. The status of the created hanke is set automatically:
-                  - PUBLIC (i.e. visible to everyone) if all mandatory fields are filled. 
-                  - DRAFT if all mandatory fields are not filled.
-        """
+A valid new hanke must comply with the restrictions in Hanke schema definition.
+
+When Hanke is created:
+1. A unique Hanke tunnus is created.
+2. The status of the created hanke is set automatically:
+    - PUBLIC (i.e. visible to everyone) if all mandatory fields are filled.
+    - DRAFT if all mandatory fields are not filled.
+"""
     )
     @ApiResponses(
         value =
@@ -200,12 +203,12 @@ class HankeController(
         summary = "Update hanke",
         description =
             """
-               Update an existing hanke. Data must comply with the restrictions defined in Hanke schema definition. 
-               
-               On update following will happen automatically:
-               1. Status is updated. PUBLIC if required fields are filled. Else DRAFT.
-               2. Tormaystarkastelu (project nuisance) is re-calculated.
-            """
+Update an existing hanke. Data must comply with the restrictions defined in Hanke schema definition.
+
+On update following will happen automatically:
+1. Status is updated. PUBLIC if required fields are filled. Else DRAFT.
+2. Tormaystarkastelu (project nuisance) is re-calculated.
+"""
     )
     @ApiResponses(
         value =

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeError.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeError.kt
@@ -10,6 +10,7 @@ enum class HankeError(val errorMessage: String) {
     HAI0002("Internal error"),
     HAI0003("Invalid data"),
     HAI0004("Resource does not exist"),
+    HAI0005("Insufficient permissions"),
     HAI1001("Hanke not found"),
     HAI1002("Invalid Hanke data"),
     HAI1003("Internal error while saving Hanke"),
@@ -40,6 +41,9 @@ enum class HankeError(val errorMessage: String) {
     HAI3001("Attachment upload failed"),
     HAI3002("Loading attachment failed"),
     HAI3003("Attachment limit reached"),
+    HAI4001("HankeKayttaja not found"),
+    HAI4002("Trying to change own permission"),
+    HAI4003("Permission data conflict"),
     ;
 
     val errorCode: String

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationController.kt
@@ -18,6 +18,7 @@ import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import mu.KotlinLogging
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
@@ -42,6 +43,7 @@ private val logger = KotlinLogging.logger {}
 @Validated
 @RestController
 @RequestMapping("/hakemukset")
+@SecurityRequirement(name = "bearerAuth")
 class ApplicationController(
     private val service: ApplicationService,
     private val hankeService: HankeService,
@@ -153,7 +155,8 @@ class ApplicationController(
                If the application hasn't changed since the last update, nothing more is done.
                If the application has been sent to Allu, it will be updated there as well.
                If an Allu-update is required, but it fails, the local version will not be updated.
-               The pendingOnClient value can't be changed with this endpoint. Use POST /hakemukset/{id}/send-application for that.
+               The pendingOnClient value can't be changed with this endpoint.
+               Use [POST /hakemukset/{id}/send-application](#/application-controller/sendApplication) for that.
             """
     )
     @ApiResponses(

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentController.kt
@@ -17,6 +17,7 @@ import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import java.util.UUID
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.DeleteMapping
@@ -30,6 +31,7 @@ import org.springframework.web.multipart.MultipartFile
 
 @RestController
 @RequestMapping("/hakemukset/{applicationId}/liitteet")
+@SecurityRequirement(name = "bearerAuth")
 class ApplicationAttachmentController(
     private val applicationAttachmentService: ApplicationAttachmentService,
     private val permissionService: PermissionService,

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentController.kt
@@ -17,6 +17,7 @@ import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import java.util.UUID
 import mu.KotlinLogging
 import org.springframework.beans.factory.annotation.Autowired
@@ -34,6 +35,7 @@ private val logger = KotlinLogging.logger {}
 
 @RestController
 @RequestMapping("/hankkeet/{hankeTunnus}/liitteet")
+@SecurityRequirement(name = "bearerAuth")
 class HankeAttachmentController(
     private val hankeAttachmentService: HankeAttachmentService,
     private val hankeService: HankeService,

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/configuration/FeatureFlags.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/configuration/FeatureFlags.kt
@@ -9,6 +9,8 @@ data class FeatureFlags(val features: Map<Feature, Boolean>) {
     /** Disabled by default, if not in application.properties. */
     private fun isEnabled(feature: Feature): Boolean = features.getOrDefault(feature, false)
 
+    fun isDisabled(feature: Feature) = !isEnabled(feature)
+
     /**
      * Throws an exception if the feature is not enabled.
      *
@@ -23,4 +25,5 @@ data class FeatureFlags(val features: Map<Feature, Boolean>) {
 
 enum class Feature {
     HANKE_EDITING,
+    USER_MANAGEMENT,
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/configuration/OpenApiConfiguration.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/configuration/OpenApiConfiguration.kt
@@ -1,7 +1,9 @@
 package fi.hel.haitaton.hanke.configuration
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType
 import io.swagger.v3.oas.annotations.info.Info
+import io.swagger.v3.oas.annotations.security.SecurityScheme
 import io.swagger.v3.oas.annotations.servers.Server
 
 @OpenAPIDefinition(
@@ -12,5 +14,11 @@ import io.swagger.v3.oas.annotations.servers.Server
             version = "1"
         ),
     servers = [Server(url = "/api/")],
+)
+@SecurityScheme(
+    name = "bearerAuth",
+    type = SecuritySchemeType.HTTP,
+    bearerFormat = "JWT",
+    scheme = "bearer",
 )
 internal class OpenAPIConfiguration

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttaja.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttaja.kt
@@ -54,12 +54,14 @@ class HankeKayttajaEntity(
      *
      * Thus, role is read primarily from [PermissionEntity] if the relation exists.
      */
-    private fun deriveRole(): Role? = permission?.role?.role ?: kayttajaTunniste?.role
+    fun deriveRole(): Role? = permission?.role?.role ?: kayttajaTunniste?.role
 }
 
 @Repository
 interface HankeKayttajaRepository : JpaRepository<HankeKayttajaEntity, UUID> {
     fun findByHankeId(hankeId: Int): List<HankeKayttajaEntity>
+
+    fun findByHankeIdAndIdIn(hankeId: Int, ids: Collection<UUID>): List<HankeKayttajaEntity>
 
     fun findByHankeIdAndSahkopostiIn(
         hankeId: Int,

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaController.kt
@@ -2,35 +2,47 @@ package fi.hel.haitaton.hanke.permissions
 
 import fi.hel.haitaton.hanke.HankeError
 import fi.hel.haitaton.hanke.HankeService
+import fi.hel.haitaton.hanke.configuration.Feature
+import fi.hel.haitaton.hanke.configuration.FeatureFlags
 import fi.hel.haitaton.hanke.currentUserId
 import fi.hel.haitaton.hanke.logging.DisclosureLogService
+import fi.hel.haitaton.hanke.validation.ValidHanke
+import io.swagger.v3.oas.annotations.Hidden
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import mu.KotlinLogging
+import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
+import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 
 private val logger = KotlinLogging.logger {}
 
 @RestController
 @RequestMapping("/hankkeet/{hankeTunnus}/kayttajat")
+@SecurityRequirement(name = "bearerAuth")
 class HankeKayttajaController(
     private val hankeService: HankeService,
     private val hankeKayttajaService: HankeKayttajaService,
     private val permissionService: PermissionService,
     private val disclosureLogService: DisclosureLogService,
+    private val featureFlags: FeatureFlags,
 ) {
 
     @GetMapping(produces = [APPLICATION_JSON_VALUE])
     @Operation(
         summary = "Get Hanke users",
-        description = "Returns a list of users and their Hanke  related information."
+        description = "Returns a list of users and their Hanke related information."
     )
     @ApiResponses(
         value =
@@ -70,5 +82,125 @@ class HankeKayttajaController(
         }
 
         return HankeKayttajaResponse(users)
+    }
+
+    @PutMapping
+    @Operation(
+        summary = "Update permissions of the listed users.",
+        description =
+            """
+For each user, permissions are updated directly to the active permissions
+if the user in question has activated his permissions. If they haven't,
+permissions are updated to the user tokens, i.e. this call will change
+which permissions the user will get when they activate their permissions.
+
+The reply from the list users endpoint can be modified and used here, but
+only the ID and role fields are read.
+
+Only the IDs that are mentioned are updated, so only updated IDs need to
+be listed. This also means that this endpoint can't be used to remove
+permissions.
+
+If removing or adding KAIKKI_OIKEUDET role, the caller needs to have those
+same permissions.
+"""
+    )
+    @ApiResponses(
+        value =
+            [
+                ApiResponse(description = "Success, no response body", responseCode = "204"),
+                ApiResponse(
+                    description = "The request body was invalid",
+                    responseCode = "400",
+                    content = [Content(schema = Schema(implementation = HankeError::class))]
+                ),
+                ApiResponse(
+                    description = "Not authorized to change admin permissions",
+                    responseCode = "403",
+                    content = [Content(schema = Schema(implementation = HankeError::class))]
+                ),
+                ApiResponse(
+                    description = "Hanke by requested tunnus not found",
+                    responseCode = "404",
+                    content = [Content(schema = Schema(implementation = HankeError::class))]
+                ),
+                ApiResponse(
+                    description =
+                        "User tried editing their own permissions or there would " +
+                            "be no users with KAIKKI_OIKEUDET left.",
+                    responseCode = "409",
+                    content = [Content(schema = Schema(implementation = HankeError::class))]
+                ),
+            ]
+    )
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun updatePermissions(
+        @ValidHanke @RequestBody permissions: PermissionUpdate,
+        @PathVariable hankeTunnus: String
+    ) {
+        featureFlags.ensureEnabled(Feature.USER_MANAGEMENT)
+
+        val userId = currentUserId()
+        val hanke = hankeService.findHankeOrThrow(hankeTunnus)
+
+        permissionService.verifyHankeUserAuthorization(
+            userId = userId,
+            hanke = hanke,
+            permissionCode = PermissionCode.MODIFY_EDIT_PERMISSIONS
+        )
+
+        val deleteAdminPermission =
+            permissionService.hasPermission(
+                hanke.id!!,
+                userId,
+                PermissionCode.MODIFY_DELETE_PERMISSIONS
+            )
+
+        hankeKayttajaService.updatePermissions(
+            hanke,
+            permissions.kayttajat.associate { it.id to it.rooli },
+            deleteAdminPermission,
+            userId
+        )
+    }
+
+    @ExceptionHandler(MissingAdminPermissionException::class)
+    @ResponseStatus(HttpStatus.FORBIDDEN)
+    @Hidden
+    fun missingAdminPermissionException(ex: MissingAdminPermissionException): HankeError {
+        logger.warn(ex) { ex.message }
+        return HankeError.HAI0005
+    }
+
+    @ExceptionHandler(ChangingOwnPermissionException::class)
+    @ResponseStatus(HttpStatus.FORBIDDEN)
+    @Hidden
+    fun changingOwnPermissionException(ex: ChangingOwnPermissionException): HankeError {
+        logger.warn(ex) { ex.message }
+        return HankeError.HAI4002
+    }
+
+    @ExceptionHandler(UsersWithoutRolesException::class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    @Hidden
+    fun usersWithoutRolesException(ex: UsersWithoutRolesException): HankeError {
+        logger.error(ex) { ex.message }
+        return HankeError.HAI4003
+    }
+
+    @ExceptionHandler(NoAdminRemainingException::class)
+    @ResponseStatus(HttpStatus.CONFLICT)
+    @Hidden
+    fun noAdminRemainingException(ex: NoAdminRemainingException): HankeError {
+        logger.warn(ex) { ex.message }
+        return HankeError.HAI4003
+    }
+
+    @ExceptionHandler(HankeKayttajatNotFoundException::class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @Hidden
+    fun hankeKayttajatNotFoundException(ex: HankeKayttajatNotFoundException): HankeError {
+        logger.warn(ex) { ex.message }
+        return HankeError.HAI4001
     }
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaService.kt
@@ -2,8 +2,11 @@ package fi.hel.haitaton.hanke.permissions
 
 import fi.hel.haitaton.hanke.HankeArgumentException
 import fi.hel.haitaton.hanke.application.ApplicationEntity
+import fi.hel.haitaton.hanke.configuration.Feature
+import fi.hel.haitaton.hanke.configuration.FeatureFlags
 import fi.hel.haitaton.hanke.domain.Hanke
 import fi.hel.haitaton.hanke.domain.Perustaja
+import java.util.UUID
 import mu.KotlinLogging
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -14,6 +17,9 @@ private val logger = KotlinLogging.logger {}
 class HankeKayttajaService(
     private val hankeKayttajaRepository: HankeKayttajaRepository,
     private val kayttajaTunnisteRepository: KayttajaTunnisteRepository,
+    private val roleRepository: RoleRepository,
+    private val permissionService: PermissionService,
+    private val featureFlags: FeatureFlags,
 ) {
 
     @Transactional(readOnly = true)
@@ -22,6 +28,9 @@ class HankeKayttajaService(
 
     @Transactional
     fun saveNewTokensFromApplication(application: ApplicationEntity, hankeId: Int) {
+        if (featureFlags.isDisabled(Feature.USER_MANAGEMENT)) {
+            return
+        }
         logger.info {
             "Creating users and user tokens for application ${application.id}, alluid=${application.alluid}}"
         }
@@ -36,6 +45,9 @@ class HankeKayttajaService(
 
     @Transactional
     fun saveNewTokensFromHanke(hanke: Hanke) {
+        if (featureFlags.isDisabled(Feature.USER_MANAGEMENT)) {
+            return
+        }
         logger.info {
             "Creating users and user tokens for hanke ${hanke.id}, hankeTunnus=${hanke.hankeTunnus}}"
         }
@@ -51,6 +63,9 @@ class HankeKayttajaService(
 
     @Transactional
     fun addHankeFounder(hankeId: Int, founder: Perustaja, permissionEntity: PermissionEntity) {
+        if (featureFlags.isDisabled(Feature.USER_MANAGEMENT)) {
+            return
+        }
         logger.info { "Saving user for Hanke perustaja." }
         saveUser(
             HankeKayttajaEntity(
@@ -61,6 +76,97 @@ class HankeKayttajaService(
                 kayttajaTunniste = null,
             )
         )
+    }
+
+    @Transactional
+    fun updatePermissions(
+        hanke: Hanke,
+        updates: Map<UUID, Role>,
+        deleteAdminPermission: Boolean,
+        userId: String,
+    ) {
+        logger.info {
+            "Updating permissions for hankekayttajat. hankeId=${hanke.id} hanketunnus=${hanke.hankeTunnus}"
+        }
+
+        val kayttajat = hankeKayttajaRepository.findByHankeIdAndIdIn(hanke.id!!, updates.keys)
+
+        if (kayttajat.any { it.permission?.userId == userId }) {
+            throw ChangingOwnPermissionException(userId)
+        }
+
+        validateAllKayttajatFound(kayttajat, updates, hanke)
+        validateAdminPermissionIfNeeded(kayttajat, updates, deleteAdminPermission, userId)
+
+        kayttajat.forEach { kayttaja ->
+            if (kayttaja.permission != null) {
+                kayttaja.permission.role = roleRepository.findOneByRole(updates[kayttaja.id]!!)
+            } else {
+                kayttaja.kayttajaTunniste!!.role = updates[kayttaja.id]!!
+            }
+        }
+
+        validateAdminRemains(hanke)
+    }
+
+    /** Check that every user an update was requested for was found as a user of the hanke. */
+    private fun validateAllKayttajatFound(
+        existingKayttajat: List<HankeKayttajaEntity>,
+        requestedUpdates: Map<UUID, Role>,
+        hanke: Hanke,
+    ) {
+        with(existingKayttajat.map { it.id }) {
+            if (!this.containsAll(requestedUpdates.keys)) {
+                val missingIds = requestedUpdates.keys.subtract(this.toSet())
+                throw HankeKayttajatNotFoundException(missingIds, hanke)
+            }
+        }
+    }
+
+    /**
+     * The user needs to have admin permission (KAIKKI_OIKEUDET role) whenever removing or adding a
+     * KAIKKI_OIKEUDET from users.
+     */
+    private fun validateAdminPermissionIfNeeded(
+        kayttajat: List<HankeKayttajaEntity>,
+        updates: Map<UUID, Role>,
+        deleteAdminPermission: Boolean,
+        userId: String,
+    ) {
+        val currentRoles = currentRoles(kayttajat)
+
+        if (
+            (currentRoles.any { (_, role) -> role == Role.KAIKKI_OIKEUDET } ||
+                updates.any { (_, role) -> role == Role.KAIKKI_OIKEUDET }) && !deleteAdminPermission
+        ) {
+            throw MissingAdminPermissionException(userId)
+        }
+    }
+
+    /**
+     * After any change to users' roles, at least one user with KAIKKI_OIKEUDET role in an activated
+     * permission needs to remain. Otherwise, there's no one who can add that role.
+     */
+    private fun validateAdminRemains(hanke: Hanke) {
+        if (
+            permissionService.findByHankeId(hanke.id!!).all { it.role.role != Role.KAIKKI_OIKEUDET }
+        ) {
+            throw NoAdminRemainingException(hanke)
+        }
+    }
+
+    /** Finds the current roles of the given HankeKayttajat. Returns an ID -> Role map with */
+    private fun currentRoles(kayttajat: List<HankeKayttajaEntity>): Map<UUID, Role> {
+        val currentRoles = kayttajat.map { it.id to it.deriveRole() }
+        currentRoles
+            .filter { (_, role) -> role == null }
+            .map { (id, _) -> id }
+            .also { missingIds ->
+                if (missingIds.isNotEmpty()) {
+                    throw UsersWithoutRolesException(missingIds)
+                }
+            }
+        return currentRoles.associate { (id, role) -> id to role!! }
     }
 
     private fun createToken(hankeId: Int, contact: UserContact) {
@@ -112,3 +218,26 @@ class HankeKayttajaService(
 }
 
 data class UserContact(val name: String, val email: String)
+
+class ChangingOwnPermissionException(userId: String) :
+    RuntimeException("User tried to change their own permissions, userId=$userId")
+
+class MissingAdminPermissionException(userId: String) :
+    RuntimeException("User doesn't have permission to change admin permissions. userId=$userId")
+
+class UsersWithoutRolesException(missingIds: Collection<UUID>) :
+    RuntimeException(
+        "Some HankeKayttaja have neither permissions nor user tokens, " +
+            "their ids = ${missingIds.joinToString()}"
+    )
+
+class NoAdminRemainingException(hanke: Hanke) :
+    RuntimeException(
+        "No one with admin rights would remain after permission changes. hankeId=${hanke.id}, hanketunnus=${hanke.hankeTunnus}"
+    )
+
+class HankeKayttajatNotFoundException(missingIds: Collection<UUID>, hanke: Hanke) :
+    RuntimeException(
+        "Some HankeKayttaja were not found. Either the IDs don't exist or they belong to another " +
+            "hanke. Missing IDs: ${missingIds.joinToString()}, hankeId=${hanke.id}, hanketunnus=${hanke.hankeTunnus}"
+    )

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/KayttajaTunniste.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/KayttajaTunniste.kt
@@ -22,7 +22,7 @@ class KayttajaTunnisteEntity(
     val tunniste: String,
     @Column(name = "created_at") val createdAt: OffsetDateTime,
     @Column(name = "sent_at") val sentAt: OffsetDateTime?,
-    @Enumerated(EnumType.STRING) val role: Role,
+    @Enumerated(EnumType.STRING) var role: Role,
     @OneToOne(mappedBy = "kayttajaTunniste") val hankeKayttaja: HankeKayttajaEntity?
 ) {
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/PermissionService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/PermissionService.kt
@@ -9,6 +9,8 @@ class PermissionService(
     private val permissionRepository: PermissionRepository,
     private val roleRepository: RoleRepository
 ) {
+    fun findByHankeId(hankeId: Int) = permissionRepository.findAllByHankeId(hankeId)
+
     fun getAllowedHankeIds(userId: String, permission: PermissionCode): List<Int> =
         permissionRepository.findAllByUserIdAndPermission(userId, permission.code).map {
             it.hankeId

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/PermissionUpdate.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/PermissionUpdate.kt
@@ -1,0 +1,13 @@
+package fi.hel.haitaton.hanke.permissions
+
+import io.swagger.v3.oas.annotations.media.Schema
+import java.util.UUID
+
+data class PermissionUpdate(
+    @field:Schema(description = "Permissions to update.") val kayttajat: List<PermissionDto>
+)
+
+data class PermissionDto(
+    @field:Schema(description = "HankeKayttaja ID") val id: UUID,
+    @field:Schema(description = "New role in Hanke") val rooli: Role,
+)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/Permissions.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/Permissions.kt
@@ -27,6 +27,8 @@ enum class PermissionCode(val code: Long) {
 interface PermissionRepository : JpaRepository<PermissionEntity, Int> {
     fun findOneByHankeIdAndUserId(hankeId: Int, userId: String): PermissionEntity?
 
+    fun findAllByHankeId(hankeId: Int): List<PermissionEntity>
+
     /**
      * Search for permissions with the given user and a single permission code. JPQL doesn't have
      * bitwise and, so we simulate it with a division (shift right) and mod. This only works when

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/testdata/TestDataController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/testdata/TestDataController.kt
@@ -9,7 +9,7 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
-private val logger = KotlinLogging.logger {} // ASDF
+private val logger = KotlinLogging.logger {}
 
 @RestController
 @RequestMapping("/testdata")

--- a/services/hanke-service/src/main/resources/application.properties
+++ b/services/hanke-service/src/main/resources/application.properties
@@ -23,6 +23,7 @@ haitaton.gdpr.delete-scope=${HAITATON_GDPR_DELETE_SCOPE:haitaton.gdprdelete}
 
 # Disable endpoints that are e.g. in development and should not be in production.
 haitaton.features.hanke-editing=${HAITATON_FEATURE_HANKE_EDITING:true}
+haitaton.features.user-management=${HAITATON_FEATURE_USER_MANAGEMENT:true}
 
 # For dev and test environments, enable the testdata controller for resetting data
 haitaton.testdata.enabled=${HAITATON_TESTDATA_ENABLED:false}

--- a/services/hanke-service/src/main/resources/db/changelog/changesets/043-add-another-index-to-hanke-kayttaja.yml
+++ b/services/hanke-service/src/main/resources/db/changelog/changesets/043-add-another-index-to-hanke-kayttaja.yml
@@ -1,0 +1,26 @@
+databaseChangeLog:
+  - changeSet:
+      id: 043-add-indices-to-hanke-kayttaja-tables
+      author: Topias Heinonen
+      comment: Indices for hanke_kayttaja and permissions to improve search performance
+      changes:
+        - createIndex:
+            tableName: hanke_kayttaja
+            indexName: hanke_kayttaja_hanke_id_idx
+            columns:
+              - column:
+                  name: hanke_id
+        - createIndex:
+            tableName: permissions
+            indexName: permissions_hanke_id_idx
+            columns:
+              - column:
+                  name: hankeid
+        - createIndex:
+            tableName: permissions
+            indexName: permissions_hankeid_userid_idx
+            columns:
+              - column:
+                  name: hankeid
+              - column:
+                  name: userid

--- a/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -113,3 +113,5 @@ databaseChangeLog:
       file: db/changelog/changesets/041-drop-column-organisaatioid-from-yhteystiedot.yml
   - include:
       file: db/changelog/changesets/042-add-indices-to-hanke-kayttaja.yml
+  - include:
+      file: db/changelog/changesets/043-add-another-index-to-hanke-kayttaja.yml


### PR DESCRIPTION
# Description

Add API for changing the permissions of hanke kayttajat.

Audit logging will be added in a separate PR.

Add a security scheme to the OpenAPI configuration. This enables the use of the Swagger UI by copying over your bearer token. Reformat some OpenAPI descriptions, since they were shown as code blocks.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1527

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
You can use Swagger UI to send requests to test the API.

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [x] I have made necessary changes to the documentation, link to confluence
 or other location: README for Swagger UI authentication
