### PR TITLE
HAI-1873 Add API for identifying a user

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeControllerITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeControllerITests.kt
@@ -28,7 +28,6 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.context.annotation.Import
-import org.springframework.http.MediaType
 import org.springframework.security.test.context.support.WithAnonymousUser
 import org.springframework.security.test.context.support.WithMockUser
 import org.springframework.security.test.web.servlet.response.SecurityMockMvcResultMatchers
@@ -105,7 +104,6 @@ class HankeControllerITests(@Autowired override val mockMvc: MockMvc) : Controll
 
             get(url)
                 .andExpect(status().isOk)
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.nimi").value("Hämeentien perusparannus ja katuvalot"))
                 .andExpect(jsonPath("$.status").value(HankeStatus.DRAFT.name))
 
@@ -151,7 +149,6 @@ class HankeControllerITests(@Autowired override val mockMvc: MockMvc) : Controll
             // we check that we get the two hankeTunnus we expect
             get(url)
                 .andExpect(status().isOk)
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$[2]").doesNotExist())
                 .andExpect(jsonPath("$[0].hankeTunnus").value(HANKE_TUNNUS))
                 .andExpect(jsonPath("$[1].hankeTunnus").value("hanketunnus2"))
@@ -188,7 +185,6 @@ class HankeControllerITests(@Autowired override val mockMvc: MockMvc) : Controll
             // we check that we get the two hankeTunnus and geometriat we expect
             get("$url/?geometry=true")
                 .andExpect(status().isOk)
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$[0].hankeTunnus").value(HANKE_TUNNUS))
                 .andExpect(jsonPath("$[1].hankeTunnus").value("hanketunnus2"))
                 .andExpect(jsonPath("$[0].id").value(hankeIds[0]))
@@ -322,7 +318,6 @@ class HankeControllerITests(@Autowired override val mockMvc: MockMvc) : Controll
 
             post(url, hankeToBeCreated)
                 .andExpect(status().isOk)
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.hankeTunnus").value(HANKE_TUNNUS))
                 .andExpect(content().json(createdHanke.toJsonString()))
 
@@ -362,7 +357,6 @@ class HankeControllerITests(@Autowired override val mockMvc: MockMvc) : Controll
 
             post(url, hankeToBeMocked)
                 .andExpect(status().isOk)
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(content().json(expectedContent))
                 .andExpect(jsonPath("$.hankeTunnus").value(HANKE_TUNNUS))
 
@@ -379,7 +373,6 @@ class HankeControllerITests(@Autowired override val mockMvc: MockMvc) : Controll
 
             post(url, hanke)
                 .andExpect(status().isInternalServerError)
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(hankeError(HankeError.HAI0002))
 
             verifySequence { hankeService.createHanke(any()) }
@@ -423,7 +416,6 @@ class HankeControllerITests(@Autowired override val mockMvc: MockMvc) : Controll
             // Call it and check results
             post(url, hankeToBeMocked)
                 .andExpect(status().isOk)
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(content().json(expectedContent))
                 // These might be redundant, but at least it is clear what we're checking here:
                 .andExpect(jsonPath("$.alkuPvm").value(expectedDateAlkuJson))
@@ -483,7 +475,6 @@ class HankeControllerITests(@Autowired override val mockMvc: MockMvc) : Controll
 
             put(url, hankeToBeUpdated)
                 .andExpect(status().isOk)
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.nimi").value(HankeFactory.defaultNimi))
                 .andExpect(jsonPath("$.status").value(HankeStatus.PUBLIC.name))
 
@@ -533,7 +524,6 @@ class HankeControllerITests(@Autowired override val mockMvc: MockMvc) : Controll
 
             put(url, hankeToBeUpdated)
                 .andExpect(status().isOk)
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(content().json(expectedContent))
                 // These might be redundant, but at least it is clear what we're checking here:
                 .andExpect(jsonPath("$.tyomaaKatuosoite").value("Testikatu 1"))

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/SpringDocITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/SpringDocITest.kt
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.MediaType
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
@@ -19,7 +20,7 @@ class SpringdocITest(@Autowired override val mockMvc: MockMvc) : ControllerTest,
 
     @Test
     fun `Should display Swagger UI page`() {
-        get("/swagger-ui/index.html")
+        get("/swagger-ui/index.html", resultType = MediaType.TEXT_HTML)
             .andExpect(status().isOk())
             .andExpect(content().string(containsString("Swagger UI")))
     }

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationControllerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationControllerITest.kt
@@ -37,7 +37,6 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.context.annotation.Import
-import org.springframework.http.MediaType.APPLICATION_JSON
 import org.springframework.http.MediaType.APPLICATION_PDF
 import org.springframework.security.test.context.support.WithMockUser
 import org.springframework.test.context.ActiveProfiles
@@ -695,9 +694,8 @@ class ApplicationControllerITest(@Autowired override val mockMvc: MockMvc) : Con
         val id = 11L
         every { applicationService.getApplicationById(id) } throws ApplicationNotFoundException(id)
 
-        get("$BASE_URL/$id/paatos", APPLICATION_PDF, APPLICATION_JSON)
+        get("$BASE_URL/$id/paatos")
             .andExpect(status().isNotFound)
-            .andExpect(content().contentType(APPLICATION_JSON))
             .andExpect(jsonPath("errorCode").value("HAI2001"))
             .andExpect(jsonPath("errorMessage").value("Application not found"))
 
@@ -715,9 +713,8 @@ class ApplicationControllerITest(@Autowired override val mockMvc: MockMvc) : Con
         every { applicationService.downloadDecision(id, USERNAME) } throws
             ApplicationDecisionNotFoundException("Decision not found in Allu. alluid=23")
 
-        get("$BASE_URL/11/paatos", APPLICATION_PDF, APPLICATION_JSON)
+        get("$BASE_URL/11/paatos")
             .andExpect(status().isNotFound)
-            .andExpect(content().contentType(APPLICATION_JSON))
             .andExpect(jsonPath("errorCode").value("HAI2006"))
             .andExpect(jsonPath("errorMessage").value("Application decision not found"))
 
@@ -737,10 +734,9 @@ class ApplicationControllerITest(@Autowired override val mockMvc: MockMvc) : Con
         every { applicationService.downloadDecision(11, USERNAME) } returns
             Pair("JS230001", pdfBytes)
 
-        get("$BASE_URL/11/paatos", APPLICATION_PDF, APPLICATION_JSON)
+        get("$BASE_URL/11/paatos", resultType = APPLICATION_PDF)
             .andExpect(status().isOk)
             .andExpect(header().string("Content-Disposition", "inline; filename=JS230001.pdf"))
-            .andExpect(content().contentType(APPLICATION_PDF))
             .andExpect(content().bytes(pdfBytes))
 
         verify { applicationService.getApplicationById(11) }
@@ -757,8 +753,7 @@ class ApplicationControllerITest(@Autowired override val mockMvc: MockMvc) : Con
             AlluDataFactory.createApplication(id = id, hankeTunnus = HANKE_TUNNUS)
         every { permissionService.hasPermission(42, USERNAME, VIEW) } returns false
 
-        get("$BASE_URL/$id/paatos", APPLICATION_PDF, APPLICATION_JSON)
-            .andExpect(status().isNotFound)
+        get("$BASE_URL/$id/paatos").andExpect(status().isNotFound)
 
         verify { applicationService.getApplicationById(id) }
         verify { permissionService.hasPermission(42, USERNAME, VIEW) }

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/AttachmentTestUtil.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/AttachmentTestUtil.kt
@@ -5,6 +5,7 @@ import fi.hel.haitaton.hanke.attachment.common.FileResult
 import fi.hel.haitaton.hanke.attachment.common.FileScanData
 import fi.hel.haitaton.hanke.attachment.common.FileScanResponse
 import fi.hel.haitaton.hanke.getResourceAsBytes
+import fi.hel.haitaton.hanke.hankeError
 import fi.hel.haitaton.hanke.toJsonString
 import okhttp3.mockwebserver.MockResponse
 import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
@@ -12,7 +13,6 @@ import org.springframework.http.MediaType.APPLICATION_PDF_VALUE
 import org.springframework.mock.web.MockMultipartFile
 import org.springframework.security.test.web.servlet.response.SecurityMockMvcResultMatchers.unauthenticated
 import org.springframework.test.web.servlet.ResultActions
-import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
 const val USERNAME = "username"
@@ -34,10 +34,7 @@ fun testFile(
 ) = MockMultipartFile(fileParam, fileName, contentType, data)
 
 fun ResultActions.andExpectError(error: HankeError): ResultActions =
-    andExpect(unauthenticated())
-        .andExpect(status().isUnauthorized)
-        .andExpect(jsonPath("$.errorCode").value(error.errorCode))
-        .andExpect(jsonPath("$.errorMessage").value(error.errorMessage))
+    andExpect(unauthenticated()).andExpect(status().isUnauthorized).andExpect(hankeError(error))
 
 fun response(data: String): MockResponse =
     MockResponse()

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentControllerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentControllerITest.kt
@@ -46,6 +46,8 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.http.HttpHeaders.CONTENT_DISPOSITION
+import org.springframework.http.MediaType
+import org.springframework.http.MediaType.APPLICATION_JSON
 import org.springframework.http.MediaType.APPLICATION_PDF
 import org.springframework.http.MediaType.APPLICATION_PDF_VALUE
 import org.springframework.mock.web.MockMultipartFile
@@ -130,7 +132,6 @@ class ApplicationAttachmentControllerITest(@Autowired override val mockMvc: Mock
         getAttachmentContent(attachmentId = attachmentId)
             .andExpect(status().isOk)
             .andExpect(header().string(CONTENT_DISPOSITION, "attachment; filename=$FILE_NAME_PDF"))
-            .andExpect(content().contentType(APPLICATION_PDF))
             .andExpect(content().bytes(dummyData))
 
         verifyOrder {
@@ -256,7 +257,7 @@ class ApplicationAttachmentControllerITest(@Autowired override val mockMvc: Mock
     @WithAnonymousUser
     fun `unauthorized without authenticated user`() {
         getMetadataList().andExpectError(HAI0001)
-        getAttachmentContent().andExpectError(HAI0001)
+        getAttachmentContent(resultType = APPLICATION_JSON).andExpectError(HAI0001)
         postAttachment().andExpectError(HAI0001)
         deleteAttachment().andExpectError(HAI0001)
     }
@@ -267,7 +268,9 @@ class ApplicationAttachmentControllerITest(@Autowired override val mockMvc: Mock
     private fun getAttachmentContent(
         applicationId: Long = APPLICATION_ID,
         attachmentId: UUID = randomUUID(),
-    ): ResultActions = get("/hakemukset/$applicationId/liitteet/$attachmentId/content")
+        resultType: MediaType = APPLICATION_PDF,
+    ): ResultActions =
+        get("/hakemukset/$applicationId/liitteet/$attachmentId/content", resultType = resultType)
 
     private fun postAttachment(
         applicationId: Long = APPLICATION_ID,

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentControllerITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentControllerITests.kt
@@ -35,6 +35,8 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.http.HttpHeaders.CONTENT_DISPOSITION
+import org.springframework.http.MediaType
+import org.springframework.http.MediaType.APPLICATION_JSON
 import org.springframework.http.MediaType.APPLICATION_PDF
 import org.springframework.http.MediaType.APPLICATION_PDF_VALUE
 import org.springframework.mock.web.MockMultipartFile
@@ -98,7 +100,6 @@ class HankeAttachmentControllerITests(@Autowired override val mockMvc: MockMvc) 
         getAttachmentContent(attachmentId = liiteId)
             .andExpect(status().isOk)
             .andExpect(header().string(CONTENT_DISPOSITION, "attachment; filename=$FILE_NAME_PDF"))
-            .andExpect(content().contentType(APPLICATION_PDF))
             .andExpect(content().bytes(dummyData))
 
         verifyOrder {
@@ -167,7 +168,7 @@ class HankeAttachmentControllerITests(@Autowired override val mockMvc: MockMvc) 
     @WithAnonymousUser
     fun `unauthorized without authenticated user`() {
         getMetadataList().andExpectError(HAI0001)
-        getAttachmentContent().andExpectError(HAI0001)
+        getAttachmentContent(resultType = APPLICATION_JSON).andExpectError(HAI0001)
         postAttachment().andExpectError(HAI0001)
         deleteAttachment().andExpectError(HAI0001)
     }
@@ -178,7 +179,9 @@ class HankeAttachmentControllerITests(@Autowired override val mockMvc: MockMvc) 
     private fun getAttachmentContent(
         hankeTunnus: String = HANKE_TUNNUS,
         attachmentId: UUID = randomUUID(),
-    ): ResultActions = get("/hankkeet/$hankeTunnus/liitteet/$attachmentId/content")
+        resultType: MediaType = APPLICATION_PDF,
+    ): ResultActions =
+        get("/hankkeet/$hankeTunnus/liitteet/$attachmentId/content", resultType = resultType)
 
     private fun postAttachment(
         hankeTunnus: String = HANKE_TUNNUS,

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/PermissionServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/PermissionServiceITest.kt
@@ -30,7 +30,6 @@ class PermissionServiceITest : DatabaseTest() {
 
     @Autowired lateinit var permissionService: PermissionService
     @Autowired lateinit var permissionRepository: PermissionRepository
-    @Autowired lateinit var kayttooikeustasoRepository: KayttooikeustasoRepository
     @Autowired lateinit var hankeService: HankeService
 
     companion object {
@@ -73,8 +72,7 @@ class PermissionServiceITest : DatabaseTest() {
         kayttooikeustaso: Kayttooikeustaso,
         allowedPermissions: Array<PermissionCode>
     ) {
-        val kayttooikeustasoEntity =
-            kayttooikeustasoRepository.findOneByKayttooikeustaso(kayttooikeustaso)
+        val kayttooikeustasoEntity = permissionService.findKayttooikeustaso(kayttooikeustaso)
 
         allowedPermissions.forEach { code ->
             assertThat(code)
@@ -100,7 +98,7 @@ class PermissionServiceITest : DatabaseTest() {
     @Test
     fun `getAllowedHankeIds with permissions returns list of IDs`() {
         val kaikkiOikeudet =
-            kayttooikeustasoRepository.findOneByKayttooikeustaso(Kayttooikeustaso.KAIKKI_OIKEUDET)
+            permissionService.findKayttooikeustaso(Kayttooikeustaso.KAIKKI_OIKEUDET)
         val hankkeet = saveSeveralHanke(3)
         hankkeet
             .map { it.id!! }
@@ -122,13 +120,11 @@ class PermissionServiceITest : DatabaseTest() {
     @Test
     fun `getAllowedHankeIds return ids with correct permissions`() {
         val kaikkiOikeudet =
-            kayttooikeustasoRepository.findOneByKayttooikeustaso(Kayttooikeustaso.KAIKKI_OIKEUDET)
-        val hankemuokkaus =
-            kayttooikeustasoRepository.findOneByKayttooikeustaso(Kayttooikeustaso.HANKEMUOKKAUS)
+            permissionService.findKayttooikeustaso(Kayttooikeustaso.KAIKKI_OIKEUDET)
+        val hankemuokkaus = permissionService.findKayttooikeustaso(Kayttooikeustaso.HANKEMUOKKAUS)
         val hakemusasiointi =
-            kayttooikeustasoRepository.findOneByKayttooikeustaso(Kayttooikeustaso.HAKEMUSASIOINTI)
-        val katseluoikeus =
-            kayttooikeustasoRepository.findOneByKayttooikeustaso(Kayttooikeustaso.KATSELUOIKEUS)
+            permissionService.findKayttooikeustaso(Kayttooikeustaso.HAKEMUSASIOINTI)
+        val katseluoikeus = permissionService.findKayttooikeustaso(Kayttooikeustaso.KATSELUOIKEUS)
         val hankkeet = saveSeveralHanke(4)
         listOf(kaikkiOikeudet, hankemuokkaus, hakemusasiointi, katseluoikeus).zip(hankkeet) {
             kayttooikeustaso,
@@ -155,7 +151,7 @@ class PermissionServiceITest : DatabaseTest() {
     @Test
     fun `hasPermission with correct permission`() {
         val kaikkiOikeudet =
-            kayttooikeustasoRepository.findOneByKayttooikeustaso(Kayttooikeustaso.KAIKKI_OIKEUDET)
+            permissionService.findKayttooikeustaso(Kayttooikeustaso.KAIKKI_OIKEUDET)
         val hankeId = saveSeveralHanke(1)[0].id!!
         permissionRepository.save(
             PermissionEntity(
@@ -171,7 +167,7 @@ class PermissionServiceITest : DatabaseTest() {
     @Test
     fun `hasPermission with insufficient permissions`() {
         val hakemusasiointi =
-            kayttooikeustasoRepository.findOneByKayttooikeustaso(Kayttooikeustaso.HAKEMUSASIOINTI)
+            permissionService.findKayttooikeustaso(Kayttooikeustaso.HAKEMUSASIOINTI)
         val hankeId = saveSeveralHanke(1)[0].id!!
         permissionRepository.save(
             PermissionEntity(
@@ -205,7 +201,7 @@ class PermissionServiceITest : DatabaseTest() {
         val hankeId = saveSeveralHanke(1)[0].id!!
         permissionRepository.deleteAll() // remove permission created in hanke creation
         val kayttooikeustaso =
-            kayttooikeustasoRepository.findOneByKayttooikeustaso(Kayttooikeustaso.KATSELUOIKEUS)
+            permissionService.findKayttooikeustaso(Kayttooikeustaso.KATSELUOIKEUS)
         permissionRepository.save(
             PermissionEntity(
                 userId = username,

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeController.kt
@@ -21,7 +21,6 @@ import jakarta.validation.ConstraintViolationException
 import mu.KotlinLogging
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpStatus
-import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.ExceptionHandler
@@ -48,7 +47,7 @@ class HankeController(
     @Autowired private val featureFlags: FeatureFlags,
 ) {
 
-    @GetMapping("/{hankeTunnus}", produces = [APPLICATION_JSON_VALUE])
+    @GetMapping("/{hankeTunnus}")
     @Operation(summary = "Get hanke", description = "Get specific hanke by hankeTunnus.")
     @ApiResponses(
         value =
@@ -77,7 +76,7 @@ class HankeController(
         return hanke
     }
 
-    @GetMapping(produces = [APPLICATION_JSON_VALUE])
+    @GetMapping
     @Operation(
         summary = "Get hanke list",
         description =
@@ -124,7 +123,7 @@ class HankeController(
         return hankeList
     }
 
-    @GetMapping("/{hankeTunnus}/hakemukset", produces = [APPLICATION_JSON_VALUE])
+    @GetMapping("/{hankeTunnus}/hakemukset")
     @Operation(
         summary = "Get hanke applications",
         description = "Returns list of applications belonging to a given hanke."
@@ -148,7 +147,7 @@ class HankeController(
         }
     }
 
-    @PostMapping(consumes = [APPLICATION_JSON_VALUE], produces = [APPLICATION_JSON_VALUE])
+    @PostMapping
     @Operation(
         summary = "Create new hanke",
         description =
@@ -194,11 +193,7 @@ When Hanke is created:
         return createdHanke
     }
 
-    @PutMapping(
-        "/{hankeTunnus}",
-        consumes = [APPLICATION_JSON_VALUE],
-        produces = [APPLICATION_JSON_VALUE]
-    )
+    @PutMapping("/{hankeTunnus}")
     @Operation(
         summary = "Update hanke",
         description =

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeError.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeError.kt
@@ -2,9 +2,11 @@ package fi.hel.haitaton.hanke
 
 import com.fasterxml.jackson.annotation.JsonFormat
 import com.fasterxml.jackson.annotation.JsonUnwrapped
+import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.ConstraintViolation
 
 @JsonFormat(shape = JsonFormat.Shape.OBJECT)
+@Schema(enumAsRef = true)
 enum class HankeError(val errorMessage: String) {
     HAI0001("Access denied"),
     HAI0002("Internal error"),
@@ -44,6 +46,7 @@ enum class HankeError(val errorMessage: String) {
     HAI4001("HankeKayttaja not found"),
     HAI4002("Trying to change own permission"),
     HAI4003("Permission data conflict"),
+    HAI4004("Kayttajatunniste not found"),
     ;
 
     val errorCode: String

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/PublicHankeController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/PublicHankeController.kt
@@ -8,7 +8,6 @@ import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
-import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
@@ -17,7 +16,7 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/public-hankkeet")
 class PublicHankeController(private val hankeService: HankeService) {
 
-    @GetMapping(produces = [APPLICATION_JSON_VALUE])
+    @GetMapping
     @Operation(
         summary = "Get list of public hanke",
         description =

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationController.kt
@@ -22,7 +22,6 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import mu.KotlinLogging
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
-import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
 import org.springframework.http.MediaType.APPLICATION_PDF
 import org.springframework.http.MediaType.APPLICATION_PDF_VALUE
 import org.springframework.http.ResponseEntity
@@ -263,7 +262,7 @@ class ApplicationController(
         return service.sendApplication(id, currentUserId())
     }
 
-    @GetMapping("/{id}/paatos", produces = [APPLICATION_PDF_VALUE, APPLICATION_JSON_VALUE])
+    @GetMapping("/{id}/paatos")
     @Operation(
         summary = "Download a decision",
         description = "Downloads a decision for this application from Allu."
@@ -271,7 +270,11 @@ class ApplicationController(
     @ApiResponses(
         value =
             [
-                ApiResponse(description = "The decision PDF", responseCode = "200"),
+                ApiResponse(
+                    description = "The decision PDF",
+                    responseCode = "200",
+                    content = [Content(mediaType = APPLICATION_PDF_VALUE)]
+                ),
                 ApiResponse(
                     description =
                         "An application was not found with the given id or the application didn't have a decision",

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttaja.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttaja.kt
@@ -34,10 +34,10 @@ class HankeKayttajaEntity(
     val sahkoposti: String,
     @OneToOne
     @JoinColumn(name = "permission_id", updatable = true, nullable = true)
-    val permission: PermissionEntity?,
+    var permission: PermissionEntity?,
     @OneToOne
     @JoinColumn(name = "tunniste_id", updatable = true, nullable = true)
-    val kayttajaTunniste: KayttajaTunnisteEntity?,
+    var kayttajaTunniste: KayttajaTunnisteEntity?,
 ) {
     fun toDto(): HankeKayttajaDto =
         HankeKayttajaDto(

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaController.kt
@@ -16,7 +16,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import mu.KotlinLogging
 import org.springframework.http.HttpStatus
-import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -38,7 +37,7 @@ class HankeKayttajaController(
     private val featureFlags: FeatureFlags,
 ) {
 
-    @GetMapping("/hankkeet/{hankeTunnus}/kayttajat", produces = [APPLICATION_JSON_VALUE])
+    @GetMapping("/hankkeet/{hankeTunnus}/kayttajat")
     @Operation(
         summary = "Get Hanke users",
         description = "Returns a list of users and their Hanke related information."

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/KayttajaTunniste.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/KayttajaTunniste.kt
@@ -65,4 +65,7 @@ class KayttajaTunnisteEntity(
     }
 }
 
-@Repository interface KayttajaTunnisteRepository : JpaRepository<KayttajaTunnisteEntity, UUID> {}
+@Repository
+interface KayttajaTunnisteRepository : JpaRepository<KayttajaTunnisteEntity, UUID> {
+    fun findByTunniste(tunniste: String): KayttajaTunnisteEntity?
+}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/PermissionService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/PermissionService.kt
@@ -22,13 +22,27 @@ class PermissionService(
         return hasPermission(kayttooikeustaso, permission)
     }
 
+    fun findPermission(hankeId: Int, userId: String): PermissionEntity? =
+        permissionRepository.findOneByHankeIdAndUserId(hankeId, userId)
+
+    /** When you don't want to accidentally update existing permissions. */
+    fun create(hankeId: Int, userId: String, kayttooikeustaso: Kayttooikeustaso): PermissionEntity {
+        val kayttooikeustasoEntity = findKayttooikeustaso(kayttooikeustaso)
+        return permissionRepository.save(
+            PermissionEntity(
+                userId = userId,
+                hankeId = hankeId,
+                kayttooikeustaso = kayttooikeustasoEntity,
+            )
+        )
+    }
+
     fun setPermission(
         hankeId: Int,
         userId: String,
         kayttooikeustaso: Kayttooikeustaso
     ): PermissionEntity {
-        val kayttooikeustasoEntity =
-            kayttooikeustasoRepository.findOneByKayttooikeustaso(kayttooikeustaso)
+        val kayttooikeustasoEntity = findKayttooikeustaso(kayttooikeustaso)
         val entity =
             permissionRepository.findOneByHankeIdAndUserId(hankeId, userId)?.apply {
                 this.kayttooikeustaso = kayttooikeustasoEntity
@@ -47,6 +61,9 @@ class PermissionService(
             throw HankeNotFoundException(hanke.hankeTunnus)
         }
     }
+
+    fun findKayttooikeustaso(kayttooikeustaso: Kayttooikeustaso): KayttooikeustasoEntity =
+        kayttooikeustasoRepository.findOneByKayttooikeustaso(kayttooikeustaso)
 
     companion object {
         fun hasPermission(

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/security/AccessRules.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/security/AccessRules.kt
@@ -6,6 +6,7 @@ import io.sentry.Sentry
 import jakarta.servlet.http.HttpServletResponse
 import mu.KotlinLogging
 import org.springframework.http.HttpMethod
+import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 
 private val logger = KotlinLogging.logger {}
@@ -45,6 +46,7 @@ object AccessRules {
                 Sentry.captureException(authenticationException)
                 response.writer.print(OBJECT_MAPPER.writeValueAsString(HankeError.HAI0001))
                 response.status = HttpServletResponse.SC_UNAUTHORIZED
+                response.contentType = APPLICATION_JSON_VALUE
             }
     }
 }

--- a/services/hanke-service/src/main/resources/application.properties
+++ b/services/hanke-service/src/main/resources/application.properties
@@ -89,6 +89,8 @@ sentry.logging.enabled=${HAITATON_SENTRY_LOGGING_ENABLED:false}
 # Default is access from behind reverse proxy.
 springdoc.swagger-ui.url=${HAITATON_SWAGGER_PATH_PREFIX:/api/v3}/api-docs
 springdoc.swagger-ui.config-url=${HAITATON_SWAGGER_PATH_PREFIX:/api/v3}/api-docs/swagger-config
+springdoc.default-produces-media-type=application/json
+springdoc.default-consumes-media-type=application/json
 
 spring.mail.host=${MAIL_SENDER_HOST:localhost}
 spring.mail.port=${MAIL_SENDER_PORT:2525}

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/ControllerTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/ControllerTest.kt
@@ -6,6 +6,7 @@ import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.ResultActions
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
 
 interface ControllerTest {
     val mockMvc: MockMvc
@@ -13,9 +14,11 @@ interface ControllerTest {
     /** Send a GET request to the given URL. */
     fun get(
         url: String,
-        vararg accept: MediaType = arrayOf(MediaType.APPLICATION_JSON)
+        resultType: MediaType = MediaType.APPLICATION_JSON,
     ): ResultActions {
-        return mockMvc.perform(MockMvcRequestBuilders.get(url).accept(*accept))
+        return mockMvc
+            .perform(MockMvcRequestBuilders.get(url).accept(MediaType.APPLICATION_JSON))
+            .andExpect(content().contentType(resultType))
     }
 
     /**


### PR DESCRIPTION
# Description

Add an endpoint that takes a user token in the request body and creates a permission for the user to the hanke the token is associated with.

The token is deleted from DB after use, since it can't be used again anyway.

The motivation is to activate the permissions that have been created for a contact person. When creating a contact person we don't know which user the contact person is, so we create a user token, that's emailed to the contact. The contact can then use this endpoint (through UI) to activate the given permission, i.e. change the token placeholder to an actual permission.

As an unreleated change, configure springdoc to use application/json as the default for all API descriptions. This way, we don't have to specify the media type for every single response, including all the error responses.

Also, configure springdoc to use a reference for the HankeError enum, so the definition isn't copied for each error response in the OpenAPI JSON. This cut down the size of the JSON file to about half.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1873

## Type of change

- [ ] Bug fix 
- [x] New feature 
- [ ] Other

# Instructions for testing
Please describe tests how this change or new feature can be tested.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 