### PR TITLE
HAI Profile overhaul

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,6 +88,8 @@ services:
       HAITATON_EMAIL_FILTER_USE: false
       CLAMAV_BASE_URL: http://clamav-api:3030
       HAITATON_TESTDATA_ENABLED: true
+      HAITATON_FEATURE_HANKE_EDITING: true
+      HAITATON_FEATURE_USER_MANAGEMENT: true
     depends_on:
       - db
       - clamav-api

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeControllerHankeEditingDisabledITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeControllerHankeEditingDisabledITests.kt
@@ -21,7 +21,7 @@ private const val BASE_URL = "/hankkeet"
 
 @WebMvcTest(HankeController::class, properties = ["haitaton.features.hanke-editing=false"])
 @Import(IntegrationTestConfiguration::class)
-@ActiveProfiles("itest")
+@ActiveProfiles("test")
 @WithMockUser(USERNAME)
 class HankeControllerHankeEditingDisabledITests(@Autowired override val mockMvc: MockMvc) :
     ControllerTest {

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeControllerITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeControllerITests.kt
@@ -48,7 +48,7 @@ private const val BASE_URL = "/hankkeet"
  */
 @WebMvcTest(HankeController::class)
 @Import(IntegrationTestConfiguration::class)
-@ActiveProfiles("itest")
+@ActiveProfiles("test")
 @WithMockUser(USERNAME)
 class HankeControllerITests(@Autowired override val mockMvc: MockMvc) : ControllerTest {
 

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeRepositoryITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeRepositoryITests.kt
@@ -12,7 +12,7 @@ import org.testcontainers.junit.jupiter.Testcontainers
 
 @Testcontainers
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@ActiveProfiles("default")
+@ActiveProfiles("test")
 internal class HankeRepositoryITests : DatabaseTest() {
 
     @Autowired private lateinit var hankeRepository: HankeRepository

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
@@ -88,7 +88,7 @@ private const val NAME_SOMETHING = "Som Et Hing"
 
 @Testcontainers
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@ActiveProfiles("default")
+@ActiveProfiles("test")
 @WithMockUser(USER_NAME)
 class HankeServiceITests : DatabaseTest() {
 

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HanketunnusServiceImplITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HanketunnusServiceImplITest.kt
@@ -10,7 +10,7 @@ import org.testcontainers.junit.jupiter.Testcontainers
 
 @Testcontainers
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@ActiveProfiles("default")
+@ActiveProfiles("test")
 internal class HanketunnusServiceImplITest : DatabaseTest() {
 
     @Autowired lateinit var hanketunnusService: HanketunnusService

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/IntegrationTestConfiguration.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/IntegrationTestConfiguration.kt
@@ -25,7 +25,6 @@ import io.sentry.protocol.SentryId
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.test.context.TestConfiguration
 import org.springframework.context.annotation.Bean
-import org.springframework.context.annotation.Profile
 import org.springframework.context.event.ContextRefreshedEvent
 import org.springframework.context.event.EventListener
 import org.springframework.jdbc.core.JdbcOperations
@@ -33,7 +32,6 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.web.SecurityFilterChain
 
 @TestConfiguration
-@Profile("itest")
 @EnableConfigurationProperties(GdprProperties::class, FeatureFlags::class)
 class IntegrationTestConfiguration {
 

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/SpringDocITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/SpringDocITest.kt
@@ -14,7 +14,7 @@ import org.testcontainers.junit.jupiter.Testcontainers
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @Testcontainers
-@ActiveProfiles("default")
+@ActiveProfiles("test")
 @AutoConfigureMockMvc
 class SpringdocITest(@Autowired override val mockMvc: MockMvc) : ControllerTest, DatabaseTest() {
 

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/StatusControllerITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/StatusControllerITests.kt
@@ -14,7 +14,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers
 
 @WebMvcTest(StatusController::class)
 @Import(IntegrationTestConfiguration::class)
-@ActiveProfiles("itest")
+@ActiveProfiles("test")
 class StatusControllerITests(@Autowired val mockMvc: MockMvc) {
 
     @Autowired lateinit var jdbcOperations: JdbcOperations

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationControllerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationControllerITest.kt
@@ -52,7 +52,7 @@ private const val BASE_URL = "/hakemukset"
 
 @WebMvcTest(ApplicationController::class)
 @Import(IntegrationTestConfiguration::class)
-@ActiveProfiles("itest")
+@ActiveProfiles("test")
 class ApplicationControllerITest(@Autowired override val mockMvc: MockMvc) : ControllerTest {
 
     @Autowired private lateinit var applicationService: ApplicationService

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceITest.kt
@@ -93,7 +93,7 @@ private val dataWithoutAreas = AlluDataFactory.createCableReportApplicationData(
 
 @Testcontainers
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@ActiveProfiles("default", "emailtest")
+@ActiveProfiles("test")
 @WithMockUser(USERNAME)
 class ApplicationServiceITest : DatabaseTest() {
 

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentControllerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentControllerITest.kt
@@ -64,7 +64,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
 @WebMvcTest(ApplicationAttachmentController::class)
 @Import(IntegrationTestConfiguration::class)
-@ActiveProfiles("itest")
+@ActiveProfiles("test")
 @WithMockUser(USERNAME)
 class ApplicationAttachmentControllerITest(@Autowired override val mockMvc: MockMvc) :
     ControllerTest {

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentServiceITest.kt
@@ -69,7 +69,7 @@ private const val ALLU_ID = 42
 
 @Testcontainers
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@ActiveProfiles("default")
+@ActiveProfiles("test")
 @WithMockUser(USERNAME)
 @TestPropertySource(locations = ["classpath:application-test.properties"])
 class ApplicationAttachmentServiceITest : DatabaseTest() {

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/common/FileScanClientITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/common/FileScanClientITest.kt
@@ -26,7 +26,7 @@ import org.testcontainers.junit.jupiter.Testcontainers
 
 @Testcontainers
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@ActiveProfiles("default")
+@ActiveProfiles("test")
 @TestPropertySource(locations = ["classpath:application-test.properties"])
 class FileScanClientITest : DatabaseTest() {
 

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentControllerITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentControllerITests.kt
@@ -53,7 +53,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
 @WebMvcTest(HankeAttachmentController::class)
 @Import(IntegrationTestConfiguration::class)
-@ActiveProfiles("itest")
+@ActiveProfiles("test")
 @WithMockUser(USERNAME)
 class HankeAttachmentControllerITests(@Autowired override val mockMvc: MockMvc) : ControllerTest {
 
@@ -201,7 +201,7 @@ class HankeAttachmentControllerITests(@Autowired override val mockMvc: MockMvc) 
     properties = ["haitaton.features.hanke-editing=false"]
 )
 @Import(IntegrationTestConfiguration::class)
-@ActiveProfiles("itest")
+@ActiveProfiles("test")
 @WithMockUser(USERNAME)
 class HankeAttachmentControllerHankeEditingDisabledITests(
     @Autowired override val mockMvc: MockMvc

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentServiceITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentServiceITests.kt
@@ -42,7 +42,7 @@ import org.testcontainers.junit.jupiter.Testcontainers
 
 @Testcontainers
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@ActiveProfiles("default")
+@ActiveProfiles("test")
 @WithMockUser(USERNAME)
 @TestPropertySource(locations = ["classpath:application-test.properties"])
 class HankeAttachmentServiceITests : DatabaseTest() {

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/domain/PublicHankeControllerITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/domain/PublicHankeControllerITests.kt
@@ -26,7 +26,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPat
 
 @WebMvcTest(PublicHankeController::class)
 @Import(IntegrationTestConfiguration::class)
-@ActiveProfiles("itest")
+@ActiveProfiles("test")
 class PublicHankeControllerITests(@Autowired override val mockMvc: MockMvc) : ControllerTest {
 
     @Autowired private lateinit var hankeService: HankeService

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/email/EmailSenderServiceFilterITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/email/EmailSenderServiceFilterITest.kt
@@ -24,7 +24,7 @@ import org.testcontainers.junit.jupiter.Testcontainers
             "haitaton.email.filter.allow-list=test@test.test;something@mail.com"
         ]
 )
-@ActiveProfiles("default", "emailtest")
+@ActiveProfiles("test")
 class EmailSenderServiceFilterITest : DatabaseTest() {
 
     companion object {

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/email/EmailSenderServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/email/EmailSenderServiceITest.kt
@@ -26,7 +26,7 @@ private const val APPLICATION_IDENTIFIER = "JS2300001"
 
 @Testcontainers
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@ActiveProfiles("default", "emailtest")
+@ActiveProfiles("test")
 class EmailSenderServiceITest : DatabaseTest() {
 
     companion object {

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/gdpr/GdprControllerITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/gdpr/GdprControllerITests.kt
@@ -35,7 +35,7 @@ private const val USERID = "test-user"
 
 @WebMvcTest(controllers = [GdprController::class], properties = ["haitaton.gdpr.disabled=false"])
 @Import(IntegrationTestConfiguration::class)
-@ActiveProfiles("itest")
+@ActiveProfiles("test")
 @WithMockUser(USERID)
 class GdprControllerITests(@Autowired var mockMvc: MockMvc) {
 

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/gdpr/GdprServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/gdpr/GdprServiceITest.kt
@@ -33,7 +33,7 @@ private const val USERID = "test-user"
 
 @Testcontainers
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@ActiveProfiles("default")
+@ActiveProfiles("test")
 @WithMockUser(USERID)
 class GdprServiceITest : DatabaseTest() {
 

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/geometria/GeometriatDaoImplITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/geometria/GeometriatDaoImplITest.kt
@@ -23,7 +23,7 @@ import org.testcontainers.junit.jupiter.Testcontainers
 
 @Testcontainers
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@ActiveProfiles("default")
+@ActiveProfiles("test")
 internal class GeometriatDaoImplITest : DatabaseTest() {
 
     private val expectedPolygonArea = 1707f

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/geometria/GeometriatServiceImplITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/geometria/GeometriatServiceImplITest.kt
@@ -25,7 +25,7 @@ import org.testcontainers.junit.jupiter.Testcontainers
 
 @Testcontainers
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@ActiveProfiles("default")
+@ActiveProfiles("test")
 @WithMockUser(username = "test")
 internal class GeometriatServiceImplITest : DatabaseTest() {
 

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/logging/AuditLogServiceITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/logging/AuditLogServiceITests.kt
@@ -25,7 +25,7 @@ import org.testcontainers.junit.jupiter.Testcontainers
 //  Thus, have to use this test containers -way, which uses the proper PostgreSQL.
 @Testcontainers
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@ActiveProfiles("default")
+@ActiveProfiles("test")
 class AuditLogServiceITests : DatabaseTest() {
 
     @Autowired private lateinit var entityManager: EntityManager

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaControllerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaControllerITest.kt
@@ -46,12 +46,9 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 private const val USERNAME = "testUser"
 private const val HANKE_TUNNUS = HankeFactory.defaultHankeTunnus
 
-@WebMvcTest(
-    HankeKayttajaController::class,
-    properties = ["haitaton.features.user-management=true"],
-)
+@WebMvcTest(HankeKayttajaController::class)
 @Import(IntegrationTestConfiguration::class)
-@ActiveProfiles("itest")
+@ActiveProfiles("test")
 @WithMockUser(USERNAME)
 class HankeKayttajaControllerITest(@Autowired override val mockMvc: MockMvc) : ControllerTest {
 
@@ -454,7 +451,7 @@ class HankeKayttajaControllerITest(@Autowired override val mockMvc: MockMvc) : C
     properties = ["haitaton.features.user-management=false"],
 )
 @Import(IntegrationTestConfiguration::class)
-@ActiveProfiles("itest")
+@ActiveProfiles("test")
 @WithMockUser(USERNAME)
 class HankeKayttajaControllerFeatureDisabledITest(@Autowired override val mockMvc: MockMvc) :
     ControllerTest {

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaServiceITest.kt
@@ -46,7 +46,7 @@ const val kayttajaTunnistePattern = "[a-zA-z0-9]{24}"
 
 @Testcontainers
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@ActiveProfiles("default")
+@ActiveProfiles("test")
 @WithMockUser(USERNAME)
 class HankeKayttajaServiceITest : DatabaseTest() {
 

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/PermissionServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/PermissionServiceITest.kt
@@ -22,7 +22,7 @@ import org.testcontainers.junit.jupiter.Testcontainers
 
 @Testcontainers
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@ActiveProfiles("default")
+@ActiveProfiles("test")
 @WithMockUser(username = "test7358")
 class PermissionServiceITest : DatabaseTest() {
 

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/testdata/TestDataControllerDisabledITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/testdata/TestDataControllerDisabledITest.kt
@@ -28,7 +28,7 @@ private const val BASE_URL = "/testdata"
     properties = ["haitaton.testdata.enabled=false"],
 )
 @Import(IntegrationTestConfiguration::class)
-@ActiveProfiles("itest")
+@ActiveProfiles("test")
 @WithMockUser(USERNAME)
 class TestDataControllerDisabledITest(@Autowired override val mockMvc: MockMvc) : ControllerTest {
 

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/testdata/TestDataControllerEnabledITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/testdata/TestDataControllerEnabledITest.kt
@@ -28,7 +28,7 @@ private const val BASE_URL = "/testdata"
     properties = ["haitaton.testdata.enabled=true"],
 )
 @Import(IntegrationTestConfiguration::class)
-@ActiveProfiles("itest")
+@ActiveProfiles("test")
 @WithMockUser(USERNAME)
 class TestDataControllerEnabledITest(@Autowired override val mockMvc: MockMvc) : ControllerTest {
 

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/testdata/TestDataServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/testdata/TestDataServiceITest.kt
@@ -25,7 +25,7 @@ private const val USERNAME = "testUser"
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
     properties = ["haitaton.testdata.enabled=true"],
 )
-@ActiveProfiles("default")
+@ActiveProfiles("test")
 @WithMockUser(USERNAME)
 class TestDataServiceITest : DatabaseTest() {
 

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluTormaysServicePGITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluTormaysServicePGITest.kt
@@ -17,7 +17,7 @@ import org.testcontainers.junit.jupiter.Testcontainers
 
 @Testcontainers
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@ActiveProfiles("default")
+@ActiveProfiles("test")
 internal class TormaystarkasteluTormaysServicePGITest : DatabaseTest() {
 
     @Autowired private lateinit var geometriatDao: GeometriatDao

--- a/services/hanke-service/src/integrationTest/resources/application-test.properties
+++ b/services/hanke-service/src/integrationTest/resources/application-test.properties
@@ -1,1 +1,0 @@
-haitaton.clamav.baseUrl=http://localhost:6789

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/configuration/Configuration.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/configuration/Configuration.kt
@@ -42,14 +42,12 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.context.annotation.Profile
 import org.springframework.http.client.reactive.ReactorClientHttpConnector
 import org.springframework.jdbc.core.JdbcOperations
 import org.springframework.web.reactive.function.client.WebClient
 import reactor.netty.http.client.HttpClient
 
 @Configuration
-@Profile("default")
 @EnableConfigurationProperties(
     GdprProperties::class,
     FeatureFlags::class,

--- a/services/hanke-service/src/main/resources/application.properties
+++ b/services/hanke-service/src/main/resources/application.properties
@@ -22,8 +22,8 @@ haitaton.gdpr.delete-scope=${HAITATON_GDPR_DELETE_SCOPE:haitaton.gdprdelete}
 #logging.level.org.springframework.security=DEBUG
 
 # Disable endpoints that are e.g. in development and should not be in production.
-haitaton.features.hanke-editing=${HAITATON_FEATURE_HANKE_EDITING:true}
-haitaton.features.user-management=${HAITATON_FEATURE_USER_MANAGEMENT:true}
+haitaton.features.hanke-editing=${HAITATON_FEATURE_HANKE_EDITING:false}
+haitaton.features.user-management=${HAITATON_FEATURE_USER_MANAGEMENT:false}
 
 # For dev and test environments, enable the testdata controller for resetting data
 haitaton.testdata.enabled=${HAITATON_TESTDATA_ENABLED:false}

--- a/services/hanke-service/src/test/resources/application-test.properties
+++ b/services/hanke-service/src/test/resources/application-test.properties
@@ -5,3 +5,6 @@ spring.mail.properties.mail.smtp.auth=false
 spring.mail.properties.mail.smtp.starttls.enable=false
 spring.mail.properties.mail.smtp.starttls.required=false
 spring.mail.properties.mail.debug=false
+haitaton.clamav.baseUrl=http://localhost:6789
+haitaton.features.hanke-editing=true
+haitaton.features.user-management=true


### PR DESCRIPTION
# Description

Remove the profiles from Configuration and IntegrationTestConfiguration. Configuration is enabled by default, and we import IntegrationTestConfiguration explicitly when we use it.

This frees us to use the test profile in all tests, especially integration tests. This means we can use application-test.properties for configuring the test environment. This, in turn, means we don't have to configure the main application.properties specifically for tests and we can use production-safe defaults.

### Jira Issue: -

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [x] Other

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 