### PR TITLE
HAI Allow for custom git pre-push hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,9 @@ This adds a hook that will build the project and run all tests and other checks
 before any push you make. The checks need to be run successfully for the push to
 happen. If necessary, the checks can be skipped with `git push --no-verify`.
 
+Custom pre-push scripts can be added under `.git/hooks/pre-push.d`. Push will
+fail if any of the pre-push scripts fail.
+
 ### Code coverage report
 
 Gradle Jacoco plugin is used to create a code coverage report.

--- a/githooks/pre-push
+++ b/githooks/pre-push
@@ -1,3 +1,16 @@
 #!/bin/sh
 
-./gradlew build integrationTest
+#!/bin/bash
+
+hooks="$(dirname "$0")/pre-push.d"
+
+for hook in ${hooks}/*; do
+    bash $hook
+    RESULT=$?
+    if [ $RESULT != 0 ]; then
+        echo "pre-push.d/$hook returned non-zero: $RESULT, abort push"
+        exit $RESULT
+    fi
+done
+
+exit 0

--- a/githooks/pre-push
+++ b/githooks/pre-push
@@ -1,7 +1,5 @@
 #!/bin/sh
 
-#!/bin/bash
-
 hooks="$(dirname "$0")/pre-push.d"
 
 for hook in ${hooks}/*; do

--- a/githooks/pre-push.d/build
+++ b/githooks/pre-push.d/build
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+./gradlew build integrationTest


### PR DESCRIPTION
# Description

I want to have a custom pre-push git hook, which isn't useful for other people. If I changed the existing one, it would get overwritten by the gradle script.

Replace the pre-push script with a script that runs all scripts from a folder. Add the maintained pre-push script as one of the files in that folder.

That is,
- `githooks/pre-push` is installed as `.git/hooks/pre-push`
- All files under `githooks/pre-push.d` are copied under `.git/hooks/pre-push.d
- A developer can add custom scripts to `.git/hooks/pre-push.d` and they won't be overwritten by the gradle build script
- `.git/hooks/pre-push` runs all scripts under `.git/hooks/pre-push.d` and fails if any of them fail

With this structure, developers can have custom hooks while still keeping the build-hook maintained in version control.

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [X] Other

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [X] I have made necessary changes to the documentation, link to confluence
 or other location: README