### PR TITLE
HAI-1875 Add audit logging for new users and tokens

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceITest.kt
@@ -345,8 +345,8 @@ class ApplicationServiceITest : DatabaseTest() {
         val otherUser = "otherUser"
         val hanke = hankeRepository.save(HankeEntity(hankeTunnus = "HAI-1234"))
         val hanke2 = hankeRepository.save(HankeEntity(hankeTunnus = "HAI-1235"))
-        permissionService.setPermission(hanke.id!!, USERNAME, Kayttooikeustaso.HAKEMUSASIOINTI)
-        permissionService.setPermission(hanke2.id!!, "otherUser", Kayttooikeustaso.HAKEMUSASIOINTI)
+        permissionService.create(hanke.id!!, USERNAME, Kayttooikeustaso.HAKEMUSASIOINTI)
+        permissionService.create(hanke2.id!!, "otherUser", Kayttooikeustaso.HAKEMUSASIOINTI)
 
         alluDataFactory.saveApplicationEntities(3, USERNAME, hanke = hanke) { _, application ->
             application.userId = USERNAME
@@ -376,8 +376,8 @@ class ApplicationServiceITest : DatabaseTest() {
         val hanke = hankeRepository.save(HankeEntity(hankeTunnus = "HAI-1234"))
         val hanke2 = hankeRepository.save(HankeEntity(hankeTunnus = "HAI-1235"))
         val hanke3 = hankeRepository.save(HankeEntity(hankeTunnus = "HAI-1236"))
-        permissionService.setPermission(hanke.id!!, USERNAME, Kayttooikeustaso.HAKEMUSASIOINTI)
-        permissionService.setPermission(hanke2.id!!, USERNAME, Kayttooikeustaso.HAKEMUSASIOINTI)
+        permissionService.create(hanke.id!!, USERNAME, Kayttooikeustaso.HAKEMUSASIOINTI)
+        permissionService.create(hanke2.id!!, USERNAME, Kayttooikeustaso.HAKEMUSASIOINTI)
         val application1 = alluDataFactory.saveApplicationEntity(username = USERNAME, hanke = hanke)
         val application2 =
             alluDataFactory.saveApplicationEntity(username = "secondUser", hanke = hanke2)

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaServiceITest.kt
@@ -973,14 +973,6 @@ class HankeKayttajaServiceITest : DatabaseTest() {
         k.prop(HankeKayttajaEntity::kayttajaTunniste).isNotNull()
     }
 
-    private fun Assert<PermissionEntity>.isOfEqualDataTo(other: PermissionEntity) =
-        given { actual ->
-            assertThat(actual.id).isEqualTo(other.id)
-            assertThat(actual.hankeId).isEqualTo(other.hankeId)
-            assertThat(actual.userId).isEqualTo(other.userId)
-            assertThat(actual.kayttooikeustaso).isEqualTo(other.kayttooikeustaso)
-        }
-
     private val expectedNames =
         arrayOf(
             "yhteys-etu1 yhteys-suku1",

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaServiceITest.kt
@@ -7,6 +7,7 @@ import assertk.assertThat
 import assertk.assertions.containsExactly
 import assertk.assertions.containsExactlyInAnyOrder
 import assertk.assertions.each
+import assertk.assertions.exactly
 import assertk.assertions.first
 import assertk.assertions.hasClass
 import assertk.assertions.hasSize
@@ -17,19 +18,27 @@ import assertk.assertions.isNotNull
 import assertk.assertions.isNull
 import assertk.assertions.matches
 import assertk.assertions.messageContains
-import com.fasterxml.jackson.databind.util.ClassUtil.hasClass
+import assertk.assertions.prop
 import fi.hel.haitaton.hanke.DatabaseTest
 import fi.hel.haitaton.hanke.factory.AlluDataFactory
+import fi.hel.haitaton.hanke.factory.AlluDataFactory.Companion.withContact
 import fi.hel.haitaton.hanke.factory.AlluDataFactory.Companion.withContacts
 import fi.hel.haitaton.hanke.factory.HankeFactory
 import fi.hel.haitaton.hanke.factory.HankeFactory.Companion.withGeneratedOmistaja
 import fi.hel.haitaton.hanke.factory.HankeFactory.Companion.withYhteystiedot
 import fi.hel.haitaton.hanke.factory.HankeYhteystietoFactory
 import fi.hel.haitaton.hanke.logging.AuditLogRepository
+import fi.hel.haitaton.hanke.logging.AuditLogTarget
 import fi.hel.haitaton.hanke.logging.ObjectType
 import fi.hel.haitaton.hanke.logging.Operation
 import fi.hel.haitaton.hanke.logging.UserRole
 import fi.hel.haitaton.hanke.test.Asserts.isRecent
+import fi.hel.haitaton.hanke.test.AuditLogEntryEntityAsserts.auditEvent
+import fi.hel.haitaton.hanke.test.AuditLogEntryEntityAsserts.hasObjectAfter
+import fi.hel.haitaton.hanke.test.AuditLogEntryEntityAsserts.hasTargetType
+import fi.hel.haitaton.hanke.test.AuditLogEntryEntityAsserts.hasUserActor
+import fi.hel.haitaton.hanke.test.AuditLogEntryEntityAsserts.isSuccess
+import fi.hel.haitaton.hanke.test.AuditLogEntryEntityAsserts.withTarget
 import fi.hel.haitaton.hanke.toChangeLogJsonString
 import java.time.OffsetDateTime
 import java.util.UUID
@@ -103,19 +112,70 @@ class HankeKayttajaServiceITest : DatabaseTest() {
         fun `Saves kayttaja with correct permission and other data`() {
             val hankeEntity = hankeFactory.saveEntity()
             val savedHankeId = hankeEntity.id!!
-            val savedPermission =
-                savePermission(savedHankeId, USERNAME, Kayttooikeustaso.KAIKKI_OIKEUDET)
+            assertThat(hankeKayttajaRepository.findAll()).isEmpty()
 
-            hankeKayttajaService.addHankeFounder(savedHankeId, perustaja, savedPermission)
+            hankeKayttajaService.addHankeFounder(savedHankeId, perustaja, USERNAME)
 
             val kayttajaEntity =
                 hankeKayttajaRepository.findAll().also { assertThat(it).hasSize(1) }.first()
             with(kayttajaEntity) {
                 assertThat(id).isNotNull()
                 assertThat(hankeId).isEqualTo(savedHankeId)
-                assertThat(permission!!).isOfEqualDataTo(savedPermission)
+                assertThat(permission).isNotNull().all {
+                    prop(PermissionEntity::kayttooikeustaso)
+                        .isEqualTo(Kayttooikeustaso.KAIKKI_OIKEUDET)
+                    prop(PermissionEntity::hankeId).isEqualTo(savedHankeId)
+                    prop(PermissionEntity::userId).isEqualTo(USERNAME)
+                }
                 assertThat(sahkoposti).isEqualTo(perustaja.email)
                 assertThat(nimi).isEqualTo(perustaja.nimi)
+            }
+        }
+
+        @Test
+        fun `Writes user and token to audit log`() {
+            val hankeEntity = hankeFactory.saveEntity()
+            val savedHankeId = hankeEntity.id!!
+            auditLogRepository.deleteAll()
+
+            hankeKayttajaService.addHankeFounder(savedHankeId, perustaja, USERNAME)
+
+            val (kayttajaEntries, tunnisteEntries) =
+                auditLogRepository
+                    .findAll()
+                    .also { assertThat(it).hasSize(2) }
+                    .partition { it.message.auditEvent.target.type == ObjectType.HANKE_KAYTTAJA }
+            assertThat(kayttajaEntries).hasSize(1)
+            assertThat(kayttajaEntries).first().isSuccess(Operation.CREATE) {
+                hasUserActor(USERNAME)
+                withTarget {
+                    prop(AuditLogTarget::id).isNotNull()
+                    prop(AuditLogTarget::type).isEqualTo(ObjectType.HANKE_KAYTTAJA)
+                    prop(AuditLogTarget::objectBefore).isNull()
+                    hasObjectAfter {
+                        prop(HankeKayttaja::id).isNotNull()
+                        prop(HankeKayttaja::hankeId).isEqualTo(savedHankeId)
+                        prop(HankeKayttaja::kayttajaTunnisteId).isNull()
+                        prop(HankeKayttaja::permissionId).isNotNull()
+                        prop(HankeKayttaja::nimi).isEqualTo(perustaja.nimi)
+                        prop(HankeKayttaja::sahkoposti).isEqualTo(perustaja.email)
+                    }
+                }
+            }
+            assertThat(tunnisteEntries).hasSize(1)
+            assertThat(tunnisteEntries).first().isSuccess(Operation.CREATE) {
+                hasUserActor(USERNAME)
+                withTarget {
+                    prop(AuditLogTarget::id).isNotNull()
+                    prop(AuditLogTarget::type).isEqualTo(ObjectType.PERMISSION)
+                    prop(AuditLogTarget::objectBefore).isNull()
+                    hasObjectAfter {
+                        prop(Permission::kayttooikeustaso)
+                            .isEqualTo(Kayttooikeustaso.KAIKKI_OIKEUDET)
+                        prop(Permission::hankeId).isEqualTo(savedHankeId)
+                        prop(Permission::userId).isEqualTo(USERNAME)
+                    }
+                }
             }
         }
     }
@@ -137,7 +197,7 @@ class HankeKayttajaServiceITest : DatabaseTest() {
                     hanke = hanke
                 )
 
-            hankeKayttajaService.saveNewTokensFromApplication(application, 1)
+            hankeKayttajaService.saveNewTokensFromApplication(application, 1, USERNAME)
 
             assertThat(kayttajaTunnisteRepository.findAll()).isEmpty()
             assertThat(hankeKayttajaRepository.findAll()).isEmpty()
@@ -167,7 +227,7 @@ class HankeKayttajaServiceITest : DatabaseTest() {
                     hanke = hanke
                 )
 
-            hankeKayttajaService.saveNewTokensFromApplication(application, hanke.id!!)
+            hankeKayttajaService.saveNewTokensFromApplication(application, hanke.id!!, USERNAME)
 
             val tunnisteet = kayttajaTunnisteRepository.findAll()
             assertThat(tunnisteet).hasSize(4)
@@ -217,7 +277,7 @@ class HankeKayttajaServiceITest : DatabaseTest() {
                     hanke = hanke
                 )
 
-            hankeKayttajaService.saveNewTokensFromApplication(application, hanke.id!!)
+            hankeKayttajaService.saveNewTokensFromApplication(application, hanke.id!!, USERNAME)
 
             assertThat(kayttajaTunnisteRepository.findAll()).hasSize(2)
             val kayttajat = hankeKayttajaRepository.findAll()
@@ -256,7 +316,7 @@ class HankeKayttajaServiceITest : DatabaseTest() {
                 )
             assertThat(kayttajaTunnisteRepository.findAll()).hasSize(2)
 
-            hankeKayttajaService.saveNewTokensFromApplication(application, hanke.id!!)
+            hankeKayttajaService.saveNewTokensFromApplication(application, hanke.id!!, USERNAME)
 
             assertThat(kayttajaTunnisteRepository.findAll()).hasSize(4)
             val kayttajat = hankeKayttajaRepository.findAll()
@@ -297,7 +357,7 @@ class HankeKayttajaServiceITest : DatabaseTest() {
                 )
             assertThat(kayttajaTunnisteRepository.findAll()).isEmpty()
 
-            hankeKayttajaService.saveNewTokensFromApplication(application, hanke.id!!)
+            hankeKayttajaService.saveNewTokensFromApplication(application, hanke.id!!, USERNAME)
 
             val tunnisteet = kayttajaTunnisteRepository.findAll()
             assertThat(tunnisteet).hasSize(2)
@@ -314,6 +374,33 @@ class HankeKayttajaServiceITest : DatabaseTest() {
                     "email4",
                 )
         }
+
+        @Test
+        fun `Writes new users and tokens to audit log`() {
+            val hanke = hankeFactory.saveEntity()
+            val applicationData =
+                AlluDataFactory.createCableReportApplicationData(
+                    customerWithContacts =
+                        AlluDataFactory.createCompanyCustomer().withContact(email = "email1"),
+                    contractorWithContacts =
+                        AlluDataFactory.createCompanyCustomer().withContact(email = "email3"),
+                )
+            val application =
+                AlluDataFactory.createApplicationEntity(
+                    applicationData = applicationData,
+                    hanke = hanke
+                )
+            auditLogRepository.deleteAll()
+
+            hankeKayttajaService.saveNewTokensFromApplication(application, hanke.id!!, USERNAME)
+
+            assertThat(auditLogRepository.findAll()).all {
+                hasSize(4)
+                each { it.auditEvent().hasUserActor(USERNAME) }
+                exactly(2) { it.hasTargetType(ObjectType.HANKE_KAYTTAJA) }
+                exactly(2) { it.hasTargetType(ObjectType.KAYTTAJA_TUNNISTE) }
+            }
+        }
     }
 
     @Nested
@@ -321,7 +408,7 @@ class HankeKayttajaServiceITest : DatabaseTest() {
 
         @Test
         fun `Does nothing if hanke has no contacts`() {
-            hankeKayttajaService.saveNewTokensFromHanke(HankeFactory.create())
+            hankeKayttajaService.saveNewTokensFromHanke(HankeFactory.create(), USERNAME)
 
             assertThat(kayttajaTunnisteRepository.findAll()).isEmpty()
             assertThat(hankeKayttajaRepository.findAll()).isEmpty()
@@ -329,20 +416,19 @@ class HankeKayttajaServiceITest : DatabaseTest() {
 
         @Test
         fun `Creates tokens for unique ones`() {
+            val hankeEntity = hankeFactory.saveMinimal()
             val hanke =
-                hankeFactory.save(
-                    HankeFactory.create()
-                        .withYhteystiedot(
-                            // each has a duplicate
-                            omistajat = listOf(1, 1),
-                            rakennuttajat = listOf(2, 2),
-                            toteuttajat = listOf(3, 3),
-                            muut = listOf(4, 4)
-                        )
-                )
+                HankeFactory.create(id = hankeEntity.id, hankeTunnus = hankeEntity.hankeTunnus)
+                    .withYhteystiedot(
+                        // each has a duplicate
+                        omistajat = listOf(1, 1),
+                        rakennuttajat = listOf(2, 2),
+                        toteuttajat = listOf(3, 3),
+                        muut = listOf(4, 4)
+                    )
             assertThat(hanke.extractYhteystiedot()).hasSize(8)
 
-            hankeKayttajaService.saveNewTokensFromHanke(hanke)
+            hankeKayttajaService.saveNewTokensFromHanke(hanke, USERNAME)
 
             val tunnisteet: List<KayttajaTunnisteEntity> = kayttajaTunnisteRepository.findAll()
             val kayttajat: List<HankeKayttajaEntity> = hankeKayttajaRepository.findAll()
@@ -353,12 +439,38 @@ class HankeKayttajaServiceITest : DatabaseTest() {
         }
 
         @Test
+        fun `Writes new users and tokens to audit log`() {
+            val hankeEntity = hankeFactory.saveMinimal()
+            val hanke =
+                HankeFactory.create(id = hankeEntity.id, hankeTunnus = hankeEntity.hankeTunnus)
+                    .withYhteystiedot(
+                        // each has a duplicate
+                        omistajat = listOf(1, 1),
+                        rakennuttajat = listOf(2, 2),
+                        toteuttajat = listOf(3, 3),
+                        muut = listOf(4, 4)
+                    )
+            auditLogRepository.deleteAll()
+
+            hankeKayttajaService.saveNewTokensFromHanke(hanke, USERNAME)
+
+            assertThat(auditLogRepository.findAll()).all {
+                hasSize(8)
+                each { it.auditEvent().hasUserActor(USERNAME) }
+                exactly(4) { it.hasTargetType(ObjectType.HANKE_KAYTTAJA) }
+                exactly(4) { it.hasTargetType(ObjectType.KAYTTAJA_TUNNISTE) }
+            }
+        }
+
+        @Test
         fun `With pre-existing permissions does not create duplicate`() {
             val hanke = hankeFactory.save()
             saveUserAndPermission(hanke.id!!, "Existing User One", "ali.kontakti@meili.com")
+            auditLogRepository.deleteAll()
 
             hankeKayttajaService.saveNewTokensFromHanke(
-                hanke.apply { this.omistajat.add(HankeYhteystietoFactory.create()) }
+                hanke.apply { this.omistajat.add(HankeYhteystietoFactory.create()) },
+                USERNAME
             )
 
             val tunnisteet = kayttajaTunnisteRepository.findAll()
@@ -370,6 +482,7 @@ class HankeKayttajaServiceITest : DatabaseTest() {
                 .containsExactly(
                     "ali.kontakti@meili.com",
                 )
+            assertThat(auditLogRepository.findAll()).isEmpty()
         }
     }
 
@@ -395,7 +508,7 @@ class HankeKayttajaServiceITest : DatabaseTest() {
             val updatedKayttaja = hankeKayttajaRepository.getReferenceById(kayttaja.id)
             assertThat(updatedKayttaja.kayttajaTunniste).isNull()
             assertThat(updatedKayttaja.permission).isNotNull().transform {
-                it.kayttooikeustaso.kayttooikeustaso == Kayttooikeustaso.HANKEMUOKKAUS
+                it.kayttooikeustaso == Kayttooikeustaso.HANKEMUOKKAUS
             }
         }
 
@@ -504,7 +617,7 @@ class HankeKayttajaServiceITest : DatabaseTest() {
 
             val updatedKayttaja = hankeKayttajaRepository.getReferenceById(kayttaja.id)
             assertThat(updatedKayttaja.permission).isNotNull().transform {
-                it.kayttooikeustaso.kayttooikeustaso == Kayttooikeustaso.HANKEMUOKKAUS
+                it.kayttooikeustaso == Kayttooikeustaso.HANKEMUOKKAUS
             }
             assertThat(updatedKayttaja.kayttajaTunniste).isNotNull().transform {
                 it.kayttooikeustaso == Kayttooikeustaso.KATSELUOIKEUS
@@ -629,7 +742,7 @@ class HankeKayttajaServiceITest : DatabaseTest() {
             val updatedKayttaja = hankeKayttajaRepository.getReferenceById(kayttaja.id)
             assertThat(updatedKayttaja.kayttajaTunniste).isNull()
             assertThat(updatedKayttaja.permission).isNotNull().transform {
-                it.kayttooikeustaso.kayttooikeustaso == Kayttooikeustaso.HANKEMUOKKAUS
+                it.kayttooikeustaso == Kayttooikeustaso.HANKEMUOKKAUS
             }
         }
 
@@ -710,7 +823,9 @@ class HankeKayttajaServiceITest : DatabaseTest() {
         @Test
         fun `Don't throw an exception if an anonymous user still has KAIKKI_OIKEUDET`() {
             val hanke = hankeFactory.save()
-            permissionService.setPermission(hanke.id!!, USERNAME, Kayttooikeustaso.KAIKKI_OIKEUDET)
+            hankeKayttajaRepository.deleteAll()
+            permissionRepository.deleteAll()
+            permissionService.create(hanke.id!!, USERNAME, Kayttooikeustaso.KAIKKI_OIKEUDET)
             val kayttaja =
                 saveUserAndPermission(
                     hanke.id!!,
@@ -722,7 +837,7 @@ class HankeKayttajaServiceITest : DatabaseTest() {
 
             val updatedKayttaja = hankeKayttajaRepository.getReferenceById(kayttaja.id)
             assertThat(updatedKayttaja.permission).isNotNull().transform {
-                it.kayttooikeustaso.kayttooikeustaso == Kayttooikeustaso.HANKEMUOKKAUS
+                it.kayttooikeustaso == Kayttooikeustaso.HANKEMUOKKAUS
             }
         }
     }
@@ -779,13 +894,10 @@ class HankeKayttajaServiceITest : DatabaseTest() {
             val hanke = hankeFactory.save()
             val kayttaja = saveUserAndToken(hanke.id!!, tunniste = tunniste)
             val permission =
-                permissionRepository.save(
-                    PermissionEntity(
-                        userId = newUserId,
-                        hankeId = hanke.id!!,
-                        kayttooikeustaso =
-                            permissionService.findKayttooikeustaso(Kayttooikeustaso.KATSELUOIKEUS)
-                    )
+                permissionService.create(
+                    userId = newUserId,
+                    hankeId = hanke.id!!,
+                    kayttooikeustaso = Kayttooikeustaso.KATSELUOIKEUS
                 )
 
             assertFailure { hankeKayttajaService.createPermissionFromToken(newUserId, tunniste) }
@@ -828,7 +940,7 @@ class HankeKayttajaServiceITest : DatabaseTest() {
             val permission = permissionRepository.findOneByHankeIdAndUserId(hanke.id!!, newUserId)
             assertThat(permission)
                 .isNotNull()
-                .transform { it.kayttooikeustaso.kayttooikeustaso }
+                .transform { it.kayttooikeustaso }
                 .isEqualTo(Kayttooikeustaso.KATSELUOIKEUS)
         }
 
@@ -844,21 +956,21 @@ class HankeKayttajaServiceITest : DatabaseTest() {
     }
 
     private fun Assert<List<KayttajaTunnisteEntity>>.areValid() = each { t ->
-        t.transform { it.id }.isNotNull()
-        t.transform { it.kayttooikeustaso }.isEqualTo(Kayttooikeustaso.KATSELUOIKEUS)
-        t.transform { it.createdAt }.isRecent()
-        t.transform { it.sentAt }.isNull()
-        t.transform { it.tunniste }.matches(Regex(kayttajaTunnistePattern))
-        t.transform { it.hankeKayttaja }.isNotNull()
+        t.prop(KayttajaTunnisteEntity::id).isNotNull()
+        t.prop(KayttajaTunnisteEntity::kayttooikeustaso).isEqualTo(Kayttooikeustaso.KATSELUOIKEUS)
+        t.prop(KayttajaTunnisteEntity::createdAt).isRecent()
+        t.prop(KayttajaTunnisteEntity::sentAt).isNull()
+        t.prop(KayttajaTunnisteEntity::tunniste).matches(Regex(kayttajaTunnistePattern))
+        t.prop(KayttajaTunnisteEntity::hankeKayttaja).isNotNull()
     }
 
     private fun Assert<List<HankeKayttajaEntity>>.areValid(hankeId: Int?) = each { k ->
-        k.transform { it.id }.isNotNull()
-        k.transform { it.nimi }.isIn(*expectedNames)
-        k.transform { it.sahkoposti }.isIn(*expectedEmails)
-        k.transform { it.hankeId }.isEqualTo(hankeId)
-        k.transform { it.permission }.isNull()
-        k.transform { it.kayttajaTunniste }.isNotNull()
+        k.prop(HankeKayttajaEntity::id).isNotNull()
+        k.prop(HankeKayttajaEntity::nimi).isIn(*expectedNames)
+        k.prop(HankeKayttajaEntity::sahkoposti).isIn(*expectedEmails)
+        k.prop(HankeKayttajaEntity::hankeId).isEqualTo(hankeId)
+        k.prop(HankeKayttajaEntity::permission).isNull()
+        k.prop(HankeKayttajaEntity::kayttajaTunniste).isNotNull()
     }
 
     private fun Assert<PermissionEntity>.isOfEqualDataTo(other: PermissionEntity) =
@@ -866,14 +978,7 @@ class HankeKayttajaServiceITest : DatabaseTest() {
             assertThat(actual.id).isEqualTo(other.id)
             assertThat(actual.hankeId).isEqualTo(other.hankeId)
             assertThat(actual.userId).isEqualTo(other.userId)
-            assertThat(actual.kayttooikeustaso).isOfEqualDataTo(other.kayttooikeustaso)
-        }
-
-    private fun Assert<KayttooikeustasoEntity>.isOfEqualDataTo(other: KayttooikeustasoEntity) =
-        given { actual ->
-            assertThat(actual.id).isEqualTo(other.id)
             assertThat(actual.kayttooikeustaso).isEqualTo(other.kayttooikeustaso)
-            assertThat(actual.permissionCode).isEqualTo(other.permissionCode)
         }
 
     private val expectedNames =
@@ -911,7 +1016,7 @@ class HankeKayttajaServiceITest : DatabaseTest() {
         userId: String = "fake id",
         kayttajaTunniste: KayttajaTunnisteEntity? = null,
     ): HankeKayttajaEntity {
-        val permissionEntity = savePermission(hankeId, userId, kayttooikeustaso)
+        val permissionEntity = permissionService.create(hankeId, userId, kayttooikeustaso)
 
         return saveUser(hankeId, nimi, sahkoposti, permissionEntity, kayttajaTunniste)
     }
@@ -945,15 +1050,6 @@ class HankeKayttajaServiceITest : DatabaseTest() {
                 sentAt = null,
                 kayttooikeustaso = kayttooikeustaso,
                 hankeKayttaja = null,
-            )
-        )
-
-    private fun savePermission(hankeId: Int, userId: String, kayttooikeustaso: Kayttooikeustaso) =
-        permissionRepository.save(
-            PermissionEntity(
-                userId = userId,
-                hankeId = hankeId,
-                kayttooikeustaso = permissionService.findKayttooikeustaso(kayttooikeustaso),
             )
         )
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeServiceImpl.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeServiceImpl.kt
@@ -21,7 +21,6 @@ import fi.hel.haitaton.hanke.logging.HankeLoggingService
 import fi.hel.haitaton.hanke.logging.Operation
 import fi.hel.haitaton.hanke.logging.YhteystietoLoggingEntryHolder
 import fi.hel.haitaton.hanke.permissions.HankeKayttajaService
-import fi.hel.haitaton.hanke.permissions.Kayttooikeustaso
 import fi.hel.haitaton.hanke.permissions.PermissionService
 import fi.hel.haitaton.hanke.tormaystarkastelu.TormaystarkasteluLaskentaService
 import fi.hel.haitaton.hanke.tormaystarkastelu.TormaystarkasteluTulos
@@ -216,7 +215,7 @@ open class HankeServiceImpl(
         postProcessAndSaveLogging(loggingEntryHolder, savedHankeEntity, userId)
 
         return createHankeDomainObjectFromEntity(entity).also {
-            hankeKayttajaService.saveNewTokensFromHanke(it)
+            hankeKayttajaService.saveNewTokensFromHanke(it, userId)
             hankeLoggingService.logUpdate(hankeBeforeUpdate, it, userId)
         }
     }
@@ -246,10 +245,8 @@ open class HankeServiceImpl(
 
     private fun initAccessForCreatedHanke(hanke: Hanke, perustaja: Perustaja?, userId: String) {
         val hankeId = hanke.id!!
-        val permissionAll =
-            permissionService.setPermission(hankeId, userId, Kayttooikeustaso.KAIKKI_OIKEUDET)
-        perustaja?.let { hankeKayttajaService.addHankeFounder(hankeId, it, permissionAll) }
-        hankeKayttajaService.saveNewTokensFromHanke(hanke)
+        hankeKayttajaService.addHankeFounder(hankeId, perustaja, userId)
+        hankeKayttajaService.saveNewTokensFromHanke(hanke, userId)
     }
 
     // TODO: functions to remove and invalidate Hanke's tormaystarkastelu-data

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationService.kt
@@ -207,7 +207,7 @@ open class ApplicationService(
             return application.toApplication()
         }
 
-        hankeKayttajaService.saveNewTokensFromApplication(application, hanke.id!!)
+        hankeKayttajaService.saveNewTokensFromApplication(application, hanke.id!!, userId)
 
         // The application should no longer be a draft
         application.applicationData = application.applicationData.copy(pendingOnClient = false)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/HankeKayttajaLoggingService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/HankeKayttajaLoggingService.kt
@@ -1,31 +1,13 @@
 package fi.hel.haitaton.hanke.logging
 
+import fi.hel.haitaton.hanke.permissions.HankeKayttaja
 import fi.hel.haitaton.hanke.permissions.KayttajaTunniste
-import fi.hel.haitaton.hanke.permissions.Kayttooikeustaso
-import fi.hel.haitaton.hanke.permissions.Permission
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
 
 @Service
 class HankeKayttajaLoggingService(private val auditLogService: AuditLogService) {
-
-    @Transactional(propagation = Propagation.MANDATORY)
-    fun logUpdate(
-        kayttooikeustasoBefore: Kayttooikeustaso,
-        permissionAfter: Permission,
-        userId: String
-    ) {
-        val permissionBefore = permissionAfter.copy(kayttooikeustaso = kayttooikeustasoBefore)
-
-        AuditLogService.updateEntry(
-                userId,
-                ObjectType.PERMISSION,
-                permissionBefore,
-                permissionAfter,
-            )
-            ?.let { auditLogService.create(it) }
-    }
 
     @Transactional(propagation = Propagation.MANDATORY)
     fun logUpdate(
@@ -40,5 +22,19 @@ class HankeKayttajaLoggingService(private val auditLogService: AuditLogService) 
                 kayttajaTunnisteAfter,
             )
             ?.let { auditLogService.create(it) }
+    }
+
+    @Transactional(propagation = Propagation.MANDATORY)
+    fun logCreate(kayttajaTunniste: KayttajaTunniste, userId: String) {
+        auditLogService.create(
+            AuditLogService.createEntry(userId, ObjectType.KAYTTAJA_TUNNISTE, kayttajaTunniste)
+        )
+    }
+
+    @Transactional(propagation = Propagation.MANDATORY)
+    fun logCreate(hankeKayttaja: HankeKayttaja, currentUser: String) {
+        auditLogService.create(
+            AuditLogService.createEntry(currentUser, ObjectType.HANKE_KAYTTAJA, hankeKayttaja)
+        )
     }
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/PermissionLoggingService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/PermissionLoggingService.kt
@@ -1,0 +1,34 @@
+package fi.hel.haitaton.hanke.logging
+
+import fi.hel.haitaton.hanke.permissions.Kayttooikeustaso
+import fi.hel.haitaton.hanke.permissions.Permission
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class PermissionLoggingService(private val auditLogService: AuditLogService) {
+    @Transactional(propagation = Propagation.MANDATORY)
+    fun logUpdate(
+        kayttooikeustasoBefore: Kayttooikeustaso,
+        permissionAfter: Permission,
+        userId: String
+    ) {
+        val permissionBefore = permissionAfter.copy(kayttooikeustaso = kayttooikeustasoBefore)
+
+        AuditLogService.updateEntry(
+                userId,
+                ObjectType.PERMISSION,
+                permissionBefore,
+                permissionAfter,
+            )
+            ?.let { auditLogService.create(it) }
+    }
+
+    @Transactional(propagation = Propagation.MANDATORY)
+    fun logCreate(permission: Permission, userId: String) {
+        auditLogService.create(
+            AuditLogService.createEntry(userId, ObjectType.PERMISSION, permission)
+        )
+    }
+}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttaja.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttaja.kt
@@ -1,5 +1,6 @@
 package fi.hel.haitaton.hanke.permissions
 
+import fi.hel.haitaton.hanke.domain.HasId
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
@@ -48,6 +49,16 @@ class HankeKayttajaEntity(
             tunnistautunut = permission != null,
         )
 
+    fun toDomain(): HankeKayttaja =
+        HankeKayttaja(
+            id = id,
+            hankeId = hankeId,
+            nimi = nimi,
+            sahkoposti = sahkoposti,
+            permissionId = permission?.id,
+            kayttajaTunnisteId = kayttajaTunniste?.id,
+        )
+
     /**
      * [KayttajaTunnisteEntity] stores kayttooikeustaso temporarily until user has signed in. After
      * that, [PermissionEntity] is used.
@@ -55,8 +66,17 @@ class HankeKayttajaEntity(
      * Thus, kayttooikeustaso is read primarily from [PermissionEntity] if the relation exists.
      */
     fun deriveKayttooikeustaso(): Kayttooikeustaso? =
-        permission?.kayttooikeustaso?.kayttooikeustaso ?: kayttajaTunniste?.kayttooikeustaso
+        permission?.kayttooikeustaso ?: kayttajaTunniste?.kayttooikeustaso
 }
+
+data class HankeKayttaja(
+    override val id: UUID,
+    val hankeId: Int,
+    val nimi: String,
+    val sahkoposti: String,
+    val permissionId: Int?,
+    val kayttajaTunnisteId: UUID?
+) : HasId<UUID>
 
 @Repository
 interface HankeKayttajaRepository : JpaRepository<HankeKayttajaEntity, UUID> {

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaService.kt
@@ -28,7 +28,7 @@ class HankeKayttajaService(
         hankeKayttajaRepository.findByHankeId(hankeId).map { it.toDto() }
 
     @Transactional
-    fun saveNewTokensFromApplication(application: ApplicationEntity, hankeId: Int) {
+    fun saveNewTokensFromApplication(application: ApplicationEntity, hankeId: Int, userId: String) {
         if (featureFlags.isDisabled(Feature.USER_MANAGEMENT)) {
             return
         }
@@ -41,11 +41,13 @@ class HankeKayttajaService(
                 .flatMap { it.contacts }
                 .mapNotNull { userContactOrNull(it.fullName(), it.email) }
 
-        filterNewContacts(hankeId, contacts).forEach { contact -> createToken(hankeId, contact) }
+        filterNewContacts(hankeId, contacts).forEach { contact ->
+            createTunnisteAndKayttaja(hankeId, contact, userId)
+        }
     }
 
     @Transactional
-    fun saveNewTokensFromHanke(hanke: Hanke) {
+    fun saveNewTokensFromHanke(hanke: Hanke, userId: String) {
         if (featureFlags.isDisabled(Feature.USER_MANAGEMENT)) {
             return
         }
@@ -59,24 +61,29 @@ class HankeKayttajaService(
                 .flatMap { it.alikontaktit }
                 .mapNotNull { userContactOrNull(it.fullName(), it.email) }
 
-        filterNewContacts(hankeId, contacts).forEach { contact -> createToken(hankeId, contact) }
+        filterNewContacts(hankeId, contacts).forEach { contact ->
+            createTunnisteAndKayttaja(hankeId, contact, userId)
+        }
     }
 
     @Transactional
-    fun addHankeFounder(hankeId: Int, founder: Perustaja, permissionEntity: PermissionEntity) {
+    fun addHankeFounder(hankeId: Int, perustaja: Perustaja?, currentUser: String) {
+        val permissionEntity =
+            permissionService.create(hankeId, currentUser, Kayttooikeustaso.KAIKKI_OIKEUDET)
+
         if (featureFlags.isDisabled(Feature.USER_MANAGEMENT)) {
             return
         }
-        logger.info { "Saving user for Hanke perustaja." }
-        saveUser(
-            HankeKayttajaEntity(
+        perustaja?.let {
+            logger.info { "Saving user for Hanke perustaja." }
+            createUser(
+                currentUser,
                 hankeId = hankeId,
-                nimi = founder.nimi!!,
-                sahkoposti = founder.email,
+                nimi = it.nimi!!,
+                sahkoposti = it.email,
                 permission = permissionEntity,
-                kayttajaTunniste = null,
             )
-        )
+        }
     }
 
     @Transactional
@@ -101,16 +108,10 @@ class HankeKayttajaService(
 
         kayttajat.forEach { kayttaja ->
             kayttaja.permission?.let { permission ->
-                val kayttooikeustasoBefore = permission.kayttooikeustaso.kayttooikeustaso
-                permission.kayttooikeustaso =
-                    permissionService.findKayttooikeustaso(updates[kayttaja.id]!!)
-                logService.logUpdate(kayttooikeustasoBefore, permission.toDomain(), userId)
+                permissionService.updateKayttooikeustaso(permission, updates[kayttaja.id]!!, userId)
             }
-                ?: kayttaja.kayttajaTunniste?.let {
-                    val kayttajaTunnisteBefore = it.toDomain()
-                    it.kayttooikeustaso = updates[kayttaja.id]!!
-                    val kayttajaTunnisteAfter = it.toDomain()
-                    logService.logUpdate(kayttajaTunnisteBefore, kayttajaTunnisteAfter, userId)
+                ?: kayttaja.kayttajaTunniste?.let { tunniste ->
+                    updateKayttooikeustaso(tunniste, updates[kayttaja.id]!!, userId)
                 }
         }
 
@@ -194,7 +195,7 @@ class HankeKayttajaService(
     private fun validateAdminRemains(hanke: Hanke) {
         if (
             permissionService.findByHankeId(hanke.id!!).all {
-                it.kayttooikeustaso.kayttooikeustaso != Kayttooikeustaso.KAIKKI_OIKEUDET
+                it.kayttooikeustaso != Kayttooikeustaso.KAIKKI_OIKEUDET
             }
         ) {
             throw NoAdminRemainingException(hanke)
@@ -222,26 +223,63 @@ class HankeKayttajaService(
         }
     }
 
-    private fun createToken(hankeId: Int, contact: UserContact) {
+    private fun createTunnisteAndKayttaja(hankeId: Int, contact: UserContact, userId: String) {
+        val kayttajaTunnisteEntity = saveTunniste(hankeId, userId)
+        createUser(
+            userId,
+            hankeId = hankeId,
+            nimi = contact.name,
+            sahkoposti = contact.email,
+            tunniste = kayttajaTunnisteEntity,
+        )
+    }
+
+    private fun updateKayttooikeustaso(
+        kayttajaTunnisteEntity: KayttajaTunnisteEntity,
+        kayttooikeustaso: Kayttooikeustaso,
+        userId: String
+    ) {
+        val kayttajaTunnisteBefore = kayttajaTunnisteEntity.toDomain()
+        kayttajaTunnisteEntity.kayttooikeustaso = kayttooikeustaso
+        val kayttajaTunnisteAfter = kayttajaTunnisteEntity.toDomain()
+        logger.info {
+            "Updated kayttooikeustaso in kayttajatunniste, " +
+                "kayttajaTunnisteId=${kayttajaTunnisteEntity.id}, " +
+                "new kayttooikeustaso=${kayttooikeustaso}, " +
+                "userId=$userId"
+        }
+        logService.logUpdate(kayttajaTunnisteBefore, kayttajaTunnisteAfter, userId)
+    }
+
+    private fun saveTunniste(hankeId: Int, userId: String): KayttajaTunnisteEntity {
         logger.info { "Creating a new user token, hankeId=$hankeId" }
         val token = KayttajaTunnisteEntity.create()
         val kayttajaTunnisteEntity = kayttajaTunnisteRepository.save(token)
         logger.info { "Saved the new user token, id=${kayttajaTunnisteEntity.id}" }
-
-        saveUser(
-            HankeKayttajaEntity(
-                hankeId = hankeId,
-                nimi = contact.name,
-                sahkoposti = contact.email,
-                permission = null,
-                kayttajaTunniste = kayttajaTunnisteEntity
-            )
-        )
+        logService.logCreate(kayttajaTunnisteEntity.toDomain(), userId)
+        return kayttajaTunnisteEntity
     }
 
-    private fun saveUser(hankeKayttajaEntity: HankeKayttajaEntity) {
-        val user = hankeKayttajaRepository.save(hankeKayttajaEntity)
-        logger.info { "Saved the user information, id=${user.id}" }
+    private fun createUser(
+        currentUser: String,
+        hankeId: Int,
+        nimi: String,
+        sahkoposti: String,
+        permission: PermissionEntity? = null,
+        tunniste: KayttajaTunnisteEntity? = null,
+    ) {
+        val kayttajaEntity =
+            hankeKayttajaRepository.save(
+                HankeKayttajaEntity(
+                    hankeId = hankeId,
+                    nimi = nimi,
+                    sahkoposti = sahkoposti,
+                    permission = permission,
+                    kayttajaTunniste = tunniste,
+                )
+            )
+        logger.info { "Saved the user information, id=${kayttajaEntity.id}" }
+        logService.logCreate(kayttajaEntity.toDomain(), currentUser)
     }
 
     private fun userContactOrNull(name: String?, email: String?): UserContact? {

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaService.kt
@@ -224,7 +224,7 @@ class HankeKayttajaService(
     }
 
     private fun createTunnisteAndKayttaja(hankeId: Int, contact: UserContact, userId: String) {
-        val kayttajaTunnisteEntity = saveTunniste(hankeId, userId)
+        val kayttajaTunnisteEntity = createTunniste(hankeId, userId)
         createUser(
             userId,
             hankeId = hankeId,
@@ -251,7 +251,7 @@ class HankeKayttajaService(
         logService.logUpdate(kayttajaTunnisteBefore, kayttajaTunnisteAfter, userId)
     }
 
-    private fun saveTunniste(hankeId: Int, userId: String): KayttajaTunnisteEntity {
+    private fun createTunniste(hankeId: Int, userId: String): KayttajaTunnisteEntity {
         logger.info { "Creating a new user token, hankeId=$hankeId" }
         val token = KayttajaTunnisteEntity.create()
         val kayttajaTunnisteEntity = kayttajaTunnisteRepository.save(token)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/Kayttooikeustaso.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/Kayttooikeustaso.kt
@@ -24,7 +24,9 @@ class KayttooikeustasoEntity(
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY) val id: Int = 0,
     @Enumerated(EnumType.STRING) val kayttooikeustaso: Kayttooikeustaso,
     val permissionCode: Long,
-)
+) {
+    fun hasPermission(permission: PermissionCode): Boolean = permissionCode and permission.code > 0
+}
 
 @Repository
 interface KayttooikeustasoRepository : JpaRepository<KayttooikeustasoEntity, Int> {

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/Permissions.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/Permissions.kt
@@ -39,7 +39,7 @@ interface PermissionRepository : JpaRepository<PermissionEntity, Int> {
      */
     @Query(
         "select pe from PermissionEntity pe " +
-            "inner join pe.kayttooikeustaso as kayttooikeustaso " +
+            "inner join pe.kayttooikeustasoEntity as kayttooikeustaso " +
             "where pe.userId = :userId " +
             "and mod(kayttooikeustaso.permissionCode / :permissionBit , 2) = 1"
     )
@@ -54,9 +54,15 @@ class PermissionEntity(
     val hankeId: Int,
     @ManyToOne(optional = false, fetch = FetchType.EAGER)
     @JoinColumn(name = "kayttooikeustaso_id")
-    var kayttooikeustaso: KayttooikeustasoEntity,
+    var kayttooikeustasoEntity: KayttooikeustasoEntity,
 ) {
-    fun toDomain() = Permission(id, userId, hankeId, kayttooikeustaso.kayttooikeustaso)
+    val kayttooikeustaso: Kayttooikeustaso
+        get() = kayttooikeustasoEntity.kayttooikeustaso
+
+    fun toDomain() = Permission(id, userId, hankeId, kayttooikeustaso)
+
+    fun hasPermission(permission: PermissionCode): Boolean =
+        kayttooikeustasoEntity.hasPermission(permission)
 }
 
 @JsonView(ChangeLogView::class)

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/TestExtensions.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/TestExtensions.kt
@@ -25,6 +25,8 @@ inline fun <reified T> ResultActions.andReturnBody(): T =
 
 fun String.getResourceAsBytes(): ByteArray = this.getResource().readBytes()
 
+inline fun <reified T> String.parseJson(): T = OBJECT_MAPPER.readValue(this)
+
 /**
  * Find all audit logs for a specific object type. Getting all and filtering would obviously not be
  * acceptable in production, but in tests we usually have a very limited number of entities at any

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceTest.kt
@@ -275,7 +275,7 @@ class ApplicationServiceTest {
         verifySequence {
             applicationRepo.findOneById(3)
             geometriatDao.isInsideHankeAlueet(1, any())
-            hankeKayttajaService.saveNewTokensFromApplication(applicationEntity, 1)
+            hankeKayttajaService.saveNewTokensFromApplication(applicationEntity, 1, USERNAME)
             geometriatDao.calculateCombinedArea(any())
             geometriatDao.calculateArea(any())
             cableReportService.create(any())
@@ -309,7 +309,7 @@ class ApplicationServiceTest {
         verifySequence {
             applicationRepo.findOneById(3)
             geometriatDao.isInsideHankeAlueet(1, any())
-            hankeKayttajaService.saveNewTokensFromApplication(applicationEntity, 1)
+            hankeKayttajaService.saveNewTokensFromApplication(applicationEntity, 1, USERNAME)
             geometriatDao.calculateCombinedArea(any())
             geometriatDao.calculateArea(any())
             cableReportService.create(any())
@@ -344,7 +344,7 @@ class ApplicationServiceTest {
             disclosureLogService wasNot called
             applicationRepo.findOneById(3)
             geometriatDao.isInsideHankeAlueet(any(), any())
-            hankeKayttajaService.saveNewTokensFromApplication(applicationEntity, 1)
+            hankeKayttajaService.saveNewTokensFromApplication(applicationEntity, 1, USERNAME)
             geometriatDao.calculateCombinedArea(any())
             geometriatDao.calculateArea(any())
             cableReportService.create(any())
@@ -387,7 +387,7 @@ class ApplicationServiceTest {
         verifySequence {
             applicationRepo.findOneById(3)
             geometriatDao.isInsideHankeAlueet(1, any())
-            hankeKayttajaService.saveNewTokensFromApplication(any(), 1)
+            hankeKayttajaService.saveNewTokensFromApplication(any(), 1, USERNAME)
             geometriatDao.calculateCombinedArea(any())
             geometriatDao.calculateArea(any())
             cableReportService.create(expectedAlluData)
@@ -424,7 +424,7 @@ class ApplicationServiceTest {
         verifySequence {
             applicationRepo.findOneById(3)
             geometriatDao.isInsideHankeAlueet(1, any())
-            hankeKayttajaService.saveNewTokensFromApplication(applicationEntity, 1)
+            hankeKayttajaService.saveNewTokensFromApplication(applicationEntity, 1, USERNAME)
             cableReportService wasNot Called
             disclosureLogService wasNot Called
             applicationLoggingService wasNot Called

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/AlluDataFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/AlluDataFactory.kt
@@ -105,6 +105,14 @@ class AlluDataFactory(
         fun Customer.withContacts(vararg contacts: Contact): CustomerWithContacts =
             CustomerWithContacts(this, contacts.asList())
 
+        fun Customer.withContact(
+            firstName: String? = "Teppo",
+            lastName: String? = "Testihenkilö",
+            email: String? = teppoEmail,
+            phone: String? = "04012345678",
+            orderer: Boolean = false,
+        ) = withContacts(createContact(firstName, lastName, email, phone, orderer))
+
         fun createContact(
             firstName: String? = "Teppo",
             lastName: String? = "Testihenkilö",

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeFactory.kt
@@ -58,10 +58,8 @@ class HankeFactory(
 
     fun save(hanke: Hanke) = hankeService.createHanke(hanke)
 
-    fun saveMinimal(hankeTunnus: String): HankeEntity =
+    fun saveMinimal(hankeTunnus: String = hanketunnusService.newHanketunnus()): HankeEntity =
         hankeRepository.save(HankeEntity(hankeTunnus = hankeTunnus))
-
-    fun saveMinimal(): HankeEntity = saveMinimal(hanketunnusService.newHanketunnus())
 
     fun saveSeveralMinimal(n: Int): List<HankeEntity> = (1..n).map { saveMinimal() }
 

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeFactory.kt
@@ -57,6 +57,7 @@ class HankeFactory(
     }
 
     fun save(hanke: Hanke) = hankeService.createHanke(hanke)
+
     fun saveMinimal(hankeTunnus: String): HankeEntity =
         hankeRepository.save(HankeEntity(hankeTunnus = hankeTunnus))
 

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeFactory.kt
@@ -4,6 +4,7 @@ import fi.hel.haitaton.hanke.HankeEntity
 import fi.hel.haitaton.hanke.HankeRepository
 import fi.hel.haitaton.hanke.HankeService
 import fi.hel.haitaton.hanke.HankeStatus
+import fi.hel.haitaton.hanke.HanketunnusService
 import fi.hel.haitaton.hanke.SuunnitteluVaihe
 import fi.hel.haitaton.hanke.TyomaaTyyppi
 import fi.hel.haitaton.hanke.Vaihe
@@ -18,7 +19,8 @@ import org.springframework.stereotype.Component
 @Component
 class HankeFactory(
     private val hankeService: HankeService,
-    private val hankeRepository: HankeRepository
+    private val hanketunnusService: HanketunnusService,
+    private val hankeRepository: HankeRepository,
 ) {
 
     /**
@@ -55,6 +57,12 @@ class HankeFactory(
     }
 
     fun save(hanke: Hanke) = hankeService.createHanke(hanke)
+    fun saveMinimal(hankeTunnus: String): HankeEntity =
+        hankeRepository.save(HankeEntity(hankeTunnus = hankeTunnus))
+
+    fun saveMinimal(): HankeEntity = saveMinimal(hanketunnusService.newHanketunnus())
+
+    fun saveSeveralMinimal(n: Int): List<HankeEntity> = (1..n).map { saveMinimal() }
 
     companion object {
 

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeKayttajaFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeKayttajaFactory.kt
@@ -1,10 +1,28 @@
 package fi.hel.haitaton.hanke.factory
 
+import fi.hel.haitaton.hanke.permissions.HankeKayttaja
 import fi.hel.haitaton.hanke.permissions.HankeKayttajaDto
 import fi.hel.haitaton.hanke.permissions.Kayttooikeustaso
 import java.util.UUID
 
 object HankeKayttajaFactory {
+
+    val KAYTTAJA_ID = UUID.fromString("639870ab-533d-4172-8e97-e5b93a275514")
+    const val HANKE_ID = 14
+    const val NIMI = "Pekka Peruskäyttäjä"
+    const val SAHKOPOSTI = "pekka@peruskäyttäjä.test"
+    val PERMISSION_ID = PermissionFactory.PERMISSION_ID
+    val TUNNISTE_ID = KayttajaTunnisteFactory.TUNNISTE_ID
+
+    fun create(
+        id: UUID = KAYTTAJA_ID,
+        hankeId: Int = HANKE_ID,
+        nimi: String = NIMI,
+        sahkoposti: String = SAHKOPOSTI,
+        permissionId: Int? = PERMISSION_ID,
+        kayttajaTunnisteId: UUID? = TUNNISTE_ID,
+    ): HankeKayttaja =
+        HankeKayttaja(id, hankeId, nimi, sahkoposti, permissionId, kayttajaTunnisteId)
 
     fun generateHankeKayttajat(amount: Int = 3): List<HankeKayttajaDto> =
         (1..amount).map {

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/KayttajaTunnisteFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/KayttajaTunnisteFactory.kt
@@ -11,7 +11,7 @@ object KayttajaTunnisteFactory {
     val CREATED_AT: OffsetDateTime = OffsetDateTime.parse("2023-08-31T14:25:13Z")
     val SENT_AT: OffsetDateTime = OffsetDateTime.parse("2023-08-31T14:25:14Z")
     val KAYTTOOIKEUSTASO: Kayttooikeustaso = Kayttooikeustaso.KATSELUOIKEUS
-    val KAYTTAJA_ID: UUID = UUID.fromString("597431b3-3be1-4594-a07a-bef77c8167df")
+    val KAYTTAJA_ID: UUID = HankeKayttajaFactory.KAYTTAJA_ID
 
     fun create(
         id: UUID = TUNNISTE_ID,

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/logging/PermissionLoggingServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/logging/PermissionLoggingServiceTest.kt
@@ -1,0 +1,113 @@
+package fi.hel.haitaton.hanke.logging
+
+import assertk.all
+import assertk.assertThat
+import assertk.assertions.isNull
+import assertk.assertions.prop
+import fi.hel.haitaton.hanke.factory.PermissionFactory
+import fi.hel.haitaton.hanke.permissions.Kayttooikeustaso
+import fi.hel.haitaton.hanke.test.AuditLogEntryAsserts.hasObjectAfter
+import fi.hel.haitaton.hanke.test.AuditLogEntryAsserts.hasObjectBefore
+import fi.hel.haitaton.hanke.test.AuditLogEntryAsserts.hasObjectId
+import fi.hel.haitaton.hanke.test.AuditLogEntryAsserts.hasObjectType
+import fi.hel.haitaton.hanke.test.AuditLogEntryAsserts.hasUserActor
+import fi.hel.haitaton.hanke.test.AuditLogEntryAsserts.isCreate
+import fi.hel.haitaton.hanke.test.AuditLogEntryAsserts.isSuccess
+import fi.hel.haitaton.hanke.test.AuditLogEntryAsserts.isUpdate
+import io.mockk.called
+import io.mockk.checkUnnecessaryStub
+import io.mockk.clearAllMocks
+import io.mockk.confirmVerified
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class PermissionLoggingServiceTest {
+    private val userId = "test"
+
+    private val auditLogService: AuditLogService = mockk(relaxed = true)
+    private val loggingService = PermissionLoggingService(auditLogService)
+
+    @BeforeEach
+    fun clearMocks() {
+        clearAllMocks()
+    }
+
+    @AfterEach
+    fun cleanUp() {
+        checkUnnecessaryStub()
+        confirmVerified(auditLogService)
+    }
+
+    @Nested
+    inner class LogCreate {
+        @Test
+        fun `Creates audit log entry for created permission`() {
+            val permission =
+                PermissionFactory.create(kayttooikeustaso = Kayttooikeustaso.HANKEMUOKKAUS)
+
+            loggingService.logCreate(permission, userId)
+
+            verify {
+                auditLogService.create(
+                    withArg { entry ->
+                        assertThat(entry).all {
+                            isCreate()
+                            isSuccess()
+                            hasUserActor(userId)
+                            hasObjectId(PermissionFactory.PERMISSION_ID)
+                            hasObjectType(ObjectType.PERMISSION)
+                            prop(AuditLogEntry::objectBefore).isNull()
+                            hasObjectAfter(permission)
+                        }
+                    }
+                )
+            }
+        }
+    }
+
+    @Nested
+    inner class LogUpdate {
+        @Test
+        fun `Creates audit log entry for updated permission`() {
+            val kayttooikeustasoBefore = Kayttooikeustaso.KATSELUOIKEUS
+            val permissionAfter =
+                PermissionFactory.create(kayttooikeustaso = Kayttooikeustaso.HANKEMUOKKAUS)
+
+            loggingService.logUpdate(kayttooikeustasoBefore, permissionAfter, userId)
+
+            verify {
+                auditLogService.create(
+                    withArg { entry ->
+                        assertThat(entry).all {
+                            isUpdate()
+                            isSuccess()
+                            hasUserActor(userId)
+                            hasObjectId(PermissionFactory.PERMISSION_ID)
+                            hasObjectType(ObjectType.PERMISSION)
+                            hasObjectBefore(
+                                permissionAfter.copy(
+                                    kayttooikeustaso = Kayttooikeustaso.KATSELUOIKEUS
+                                )
+                            )
+                            hasObjectAfter(permissionAfter)
+                        }
+                    }
+                )
+            }
+        }
+
+        @Test
+        fun `Doesn't create audit log entry if permission not updated`() {
+            val kayttooikeustasoBefore = PermissionFactory.KAYTTOOIKEUSTASO
+            val permissionAfter = PermissionFactory.create()
+
+            loggingService.logUpdate(kayttooikeustasoBefore, permissionAfter, userId)
+
+            verify { auditLogService wasNot called }
+        }
+    }
+}

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/test/AuditLogEntryAsserts.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/test/AuditLogEntryAsserts.kt
@@ -1,0 +1,62 @@
+package fi.hel.haitaton.hanke.test
+
+import assertk.Assert
+import assertk.all
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotNull
+import assertk.assertions.isNull
+import assertk.assertions.prop
+import fi.hel.haitaton.hanke.logging.AuditLogEntry
+import fi.hel.haitaton.hanke.logging.ObjectType
+import fi.hel.haitaton.hanke.logging.Operation
+import fi.hel.haitaton.hanke.logging.Status
+import fi.hel.haitaton.hanke.logging.UserRole
+import fi.hel.haitaton.hanke.parseJson
+
+object AuditLogEntryAsserts {
+    fun Assert<AuditLogEntry>.isSuccess() = all {
+        prop(AuditLogEntry::status).isEqualTo(Status.SUCCESS)
+        prop(AuditLogEntry::failureDescription).isNull()
+    }
+
+    fun Assert<AuditLogEntry>.hasUserActor(userId: String) = all {
+        prop(AuditLogEntry::userRole).isEqualTo(UserRole.USER)
+        prop(AuditLogEntry::userId).isEqualTo(userId)
+    }
+
+    inline fun <reified T> Assert<AuditLogEntry>.hasObjectAfter(after: T) = hasObjectAfter {
+        isEqualTo(after)
+    }
+
+    inline fun <reified T> Assert<AuditLogEntry>.hasObjectAfter(
+        crossinline body: Assert<T>.() -> Unit
+    ) =
+        prop(AuditLogEntry::objectAfter)
+            .isNotNull()
+            .transform { it.parseJson<T>() }
+            .all { body(this) }
+
+    inline fun <reified T> Assert<AuditLogEntry>.hasObjectBefore(after: T) = hasObjectBefore {
+        isEqualTo(after)
+    }
+
+    inline fun <reified T> Assert<AuditLogEntry>.hasObjectBefore(
+        crossinline body: Assert<T>.() -> Unit
+    ) =
+        prop(AuditLogEntry::objectBefore)
+            .isNotNull()
+            .transform { it.parseJson<T>() }
+            .all { body(this) }
+
+    fun Assert<AuditLogEntry>.hasObjectId(id: Any) =
+        prop(AuditLogEntry::objectId).isNotNull().isEqualTo(id.toString())
+
+    fun Assert<AuditLogEntry>.hasObjectType(type: ObjectType) =
+        prop(AuditLogEntry::objectType).isNotNull().isEqualTo(type)
+
+    fun Assert<AuditLogEntry>.isUpdate() =
+        prop(AuditLogEntry::operation).isEqualTo(Operation.UPDATE)
+
+    fun Assert<AuditLogEntry>.isCreate() =
+        prop(AuditLogEntry::operation).isEqualTo(Operation.CREATE)
+}

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/test/AuditLogEntryEntityAsserts.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/test/AuditLogEntryEntityAsserts.kt
@@ -1,0 +1,79 @@
+package fi.hel.haitaton.hanke.test
+
+import assertk.Assert
+import assertk.all
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isNotNull
+import assertk.assertions.isNull
+import assertk.assertions.prop
+import fi.hel.haitaton.hanke.logging.AuditLogActor
+import fi.hel.haitaton.hanke.logging.AuditLogEntryEntity
+import fi.hel.haitaton.hanke.logging.AuditLogEvent
+import fi.hel.haitaton.hanke.logging.AuditLogMessage
+import fi.hel.haitaton.hanke.logging.AuditLogTarget
+import fi.hel.haitaton.hanke.logging.ObjectType
+import fi.hel.haitaton.hanke.logging.Operation
+import fi.hel.haitaton.hanke.logging.Status
+import fi.hel.haitaton.hanke.logging.UserRole
+import fi.hel.haitaton.hanke.parseJson
+import fi.hel.haitaton.hanke.test.Asserts.isRecent
+
+object AuditLogEntryEntityAsserts {
+    fun Assert<AuditLogEntryEntity>.auditEvent() =
+        prop(AuditLogEntryEntity::message).prop(AuditLogMessage::auditEvent)
+
+    fun Assert<AuditLogEntryEntity>.auditEvent(body: Assert<AuditLogEvent>.() -> Unit) =
+        auditEvent().all { body(this) }
+
+    fun Assert<AuditLogActor>.isUser(userId: String) =
+        this.all {
+            prop(AuditLogActor::role).isEqualTo(UserRole.USER)
+            prop(AuditLogActor::userId).isNotNull().isEqualTo(userId)
+        }
+
+    fun Assert<AuditLogEvent>.hasUserActor(userId: String) =
+        prop(AuditLogEvent::actor).isUser(userId)
+
+    fun Assert<AuditLogEvent>.withTarget(body: Assert<AuditLogTarget>.() -> Unit) =
+        prop(AuditLogEvent::target).all(body)
+
+    inline fun <reified T> Assert<AuditLogTarget>.hasObjectBefore(before: T) =
+        prop(AuditLogTarget::objectBefore)
+            .isNotNull()
+            .transform { it.parseJson<T>() }
+            .isEqualTo(before)
+
+    inline fun <reified T> Assert<AuditLogTarget>.hasObjectAfter(after: T) =
+        hasObjectAfter<T> { isEqualTo(after) }
+
+    inline fun <reified T> Assert<AuditLogTarget>.hasObjectAfter(
+        crossinline body: Assert<T>.() -> Unit
+    ) =
+        prop(AuditLogTarget::objectAfter)
+            .isNotNull()
+            .transform { it.parseJson<T>() }
+            .all { body(this) }
+
+    fun Assert<AuditLogTarget>.hasId(id: Any) =
+        prop(AuditLogTarget::id).isNotNull().isEqualTo(id.toString())
+
+    fun Assert<AuditLogEntryEntity>.hasTargetType(type: ObjectType) =
+        auditEvent().prop(AuditLogEvent::target).prop(AuditLogTarget::type).isEqualTo(type)
+
+    fun Assert<AuditLogEntryEntity>.isSuccess(
+        operation: Operation,
+        body: Assert<AuditLogEvent>.() -> Unit,
+    ) = all {
+        prop(AuditLogEntryEntity::isSent).isFalse()
+        prop(AuditLogEntryEntity::createdAt).isRecent()
+        prop(AuditLogEntryEntity::id).isNotNull()
+        auditEvent {
+            prop(AuditLogEvent::status).isEqualTo(Status.SUCCESS)
+            prop(AuditLogEvent::operation).isEqualTo(operation)
+            prop(AuditLogEvent::dateTime).isRecent()
+            prop(AuditLogEvent::failureDescription).isNull()
+            all(body)
+        }
+    }
+}


### PR DESCRIPTION
# Description

Add logging for creating permissions, hankekayttaja and hanketunniste.

Adding the audit reasonably required some refactoring:
- In PermissionService, make the old setPermission function be explicitly for creating new permisisions, so logging can be added.
- Move updating the kayttooikeustaso of a permission to PermissionService to centralize modifications and logging.
- In HankeKayttajaService, make the saveUser function to handle creating new users explicitly so that logging can be added.
- Rename kayttooikeustaso in PermissionEntity to kayttooikeustasoEntity and add a new getter for the actual kayttooikeustaso, so that `permissionEntity.kayttooikeustaso` is required instead of the old `permissionEntity.kayttooikeustaso.kayttooikeustaso`.
- Change references to permissionEntity.kayttooikeustasoEntity to use either the new getter for reads or PermissionService functions for modifications where ever possible.
- Move creating the permission for a founder inside addHankeFounder, since it seemed like a better packaging and made testing the audit logs easier.
- Move the static hasPermission from PermissionService's companion object to PermissionEntity and KayttooikeustasoEntity.
- Add userIds to several calls se that the logging can use it.
- Move Permission logging to PermissionLoggingService from HankeKayttajaLoggingService.
- In tests, use custom asserts to make audit log tests more readable and props to give better error messages when a test fails.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1875

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [X] Other

# Instructions for testing
- Create and send a johtoselvityshakemus.
- Check that there are creates for hankekayttaja and kayttajatunniste and one create for permission in the database.
 
# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 