### PR TITLE
HAI-1526 Send hanke invitation emails

### DIFF
--- a/email/kayttaja-lisatty-hakemus.mjml
+++ b/email/kayttaja-lisatty-hakemus.mjml
@@ -10,7 +10,8 @@
                     Haitaton: Sinut on lisätty hakemukselle {{applicationIdentifier}}
                 </mj-text>
                 <mj-text mj-class="basic-txt">
-                    {{inviterInfo}} on tehnyt {{applicationType}} ({{applicationIdentifier}}) hankkeella
+                    {{inviterName}} ({{inviterEmail}}) on tehnyt {{applicationType}} ({{applicationIdentifier}})
+                    hankkeella
                     {{hankeTunnus}}, ja lähettänyt sen käsittelyyn. Sinut on määritetty hakemuksella rooliin
                     {{recipientRole}}. Tarkastele hakemusta Haitattomassa
                     <a href="{{baseUrl}}">{{baseUrl}}</a>

--- a/email/kayttaja-lisatty-hanke.mjml
+++ b/email/kayttaja-lisatty-hanke.mjml
@@ -10,8 +10,8 @@
                     Haitaton: Sinut on lisätty hankkeelle {{hankeTunnus}}
                 </mj-text>
                 <mj-text mj-class="basic-txt">
-                    {{inviterInfo}} lisäsi sinut hankkeelle <b>{{hankeNimi}} ({{hankeTunnus}})</b>. Tunnistaudu
-                    Haitattomaan alla olevan linkin kautta.
+                    {{inviterName}} ({{inviterEmail}}) lisäsi sinut hankkeelle <b>{{hankeNimi}} ({{hankeTunnus}})</b>.
+                    Tunnistaudu Haitattomaan alla olevan linkin kautta.
                 </mj-text>
                 <mj-text mj-class="basic-txt">
                     <a href="{{baseUrl}}/{{invitationToken}}">Haitattomaan</a>

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeControllerITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeControllerITests.kt
@@ -7,6 +7,7 @@ import fi.hel.haitaton.hanke.factory.AlluDataFactory
 import fi.hel.haitaton.hanke.factory.DateFactory
 import fi.hel.haitaton.hanke.factory.HankeFactory
 import fi.hel.haitaton.hanke.factory.HankeFactory.Companion.withGeneratedOmistaja
+import fi.hel.haitaton.hanke.factory.HankeFactory.Companion.withYhteystiedot
 import fi.hel.haitaton.hanke.geometria.Geometriat
 import fi.hel.haitaton.hanke.logging.DisclosureLogService
 import fi.hel.haitaton.hanke.permissions.PermissionCode
@@ -329,14 +330,19 @@ class HankeControllerITests(@Autowired override val mockMvc: MockMvc) : Controll
 
         @Test
         fun `Sanitize hanke input and return 200`() {
-            val hanke = HankeFactory.create().apply { generated = true }
-            every { hankeService.createHanke(hanke.copy(id = null, generated = false)) } returns
-                hanke.copy(generated = false)
+            val hanke = HankeFactory.create().withYhteystiedot().apply { generated = true }
+            val expectedServiceArgument =
+                hanke.apply {
+                    generated = false
+                    id = null
+                }
+            every { hankeService.createHanke(expectedServiceArgument) } returns
+                expectedServiceArgument
 
             post(url, hanke).andExpect(status().isOk)
 
             verifySequence {
-                hankeService.createHanke(any())
+                hankeService.createHanke(expectedServiceArgument)
                 disclosureLogService.saveDisclosureLogsForHanke(any(), any())
             }
         }

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeControllerITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeControllerITests.kt
@@ -332,10 +332,7 @@ class HankeControllerITests(@Autowired override val mockMvc: MockMvc) : Controll
         fun `Sanitize hanke input and return 200`() {
             val hanke = HankeFactory.create().withYhteystiedot().apply { generated = true }
             val expectedServiceArgument =
-                hanke.apply {
-                    generated = false
-                    id = null
-                }
+                HankeFactory.create(id = null).withYhteystiedot().apply { generated = false }
             every { hankeService.createHanke(expectedServiceArgument) } returns
                 expectedServiceArgument
 

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/email/EmailSenderServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/email/EmailSenderServiceITest.kt
@@ -163,18 +163,6 @@ class EmailSenderServiceITest : DatabaseTest() {
                 contains("""<a href="http://localhost:3001/${data.invitationToken}">""")
             }
         }
-
-        @Test
-        fun `sendHankeInvitationEmail handles input without inviter name`() {
-            val data = hankeInvitationData(inviterName = null)
-
-            emailSenderService.sendHankeInvitationEmail(data)
-
-            val email = greenMail.firstReceivedMessage()
-            val (textBody, htmlBody) = getBodiesFromHybridEmail(email)
-            assertThat(textBody).contains("Asioija ${data.inviterEmail}")
-            assertThat(htmlBody).contains("Asioija ${data.inviterEmail}")
-        }
     }
 
     @Nested
@@ -229,18 +217,6 @@ class EmailSenderServiceITest : DatabaseTest() {
                 contains("""<a href="http://localhost:3001">""")
             }
         }
-
-        @Test
-        fun `sendApplicationInvitationEmail handles input without inviter name`() {
-            val data = applicationInvitationData(inviterName = null)
-
-            emailSenderService.sendApplicationInvitationEmail(data)
-
-            val email = greenMail.firstReceivedMessage()
-            val (textBody, htmlBody) = getBodiesFromHybridEmail(email)
-            assertThat(textBody).contains("Asioija ${data.inviterEmail} on tehnyt")
-            assertThat(htmlBody).contains("Asioija ${data.inviterEmail} on tehnyt")
-        }
     }
 
     /** Returns a (text body, HTML body) pair. */
@@ -270,7 +246,7 @@ class EmailSenderServiceITest : DatabaseTest() {
         return Pair(bodies[0], bodies[1])
     }
 
-    private fun hankeInvitationData(inviterName: String? = DEFAULT_INVITER_NAME) =
+    private fun hankeInvitationData(inviterName: String = DEFAULT_INVITER_NAME) =
         HankeInvitationData(
             inviterName = inviterName,
             inviterEmail = "kalle.kutsuja@test.fi",
@@ -280,7 +256,7 @@ class EmailSenderServiceITest : DatabaseTest() {
             invitationToken = "MgtzRbcPsvoKQamnaSxCnmW7",
         )
 
-    private fun applicationInvitationData(inviterName: String? = DEFAULT_INVITER_NAME) =
+    private fun applicationInvitationData(inviterName: String = DEFAULT_INVITER_NAME) =
         ApplicationInvitationData(
             inviterName = inviterName,
             inviterEmail = "kalle.kutsuja@test.fi",

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaServiceITest.kt
@@ -132,14 +132,14 @@ class HankeKayttajaServiceITest : DatabaseTest() {
     }
 
     @Nested
-    inner class GetKayttajaByCurrentUser {
+    inner class GetKayttajaByUserId {
 
         @Test
         fun `When user exists should return current hanke user`() {
             val hankeWithApplications = hankeFactory.saveGenerated(userId = USERNAME)
 
             val result: HankeKayttajaDto? =
-                hankeKayttajaService.getKayttajaByUserId(hankeId = hankeWithApplications.hanke.id!!)
+                hankeKayttajaService.getKayttajaByUserId(hankeWithApplications.hanke.id!!, USERNAME)
 
             assertThat(result).isNotNull()
             with(result!!) {
@@ -153,7 +153,7 @@ class HankeKayttajaServiceITest : DatabaseTest() {
 
         @Test
         fun `When no hanke should return null`() {
-            val result: HankeKayttajaDto? = hankeKayttajaService.getKayttajaByUserId(hankeId = 123)
+            val result: HankeKayttajaDto? = hankeKayttajaService.getKayttajaByUserId(123, USERNAME)
 
             assertThat(result).isNull()
         }
@@ -164,7 +164,7 @@ class HankeKayttajaServiceITest : DatabaseTest() {
             permissionRepository.deleteAll()
 
             val result: HankeKayttajaDto? =
-                hankeKayttajaService.getKayttajaByUserId(hankeId = hanke.id!!)
+                hankeKayttajaService.getKayttajaByUserId(hanke.id!!, USERNAME)
 
             assertThat(result).isNull()
         }
@@ -173,11 +173,11 @@ class HankeKayttajaServiceITest : DatabaseTest() {
         fun `When no kayttaja should return null`() {
             val hankeWithApplications = hankeFactory.saveGenerated(userId = USERNAME)
             val hankeId = hankeWithApplications.hanke.id!!
-            val jou = hankeKayttajaService.getKayttajaByUserId(hankeId)!!
+            val jou = hankeKayttajaService.getKayttajaByUserId(hankeId, USERNAME)!!
             hankeKayttajaRepository.deleteById(jou.id)
 
             val result: HankeKayttajaDto? =
-                hankeKayttajaService.getKayttajaByUserId(hankeId = hankeId)
+                hankeKayttajaService.getKayttajaByUserId(hankeId, USERNAME)
 
             assertThat(result).isNull()
         }

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaServiceITest.kt
@@ -17,7 +17,6 @@ import assertk.assertions.isIn
 import assertk.assertions.isNotEmpty
 import assertk.assertions.isNotNull
 import assertk.assertions.isNull
-import assertk.assertions.isTrue
 import assertk.assertions.matches
 import assertk.assertions.messageContains
 import assertk.assertions.prop
@@ -138,7 +137,7 @@ class HankeKayttajaServiceITest : DatabaseTest() {
         fun `When user exists should return current hanke user`() {
             val hankeWithApplications = hankeFactory.saveGenerated(userId = USERNAME)
 
-            val result: HankeKayttajaDto? =
+            val result: HankeKayttajaEntity? =
                 hankeKayttajaService.getKayttajaByUserId(hankeWithApplications.hanke.id!!, USERNAME)
 
             assertThat(result).isNotNull()
@@ -146,14 +145,15 @@ class HankeKayttajaServiceITest : DatabaseTest() {
                 assertThat(id).isNotNull()
                 assertThat(sahkoposti).isEqualTo(teppoEmail)
                 assertThat(nimi).isEqualTo(TEPPO_TESTI)
-                assertThat(kayttooikeustaso).isEqualTo(Kayttooikeustaso.KAIKKI_OIKEUDET)
-                assertThat(tunnistautunut).isTrue()
+                assertThat(permission?.kayttooikeustaso).isEqualTo(Kayttooikeustaso.KAIKKI_OIKEUDET)
+                assertThat(permission).isNotNull()
             }
         }
 
         @Test
         fun `When no hanke should return null`() {
-            val result: HankeKayttajaDto? = hankeKayttajaService.getKayttajaByUserId(123, USERNAME)
+            val result: HankeKayttajaEntity? =
+                hankeKayttajaService.getKayttajaByUserId(123, USERNAME)
 
             assertThat(result).isNull()
         }
@@ -163,7 +163,7 @@ class HankeKayttajaServiceITest : DatabaseTest() {
             val hanke = hankeFactory.save()
             permissionRepository.deleteAll()
 
-            val result: HankeKayttajaDto? =
+            val result: HankeKayttajaEntity? =
                 hankeKayttajaService.getKayttajaByUserId(hanke.id!!, USERNAME)
 
             assertThat(result).isNull()
@@ -176,7 +176,7 @@ class HankeKayttajaServiceITest : DatabaseTest() {
             val createdKayttaja = hankeKayttajaService.getKayttajaByUserId(hankeId, USERNAME)!!
             hankeKayttajaRepository.deleteById(createdKayttaja.id)
 
-            val result: HankeKayttajaDto? =
+            val result: HankeKayttajaEntity? =
                 hankeKayttajaService.getKayttajaByUserId(hankeId, USERNAME)
 
             assertThat(result).isNull()

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaServiceITest.kt
@@ -14,19 +14,27 @@ import assertk.assertions.hasSize
 import assertk.assertions.isEmpty
 import assertk.assertions.isEqualTo
 import assertk.assertions.isIn
+import assertk.assertions.isNotEmpty
 import assertk.assertions.isNotNull
 import assertk.assertions.isNull
+import assertk.assertions.isTrue
 import assertk.assertions.matches
 import assertk.assertions.messageContains
 import assertk.assertions.prop
+import com.ninjasquad.springmockk.MockkBean
 import fi.hel.haitaton.hanke.DatabaseTest
+import fi.hel.haitaton.hanke.email.EmailSenderService
+import fi.hel.haitaton.hanke.email.HankeInvitationData
 import fi.hel.haitaton.hanke.factory.AlluDataFactory
+import fi.hel.haitaton.hanke.factory.AlluDataFactory.Companion.defaultApplicationName
+import fi.hel.haitaton.hanke.factory.AlluDataFactory.Companion.teppoEmail
 import fi.hel.haitaton.hanke.factory.AlluDataFactory.Companion.withContact
 import fi.hel.haitaton.hanke.factory.AlluDataFactory.Companion.withContacts
 import fi.hel.haitaton.hanke.factory.HankeFactory
 import fi.hel.haitaton.hanke.factory.HankeFactory.Companion.withGeneratedOmistaja
 import fi.hel.haitaton.hanke.factory.HankeFactory.Companion.withYhteystiedot
 import fi.hel.haitaton.hanke.factory.HankeYhteystietoFactory
+import fi.hel.haitaton.hanke.factory.TEPPO_TESTI
 import fi.hel.haitaton.hanke.logging.AuditLogRepository
 import fi.hel.haitaton.hanke.logging.AuditLogTarget
 import fi.hel.haitaton.hanke.logging.ObjectType
@@ -40,8 +48,15 @@ import fi.hel.haitaton.hanke.test.AuditLogEntryEntityAsserts.hasUserActor
 import fi.hel.haitaton.hanke.test.AuditLogEntryEntityAsserts.isSuccess
 import fi.hel.haitaton.hanke.test.AuditLogEntryEntityAsserts.withTarget
 import fi.hel.haitaton.hanke.toChangeLogJsonString
+import io.mockk.checkUnnecessaryStub
+import io.mockk.clearAllMocks
+import io.mockk.confirmVerified
+import io.mockk.justRun
+import io.mockk.verify
 import java.time.OffsetDateTime
 import java.util.UUID
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -60,6 +75,7 @@ const val kayttajaTunnistePattern = "[a-zA-z0-9]{24}"
 class HankeKayttajaServiceITest : DatabaseTest() {
 
     @Autowired private lateinit var hankeKayttajaService: HankeKayttajaService
+    @Autowired private lateinit var permissionService: PermissionService
 
     @Autowired private lateinit var hankeFactory: HankeFactory
 
@@ -68,7 +84,18 @@ class HankeKayttajaServiceITest : DatabaseTest() {
     @Autowired private lateinit var permissionRepository: PermissionRepository
     @Autowired private lateinit var auditLogRepository: AuditLogRepository
 
-    @Autowired private lateinit var permissionService: PermissionService
+    @MockkBean private lateinit var emailSenderService: EmailSenderService
+
+    @BeforeEach
+    fun setup() {
+        clearAllMocks()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        checkUnnecessaryStub()
+        confirmVerified(emailSenderService)
+    }
 
     @Nested
     inner class GetKayttajatByHankeId {
@@ -101,6 +128,58 @@ class HankeKayttajaServiceITest : DatabaseTest() {
                 assertThat(kayttooikeustaso).isEqualTo(entity.kayttajaTunniste!!.kayttooikeustaso)
                 assertThat(tunnistautunut).isEqualTo(false)
             }
+        }
+    }
+
+    @Nested
+    inner class GetKayttajaByCurrentUser {
+
+        @Test
+        fun `When user exists should return current hanke user`() {
+            val hankeWithApplications = hankeFactory.saveGenerated(userId = USERNAME)
+
+            val result: HankeKayttajaDto? =
+                hankeKayttajaService.getKayttajaByUserId(hankeId = hankeWithApplications.hanke.id!!)
+
+            assertThat(result).isNotNull()
+            with(result!!) {
+                assertThat(id).isNotNull()
+                assertThat(sahkoposti).isEqualTo(teppoEmail)
+                assertThat(nimi).isEqualTo(TEPPO_TESTI)
+                assertThat(kayttooikeustaso).isEqualTo(Kayttooikeustaso.KAIKKI_OIKEUDET)
+                assertThat(tunnistautunut).isTrue()
+            }
+        }
+
+        @Test
+        fun `When no hanke should return null`() {
+            val result: HankeKayttajaDto? = hankeKayttajaService.getKayttajaByUserId(hankeId = 123)
+
+            assertThat(result).isNull()
+        }
+
+        @Test
+        fun `When no related permission should return null`() {
+            val hanke = hankeFactory.save()
+            permissionRepository.deleteAll()
+
+            val result: HankeKayttajaDto? =
+                hankeKayttajaService.getKayttajaByUserId(hankeId = hanke.id!!)
+
+            assertThat(result).isNull()
+        }
+
+        @Test
+        fun `When no kayttaja should return null`() {
+            val hankeWithApplications = hankeFactory.saveGenerated(userId = USERNAME)
+            val hankeId = hankeWithApplications.hanke.id!!
+            val jou = hankeKayttajaService.getKayttajaByUserId(hankeId)!!
+            hankeKayttajaRepository.deleteById(jou.id)
+
+            val result: HankeKayttajaDto? =
+                hankeKayttajaService.getKayttajaByUserId(hankeId = hankeId)
+
+            assertThat(result).isNull()
         }
     }
 
@@ -483,6 +562,27 @@ class HankeKayttajaServiceITest : DatabaseTest() {
                     "ali.kontakti@meili.com",
                 )
             assertThat(auditLogRepository.findAll()).isEmpty()
+        }
+
+        @Test
+        fun `Sends emails for new hanke users`() {
+            val hanke = hankeFactory.saveGenerated(userId = USERNAME).hanke
+            val hankeWithYhteystiedot = hanke.withYhteystiedot() // 4 sub contacts
+            val capturedEmails = mutableListOf<HankeInvitationData>()
+            justRun { emailSenderService.sendHankeInvitationEmail(capture(capturedEmails)) }
+
+            hankeKayttajaService.saveNewTokensFromHanke(hankeWithYhteystiedot, USERNAME)
+
+            verify(exactly = 4) { emailSenderService.sendHankeInvitationEmail(any()) }
+            assertThat(capturedEmails).each { inv ->
+                inv.transform { it.inviterName }.isEqualTo(TEPPO_TESTI)
+                inv.transform { it.inviterEmail }.isEqualTo(teppoEmail)
+                inv.transform { it.recipientEmail }
+                    .isIn("yhteys-email1", "yhteys-email2", "yhteys-email3", "yhteys-email4")
+                inv.transform { it.hankeTunnus }.isEqualTo(hanke.hankeTunnus!!)
+                inv.transform { it.hankeNimi }.isEqualTo(defaultApplicationName)
+                inv.transform { it.invitationToken }.isNotEmpty()
+            }
         }
     }
 

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaServiceITest.kt
@@ -173,8 +173,8 @@ class HankeKayttajaServiceITest : DatabaseTest() {
         fun `When no kayttaja should return null`() {
             val hankeWithApplications = hankeFactory.saveGenerated(userId = USERNAME)
             val hankeId = hankeWithApplications.hanke.id!!
-            val jou = hankeKayttajaService.getKayttajaByUserId(hankeId, USERNAME)!!
-            hankeKayttajaRepository.deleteById(jou.id)
+            val createdKayttaja = hankeKayttajaService.getKayttajaByUserId(hankeId, USERNAME)!!
+            hankeKayttajaRepository.deleteById(createdKayttaja.id)
 
             val result: HankeKayttajaDto? =
                 hankeKayttajaService.getKayttajaByUserId(hankeId, USERNAME)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeController.kt
@@ -182,7 +182,11 @@ When Hanke is created:
         if (hanke == null) {
             throw HankeArgumentException("No hanke given when creating hanke")
         }
-        val sanitizedHanke = hanke.copy(id = null, generated = false)
+        val sanitizedHanke =
+            hanke.apply {
+                id = null
+                generated = false
+            }
 
         val userId = currentUserId()
         logger.info { "Creating Hanke for user $userId: ${hanke.toLogString()} " }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeController.kt
@@ -182,16 +182,14 @@ When Hanke is created:
         if (hanke == null) {
             throw HankeArgumentException("No hanke given when creating hanke")
         }
-        val sanitizedHanke =
-            hanke.apply {
-                id = null
-                generated = false
-            }
+
+        hanke.id = null
+        hanke.generated = false
 
         val userId = currentUserId()
         logger.info { "Creating Hanke for user $userId: ${hanke.toLogString()} " }
 
-        val createdHanke = hankeService.createHanke(sanitizedHanke)
+        val createdHanke = hankeService.createHanke(hanke)
 
         disclosureLogService.saveDisclosureLogsForHanke(createdHanke, userId)
         return createdHanke

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/email/EmailSenderService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/email/EmailSenderService.kt
@@ -80,7 +80,8 @@ class EmailSenderService(
         val templateData =
             mapOf(
                 "baseUrl" to emailConfig.baseUrl,
-                "inviterInfo" to inviterInfo(data.inviterName, data.inviterEmail),
+                "inviterName" to data.inviterName,
+                "inviterEmail" to data.inviterEmail,
                 "hankeTunnus" to data.hankeTunnus,
                 "hankeNimi" to data.hankeNimi,
                 "invitationToken" to data.invitationToken,
@@ -97,7 +98,8 @@ class EmailSenderService(
         val templateData =
             mapOf(
                 "baseUrl" to emailConfig.baseUrl,
-                "inviterInfo" to inviterInfo(data.inviterName, data.inviterEmail),
+                "inviterName" to data.inviterName,
+                "inviterEmail" to data.inviterEmail,
                 "applicationType" to applicationTypeText,
                 "applicationIdentifier" to data.applicationIdentifier,
                 "hankeTunnus" to data.hankeTunnus,
@@ -126,8 +128,6 @@ class EmailSenderService(
         helper.setFrom(emailConfig.from)
         mailSender.send(mimeMessage)
     }
-
-    private fun inviterInfo(name: String, email: String): String = "$name ($email)"
 
     private fun convertApplicationTypeFinnish(type: ApplicationType): String =
         when (type) {

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/email/EmailSenderService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/email/EmailSenderService.kt
@@ -27,7 +27,7 @@ data class EmailFilterProperties(
 )
 
 data class ApplicationInvitationData(
-    val inviterName: String?,
+    val inviterName: String,
     val inviterEmail: String,
     val recipientEmail: String,
     val applicationType: ApplicationType,
@@ -37,7 +37,7 @@ data class ApplicationInvitationData(
 )
 
 data class HankeInvitationData(
-    val inviterName: String?,
+    val inviterName: String,
     val inviterEmail: String,
     val recipientEmail: String,
     val hankeTunnus: String,
@@ -80,7 +80,7 @@ class EmailSenderService(
         val templateData =
             mapOf(
                 "baseUrl" to emailConfig.baseUrl,
-                "inviterInfo" to defineInviterInfo(data.inviterName, data.inviterEmail),
+                "inviterInfo" to inviterInfo(data.inviterName, data.inviterEmail),
                 "hankeTunnus" to data.hankeTunnus,
                 "hankeNimi" to data.hankeNimi,
                 "invitationToken" to data.invitationToken,
@@ -97,7 +97,7 @@ class EmailSenderService(
         val templateData =
             mapOf(
                 "baseUrl" to emailConfig.baseUrl,
-                "inviterInfo" to defineInviterInfo(data.inviterName, data.inviterEmail),
+                "inviterInfo" to inviterInfo(data.inviterName, data.inviterEmail),
                 "applicationType" to applicationTypeText,
                 "applicationIdentifier" to data.applicationIdentifier,
                 "hankeTunnus" to data.hankeTunnus,
@@ -127,8 +127,7 @@ class EmailSenderService(
         mailSender.send(mimeMessage)
     }
 
-    private fun defineInviterInfo(name: String?, email: String): String =
-        if (name.isNullOrBlank()) "Asioija $email" else "$name ($email)"
+    private fun inviterInfo(name: String, email: String): String = "$name ($email)"
 
     private fun convertApplicationTypeFinnish(type: ApplicationType): String =
         when (type) {

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttaja.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttaja.kt
@@ -88,4 +88,6 @@ interface HankeKayttajaRepository : JpaRepository<HankeKayttajaEntity, UUID> {
         hankeId: Int,
         sahkopostit: List<String>
     ): List<HankeKayttajaEntity>
+
+    fun findByPermissionId(permissionId: Int): HankeKayttajaEntity?
 }

--- a/services/hanke-service/src/main/resources/email/template/kayttaja-lisatty-hakemus.html.mustache
+++ b/services/hanke-service/src/main/resources/email/template/kayttaja-lisatty-hakemus.html.mustache
@@ -86,7 +86,7 @@
                             <tr>
                                 <td align="left" style="font-size:0px;padding:16px 24px 16px 24px;word-break:break-word;">
                                     <div style="font-family:Arial;font-size:16px;line-height:1;text-align:left;color:#000000;">
-                                        {{inviterInfo}} on tehnyt {{applicationType}} ({{applicationIdentifier}}) hankkeella {{hankeTunnus}}, ja l&auml;hett&auml;nyt sen k&auml;sittelyyn. Sinut on m&auml;&auml;ritetty hakemuksella rooliin {{recipientRole}}. Tarkastele hakemusta Haitattomassa <a href="{{baseUrl}}">{{baseUrl}}</a>
+                                        {{inviterName}} ({{inviterEmail}}) on tehnyt {{applicationType}} ({{applicationIdentifier}}) hankkeella {{hankeTunnus}}, ja l&auml;hett&auml;nyt sen k&auml;sittelyyn. Sinut on m&auml;&auml;ritetty hakemuksella rooliin {{recipientRole}}. Tarkastele hakemusta Haitattomassa <a href="{{baseUrl}}">{{baseUrl}}</a>
                                     </div></td>
                             </tr>
                             <tr>

--- a/services/hanke-service/src/main/resources/email/template/kayttaja-lisatty-hakemus.text.mustache
+++ b/services/hanke-service/src/main/resources/email/template/kayttaja-lisatty-hakemus.text.mustache
@@ -1,6 +1,6 @@
 Haitaton: Sinut on lisätty hakemukselle {{applicationIdentifier}}
 
-{{inviterInfo}} on tehnyt {{applicationType}} ({{applicationIdentifier}}) hankkeella {{hankeTunnus}}, ja lähettänyt sen käsittelyyn. Sinut on määritetty hakemuksella rooliin {{recipientRole}}. Tarkastele hakemusta Haitattomassa: {{baseUrl}}
+{{inviterName}} ({{inviterEmail}}) on tehnyt {{applicationType}} ({{applicationIdentifier}}) hankkeella {{hankeTunnus}}, ja lähettänyt sen käsittelyyn. Sinut on määritetty hakemuksella rooliin {{recipientRole}}. Tarkastele hakemusta Haitattomassa: {{baseUrl}}
 
 Löydät hakemuksesi siirtymällä etusivulta Omiin hankkeisiin ja valitsemalla sieltä oikean hankkeen. Avaa listanäkymässä hankkeen tiedot ja valitse “Näytä hankkeen hakemukset”.
 

--- a/services/hanke-service/src/main/resources/email/template/kayttaja-lisatty-hanke.html.mustache
+++ b/services/hanke-service/src/main/resources/email/template/kayttaja-lisatty-hanke.html.mustache
@@ -86,7 +86,7 @@
                             <tr>
                                 <td align="left" style="font-size:0px;padding:16px 24px 16px 24px;word-break:break-word;">
                                     <div style="font-family:Arial;font-size:16px;line-height:1;text-align:left;color:#000000;">
-                                        {{inviterInfo}} lis&auml;si sinut hankkeelle <b>{{hankeNimi}} ({{hankeTunnus}})</b>. Tunnistaudu Haitattomaan alla olevan linkin kautta.
+                                        {{inviterName}} ({{inviterEmail}}) lis&auml;si sinut hankkeelle <b>{{hankeNimi}} ({{hankeTunnus}})</b>. Tunnistaudu Haitattomaan alla olevan linkin kautta.
                                     </div></td>
                             </tr>
                             <tr>

--- a/services/hanke-service/src/main/resources/email/template/kayttaja-lisatty-hanke.text.mustache
+++ b/services/hanke-service/src/main/resources/email/template/kayttaja-lisatty-hanke.text.mustache
@@ -1,6 +1,6 @@
 Haitaton: Sinut on lisätty hankkeelle {{hankeTunnus}}
 
-{{inviterInfo}} lisäsi sinut hankkeelle {{hankeNimi}} ({{hankeTunnus}}). Tunnistaudu Haitattomaan alla olevan linkin kautta.
+{{inviterName}} ({{inviterEmail}}) lisäsi sinut hankkeelle {{hankeNimi}} ({{hankeTunnus}}). Tunnistaudu Haitattomaan alla olevan linkin kautta.
 {{baseUrl}}/{{invitationToken}}
 
 Löydät hankkeesi Haitattoman etusivun Omat hankkeet -osion alta hankkeen nimellä.

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeFactory.kt
@@ -8,6 +8,7 @@ import fi.hel.haitaton.hanke.HanketunnusService
 import fi.hel.haitaton.hanke.SuunnitteluVaihe
 import fi.hel.haitaton.hanke.TyomaaTyyppi
 import fi.hel.haitaton.hanke.Vaihe
+import fi.hel.haitaton.hanke.application.CableReportWithoutHanke
 import fi.hel.haitaton.hanke.domain.Hanke
 import fi.hel.haitaton.hanke.domain.HankeYhteystieto
 import fi.hel.haitaton.hanke.domain.Hankealue
@@ -63,6 +64,12 @@ class HankeFactory(
 
     fun saveSeveralMinimal(n: Int): List<HankeEntity> = (1..n).map { saveMinimal() }
 
+    fun saveGenerated(
+        cableReportWithoutHanke: CableReportWithoutHanke =
+            AlluDataFactory.cableReportWithoutHanke(),
+        userId: String
+    ) = hankeService.generateHankeWithApplication(cableReportWithoutHanke, userId)
+
     companion object {
 
         const val defaultHankeTunnus = "HAI21-1"
@@ -106,12 +113,6 @@ class HankeFactory(
                 null,
                 hankeStatus,
             )
-
-        /** Create minimal Entity with identifier fields and mandatory fields. */
-        fun createMinimalEntity(
-            id: Int? = defaultId,
-            hankeTunnus: String? = defaultHankeTunnus,
-        ) = HankeEntity(id = id, hankeTunnus = hankeTunnus)
 
         /**
          * Add a hankealue with haitat to a test Hanke.


### PR DESCRIPTION
# Description

Include the email sending feature to creation of new hanke users.

Note: this commit does not include sending of application invitations. It will be implemented on another commit.

Additional: fix a bug in hanke controller where .copy function did not copy fields that are not in the hanke constructor.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1526

## Type of change

- [ ] Bug fix 
- [x] New feature 
- [ ] Other

# Instructions for testing
Apart from unit tests, there is no easy way of verifying this. Verifying the outgoing email would require a hanke with contact persons. That depends on: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1586 . Furthermore, having a hankekayttaja for hanke creator depends on this: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1348

However, this feature is guarded by a feature flag so it should be safe to have some of this as unused code for now.

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 

# Other relevant info
Please describe here if there is e.g. some requirements for this change or
 other info that the tester/user needs to know.