### PR TITLE
HAI Add OIDC client id to docker compose config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -107,6 +107,8 @@ services:
       dockerfile: ${FRONT_DOCKERFILE}
     image: haitaton-ui
     container_name: haitaton-ui
+    environment:
+      REACT_APP_OIDC_CLIENT_ID: haitaton-ui-dev
     ports:
       - 8000:8000
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -108,7 +108,10 @@ services:
     image: haitaton-ui
     container_name: haitaton-ui
     environment:
-      REACT_APP_OIDC_CLIENT_ID: haitaton-ui-dev
+      # Possible values:
+      # - haitaton-ui-dev for Suomi.fi authentication
+      # - haitaton-admin-ui-dev for Helsinki AD authentication
+      REACT_APP_OIDC_CLIENT_ID: haitaton-admin-ui-dev
     ports:
       - 8000:8000
     volumes:


### PR DESCRIPTION
# Description

Add REACT_APP_OIDC_CLIENT_ID to docker compose config for Haitaton UI. This enables changing from Helsinki AD login to Suomi.fi login quickly without rebuilding the UI.

Just edit the value in docker-compose.yml and then restart the service without rebuilding:
```sh
docker-compose stop haitaton-ui && docker-compose up -d --no-deps haitaton-ui
```

### Jira Issue: 

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [X] Other

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 