### PR TITLE
HAI-1514 Add permission code for resending invitations

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/KayttooikeustasoEntityITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/KayttooikeustasoEntityITest.kt
@@ -34,6 +34,7 @@ class KayttooikeustasoEntityITest : DatabaseTest() {
                         PermissionCode.MODIFY_EDIT_PERMISSIONS,
                         PermissionCode.EDIT_APPLICATIONS,
                         PermissionCode.MODIFY_APPLICATION_PERMISSIONS,
+                        PermissionCode.RESEND_INVITATION,
                     )
                 ),
                 Arguments.of(
@@ -41,6 +42,7 @@ class KayttooikeustasoEntityITest : DatabaseTest() {
                     listOf(
                         PermissionCode.VIEW,
                         PermissionCode.EDIT,
+                        PermissionCode.RESEND_INVITATION,
                     )
                 ),
                 Arguments.of(
@@ -48,6 +50,7 @@ class KayttooikeustasoEntityITest : DatabaseTest() {
                     listOf(
                         PermissionCode.VIEW,
                         PermissionCode.EDIT_APPLICATIONS,
+                        PermissionCode.RESEND_INVITATION,
                     )
                 ),
                 Arguments.of(Kayttooikeustaso.KATSELUOIKEUS, listOf(PermissionCode.VIEW)),

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/Permissions.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/Permissions.kt
@@ -15,6 +15,7 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 
+/** The codes are just bitmasks. Their value or order has no meaning. */
 enum class PermissionCode(val code: Long) {
     VIEW(1),
     MODIFY_VIEW_PERMISSIONS(2),
@@ -23,7 +24,8 @@ enum class PermissionCode(val code: Long) {
     DELETE(16),
     MODIFY_DELETE_PERMISSIONS(32),
     EDIT_APPLICATIONS(64),
-    MODIFY_APPLICATION_PERMISSIONS(128)
+    MODIFY_APPLICATION_PERMISSIONS(128),
+    RESEND_INVITATION(256),
 }
 
 @Repository

--- a/services/hanke-service/src/main/resources/db/changelog/changesets/045-add-new-permission-code.sql
+++ b/services/hanke-service/src/main/resources/db/changelog/changesets/045-add-new-permission-code.sql
@@ -1,0 +1,7 @@
+--liquibase formatted sql
+--changeset Topias Heinonen:045-add-new-permission-code
+--comment: Add RESEND_INVITATION permission code
+
+UPDATE kayttooikeustaso
+SET permissioncode = permissioncode | 256
+WHERE kayttooikeustaso IN ('KAIKKI_OIKEUDET','KAIKKIEN_MUOKKAUS', 'HANKEMUOKKAUS', 'HAKEMUSASIOINTI');

--- a/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -117,3 +117,5 @@ databaseChangeLog:
       file: db/changelog/changesets/043-add-another-index-to-hanke-kayttaja.yml
   - include:
       file: db/changelog/changesets/044-rename-role-to-kayttooikeustaso.yml
+  - include:
+      file: db/changelog/changesets/045-add-new-permission-code.sql


### PR DESCRIPTION
# Description

Add a new permission code for resending invitations. This permission code will be checked when the user calls the API for resending.

Resending the invitations doesn't fit any of the existing permissions and the group of kayttooikeustaso who can access it doesn't match any existing permission.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1514

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 