### PR TITLE
HAI-1514 Add API for resending invitations

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeAuthorizerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeAuthorizerITest.kt
@@ -77,9 +77,6 @@ class HankeAuthorizerITest(
 
         @Test
         fun `throws error if enum value not found`() {
-            val hanke = hankeFactory.saveMinimal(hankeTunnus = hankeTunnus)
-            permissionService.create(hanke.id!!, USERNAME, Kayttooikeustaso.KATSELUOIKEUS)
-
             assertFailure { authorizer.authorizeHankeTunnus(hankeTunnus, "Not real") }
                 .all {
                     hasClass(IllegalArgumentException::class)

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaAuthorizerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaAuthorizerITest.kt
@@ -1,0 +1,95 @@
+package fi.hel.haitaton.hanke.permissions
+
+import assertk.all
+import assertk.assertFailure
+import assertk.assertThat
+import assertk.assertions.hasClass
+import assertk.assertions.isTrue
+import assertk.assertions.messageContains
+import fi.hel.haitaton.hanke.DatabaseTest
+import fi.hel.haitaton.hanke.factory.HankeFactory
+import fi.hel.haitaton.hanke.factory.HankeKayttajaFactory
+import java.util.UUID
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.test.context.ActiveProfiles
+import org.testcontainers.junit.jupiter.Testcontainers
+
+private const val USERNAME = "test7358"
+
+@Testcontainers
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+@WithMockUser(USERNAME)
+class HankeKayttajaAuthorizerITest(
+    @Autowired private val authorizer: HankeKayttajaAuthorizer,
+    @Autowired private val hankeFactory: HankeFactory,
+    @Autowired private val hankeKayttajaFactory: HankeKayttajaFactory,
+    @Autowired private val permissionService: PermissionService,
+) : DatabaseTest() {
+
+    @Nested
+    inner class AuthorizeKayttajaId {
+        @Test
+        fun `throws exception if kayttajaId is not found`() {
+            val kayttajaId = UUID.fromString("bb201bf3-58b7-48d5-a7e4-e358370f74e1")
+
+            assertFailure { authorizer.authorizeKayttajaId(kayttajaId, PermissionCode.VIEW.name) }
+                .all {
+                    hasClass(HankeKayttajaNotFoundException::class)
+                    messageContains(kayttajaId.toString())
+                }
+        }
+
+        @Test
+        fun `throws exception if user doesn't have any permission for the hanke`() {
+            val hankeId = hankeFactory.saveMinimal().id!!
+            val kayttajaId = hankeKayttajaFactory.saveUser(hankeId).id
+
+            assertFailure { authorizer.authorizeKayttajaId(kayttajaId, PermissionCode.VIEW.name) }
+                .all {
+                    hasClass(HankeKayttajaNotFoundException::class)
+                    messageContains(kayttajaId.toString())
+                }
+        }
+
+        @Test
+        fun `throws exception if user doesn't have the required permission for the hanke`() {
+            val hankeId = hankeFactory.saveMinimal().id!!
+            val kayttajaId = hankeKayttajaFactory.saveUserAndPermission(hankeId).id
+            permissionService.create(hankeId, USERNAME, Kayttooikeustaso.KATSELUOIKEUS)
+
+            assertFailure { authorizer.authorizeKayttajaId(kayttajaId, PermissionCode.EDIT.name) }
+                .all {
+                    hasClass(HankeKayttajaNotFoundException::class)
+                    messageContains(kayttajaId.toString())
+                }
+        }
+
+        @Test
+        fun `return true if user has the required permission for the hanke`() {
+            val hankeId = hankeFactory.saveMinimal().id!!
+            val kayttajaId = hankeKayttajaFactory.saveUserAndPermission(hankeId).id
+            permissionService.create(hankeId, USERNAME, Kayttooikeustaso.HANKEMUOKKAUS)
+
+            assertThat(authorizer.authorizeKayttajaId(kayttajaId, PermissionCode.EDIT.name))
+                .isTrue()
+        }
+
+        @Test
+        fun `throws error if enum value not found`() {
+            val kayttajaId = UUID.fromString("bb201bf3-58b7-48d5-a7e4-e358370f74e1")
+
+            assertFailure { authorizer.authorizeKayttajaId(kayttajaId, "Not real") }
+                .all {
+                    hasClass(IllegalArgumentException::class)
+                    messageContains(
+                        "No enum constant fi.hel.haitaton.hanke.permissions.PermissionCode.Not real"
+                    )
+                }
+        }
+    }
+}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/HankeKayttajaLoggingService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/HankeKayttajaLoggingService.kt
@@ -32,6 +32,13 @@ class HankeKayttajaLoggingService(private val auditLogService: AuditLogService) 
     }
 
     @Transactional(propagation = Propagation.MANDATORY)
+    fun logDelete(tunniste: KayttajaTunniste, currentUserId: String) {
+        auditLogService.create(
+            AuditLogService.deleteEntry(currentUserId, ObjectType.KAYTTAJA_TUNNISTE, tunniste)
+        )
+    }
+
+    @Transactional(propagation = Propagation.MANDATORY)
     fun logCreate(hankeKayttaja: HankeKayttaja, currentUser: String) {
         auditLogService.create(
             AuditLogService.createEntry(currentUser, ObjectType.HANKE_KAYTTAJA, hankeKayttaja)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttaja.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttaja.kt
@@ -36,7 +36,7 @@ class HankeKayttajaEntity(
     @OneToOne
     @JoinColumn(name = "permission_id", updatable = true, nullable = true)
     var permission: PermissionEntity?,
-    @OneToOne
+    @OneToOne(orphanRemoval = true)
     @JoinColumn(name = "tunniste_id", updatable = true, nullable = true)
     var kayttajaTunniste: KayttajaTunnisteEntity?,
 ) {

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaAuthorizer.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaAuthorizer.kt
@@ -1,10 +1,23 @@
 package fi.hel.haitaton.hanke.permissions
 
 import fi.hel.haitaton.hanke.HankeRepository
+import java.util.UUID
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Component
 
 @Component
 class HankeKayttajaAuthorizer(
     permissionService: PermissionService,
     hankeRepository: HankeRepository,
-) : Authorizer(permissionService, hankeRepository)
+    private val hankeKayttajaRepository: HankeKayttajaRepository,
+) : Authorizer(permissionService, hankeRepository) {
+
+    fun authorizeKayttajaId(hankeKayttajaId: UUID, permissionCode: PermissionCode): Boolean {
+        val hankeId = hankeKayttajaRepository.findByIdOrNull(hankeKayttajaId)?.hankeId
+        authorize(hankeId, permissionCode) { HankeKayttajaNotFoundException(hankeKayttajaId) }
+        return true
+    }
+
+    fun authorizeKayttajaId(hankeKayttajaId: UUID, permissionCode: String): Boolean =
+        authorizeKayttajaId(hankeKayttajaId, PermissionCode.valueOf(permissionCode))
+}

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/domain/UserContactTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/domain/UserContactTest.kt
@@ -15,7 +15,7 @@ import fi.hel.haitaton.hanke.factory.AlluDataFactory.Companion.rakennuttajaCusto
 import fi.hel.haitaton.hanke.factory.AlluDataFactory.Companion.suorittajaApplicationContact
 import fi.hel.haitaton.hanke.factory.AlluDataFactory.Companion.suorittajaCustomerContact
 import fi.hel.haitaton.hanke.factory.AlluDataFactory.Companion.teppoEmail
-import fi.hel.haitaton.hanke.factory.HankeKayttajaFactory.createEntity
+import fi.hel.haitaton.hanke.factory.HankeKayttajaFactory
 import fi.hel.haitaton.hanke.factory.TEPPO_TESTI
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -100,7 +100,8 @@ class UserContactTest {
                     customerWithContacts = hakijaCustomerContact,
                     contractorWithContacts = suorittajaCustomerContact
                 )
-            val kayttaja = createEntity(sahkoposti = suorittajaApplicationContact.email)
+            val kayttaja =
+                HankeKayttajaFactory.createEntity(sahkoposti = suorittajaApplicationContact.email)
 
             val result = applicationData.typedContacts(omit = kayttaja.sahkoposti)
 

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeKayttajaFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeKayttajaFactory.kt
@@ -3,55 +3,122 @@ package fi.hel.haitaton.hanke.factory
 import fi.hel.haitaton.hanke.permissions.HankeKayttaja
 import fi.hel.haitaton.hanke.permissions.HankeKayttajaDto
 import fi.hel.haitaton.hanke.permissions.HankeKayttajaEntity
+import fi.hel.haitaton.hanke.permissions.HankeKayttajaRepository
 import fi.hel.haitaton.hanke.permissions.KayttajaTunnisteEntity
+import fi.hel.haitaton.hanke.permissions.KayttajaTunnisteRepository
 import fi.hel.haitaton.hanke.permissions.Kayttooikeustaso
 import fi.hel.haitaton.hanke.permissions.PermissionEntity
+import fi.hel.haitaton.hanke.permissions.PermissionService
+import java.time.OffsetDateTime
 import java.util.UUID
+import org.springframework.stereotype.Component
 
-object HankeKayttajaFactory {
+@Component
+class HankeKayttajaFactory(
+    private val hankeKayttajaRepository: HankeKayttajaRepository,
+    private val permissionService: PermissionService,
+    private val kayttajaTunnisteRepository: KayttajaTunnisteRepository
+) {
 
-    val KAYTTAJA_ID = UUID.fromString("639870ab-533d-4172-8e97-e5b93a275514")
-    const val HANKE_ID = 14
-    const val NIMI = "Pekka Peruskäyttäjä"
-    const val SAHKOPOSTI = "pekka@peruskäyttäjä.test"
-    val PERMISSION_ID = PermissionFactory.PERMISSION_ID
-    val TUNNISTE_ID = KayttajaTunnisteFactory.TUNNISTE_ID
+    fun saveUserAndToken(
+        hankeId: Int,
+        nimi: String = "Kake Katselija",
+        sahkoposti: String = "kake@katselu.test",
+        kayttooikeustaso: Kayttooikeustaso = Kayttooikeustaso.KATSELUOIKEUS,
+        tunniste: String = "existing",
+    ): HankeKayttajaEntity {
+        val kayttajaTunnisteEntity = saveToken(tunniste, kayttooikeustaso)
+        return saveUser(hankeId, nimi, sahkoposti, null, kayttajaTunnisteEntity)
+    }
 
-    fun create(
-        id: UUID = KAYTTAJA_ID,
-        hankeId: Int = HANKE_ID,
-        nimi: String = NIMI,
-        sahkoposti: String = SAHKOPOSTI,
-        permissionId: Int? = PERMISSION_ID,
-        kayttajaTunnisteId: UUID? = TUNNISTE_ID,
-    ): HankeKayttaja =
-        HankeKayttaja(id, hankeId, nimi, sahkoposti, permissionId, kayttajaTunnisteId)
-
-    fun createEntity(
-        id: UUID = KAYTTAJA_ID,
-        hankeId: Int = HANKE_ID,
-        nimi: String = NIMI,
-        sahkoposti: String = SAHKOPOSTI,
-        permission: PermissionEntity? = null,
+    fun saveUserAndPermission(
+        hankeId: Int,
+        nimi: String = "Kake Katselija",
+        sahkoposti: String = "kake@katselu.test",
+        kayttooikeustaso: Kayttooikeustaso = Kayttooikeustaso.KATSELUOIKEUS,
+        userId: String = "fake id",
         kayttajaTunniste: KayttajaTunnisteEntity? = null,
-    ): HankeKayttajaEntity =
-        HankeKayttajaEntity(
-            id,
-            hankeId,
-            nimi,
-            sahkoposti,
-            permission = permission,
-            kayttajaTunniste = kayttajaTunniste
+    ): HankeKayttajaEntity {
+        val permissionEntity = permissionService.create(hankeId, userId, kayttooikeustaso)
+
+        return saveUser(hankeId, nimi, sahkoposti, permissionEntity, kayttajaTunniste)
+    }
+
+    fun saveUser(
+        hankeId: Int,
+        nimi: String = "Kake Katselija",
+        sahkoposti: String = "kake@katselu.test",
+        permissionEntity: PermissionEntity? = null,
+        kayttajaTunniste: KayttajaTunnisteEntity? = null,
+    ): HankeKayttajaEntity {
+        return hankeKayttajaRepository.save(
+            HankeKayttajaEntity(
+                hankeId = hankeId,
+                nimi = nimi,
+                sahkoposti = sahkoposti,
+                permission = permissionEntity,
+                kayttajaTunniste = kayttajaTunniste,
+            )
+        )
+    }
+
+    fun saveToken(
+        tunniste: String = "existing",
+        kayttooikeustaso: Kayttooikeustaso = Kayttooikeustaso.KATSELUOIKEUS,
+    ) =
+        kayttajaTunnisteRepository.save(
+            KayttajaTunnisteEntity(
+                tunniste = tunniste,
+                createdAt = OffsetDateTime.parse("2023-03-31T15:41:21Z"),
+                kayttooikeustaso = kayttooikeustaso,
+                hankeKayttaja = null,
+            )
         )
 
-    fun generateHankeKayttajat(amount: Int = 3): List<HankeKayttajaDto> =
-        (1..amount).map {
-            HankeKayttajaDto(
-                id = UUID.randomUUID(),
-                sahkoposti = "email.$it.address.com",
-                nimi = "test name$it",
-                kayttooikeustaso = Kayttooikeustaso.KATSELUOIKEUS,
-                tunnistautunut = it % 2 == 0
+    companion object {
+        val KAYTTAJA_ID = UUID.fromString("639870ab-533d-4172-8e97-e5b93a275514")
+        const val HANKE_ID = 14
+        const val NIMI = "Pekka Peruskäyttäjä"
+        const val SAHKOPOSTI = "pekka@peruskäyttäjä.test"
+        val PERMISSION_ID = PermissionFactory.PERMISSION_ID
+        val TUNNISTE_ID = KayttajaTunnisteFactory.TUNNISTE_ID
+
+        fun create(
+            id: UUID = KAYTTAJA_ID,
+            hankeId: Int = HANKE_ID,
+            nimi: String = NIMI,
+            sahkoposti: String = SAHKOPOSTI,
+            permissionId: Int? = PERMISSION_ID,
+            kayttajaTunnisteId: UUID? = TUNNISTE_ID,
+        ): HankeKayttaja =
+            HankeKayttaja(id, hankeId, nimi, sahkoposti, permissionId, kayttajaTunnisteId)
+
+        fun createEntity(
+            id: UUID = KAYTTAJA_ID,
+            hankeId: Int = HANKE_ID,
+            nimi: String = NIMI,
+            sahkoposti: String = SAHKOPOSTI,
+            permission: PermissionEntity? = null,
+            kayttajaTunniste: KayttajaTunnisteEntity? = null,
+        ): HankeKayttajaEntity =
+            HankeKayttajaEntity(
+                id,
+                hankeId,
+                nimi,
+                sahkoposti,
+                permission = permission,
+                kayttajaTunniste = kayttajaTunniste
             )
-        }
+
+        fun generateHankeKayttajat(amount: Int = 3): List<HankeKayttajaDto> =
+            (1..amount).map {
+                HankeKayttajaDto(
+                    id = UUID.randomUUID(),
+                    sahkoposti = "email.$it.address.com",
+                    nimi = "test name$it",
+                    kayttooikeustaso = Kayttooikeustaso.KATSELUOIKEUS,
+                    tunnistautunut = it % 2 == 0
+                )
+            }
+    }
 }


### PR DESCRIPTION
# Description

Add an endpoint for resending the invitation emails. The email is identical to the one that was sent the first time the user was added as a contact.

Removes the old invitation token and link and creates a new one. This resets any period of validity for the token. It also means the original and any previous emails will no longer work.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1514

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
1. Setup a johtoselvitys with contacts.
2. Use [Swagger UI](http://localhost:3001/api/swagger-ui/index.html#/hanke-kayttaja-controller/resendInvitations) to call the endpoint.
3. Check [smtp4dev](http://localhost:3003/) that the email was sent.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: -