### PR TITLE
HAI-1514 Remove sentAt from KayttajaTunniste

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceITest.kt
@@ -1054,7 +1054,6 @@ class ApplicationServiceITest : DatabaseTest() {
             assertThat(tunnisteet).hasSize(1)
             assertThat(tunnisteet[0].kayttooikeustaso).isEqualTo(Kayttooikeustaso.KATSELUOIKEUS)
             assertThat(tunnisteet[0].createdAt).isRecent()
-            assertThat(tunnisteet[0].sentAt).isRecent()
             assertThat(tunnisteet[0].tunniste).matches(Regex(kayttajaTunnistePattern))
             assertThat(tunnisteet[0].hankeKayttaja).isNotNull()
             val kayttaja = tunnisteet[0].hankeKayttaja!!

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaServiceITest.kt
@@ -823,7 +823,6 @@ class HankeKayttajaServiceITest : DatabaseTest() {
                     KayttajaTunnisteEntity(
                         tunniste = "token for both",
                         createdAt = OffsetDateTime.parse("2023-03-31T15:41:21Z"),
-                        sentAt = null,
                         kayttooikeustaso = Kayttooikeustaso.KATSELUOIKEUS,
                         hankeKayttaja = null,
                     )
@@ -1183,7 +1182,6 @@ class HankeKayttajaServiceITest : DatabaseTest() {
         t.prop(KayttajaTunnisteEntity::id).isNotNull()
         t.prop(KayttajaTunnisteEntity::kayttooikeustaso).isEqualTo(Kayttooikeustaso.KATSELUOIKEUS)
         t.prop(KayttajaTunnisteEntity::createdAt).isRecent()
-        t.prop(KayttajaTunnisteEntity::sentAt).isRecent()
         t.prop(KayttajaTunnisteEntity::tunniste).matches(Regex(kayttajaTunnistePattern))
         t.prop(KayttajaTunnisteEntity::hankeKayttaja).isNotNull()
     }
@@ -1263,7 +1261,6 @@ class HankeKayttajaServiceITest : DatabaseTest() {
             KayttajaTunnisteEntity(
                 tunniste = tunniste,
                 createdAt = OffsetDateTime.parse("2023-03-31T15:41:21Z"),
-                sentAt = null,
                 kayttooikeustaso = kayttooikeustaso,
                 hankeKayttaja = null,
             )

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaService.kt
@@ -10,7 +10,6 @@ import fi.hel.haitaton.hanke.domain.Perustaja
 import fi.hel.haitaton.hanke.domain.UserContact
 import fi.hel.haitaton.hanke.email.EmailSenderService
 import fi.hel.haitaton.hanke.email.HankeInvitationData
-import fi.hel.haitaton.hanke.getCurrentTimeUTC
 import fi.hel.haitaton.hanke.logging.HankeKayttajaLoggingService
 import java.util.UUID
 import mu.KotlinLogging
@@ -335,7 +334,7 @@ class HankeKayttajaService(
         userId: String,
     ): KayttajaTunnisteEntity {
         logger.info { "Creating a new user token, hankeId=$hankeId" }
-        val token = KayttajaTunnisteEntity.create(sentAt = getCurrentTimeUTC().toOffsetDateTime())
+        val token = KayttajaTunnisteEntity.create()
         val kayttajaTunnisteEntity = kayttajaTunnisteRepository.save(token)
         logger.info { "Saved the new user token, id=${kayttajaTunnisteEntity.id}" }
         logService.logCreate(kayttajaTunnisteEntity.toDomain(), userId)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/KayttajaTunniste.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/KayttajaTunniste.kt
@@ -23,7 +23,6 @@ data class KayttajaTunniste(
     override val id: UUID,
     val tunniste: String,
     val createdAt: OffsetDateTime,
-    val sentAt: OffsetDateTime?,
     var kayttooikeustaso: Kayttooikeustaso,
     val hankeKayttajaId: UUID?
 ) : HasId<UUID>
@@ -34,24 +33,21 @@ class KayttajaTunnisteEntity(
     @Id val id: UUID = UUID.randomUUID(),
     val tunniste: String,
     @Column(name = "created_at") val createdAt: OffsetDateTime,
-    @Column(name = "sent_at") val sentAt: OffsetDateTime?,
     @Enumerated(EnumType.STRING) var kayttooikeustaso: Kayttooikeustaso,
     @OneToOne(mappedBy = "kayttajaTunniste") val hankeKayttaja: HankeKayttajaEntity?
 ) {
 
-    fun toDomain() =
-        KayttajaTunniste(id, tunniste, createdAt, sentAt, kayttooikeustaso, hankeKayttaja?.id)
+    fun toDomain() = KayttajaTunniste(id, tunniste, createdAt, kayttooikeustaso, hankeKayttaja?.id)
 
     companion object {
         private const val tokenLength: Int = 24
         private val charPool: List<Char> = ('a'..'z') + ('A'..'Z') + ('0'..'9')
         private val secureRandom: SecureRandom = SecureRandom()
 
-        fun create(sentAt: OffsetDateTime? = null) =
+        fun create() =
             KayttajaTunnisteEntity(
                 tunniste = randomToken(),
                 createdAt = getCurrentTimeUTC().toOffsetDateTime(),
-                sentAt = sentAt,
                 kayttooikeustaso = Kayttooikeustaso.KATSELUOIKEUS,
                 hankeKayttaja = null
             )

--- a/services/hanke-service/src/main/resources/db/changelog/changesets/046-remove-sentat-from-tunniste.yml
+++ b/services/hanke-service/src/main/resources/db/changelog/changesets/046-remove-sentat-from-tunniste.yml
@@ -1,0 +1,9 @@
+databaseChangeLog:
+  - changeSet:
+      id: 046-remove-sentat-from-tunniste
+      author: Topias Heinonen
+      comment: Drop sentAt from kayttaja_tunniste since the tokens are recreated whenever they're sent.
+      changes:
+        - dropColumn:
+            tableName: kayttaja_tunniste
+            columnName: sent_at

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/KayttajaTunnisteFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/KayttajaTunnisteFactory.kt
@@ -9,7 +9,6 @@ object KayttajaTunnisteFactory {
     val TUNNISTE_ID: UUID = UUID.fromString("b514795c-d982-430a-836b-91371829db51")
     const val TUNNISTE: String = "K6NqNdCJOrNRh45aCP08e9wc"
     val CREATED_AT: OffsetDateTime = OffsetDateTime.parse("2023-08-31T14:25:13Z")
-    val SENT_AT: OffsetDateTime = OffsetDateTime.parse("2023-08-31T14:25:14Z")
     val KAYTTOOIKEUSTASO: Kayttooikeustaso = Kayttooikeustaso.KATSELUOIKEUS
     val KAYTTAJA_ID: UUID = HankeKayttajaFactory.KAYTTAJA_ID
 
@@ -17,8 +16,7 @@ object KayttajaTunnisteFactory {
         id: UUID = TUNNISTE_ID,
         tunniste: String = TUNNISTE,
         createdAt: OffsetDateTime = CREATED_AT,
-        sentAt: OffsetDateTime? = SENT_AT,
         kayttooikeustaso: Kayttooikeustaso = KAYTTOOIKEUSTASO,
         hankeKayttajaId: UUID? = KAYTTAJA_ID,
-    ) = KayttajaTunniste(id, tunniste, createdAt, sentAt, kayttooikeustaso, hankeKayttajaId)
+    ) = KayttajaTunniste(id, tunniste, createdAt, kayttooikeustaso, hankeKayttajaId)
 }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/logging/HankeKayttajaLoggingServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/logging/HankeKayttajaLoggingServiceTest.kt
@@ -74,7 +74,7 @@ class HankeKayttajaLoggingServiceTest {
     inner class LogTunnisteUpdate {
         @Test
         fun `Creates audit log entry for updated kayttajatunniste`() {
-            val kayttajaTunnisteBefore = KayttajaTunnisteFactory.create(sentAt = null)
+            val kayttajaTunnisteBefore = KayttajaTunnisteFactory.create()
             val kayttajaTunnisteAfter =
                 KayttajaTunnisteFactory.create(kayttooikeustaso = Kayttooikeustaso.HANKEMUOKKAUS)
 


### PR DESCRIPTION
# Description

Remove the sentAt field and column from KayttajaTunniste.

We are recreating the tokens whenever they are sent. So the createdAt and sentAt of the tokens would always be the same value, or at least within a couple of milliseconds from each other.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1514

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [X] Other