### PR TITLE
HAI-1852 Reverse foreign key between HankeKayttaja and KayttajaTunniste

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
@@ -5,6 +5,7 @@ import assertk.assertFailure
 import assertk.assertions.each
 import assertk.assertions.hasClass
 import assertk.assertions.hasSize
+import assertk.assertions.isEmpty
 import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
 import assertk.assertions.isNotNull
@@ -1272,6 +1273,19 @@ class HankeServiceITests : DatabaseTest() {
 
         assertThat(hankeRepository.findByIdOrNull(hanke.id)).isNotNull
         verify { cableReportService.getApplicationInformation(hakemusAlluId) }
+    }
+
+    @Test
+    fun `deleteHanke when hanke has users should remove users and tokens`() {
+        val hanke = hankeFactory.save(HankeFactory.create().withYhteystiedot()).hankeTunnus!!
+        assertk.assertThat(hankeKayttajaRepository.findAll()).hasSize(4)
+        assertk.assertThat(kayttajaTunnisteRepository.findAll()).hasSize(4)
+
+        hankeService.deleteHanke(hanke, USER_NAME)
+
+        assertk.assertThat(hankeRepository.findAll()).isEmpty()
+        assertk.assertThat(hankeKayttajaRepository.findAll()).isEmpty()
+        assertk.assertThat(kayttajaTunnisteRepository.findAll()).isEmpty()
     }
 
     @Test

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceITest.kt
@@ -1040,7 +1040,7 @@ class ApplicationServiceITest : DatabaseTest() {
             assertThat(tunnisteet[0].createdAt).isRecent()
             assertThat(tunnisteet[0].tunniste).matches(Regex(kayttajaTunnistePattern))
             assertThat(tunnisteet[0].hankeKayttaja).isNotNull()
-            val kayttaja = tunnisteet[0].hankeKayttaja!!
+            val kayttaja = tunnisteet[0].hankeKayttaja
             assertThat(kayttaja.nimi).isEqualTo("Teppo Testihenkilö")
             assertThat(kayttaja.sahkoposti).isEqualTo(teppoEmail)
             assertThat(kayttaja.hankeId).isEqualTo(application.hanke.id)

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/logging/AuditLogServiceITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/logging/AuditLogServiceITests.kt
@@ -20,9 +20,6 @@ import org.testcontainers.junit.jupiter.Testcontainers
  * repositories have no additional code over the base JPARepository, so only the configs/setups get
  * indirectly tested.
  */
-// NOTE: using @DataJpaTest(properties = ["spring.liquibase.enabled=false"])
-//  fails; it seems the way it tries to use schemas is not compatible with H2.
-//  Thus, have to use this test containers -way, which uses the proper PostgreSQL.
 @Testcontainers
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("test")

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaControllerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaControllerITest.kt
@@ -468,18 +468,6 @@ class HankeKayttajaControllerITest(@Autowired override val mockMvc: MockMvc) : C
         }
 
         @Test
-        fun `Returns 500 when tunniste is orphaned`() {
-            every { hankeKayttajaService.createPermissionFromToken(USERNAME, tunniste) } throws
-                OrphanedTunnisteException(USERNAME, tunnisteId)
-
-            post(url, Tunnistautuminen(tunniste))
-                .andExpect(status().isInternalServerError)
-                .andExpect(hankeError(HankeError.HAI4001))
-
-            verify { hankeKayttajaService.createPermissionFromToken(USERNAME, tunniste) }
-        }
-
-        @Test
         fun `Returns 409 when user already has a permission`() {
             every { hankeKayttajaService.createPermissionFromToken(USERNAME, tunniste) } throws
                 UserAlreadyHasPermissionException(USERNAME, tunnisteId, permissionId)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttaja.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttaja.kt
@@ -36,9 +36,7 @@ class HankeKayttajaEntity(
     @OneToOne
     @JoinColumn(name = "permission_id", updatable = true, nullable = true)
     var permission: PermissionEntity?,
-    @OneToOne(orphanRemoval = true)
-    @JoinColumn(name = "tunniste_id", updatable = true, nullable = true)
-    var kayttajaTunniste: KayttajaTunnisteEntity?,
+    @OneToOne(mappedBy = "hankeKayttaja") var kayttajaTunniste: KayttajaTunnisteEntity?,
 ) {
     fun toDto(): HankeKayttajaDto =
         HankeKayttajaDto(

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaController.kt
@@ -324,14 +324,6 @@ of the token and link will be reset.
     }
 
     @ExceptionHandler
-    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
-    @Hidden
-    fun orphanedTunnisteException(ex: OrphanedTunnisteException): HankeError {
-        logger.error(ex) { ex.message }
-        return HankeError.HAI4001
-    }
-
-    @ExceptionHandler
     @ResponseStatus(HttpStatus.CONFLICT)
     @Hidden
     fun userAlreadyHasPermissionException(ex: UserAlreadyHasPermissionException): HankeError {

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/KayttajaTunniste.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/KayttajaTunniste.kt
@@ -9,6 +9,7 @@ import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
 import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
 import jakarta.persistence.OneToOne
 import jakarta.persistence.Table
 import java.security.SecureRandom
@@ -34,22 +35,24 @@ class KayttajaTunnisteEntity(
     val tunniste: String,
     @Column(name = "created_at") val createdAt: OffsetDateTime,
     @Enumerated(EnumType.STRING) var kayttooikeustaso: Kayttooikeustaso,
-    @OneToOne(mappedBy = "kayttajaTunniste") val hankeKayttaja: HankeKayttajaEntity?
+    @OneToOne
+    @JoinColumn(name = "hanke_kayttaja_id", updatable = false, nullable = false, unique = true)
+    val hankeKayttaja: HankeKayttajaEntity,
 ) {
 
-    fun toDomain() = KayttajaTunniste(id, tunniste, createdAt, kayttooikeustaso, hankeKayttaja?.id)
+    fun toDomain() = KayttajaTunniste(id, tunniste, createdAt, kayttooikeustaso, hankeKayttaja.id)
 
     companion object {
         private const val tokenLength: Int = 24
         private val charPool: List<Char> = ('a'..'z') + ('A'..'Z') + ('0'..'9')
         private val secureRandom: SecureRandom = SecureRandom()
 
-        fun create() =
+        fun create(hankeKayttaja: HankeKayttajaEntity) =
             KayttajaTunnisteEntity(
                 tunniste = randomToken(),
                 createdAt = getCurrentTimeUTC().toOffsetDateTime(),
                 kayttooikeustaso = Kayttooikeustaso.KATSELUOIKEUS,
-                hankeKayttaja = null
+                hankeKayttaja = hankeKayttaja
             )
 
         private fun randomToken(): String =

--- a/services/hanke-service/src/main/resources/db/changelog/changesets/047-reverse-tunniste-foreign-key-direction.sql
+++ b/services/hanke-service/src/main/resources/db/changelog/changesets/047-reverse-tunniste-foreign-key-direction.sql
@@ -1,0 +1,28 @@
+--liquibase formatted sql
+--changeset Topias Heinonen:047-reverse-tunniste-foreign-key-direction
+--comment: Add RESEND_INVITATION permission code
+
+ALTER TABLE kayttaja_tunniste
+    ADD COLUMN hanke_kayttaja_id uuid;
+
+UPDATE kayttaja_tunniste
+SET hanke_kayttaja_id = (SELECT hanke_kayttaja.id
+                         from hanke_kayttaja
+                         WHERE hanke_kayttaja.tunniste_id = kayttaja_tunniste.id);
+
+-- The ones where hanke_kayttaja_id is null are orphans,
+-- i.e. ones where there's no hanke_kayttaja that links to them.
+DELETE
+FROM kayttaja_tunniste
+WHERE hanke_kayttaja_id IS NULL;
+
+ALTER TABLE hanke_kayttaja
+    DROP CONSTRAINT IF EXISTS fk_hankekayttaja_kayttajatunniste,
+    DROP COLUMN IF EXISTS tunniste_id;
+
+ALTER TABLE kayttaja_tunniste
+    ALTER COLUMN hanke_kayttaja_id SET NOT NULL,
+    ADD CONSTRAINT fk_kayttajatunniste_hankekayttaja FOREIGN KEY (hanke_kayttaja_id) REFERENCES hanke_kayttaja (id) ON DELETE CASCADE,
+    ADD CONSTRAINT uk_hanke_kayttaja_id UNIQUE (hanke_kayttaja_id);
+
+COMMENT ON COLUMN kayttaja_tunniste.hanke_kayttaja_id IS 'The kayttaja this tunniste belongs to. This field is unique, so there can be only one tunniste for each kayttaja.';

--- a/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -119,3 +119,7 @@ databaseChangeLog:
       file: db/changelog/changesets/044-rename-role-to-kayttooikeustaso.yml
   - include:
       file: db/changelog/changesets/045-add-new-permission-code.sql
+  - include:
+      file: db/changelog/changesets/046-remove-sentat-from-tunniste.yml
+  - include:
+      file: db/changelog/changesets/047-reverse-tunniste-foreign-key-direction.sql

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeKayttajaFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeKayttajaFactory.kt
@@ -26,10 +26,8 @@ class HankeKayttajaFactory(
         sahkoposti: String = "kake@katselu.test",
         kayttooikeustaso: Kayttooikeustaso = Kayttooikeustaso.KATSELUOIKEUS,
         tunniste: String = "existing",
-    ): HankeKayttajaEntity {
-        val kayttajaTunnisteEntity = saveToken(tunniste, kayttooikeustaso)
-        return saveUser(hankeId, nimi, sahkoposti, null, kayttajaTunnisteEntity)
-    }
+    ): HankeKayttajaEntity =
+        addToken(saveUser(hankeId, nimi, sahkoposti, null), tunniste, kayttooikeustaso)
 
     fun saveUserAndPermission(
         hankeId: Int,
@@ -37,11 +35,10 @@ class HankeKayttajaFactory(
         sahkoposti: String = "kake@katselu.test",
         kayttooikeustaso: Kayttooikeustaso = Kayttooikeustaso.KATSELUOIKEUS,
         userId: String = "fake id",
-        kayttajaTunniste: KayttajaTunnisteEntity? = null,
     ): HankeKayttajaEntity {
         val permissionEntity = permissionService.create(hankeId, userId, kayttooikeustaso)
 
-        return saveUser(hankeId, nimi, sahkoposti, permissionEntity, kayttajaTunniste)
+        return saveUser(hankeId, nimi, sahkoposti, permissionEntity)
     }
 
     fun saveUser(
@@ -62,7 +59,16 @@ class HankeKayttajaFactory(
         )
     }
 
-    fun saveToken(
+    fun addToken(
+        hankeKayttaja: HankeKayttajaEntity,
+        tunniste: String = "existing",
+        kayttooikeustaso: Kayttooikeustaso = Kayttooikeustaso.KATSELUOIKEUS,
+    ): HankeKayttajaEntity {
+        hankeKayttaja.kayttajaTunniste = hankeKayttaja.saveToken(tunniste, kayttooikeustaso)
+        return hankeKayttajaRepository.save(hankeKayttaja)
+    }
+
+    private fun HankeKayttajaEntity.saveToken(
         tunniste: String = "existing",
         kayttooikeustaso: Kayttooikeustaso = Kayttooikeustaso.KATSELUOIKEUS,
     ) =
@@ -71,7 +77,7 @@ class HankeKayttajaFactory(
                 tunniste = tunniste,
                 createdAt = OffsetDateTime.parse("2023-03-31T15:41:21Z"),
                 kayttooikeustaso = kayttooikeustaso,
-                hankeKayttaja = null,
+                hankeKayttaja = this,
             )
         )
 

--- a/services/hanke-service/src/test/resources/application-test.properties
+++ b/services/hanke-service/src/test/resources/application-test.properties
@@ -1,10 +1,11 @@
+haitaton.clamav.baseUrl=http://localhost:6789
 haitaton.email.filter.use=false
 haitaton.email.from=no-reply@hel.fi
+haitaton.features.hanke-editing=true
+haitaton.features.user-management=true
+spring.jpa.show-sql=false
 spring.mail.port=3025
+spring.mail.properties.mail.debug=false
 spring.mail.properties.mail.smtp.auth=false
 spring.mail.properties.mail.smtp.starttls.enable=false
 spring.mail.properties.mail.smtp.starttls.required=false
-spring.mail.properties.mail.debug=false
-haitaton.clamav.baseUrl=http://localhost:6789
-haitaton.features.hanke-editing=true
-haitaton.features.user-management=true


### PR DESCRIPTION
# Description

It makes more sense that KayttajaTunniste has a foreign key for HankeKayttaja than the reverse. This way it's impossible to have an orphaned tunniste hanging around.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1852

## Type of change

- [X] Bug fix 
- [ ] New feature 
- [ ] Other

# Instructions for testing
1. Send a johtoselvityshakemus with various contacts.
2. Check that they have tokens.
3. Cancel the generated hanke.
4. Check that the tokens were deleted.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [X] I have made necessary changes to the documentation, link to confluence
 or other location: https://helsinkisolutionoffice.atlassian.net/wiki/spaces/HAI/pages/8286371894/Tekninen+toteutuskuvaus#K%C3%A4ytt%C3%A4j%C3%A4roolit-ja-oikeudet

# Other relevant info
This was done on top of #430, since that adds logic for recreating tokens.