### PR TITLE
HAI-1872 Add validation for nimi and hankealue nimi lengths

### DIFF
--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Constants.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Constants.kt
@@ -22,6 +22,12 @@ val TZ_UTC: ZoneId = ZoneId.of("UTC")
 val DATABASE_TIMESTAMP_FORMAT: DateTimeFormatter =
     DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS")
 
+/** Hanke names are limited to 100 characters in the DB. */
+const val MAXIMUM_HANKE_NIMI_LENGTH = 100
+
+/** Hanke alue names are limited to 100 characters in the DB. */
+const val MAXIMUM_HANKE_ALUE_NIMI_LENGTH = 100
+
 // Note: database definition has no limit, so this is sort of important; must be quite long,
 // but not excessive (considering database size etc.)
 const val MAXIMUM_TYOMAAKATUOSOITE_LENGTH = 2000

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeFactory.kt
@@ -18,7 +18,6 @@ import fi.hel.haitaton.hanke.Vaihe.SUUNNITTELU
 import fi.hel.haitaton.hanke.application.CableReportWithoutHanke
 import fi.hel.haitaton.hanke.domain.Hanke
 import fi.hel.haitaton.hanke.domain.HankeYhteystieto
-import fi.hel.haitaton.hanke.domain.Hankealue
 import fi.hel.haitaton.hanke.domain.Perustaja
 import fi.hel.haitaton.hanke.factory.AttachmentFactory.Companion.hankeAttachmentEntity
 import fi.hel.haitaton.hanke.factory.HankeYhteystietoFactory.createEntity
@@ -175,17 +174,20 @@ class HankeFactory(
          * ```
          */
         fun Hanke.withHankealue(
-            alue: Hankealue =
-                HankealueFactory.create(
-                    hankeId = this.id,
-                    haittaAlkuPvm = DateFactory.getStartDatetime(),
-                    haittaLoppuPvm = DateFactory.getEndDatetime()
-                )
+            nimi: String? = null,
+            haittaAlkuPvm: ZonedDateTime? = DateFactory.getStartDatetime(),
+            haittaLoppuPvm: ZonedDateTime? = DateFactory.getEndDatetime(),
         ): Hanke {
             this.tyomaaKatuosoite = "Testikatu 1"
             this.tyomaaTyyppi.add(TyomaaTyyppi.VESI)
             this.tyomaaTyyppi.add(TyomaaTyyppi.MUU)
-
+            val alue =
+                HankealueFactory.create(
+                    hankeId = this.id,
+                    nimi = nimi,
+                    haittaAlkuPvm = haittaAlkuPvm,
+                    haittaLoppuPvm = haittaLoppuPvm,
+                )
             this.alueet.add(alue)
 
             return this

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/validation/HankeValidatorTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/validation/HankeValidatorTest.kt
@@ -1,0 +1,275 @@
+package fi.hel.haitaton.hanke.validation
+
+import assertk.assertThat
+import assertk.assertions.isFalse
+import assertk.assertions.isTrue
+import fi.hel.haitaton.hanke.HankeError
+import fi.hel.haitaton.hanke.MAXIMUM_DATE
+import fi.hel.haitaton.hanke.MAXIMUM_HANKE_ALUE_NIMI_LENGTH
+import fi.hel.haitaton.hanke.MAXIMUM_HANKE_NIMI_LENGTH
+import fi.hel.haitaton.hanke.MAXIMUM_TYOMAAKATUOSOITE_LENGTH
+import fi.hel.haitaton.hanke.SuunnitteluVaihe
+import fi.hel.haitaton.hanke.Vaihe
+import fi.hel.haitaton.hanke.factory.DateFactory
+import fi.hel.haitaton.hanke.factory.HankeFactory
+import fi.hel.haitaton.hanke.factory.HankeFactory.Companion.withHankealue
+import io.mockk.clearAllMocks
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import io.mockk.verifySequence
+import jakarta.validation.ConstraintValidatorContext
+import jakarta.validation.ConstraintValidatorContext.ConstraintViolationBuilder
+import jakarta.validation.ConstraintValidatorContext.ConstraintViolationBuilder.NodeBuilderCustomizableContext
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class HankeValidatorTest {
+
+    private val hankeValidator = HankeValidator()
+    private var context: ConstraintValidatorContext = mockk(relaxUnitFun = true)
+    private var violationBuilder: ConstraintViolationBuilder = mockk(relaxUnitFun = true)
+    private var nodeBuilder: NodeBuilderCustomizableContext = mockk(relaxUnitFun = true)
+
+    @BeforeEach
+    fun setUp() {
+        clearAllMocks()
+        every { context.buildConstraintViolationWithTemplate(any()) } returns violationBuilder
+        every { violationBuilder.addConstraintViolation() } returns context
+        every { violationBuilder.addPropertyNode(any()) } returns nodeBuilder
+        every { nodeBuilder.addConstraintViolation() } returns context
+    }
+
+    @AfterEach
+    fun checkMocks() {
+        // Don't check for unnecessary stubbing. The stubs are the same for all tests.
+        confirmVerified(context, violationBuilder, nodeBuilder)
+    }
+
+    @Test
+    fun `fails if hanke is null`() {
+        assertThat(hankeValidator.isValid(null, context)).isFalse()
+
+        verifySequence {
+            context.buildConstraintViolationWithTemplate(HankeError.HAI1002.toString())
+            violationBuilder.addConstraintViolation()
+        }
+    }
+
+    @Test
+    fun `succeeds for the default hanke`() {
+        val hanke = HankeFactory.create()
+
+        assertThat(hankeValidator.isValid(hanke, context)).isTrue()
+    }
+
+    @Test
+    fun `fails if nimi is missing`() {
+        val hanke = HankeFactory.create(nimi = null)
+
+        assertThat(hankeValidator.isValid(hanke, context)).isFalse()
+
+        verifyError(HankeError.HAI1002, "nimi")
+    }
+
+    @Test
+    fun `fails if nimi is empty`() {
+        val hanke = HankeFactory.create(nimi = "")
+
+        assertThat(hankeValidator.isValid(hanke, context)).isFalse()
+
+        verifyError(HankeError.HAI1002, "nimi")
+    }
+
+    @Test
+    fun `succeeds if nimi is almost too long`() {
+        val hanke = HankeFactory.create(nimi = "F".repeat(MAXIMUM_HANKE_NIMI_LENGTH))
+
+        assertThat(hankeValidator.isValid(hanke, context)).isTrue()
+    }
+
+    @Test
+    fun `fails if nimi is too long`() {
+        val hanke = HankeFactory.create(nimi = "F".repeat(MAXIMUM_HANKE_NIMI_LENGTH + 1))
+
+        assertThat(hankeValidator.isValid(hanke, context)).isFalse()
+
+        verifyError(HankeError.HAI1002, "nimi")
+    }
+
+    @Test
+    fun `fails if vaihe is null`() {
+        val hanke = HankeFactory.create(vaihe = null)
+
+        assertThat(hankeValidator.isValid(hanke, context)).isFalse()
+
+        verifyError(HankeError.HAI1002, "vaihe")
+    }
+
+    @Test
+    fun `fails if vaihe is suunnittelu and suunnitteluVaihe is null`() {
+        val hanke = HankeFactory.create(vaihe = Vaihe.SUUNNITTELU, suunnitteluVaihe = null)
+
+        assertThat(hankeValidator.isValid(hanke, context)).isFalse()
+
+        verifyError(HankeError.HAI1002, "suunnitteluVaihe")
+    }
+
+    @Test
+    fun `succeeds if vaihe is suunnittelu and suunnitteluVaihe is defined`() {
+        val hanke =
+            HankeFactory.create(
+                vaihe = Vaihe.SUUNNITTELU,
+                suunnitteluVaihe = SuunnitteluVaihe.YLEIS_TAI_HANKE
+            )
+
+        assertThat(hankeValidator.isValid(hanke, context)).isTrue()
+    }
+
+    @Test
+    fun `succeeds if tyomaaKatuosoite is null`() {
+        val hanke = HankeFactory.create().apply { tyomaaKatuosoite = null }
+
+        assertThat(hankeValidator.isValid(hanke, context)).isTrue()
+    }
+
+    @Test
+    fun `succeeds if tyomaaKatuosoite is almost too long`() {
+        val hanke =
+            HankeFactory.create().apply {
+                tyomaaKatuosoite = "F".repeat(MAXIMUM_TYOMAAKATUOSOITE_LENGTH)
+            }
+
+        assertThat(hankeValidator.isValid(hanke, context)).isTrue()
+    }
+
+    @Test
+    fun `fails if tyomaaKatuosoite is too long`() {
+        val hanke =
+            HankeFactory.create().apply {
+                tyomaaKatuosoite = "F".repeat(MAXIMUM_TYOMAAKATUOSOITE_LENGTH + 1)
+            }
+
+        assertThat(hankeValidator.isValid(hanke, context)).isFalse()
+
+        verifyError(HankeError.HAI1002, "tyomaaKatuosoite")
+    }
+
+    @Test
+    fun `succeeds for the default hanke with an alue`() {
+        val hanke = HankeFactory.create().withHankealue()
+
+        assertThat(hankeValidator.isValid(hanke, context)).isTrue()
+    }
+
+    @Test
+    fun `succeeds if hanke alue nimi is null`() {
+        val hanke = HankeFactory.create().withHankealue(nimi = null)
+
+        assertThat(hankeValidator.isValid(hanke, context)).isTrue()
+    }
+
+    @Test
+    fun `succeeds if hanke alue nimi is almost too long`() {
+        val hanke =
+            HankeFactory.create().withHankealue(nimi = "F".repeat(MAXIMUM_HANKE_ALUE_NIMI_LENGTH))
+
+        assertThat(hankeValidator.isValid(hanke, context)).isTrue()
+    }
+
+    @Test
+    fun `fails if hanke alue nimi is null`() {
+        val hanke =
+            HankeFactory.create()
+                .withHankealue(nimi = "F".repeat(MAXIMUM_HANKE_ALUE_NIMI_LENGTH + 1))
+
+        assertThat(hankeValidator.isValid(hanke, context)).isFalse()
+
+        verifyError(HankeError.HAI1032, "alueet[0].nimi")
+    }
+
+    @Test
+    fun `fails if haitta alku pvm is too far in the future`() {
+        val hanke = HankeFactory.create().withHankealue(haittaAlkuPvm = MAXIMUM_DATE.plusDays(1))
+
+        assertThat(hankeValidator.isValid(hanke, context)).isFalse()
+
+        verifyError(HankeError.HAI1032, "alueet[0].haittaAlkuPvm")
+        verifyError(HankeError.HAI1032, "alueet[0].haittaLoppuPvm")
+    }
+
+    @Test
+    fun `fails if haitta alku pvm is null`() {
+        val hanke = HankeFactory.create().withHankealue(haittaAlkuPvm = null)
+
+        assertThat(hankeValidator.isValid(hanke, context)).isFalse()
+
+        verifyError(HankeError.HAI1032, "alueet[0].haittaAlkuPvm")
+    }
+
+    @Test
+    fun `fails if haitta loppu pvm is null`() {
+        val hanke = HankeFactory.create().withHankealue(haittaLoppuPvm = null)
+
+        assertThat(hankeValidator.isValid(hanke, context)).isFalse()
+
+        verifyError(HankeError.HAI1032, "alueet[0].haittaLoppuPvm")
+    }
+
+    @Test
+    fun `fails if haitta loppu pvm is too far in the future`() {
+        val hanke = HankeFactory.create().withHankealue(haittaLoppuPvm = MAXIMUM_DATE.plusDays(1))
+
+        assertThat(hankeValidator.isValid(hanke, context)).isFalse()
+
+        verifyError(HankeError.HAI1032, "alueet[0].haittaLoppuPvm")
+    }
+
+    @Test
+    fun `succeeds if haitta loppu pvm is same as start date`() {
+        val hanke =
+            HankeFactory.create().withHankealue(haittaLoppuPvm = DateFactory.getStartDatetime())
+
+        assertThat(hankeValidator.isValid(hanke, context)).isTrue()
+    }
+
+    @Test
+    fun `fails if haitta loppu pvm is before start date`() {
+        val hanke =
+            HankeFactory.create()
+                .withHankealue(haittaLoppuPvm = DateFactory.getStartDatetime().minusMinutes(1))
+
+        assertThat(hankeValidator.isValid(hanke, context)).isFalse()
+
+        verifyError(HankeError.HAI1032, "alueet[0].haittaLoppuPvm")
+    }
+
+    @Test
+    fun `with several failing alue and a failing hanke, adds all error nodes`() {
+        val hanke =
+            HankeFactory.create(nimi = "")
+                .withHankealue(haittaLoppuPvm = null, haittaAlkuPvm = null)
+                .withHankealue(nimi = "F".repeat(101))
+                .withHankealue(haittaAlkuPvm = null)
+                .withHankealue(haittaLoppuPvm = DateFactory.getStartDatetime().minusMinutes(1))
+
+        assertThat(hankeValidator.isValid(hanke, context)).isFalse()
+
+        verifyError(HankeError.HAI1002, "nimi")
+        verifyError(HankeError.HAI1032, "alueet[0].haittaLoppuPvm")
+        verifyError(HankeError.HAI1032, "alueet[0].haittaAlkuPvm")
+        verifyError(HankeError.HAI1032, "alueet[1].nimi")
+        verifyError(HankeError.HAI1032, "alueet[2].haittaAlkuPvm")
+        verifyError(HankeError.HAI1032, "alueet[3].haittaLoppuPvm")
+    }
+
+    private fun verifyError(error: HankeError, node: String) {
+        verify {
+            context.buildConstraintViolationWithTemplate(error.toString())
+            violationBuilder.addPropertyNode(node)
+            nodeBuilder.addConstraintViolation()
+        }
+    }
+}


### PR DESCRIPTION
# Description

The database is limited to 100 characters for nimi and hankealue. To avoid database errors, limit the length of nimi and hankealue to the same 100 characters in validation.

Also, refactor HankeValidator to reuse some of the code better. Use the Validators-methods for finding the paths with errors. Then map those paths to validator context violations.

Add comprehensive tests for HankeValidator to know the refactoring didn't change behaviour.

Refactor HankeControllerTest to use Mockk instead of Mockito. It was the last place Mockito was used. I thought I needed it for this PR, but I ended up doing a separate test class. I had already refactored it, so I decided to add the changes here anyway.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1872

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [X] Other

# Instructions for testing
Try to create hanke with a name of over 100 characters. The error the backend gives should make sense now.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 