### PR TITLE
HAI-1940 Add response to identification API

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
@@ -142,6 +142,23 @@ class HankeServiceITests : DatabaseTest() {
         }
     }
 
+    @Nested
+    inner class LoadHankeById {
+        @Test
+        fun `returns null if hanke not found`() {
+            assertThat(hankeService.loadHankeById(44)).isNull()
+        }
+
+        @Test
+        fun `returns hanke if hanke exists`() {
+            val hanke = hankeFactory.save()
+
+            val response = hankeService.loadHankeById(hanke.id!!)
+
+            assertk.assertThat(response).isNotNull().prop(Hanke::id).isEqualTo(hanke.id!!)
+        }
+    }
+
     @Test
     fun `create Hanke with full data set succeeds and returns a new domain object with the correct values`() {
         val hanke: Hanke = getATestHanke().withYhteystiedot { it.id = null }.withHankealue()

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeService.kt
@@ -27,5 +27,7 @@ interface HankeService {
 
     fun loadPublicHanke(): List<Hanke>
 
+    @Transactional(readOnly = true) fun loadHankeById(id: Int): Hanke?
+
     fun loadHankkeetByIds(ids: List<Int>): List<Hanke>
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeService.kt
@@ -3,7 +3,6 @@ package fi.hel.haitaton.hanke
 import fi.hel.haitaton.hanke.application.Application
 import fi.hel.haitaton.hanke.application.CableReportWithoutHanke
 import fi.hel.haitaton.hanke.domain.Hanke
-import org.springframework.transaction.annotation.Transactional
 
 interface HankeService {
 
@@ -13,21 +12,20 @@ interface HankeService {
 
     fun getHankeApplications(hankeTunnus: String): List<Application>
 
-    @Transactional fun createHanke(hanke: Hanke): Hanke
+    fun createHanke(hanke: Hanke): Hanke
 
-    @Transactional
     fun generateHankeWithApplication(
         cableReport: CableReportWithoutHanke,
         userId: String
     ): Application
 
-    @Transactional fun updateHanke(hanke: Hanke): Hanke
+    fun updateHanke(hanke: Hanke): Hanke
 
-    @Transactional fun deleteHanke(hankeTunnus: String, userId: String)
+    fun deleteHanke(hankeTunnus: String, userId: String)
 
     fun loadPublicHanke(): List<Hanke>
 
-    @Transactional(readOnly = true) fun loadHankeById(id: Int): Hanke?
+    fun loadHankeById(id: Int): Hanke?
 
     fun loadHankkeetByIds(ids: List<Int>): List<Hanke>
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeServiceImpl.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeServiceImpl.kt
@@ -26,6 +26,7 @@ import fi.hel.haitaton.hanke.tormaystarkastelu.TormaystarkasteluTulosEntity
 import fi.hel.haitaton.hanke.validation.HankePublicValidator
 import java.time.ZonedDateTime
 import mu.KotlinLogging
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.transaction.annotation.Transactional
 
 private val logger = KotlinLogging.logger {}
@@ -93,6 +94,10 @@ open class HankeServiceImpl(
         hankeRepository.findAllByStatus(HankeStatus.PUBLIC).map {
             createHankeDomainObjectFromEntity(it)
         }
+
+    @Transactional(readOnly = true)
+    override fun loadHankeById(id: Int): Hanke? =
+        hankeRepository.findByIdOrNull(id)?.let { createHankeDomainObjectFromEntity(it) }
 
     @Transactional(readOnly = true)
     override fun loadHankkeetByIds(ids: List<Int>) =

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaService.kt
@@ -170,7 +170,7 @@ class HankeKayttajaService(
     }
 
     @Transactional
-    fun createPermissionFromToken(userId: String, tunniste: String) {
+    fun createPermissionFromToken(userId: String, tunniste: String): HankeKayttaja {
         logger.info { "Trying to activate token $tunniste for user $userId" }
         val tunnisteEntity =
             kayttajaTunnisteRepository.findByTunniste(tunniste)
@@ -198,6 +198,9 @@ class HankeKayttajaService(
 
         kayttaja.kayttajaTunniste = null
         kayttajaTunnisteRepository.delete(tunnisteEntity)
+        logService.logDelete(tunnisteEntity.toDomain(), userId)
+
+        return kayttaja.toDomain()
     }
 
     @Transactional


### PR DESCRIPTION
# Description

Add a response to identification API with the ID of the activated user and tunnus and name of the associated hanke.

Also add a missing audit log for deleting the tunniste to the identification run.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1940

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
When identifying, the endpoint should return a response.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [X] I have made necessary changes to the documentation, link to confluence
 or other location: https://helsinkisolutionoffice.atlassian.net/wiki/spaces/HAI/pages/8219721755/K+ytt+oikeuksien+hallinta