### PR TITLE
HAI-1898 Remove ykt value from tyomaatyyppi enum

### DIFF
--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Persistence.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Persistence.kt
@@ -59,7 +59,6 @@ enum class TyomaaTyyppi {
     SAHKO,
     TIETOLIIKENNE,
     LIIKENNEVALO,
-    YKT,
     ULKOVALAISTUS,
     KAAPPITYO,
     KAUKOLAMPO,


### PR DESCRIPTION
# Description

Remove ykt value from tyomaatyyppi enum. This infromation is handled via boolean onYKTHanke field in Hanke object. Remove it from the enum as redundant.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1898

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [x] Other

# Instructions for testing
Please describe tests how this change or new feature can be tested.

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 

# Other relevant info
Please describe here if there is e.g. some requirements for this change or
 other info that the tester/user needs to know.