### PR TITLE
HAI-1876 Separate buses and trams to separate indexes

### DIFF
--- a/services/hanke-service/src/integrationTest/resources/fi/hel/haitaton/hanke/logging/expectedHankeWithPoints.json.mustache
+++ b/services/hanke-service/src/integrationTest/resources/fi/hel/haitaton/hanke/logging/expectedHankeWithPoints.json.mustache
@@ -99,6 +99,8 @@
   "tormaystarkasteluTulos": {
     "perusIndeksi": 1.4,
     "pyorailyIndeksi": 1.0,
+    "linjaautoIndeksi": 1.0,
+    "raitiovaunuIndeksi": 1.0,
     "joukkoliikenneIndeksi": 1.0,
     "liikennehaittaIndeksi": {
       "indeksi": 1.4,

--- a/services/hanke-service/src/integrationTest/resources/fi/hel/haitaton/hanke/logging/expectedHankeWithPolygon.json.mustache
+++ b/services/hanke-service/src/integrationTest/resources/fi/hel/haitaton/hanke/logging/expectedHankeWithPolygon.json.mustache
@@ -96,6 +96,8 @@
   "tormaystarkasteluTulos": {
     "perusIndeksi": 1.4,
     "pyorailyIndeksi": 1.0,
+    "linjaautoIndeksi": 1.0,
+    "raitiovaunuIndeksi": 1.0,
     "joukkoliikenneIndeksi": 1.0,
     "liikennehaittaIndeksi": {
       "indeksi": 1.4,

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeMapper.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeMapper.kt
@@ -78,6 +78,6 @@ object HankeMapper {
 
     private fun tormaystarkasteluTulos(entity: HankeEntity) =
         entity.tormaystarkasteluTulokset.firstOrNull()?.let {
-            TormaystarkasteluTulos(it.perus, it.pyoraily, it.joukkoliikenne)
+            TormaystarkasteluTulos(it.perus, it.pyoraily, it.linjaauto, it.raitiovaunu)
         }
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeServiceImpl.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeServiceImpl.kt
@@ -253,7 +253,8 @@ open class HankeServiceImpl(
                 TormaystarkasteluTulosEntity(
                     perus = it.perusIndeksi,
                     pyoraily = it.pyorailyIndeksi,
-                    joukkoliikenne = it.joukkoliikenneIndeksi,
+                    linjaauto = it.linjaautoIndeksi,
+                    raitiovaunu = it.raitiovaunuIndeksi,
                     hanke = target
                 )
             )

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluTormaysServicePG.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluTormaysServicePG.kt
@@ -151,7 +151,7 @@ enum class TormaystarkasteluKatuluokka(val value: Int, val katuluokka: String) {
 
     companion object {
         fun valueOfKatuluokka(katuluokka: String): TormaystarkasteluKatuluokka {
-            return values().first { it.katuluokka == katuluokka }
+            return entries.first { it.katuluokka == katuluokka }
         }
     }
 }
@@ -163,9 +163,16 @@ enum class TormaystarkasteluBussiRunkolinja(val runkolinja: String) {
 
     companion object {
         fun valueOfRunkolinja(runkolinja: String): TormaystarkasteluBussiRunkolinja? {
-            return values().find { it.runkolinja == runkolinja }
+            return entries.find { it.runkolinja == runkolinja }
         }
     }
+
+    fun toBussiLiikenneLuokittelu(): BussiLiikenneLuokittelu =
+        when (this) {
+            ON -> BussiLiikenneLuokittelu.RUNKOLINJA
+            LAHES -> BussiLiikenneLuokittelu.RUNKOLINJAMAINEN
+            EI -> BussiLiikenneLuokittelu.PERUS
+        }
 }
 
 enum class TormaystarkasteluRaitiotiekaistatyyppi(val value: Int, val kaistatyyppi: String) {
@@ -174,7 +181,7 @@ enum class TormaystarkasteluRaitiotiekaistatyyppi(val value: Int, val kaistatyyp
 
     companion object {
         fun valueOfKaistatyyppi(kaistatyyppi: String): TormaystarkasteluRaitiotiekaistatyyppi {
-            return values().first { it.kaistatyyppi == kaistatyyppi }
+            return entries.first { it.kaistatyyppi == kaistatyyppi }
         }
     }
 }

--- a/services/hanke-service/src/main/resources/db/changelog/changesets/049-add-bus-and-tram-indexes.sql
+++ b/services/hanke-service/src/main/resources/db/changelog/changesets/049-add-bus-and-tram-indexes.sql
@@ -1,0 +1,35 @@
+--liquibase formatted sql
+--changeset Topias Heinonen:049-add-bus-and-tram-indexes
+--comment: Replace joukkoliikenneindeksi with separate bus and tram indexes. Make the indexes NOT NULL.
+
+ALTER TABLE tormaystarkastelutulos
+    ADD COLUMN linjaauto   DOUBLE PRECISION,
+    ADD COLUMN raitiovaunu DOUBLE PRECISION;
+
+-- There are no rows in production, so copy the old index to both new indexes to have some values there.
+-- New indexes can be calculated by doing any update on the hanke.
+UPDATE tormaystarkastelutulos
+SET (linjaauto, raitiovaunu) = (joukkoliikenne, joukkoliikenne);
+
+ALTER TABLE tormaystarkastelutulos
+    DROP COLUMN joukkoliikenne;
+
+-- These are not nullable in the entity, so the DB should match.
+ALTER TABLE tormaystarkastelutulos
+    ALTER COLUMN perus SET NOT NULL,
+    ALTER COLUMN pyoraily SET NOT NULL,
+    ALTER COLUMN linjaauto SET NOT NULL,
+    ALTER COLUMN raitiovaunu SET NOT NULL;
+
+-- These have been removed from the entity long ago.
+ALTER TABLE tormaystarkastelutulos
+    DROP COLUMN tila,
+    DROP COLUMN tilachangedat;
+
+-- Set a default for createdat, so it can used for maintenance.
+-- Not mapped to the entity.
+ALTER TABLE tormaystarkastelutulos
+    ALTER COLUMN createdat SET DEFAULT CURRENT_TIMESTAMP;
+
+COMMENT ON COLUMN tormaystarkastelutulos.perus IS 'Nuisance index score for car traffic';
+COMMENT ON COLUMN tormaystarkastelutulos.pyoraily IS 'Nuisance index score for car traffic'

--- a/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -125,3 +125,5 @@ databaseChangeLog:
       file: db/changelog/changesets/047-reverse-tunniste-foreign-key-direction.sql
   - include:
       file: db/changelog/changesets/048-add-y-tunnus-to-hankeyhteystieto.yml
+  - include:
+      file: db/changelog/changesets/049-add-bus-and-tram-indexes.sql

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeFactory.kt
@@ -196,10 +196,16 @@ class HankeFactory(
         fun Hanke.withTormaystarkasteluTulos(
             perusIndeksi: Float = 1f,
             pyorailyIndeksi: Float = 1f,
-            joukkoliikenneIndeksi: Float = 1f,
+            linjaautoIndeksi: Float = 1f,
+            raitiovaunuIndeksi: Float = 1f,
         ): Hanke {
             this.tormaystarkasteluTulos =
-                TormaystarkasteluTulos(perusIndeksi, pyorailyIndeksi, joukkoliikenneIndeksi)
+                TormaystarkasteluTulos(
+                    perusIndeksi,
+                    pyorailyIndeksi,
+                    linjaautoIndeksi,
+                    raitiovaunuIndeksi,
+                )
             return this
         }
 
@@ -383,7 +389,8 @@ class HankeFactory(
                 id = id,
                 perus = 1.25f,
                 pyoraily = 2.5f,
-                joukkoliikenne = 3.75f,
+                linjaauto = 3.75f,
+                raitiovaunu = 3.75f,
                 hanke = hankeEntity,
             )
     }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluLaskentaServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluLaskentaServiceTest.kt
@@ -1,5 +1,6 @@
 package fi.hel.haitaton.hanke.tormaystarkastelu
 
+import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNotNull
 import fi.hel.haitaton.hanke.HankeStatus
@@ -12,20 +13,42 @@ import fi.hel.haitaton.hanke.domain.Hanke
 import fi.hel.haitaton.hanke.domain.Hankealue
 import fi.hel.haitaton.hanke.factory.HankeFactory
 import fi.hel.haitaton.hanke.geometria.Geometriat
+import fi.hel.haitaton.hanke.tormaystarkastelu.TormaystarkasteluLiikennemaaranEtaisyys.RADIUS_15
+import fi.hel.haitaton.hanke.tormaystarkastelu.TormaystarkasteluLiikennemaaranEtaisyys.RADIUS_30
+import io.mockk.checkUnnecessaryStub
+import io.mockk.clearAllMocks
+import io.mockk.confirmVerified
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
+import io.mockk.verifyAll
 import java.time.ZonedDateTime
-import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvFileSource
+import org.junit.jupiter.params.provider.CsvSource
+import org.junit.jupiter.params.provider.EnumSource
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 internal class TormaystarkasteluLaskentaServiceTest {
 
     private val tormaysService: TormaystarkasteluTormaysService = mockk()
     private val laskentaService = TormaystarkasteluLaskentaService(tormaysService)
+
+    @BeforeEach
+    fun clearMocks() {
+        clearAllMocks()
+    }
+
+    @AfterEach
+    fun checkMocks() {
+        checkUnnecessaryStub()
+        confirmVerified(tormaysService)
+    }
 
     @ParameterizedTest(name = "Perusindeksi with default weights should be {0}")
     @CsvFileSource(resources = ["perusindeksi-test.csv"], numLinesToSkip = 1)
@@ -50,16 +73,372 @@ internal class TormaystarkasteluLaskentaServiceTest {
         assertThat(perusindeksi).isEqualTo(indeksi)
     }
 
+    @Nested
+    inner class KatuluokkaLuokittelu {
+        // The parameter is only used to call mocks
+        val geometriat = listOf<Geometriat>()
+
+        @Nested
+        inner class WithYlreParts {
+            @BeforeEach
+            fun mockYlreParts() {
+                every { tormaysService.anyIntersectsYleinenKatuosa(geometriat) } returns true
+            }
+
+            @AfterEach
+            fun verifyYlreParts() {
+                verify { tormaysService.anyIntersectsYleinenKatuosa(geometriat) }
+            }
+
+            @Nested
+            inner class WithoutStreetClasses {
+                @BeforeEach
+                fun mockStreetClasses() {
+                    every {
+                        tormaysService.maxIntersectingLiikenteellinenKatuluokka(geometriat)
+                    } returns null
+                }
+
+                @AfterEach
+                fun verifyYlreParts() {
+                    verify { tormaysService.maxIntersectingLiikenteellinenKatuluokka(geometriat) }
+                }
+
+                @Test
+                fun `returns 0 when there are no ylre classes`() {
+                    every {
+                        tormaysService.maxIntersectingYleinenkatualueKatuluokka(geometriat)
+                    } returns null
+
+                    val result = laskentaService.katuluokkaLuokittelu(geometriat)
+
+                    assertThat(result).isEqualTo(0)
+                    verify { tormaysService.maxIntersectingYleinenkatualueKatuluokka(geometriat) }
+                }
+
+                @ParameterizedTest
+                @EnumSource(TormaystarkasteluKatuluokka::class)
+                fun `returns ylre class value when it exists`(
+                    ylreClass: TormaystarkasteluKatuluokka
+                ) {
+                    every {
+                        tormaysService.maxIntersectingYleinenkatualueKatuluokka(geometriat)
+                    } returns ylreClass.value
+
+                    val result = laskentaService.katuluokkaLuokittelu(geometriat)
+
+                    assertThat(result).isEqualTo(ylreClass.value)
+                    verify { tormaysService.maxIntersectingYleinenkatualueKatuluokka(geometriat) }
+                }
+            }
+
+            @ParameterizedTest
+            @EnumSource(TormaystarkasteluKatuluokka::class)
+            fun `returns street class value when it exists`(
+                streetClass: TormaystarkasteluKatuluokka
+            ) {
+                every {
+                    tormaysService.maxIntersectingLiikenteellinenKatuluokka(geometriat)
+                } returns streetClass.value
+
+                val result = laskentaService.katuluokkaLuokittelu(geometriat)
+
+                assertThat(result).isEqualTo(streetClass.value)
+                verify { tormaysService.maxIntersectingLiikenteellinenKatuluokka(geometriat) }
+            }
+        }
+
+        @Nested
+        inner class WithoutYlreParts {
+            @BeforeEach
+            fun mockYlreParts() {
+                every { tormaysService.anyIntersectsYleinenKatuosa(geometriat) } returns false
+            }
+
+            @AfterEach
+            fun verifyYlreParts() {
+                verify { tormaysService.anyIntersectsYleinenKatuosa(geometriat) }
+            }
+
+            @Test
+            fun `returns 0 without ylre classes`() {
+                every {
+                    tormaysService.maxIntersectingYleinenkatualueKatuluokka(geometriat)
+                } returns null
+
+                val result = laskentaService.katuluokkaLuokittelu(geometriat)
+
+                assertThat(result).isEqualTo(0)
+                verify { tormaysService.maxIntersectingYleinenkatualueKatuluokka(geometriat) }
+            }
+
+            @ParameterizedTest
+            @EnumSource(TormaystarkasteluKatuluokka::class)
+            fun `returns ylre classes when it exists and street classes doesn't`(
+                ylreClass: TormaystarkasteluKatuluokka
+            ) {
+                every {
+                    tormaysService.maxIntersectingYleinenkatualueKatuluokka(geometriat)
+                } returns ylreClass.value
+                every {
+                    tormaysService.maxIntersectingLiikenteellinenKatuluokka(geometriat)
+                } returns null
+
+                val result = laskentaService.katuluokkaLuokittelu(geometriat)
+
+                assertThat(result).isEqualTo(ylreClass.value)
+                verify {
+                    tormaysService.maxIntersectingYleinenkatualueKatuluokka(geometriat)
+                    tormaysService.maxIntersectingLiikenteellinenKatuluokka(geometriat)
+                }
+            }
+
+            @ParameterizedTest
+            @EnumSource(TormaystarkasteluKatuluokka::class)
+            fun `returns street classes when both it and ylre classes exist`(
+                streetClass: TormaystarkasteluKatuluokka
+            ) {
+                every {
+                    tormaysService.maxIntersectingYleinenkatualueKatuluokka(geometriat)
+                } returns 2
+                every {
+                    tormaysService.maxIntersectingLiikenteellinenKatuluokka(geometriat)
+                } returns streetClass.value
+
+                val result = laskentaService.katuluokkaLuokittelu(geometriat)
+
+                assertThat(result).isEqualTo(streetClass.value)
+                verify {
+                    tormaysService.maxIntersectingYleinenkatualueKatuluokka(geometriat)
+                    tormaysService.maxIntersectingLiikenteellinenKatuluokka(geometriat)
+                }
+            }
+        }
+    }
+
+    @Nested
+    inner class LiikennemaaraLuokittelu {
+        // The parameter is only used to call mocks
+        val geometriat = listOf<Geometriat>()
+
+        @Test
+        fun `returns 0 when street class is 0`() {
+            val result = laskentaService.liikennemaaraLuokittelu(geometriat, 0)
+
+            assertThat(result).isEqualTo(0)
+        }
+
+        @Test
+        fun `uses small radius for traffic amounts when street class is 3`() {
+            every { tormaysService.maxLiikennemaara(geometriat, RADIUS_15) } returns 1500
+
+            val result = laskentaService.liikennemaaraLuokittelu(geometriat, 3)
+
+            assertThat(result).isEqualTo(3)
+            verify { tormaysService.maxLiikennemaara(geometriat, RADIUS_15) }
+        }
+
+        @Test
+        fun `uses large radius for traffic amounts when street class is 4`() {
+            every { tormaysService.maxLiikennemaara(geometriat, RADIUS_30) } returns 1500
+
+            val result = laskentaService.liikennemaaraLuokittelu(geometriat, 4)
+
+            assertThat(result).isEqualTo(3)
+            verify { tormaysService.maxLiikennemaara(geometriat, RADIUS_30) }
+        }
+
+        @Test
+        fun `returns 0 if there is no traffic`() {
+            every { tormaysService.maxLiikennemaara(geometriat, RADIUS_15) } returns null
+
+            val result = laskentaService.liikennemaaraLuokittelu(geometriat, 1)
+
+            assertThat(result).isEqualTo(0)
+            verify { tormaysService.maxLiikennemaara(geometriat, RADIUS_15) }
+        }
+
+        @ParameterizedTest
+        @CsvSource(
+            "-140,0",
+            "0,0",
+            "1,1",
+            "499,1",
+            "500,2",
+            "1499,2",
+            "1500,3",
+            "4999,3",
+            "5000,4",
+            "9999,4",
+            "10000,5",
+            "18000,5",
+        )
+        fun `returns matching classification when there is traffic`(
+            volume: Int,
+            expectedResult: Int
+        ) {
+            every { tormaysService.maxLiikennemaara(geometriat, RADIUS_15) } returns volume
+
+            val result = laskentaService.liikennemaaraLuokittelu(geometriat, 1)
+
+            assertThat(result).isEqualTo(expectedResult)
+            verify { tormaysService.maxLiikennemaara(geometriat, RADIUS_15) }
+        }
+    }
+
+    @Nested
+    inner class PyorailyLuokittelu {
+        // The parameter is only used to call mocks
+        val geometriat = listOf<Geometriat>()
+
+        @Test
+        fun `returns 5 when intersect with priority route`() {
+            every { tormaysService.anyIntersectsWithCyclewaysPriority(geometriat) } returns true
+
+            val result = laskentaService.pyorailyLuokittelu(geometriat)
+
+            assertThat(result).isEqualTo(5)
+            verify { tormaysService.anyIntersectsWithCyclewaysPriority(geometriat) }
+        }
+
+        @Test
+        fun `returns 4 when intersect with main route, but not priority route`() {
+            every { tormaysService.anyIntersectsWithCyclewaysPriority(geometriat) } returns false
+            every { tormaysService.anyIntersectsWithCyclewaysMain(geometriat) } returns true
+
+            val result = laskentaService.pyorailyLuokittelu(geometriat)
+
+            assertThat(result).isEqualTo(4)
+            verifyAll {
+                tormaysService.anyIntersectsWithCyclewaysPriority(geometriat)
+                tormaysService.anyIntersectsWithCyclewaysMain(geometriat)
+            }
+        }
+
+        @Test
+        fun `returns 0 when doesn't intersect with either`() {
+            every { tormaysService.anyIntersectsWithCyclewaysPriority(geometriat) } returns false
+            every { tormaysService.anyIntersectsWithCyclewaysMain(geometriat) } returns false
+
+            val result = laskentaService.pyorailyLuokittelu(geometriat)
+
+            assertThat(result).isEqualTo(0)
+            verifyAll {
+                tormaysService.anyIntersectsWithCyclewaysPriority(geometriat)
+                tormaysService.anyIntersectsWithCyclewaysMain(geometriat)
+            }
+        }
+    }
+
+    @Nested
+    inner class BussiLuokittelu {
+        // The parameter is only used to call mocks
+        val geometriat = listOf<Geometriat>()
+
+        @Test
+        fun `returns 5 when intersects with critical bus routes`() {
+            every { tormaysService.anyIntersectsCriticalBusRoutes(geometriat) } returns true
+
+            val result = laskentaService.bussiLuokittelu(geometriat)
+
+            assertThat(result).isEqualTo(5)
+            verify { tormaysService.anyIntersectsCriticalBusRoutes(geometriat) }
+        }
+
+        @Test
+        fun `returns 0 when doesn't intersect with any bus lines`() {
+            every { tormaysService.anyIntersectsCriticalBusRoutes(geometriat) } returns false
+            every { tormaysService.getIntersectingBusRoutes(geometriat) } returns setOf()
+
+            val result = laskentaService.bussiLuokittelu(geometriat)
+
+            assertThat(result).isEqualTo(0)
+            verifyAll {
+                tormaysService.anyIntersectsCriticalBusRoutes(geometriat)
+                tormaysService.getIntersectingBusRoutes(geometriat)
+            }
+        }
+
+        @ParameterizedTest
+        @CsvSource(
+            "0,2",
+            "4,2",
+            "5,3",
+            "10,3",
+            "11,4",
+            "20,4",
+            "21,5",
+            "100,5",
+        )
+        fun `returns classification based on rush hour buses when there's no trunk line`(
+            rushHourBuses: Int,
+            expectedResult: Int,
+        ) {
+            val busLines =
+                setOf(
+                    TormaystarkasteluBussireitti(
+                        "",
+                        0,
+                        rushHourBuses,
+                        TormaystarkasteluBussiRunkolinja.EI
+                    )
+                )
+            every { tormaysService.anyIntersectsCriticalBusRoutes(geometriat) } returns false
+            every { tormaysService.getIntersectingBusRoutes(geometriat) } returns busLines
+
+            val result = laskentaService.bussiLuokittelu(geometriat)
+
+            assertThat(result).isEqualTo(expectedResult)
+            verifyAll {
+                tormaysService.anyIntersectsCriticalBusRoutes(geometriat)
+                tormaysService.getIntersectingBusRoutes(geometriat)
+            }
+        }
+
+        @ParameterizedTest
+        @CsvSource(
+            "ON,4",
+            "LAHES,3",
+            "EI,2",
+        )
+        fun `returns classification based on trunk lines when there are just a few buses`(
+            runkolinja: TormaystarkasteluBussiRunkolinja,
+            expectedResult: Int
+        ) {
+            val busLines = setOf(TormaystarkasteluBussireitti("", 0, 2, runkolinja))
+            every { tormaysService.anyIntersectsCriticalBusRoutes(geometriat) } returns false
+            every { tormaysService.getIntersectingBusRoutes(geometriat) } returns busLines
+
+            val result = laskentaService.bussiLuokittelu(geometriat)
+
+            assertThat(result).isEqualTo(expectedResult)
+            verifyAll {
+                tormaysService.anyIntersectsCriticalBusRoutes(geometriat)
+                tormaysService.getIntersectingBusRoutes(geometriat)
+            }
+        }
+    }
+
     @Test
     fun `calculateTormaystarkastelu happy case`() {
         val hanke = setupHappyCase()
 
         val tulos = laskentaService.calculateTormaystarkastelu(hanke)
 
-        assertk.assertThat(tulos).isNotNull()
-        assertk.assertThat(tulos!!.liikennehaittaIndeksi).isNotNull()
-        assertk.assertThat(tulos.liikennehaittaIndeksi.indeksi).isNotNull()
-        assertk.assertThat(tulos.liikennehaittaIndeksi.indeksi).isEqualTo(4.0f)
+        assertThat(tulos).isNotNull()
+        assertThat(tulos!!.liikennehaittaIndeksi).isNotNull()
+        assertThat(tulos.liikennehaittaIndeksi.indeksi).isNotNull()
+        assertThat(tulos.liikennehaittaIndeksi.indeksi).isEqualTo(4.0f)
+
+        verifyAll {
+            tormaysService.anyIntersectsYleinenKatuosa(hanke.alueidenGeometriat())
+            tormaysService.maxIntersectingLiikenteellinenKatuluokka(hanke.alueidenGeometriat())
+            tormaysService.maxLiikennemaara(hanke.alueidenGeometriat(), RADIUS_30)
+            tormaysService.anyIntersectsWithCyclewaysPriority(hanke.alueidenGeometriat())
+            tormaysService.anyIntersectsWithCyclewaysMain(hanke.alueidenGeometriat())
+            tormaysService.anyIntersectsCriticalBusRoutes(hanke.alueidenGeometriat())
+            tormaysService.maxIntersectingTramByLaneType(hanke.alueidenGeometriat())
+        }
     }
 
     private fun setupHappyCase(): Hanke {
@@ -88,17 +467,10 @@ internal class TormaystarkasteluLaskentaServiceTest {
         every { tormaysService.anyIntersectsYleinenKatuosa(hanke.alueidenGeometriat()) } returns
             true
         every {
-            tormaysService.maxIntersectingYleinenkatualueKatuluokka(hanke.alueidenGeometriat())
-        } returns TormaystarkasteluKatuluokka.ALUEELLINEN_KOKOOJAKATU.value
-        every {
             tormaysService.maxIntersectingLiikenteellinenKatuluokka(hanke.alueidenGeometriat())
         } returns TormaystarkasteluKatuluokka.ALUEELLINEN_KOKOOJAKATU.value
-        every {
-            tormaysService.maxLiikennemaara(
-                hanke.alueidenGeometriat(),
-                TormaystarkasteluLiikennemaaranEtaisyys.RADIUS_30
-            )
-        } returns 1000
+        every { tormaysService.maxLiikennemaara(hanke.alueidenGeometriat(), RADIUS_30) } returns
+            1000
         every {
             tormaysService.anyIntersectsWithCyclewaysPriority(hanke.alueidenGeometriat())
         } returns false


### PR DESCRIPTION
# Description

In törmäystarkastelu, save bus and tram indexes separately. Remove the old joukkoliikenneindeksi from the DB.

Also bring the tormaystarkastelutulos table up to match the current entity. Changes to the entity have not been reflected in the table.

Return the new indexes separately from the API. Also return the old joukkoliikenneindeksi for compatibility, but calculate it's value on the fly from the bus and tram indexes.

Also remove `equals` and `hashCode` from `TormaystarkasteluTulosEntity`. The entities are not placed in sets or used as keys in a HashMap, so they are not needed. They were never called, which shows up as an error in test coverage reports.

Add tests for TormaystarkasteluLaskentaService. I perhaps added more tests than strictly necessary. I wanted to get full coverage and - perhaps more importantly - I wanted the tests to be helpful in understanding the behaviour of the classification functions.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1876

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 