### PR TITLE
HAI-1931 Add ytunnus for hanke contacts

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
@@ -37,6 +37,7 @@ import fi.hel.haitaton.hanke.factory.HankeFactory.Companion.withGeneratedOmistaj
 import fi.hel.haitaton.hanke.factory.HankeFactory.Companion.withGeneratedRakennuttaja
 import fi.hel.haitaton.hanke.factory.HankeFactory.Companion.withHankealue
 import fi.hel.haitaton.hanke.factory.HankeFactory.Companion.withYhteystiedot
+import fi.hel.haitaton.hanke.factory.HankeYhteystietoFactory.defaultYtunnus
 import fi.hel.haitaton.hanke.factory.HankealueFactory
 import fi.hel.haitaton.hanke.geometria.Geometriat
 import fi.hel.haitaton.hanke.logging.AuditLogEntryEntity
@@ -215,10 +216,6 @@ class HankeServiceITests : DatabaseTest() {
         val rakennuttaja: HankeYhteystieto = returnedHanke.rakennuttajat[0]
         val toteuttaja: HankeYhteystieto = returnedHanke.toteuttajat[0]
         val muu: HankeYhteystieto = returnedHanke.muut[0]
-        assertThat(omistaja).isNotNull
-        assertThat(rakennuttaja).isNotNull
-        assertThat(toteuttaja).isNotNull
-        assertThat(muu).isNotNull
         // Check yhteystieto tyyppi
         listOf(omistaja, rakennuttaja, toteuttaja, muu).forEach {
             assertThat(listOf(YRITYS, YKSITYISHENKILO, YHTEISO)).contains(it.tyyppi)
@@ -233,6 +230,7 @@ class HankeServiceITests : DatabaseTest() {
         assertThat(muu.osasto).isNotEmpty
         assertThat(muu.rooli).isNotEmpty
         listOf(omistaja, rakennuttaja, toteuttaja, muu).forEach {
+            assertThat(it.ytunnus).isEqualTo(defaultYtunnus)
             verifyYhteyshenkilot(it.alikontaktit)
         }
         // Check that all fields got there and back (with just one of the Yhteystietos):
@@ -993,7 +991,7 @@ class HankeServiceITests : DatabaseTest() {
         assertThat(application.applicationData.name)
             .isEqualTo(inputApplication.applicationData.name)
         val hanke = hankeRepository.findByHankeTunnus(application.hankeTunnus)!!
-        assertThat(hanke.generated).isTrue()
+        assertThat(hanke.generated).isTrue
         assertThat(hanke.status).isEqualTo(HankeStatus.DRAFT)
         assertThat(hanke.hankeTunnus).isEqualTo(application.hankeTunnus)
         assertThat(hanke.nimi).isEqualTo(application.applicationData.name)
@@ -1609,6 +1607,7 @@ class HankeServiceITests : DatabaseTest() {
           "id":$id,
           "nimi":"etu$i suku$i",
           "email":"email$i",
+          "ytunnus": $defaultYtunnus,
           "puhelinnumero":"010$i$i$i$i$i$i$i",
           "organisaatioNimi":"org$i",
           "osasto":"osasto$i",

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeServiceImpl.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeServiceImpl.kt
@@ -655,6 +655,7 @@ open class HankeServiceImpl(
                     contactType = contactType,
                     nimi = hankeYht.nimi,
                     email = hankeYht.email,
+                    ytunnus = hankeYht.ytunnus,
                     puhelinnumero = hankeYht.puhelinnumero,
                     organisaatioNimi = hankeYht.organisaatioNimi,
                     osasto = hankeYht.osasto,
@@ -712,6 +713,7 @@ open class HankeServiceImpl(
                 // Update values in the persisted entity:
                 existingYT.nimi = hankeYht.nimi
                 existingYT.email = hankeYht.email
+                existingYT.ytunnus = hankeYht.ytunnus
                 existingYT.puhelinnumero = hankeYht.puhelinnumero
                 existingYT.yhteyshenkilot = hankeYht.alikontaktit
                 hankeYht.organisaatioNimi?.let {

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeYhteystietoEntity.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeYhteystietoEntity.kt
@@ -45,6 +45,9 @@ class HankeYhteystietoEntity(
     @Column(columnDefinition = "jsonb")
     var yhteyshenkilot: List<Yhteyshenkilo> = listOf(),
 
+    /** For contacts with tyyppi other than YKSITYISHENKILO. */
+    @JsonView(ChangeLogView::class) @Column(name = "y_tunnus") var ytunnus: String? = null,
+
     // Personal data processing restriction (or other needs to prevent changes)
     @JsonView(NotInChangeLogView::class) var dataLocked: Boolean? = false,
     @JsonView(NotInChangeLogView::class) var dataLockInfo: String? = null,
@@ -68,6 +71,7 @@ class HankeYhteystietoEntity(
             id = id,
             nimi = nimi,
             email = email,
+            ytunnus = ytunnus,
             alikontaktit = yhteyshenkilot,
             puhelinnumero = puhelinnumero,
             organisaatioNimi = organisaatioNimi,

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Utils.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Utils.kt
@@ -1,6 +1,5 @@
 package fi.hel.haitaton.hanke
 
-import fi.hel.haitaton.hanke.domain.BusinessId
 import java.time.LocalDateTime
 import java.time.ZonedDateTime
 import java.time.temporal.ChronoUnit
@@ -31,7 +30,7 @@ fun getCurrentTimeUTCAsLocalTime(): LocalDateTime = getCurrentTimeUTC().toLocalD
 fun currentUserId(): String = SecurityContextHolder.getContext().authentication.name
 
 /**
- * Valid businessId (y-tunnus) requirements:
+ * Valid business id (y-tunnus) requirements:
  * 1. format NNNNNNN-T, where N = sequence number and T = check number.
  * 2. documentation of check mark calculation:
  * ```
@@ -40,8 +39,13 @@ fun currentUserId(): String = SecurityContextHolder.getContext().authentication.
  *
  * Only verifies that the id is of valid form. It does not guarantee that it actually exists.
  */
-fun BusinessId.isValidBusinessId(): Boolean {
-    logger.info { "Verifying businessId: $this" }
+fun String?.isValidBusinessId(): Boolean {
+    logger.info { "Verifying business id: $this" }
+
+    if (this == null) {
+        logger.warn { "Business id is null." }
+        return false
+    }
 
     val matchResult = businessIdRegex.find(this)
     if (matchResult == null) {

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/AlluCommonDomain.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/AlluCommonDomain.kt
@@ -3,7 +3,6 @@ package fi.hel.haitaton.hanke.allu
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonView
 import fi.hel.haitaton.hanke.ChangeLogView
-import fi.hel.haitaton.hanke.domain.BusinessId
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class CustomerWithContacts(val customer: Customer, val contacts: List<Contact>)
@@ -24,7 +23,7 @@ data class Customer(
     val country: String, // ISO 3166-1 alpha-2 country code
     val email: String?,
     val phone: String?,
-    val registryKey: BusinessId?, // y-tunnus
+    val registryKey: String?, // y-tunnus
     val ovt: String?, // e-invoice identifier (ovt-tunnus)
     val invoicingOperator: String?, // e-invoicing operator code
     val sapCustomerNumber: String? // customer's sap number

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/CustomerWithContacts.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/CustomerWithContacts.kt
@@ -11,7 +11,6 @@ import fi.hel.haitaton.hanke.allu.CustomerType
 import fi.hel.haitaton.hanke.allu.CustomerWithContacts as AlluCustomerWithContacts
 import fi.hel.haitaton.hanke.allu.PostalAddress as AlluPostalAddress
 import fi.hel.haitaton.hanke.allu.StreetAddress as AlluStreetAddress
-import fi.hel.haitaton.hanke.domain.BusinessId
 import fi.hel.haitaton.hanke.domain.Perustaja
 
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -69,7 +68,7 @@ data class Customer(
     val country: String, // ISO 3166-1 alpha-2 country code
     val email: String?,
     val phone: String?,
-    val registryKey: BusinessId?, // y-tunnus
+    val registryKey: String?, // y-tunnus
     val ovt: String?, // e-invoice identifier (ovt-tunnus)
     val invoicingOperator: String?, // e-invoicing operator code
     val sapCustomerNumber: String?, // customer's sap number

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/HankeYhteystieto.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/HankeYhteystieto.kt
@@ -54,6 +54,10 @@ data class HankeYhteystieto(
     @JsonView(ChangeLogView::class)
     @field:Schema(description = "Contact type")
     var tyyppi: YhteystietoTyyppi? = null,
+    //
+    @JsonView(ChangeLogView::class)
+    @field:Schema(description = "Business id, for contacts with tyyppi other than YKSITYISHENKILO")
+    val ytunnus: String? = null,
 
     // Metadata
     @JsonView(NotInChangeLogView::class)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/TypeAliases.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/TypeAliases.kt
@@ -1,4 +1,0 @@
-package fi.hel.haitaton.hanke.domain
-
-/** Y-tunnus. */
-typealias BusinessId = String

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/gdpr/GdprInfo.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/gdpr/GdprInfo.kt
@@ -1,7 +1,5 @@
 package fi.hel.haitaton.hanke.gdpr
 
-import fi.hel.haitaton.hanke.domain.BusinessId
-
 data class GdprInfo(
     val name: String? = null,
     val phone: String? = null,
@@ -13,6 +11,6 @@ data class GdprInfo(
 data class GdprOrganisation(
     val id: Int? = null,
     val name: String? = null,
-    val registryKey: BusinessId? = null,
+    val registryKey: String? = null,
     val department: String? = null,
 )

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/validation/HankePublicValidator.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/validation/HankePublicValidator.kt
@@ -5,6 +5,10 @@ import fi.hel.haitaton.hanke.Yhteyshenkilo
 import fi.hel.haitaton.hanke.domain.Hanke
 import fi.hel.haitaton.hanke.domain.HankeYhteystieto
 import fi.hel.haitaton.hanke.domain.Hankealue
+import fi.hel.haitaton.hanke.domain.YhteystietoTyyppi.YHTEISO
+import fi.hel.haitaton.hanke.domain.YhteystietoTyyppi.YKSITYISHENKILO
+import fi.hel.haitaton.hanke.domain.YhteystietoTyyppi.YRITYS
+import fi.hel.haitaton.hanke.isValidBusinessId
 import fi.hel.haitaton.hanke.validation.Validators.firstOf
 import fi.hel.haitaton.hanke.validation.Validators.notBlank
 import fi.hel.haitaton.hanke.validation.Validators.notEmpty
@@ -12,6 +16,7 @@ import fi.hel.haitaton.hanke.validation.Validators.notNull
 import fi.hel.haitaton.hanke.validation.Validators.notNullOrBlank
 import fi.hel.haitaton.hanke.validation.Validators.notNullOrEmpty
 import fi.hel.haitaton.hanke.validation.Validators.validate
+import fi.hel.haitaton.hanke.validation.Validators.validateTrue
 
 /**
  * Validator for checking whether a hanke can be public. A hanke is considered public if all
@@ -61,6 +66,12 @@ object HankePublicValidator {
     private fun validateYhteystieto(yhteystieto: HankeYhteystieto, path: String): ValidationResult =
         validate { notBlank(yhteystieto.nimi, "$path.nimi") }
             .and { notBlank(yhteystieto.email, "$path.email") }
+            .andWhen(yhteystieto.tyyppi in listOf(YRITYS, YHTEISO)) {
+                validateTrue(yhteystieto.ytunnus.isValidBusinessId(), "$path.ytunnus")
+            }
+            .andWhen(yhteystieto.tyyppi == YKSITYISHENKILO) {
+                validateTrue(yhteystieto.ytunnus == null, "$path.ytunnus")
+            }
             .andAllIn(yhteystieto.alikontaktit, "alikontaktit", ::validateAlikontakti)
 
     private fun validateAlikontakti(yhteyshenkilo: Yhteyshenkilo, path: String): ValidationResult =

--- a/services/hanke-service/src/main/resources/db/changelog/changesets/048-add-y-tunnus-to-hankeyhteystieto.yml
+++ b/services/hanke-service/src/main/resources/db/changelog/changesets/048-add-y-tunnus-to-hankeyhteystieto.yml
@@ -1,0 +1,13 @@
+databaseChangeLog:
+  - changeSet:
+      id: 048-add-y-tunnus-to-hankeyhteystieto
+      author: Niko Pitkonen
+      changes:
+        - addColumn:
+            tableName: hankeyhteystieto
+            columns:
+              - column:
+                  name: y_tunnus
+                  type: varchar(9)
+                  constraints:
+                    nullable: true

--- a/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -123,3 +123,5 @@ databaseChangeLog:
       file: db/changelog/changesets/046-remove-sentat-from-tunniste.yml
   - include:
       file: db/changelog/changesets/047-reverse-tunniste-foreign-key-direction.sql
+  - include:
+      file: db/changelog/changesets/048-add-y-tunnus-to-hankeyhteystieto.yml

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/HankeMapperTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/HankeMapperTest.kt
@@ -10,10 +10,12 @@ import fi.hel.haitaton.hanke.ContactType.OMISTAJA
 import fi.hel.haitaton.hanke.ContactType.RAKENNUTTAJA
 import fi.hel.haitaton.hanke.ContactType.TOTEUTTAJA
 import fi.hel.haitaton.hanke.domain.Hanke
+import fi.hel.haitaton.hanke.domain.YhteystietoTyyppi.YRITYS
 import fi.hel.haitaton.hanke.factory.AlluDataFactory.Companion.teppoEmail
 import fi.hel.haitaton.hanke.factory.DateFactory
 import fi.hel.haitaton.hanke.factory.HankeFactory
-import fi.hel.haitaton.hanke.factory.HankeYhteystietoFactory.create
+import fi.hel.haitaton.hanke.factory.HankeYhteystietoFactory
+import fi.hel.haitaton.hanke.factory.HankeYhteystietoFactory.defaultYtunnus
 import fi.hel.haitaton.hanke.factory.HankealueFactory
 import fi.hel.haitaton.hanke.factory.TEPPO_TESTI
 import fi.hel.haitaton.hanke.geometria.Geometriat
@@ -61,10 +63,12 @@ class HankeMapperTest {
 
     private fun expectedYhteystieto(hankeEntity: HankeEntity, type: ContactType, id: Int) =
         mutableListOf(
-            create(
+            HankeYhteystietoFactory.create(
                 id = id,
                 nimi = "$TEPPO_TESTI $type",
                 email = "$type.$teppoEmail",
+                tyyppi = YRITYS,
+                ytunnus = defaultYtunnus,
                 createdAt = hankeEntity.yhteystietoCreatedAt(type),
                 modifiedAt = hankeEntity.yhteystietoModifiedAt(type),
             )

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/UtilsKtTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/UtilsKtTest.kt
@@ -1,10 +1,10 @@
 package fi.hel.haitaton.hanke
 
-import fi.hel.haitaton.hanke.domain.BusinessId
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.NullSource
 import org.junit.jupiter.params.provider.ValueSource
 
 class UtilsKtTest {
@@ -27,7 +27,7 @@ class UtilsKtTest {
                     "6545312-3"
                 ]
         )
-        fun `isValid when valid businessId returns true`(businessId: BusinessId) {
+        fun `isValid when valid businessId returns true`(businessId: String) {
             assertTrue(businessId.isValidBusinessId())
         }
 
@@ -45,7 +45,8 @@ class UtilsKtTest {
                     "8238445-A"
                 ]
         )
-        fun `isValid when not valid businessId returns false`(businessId: BusinessId) {
+        @NullSource
+        fun `isValid when not valid businessId returns false`(businessId: String?) {
             assertFalse(businessId.isValidBusinessId())
         }
     }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeYhteystietoFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeYhteystietoFactory.kt
@@ -5,7 +5,9 @@ import fi.hel.haitaton.hanke.HankeEntity
 import fi.hel.haitaton.hanke.HankeYhteystietoEntity
 import fi.hel.haitaton.hanke.Yhteyshenkilo
 import fi.hel.haitaton.hanke.domain.HankeYhteystieto
+import fi.hel.haitaton.hanke.domain.YhteystietoTyyppi
 import fi.hel.haitaton.hanke.domain.YhteystietoTyyppi.YHTEISO
+import fi.hel.haitaton.hanke.domain.YhteystietoTyyppi.YKSITYISHENKILO
 import fi.hel.haitaton.hanke.domain.YhteystietoTyyppi.YRITYS
 import fi.hel.haitaton.hanke.factory.AlluDataFactory.Companion.teppoEmail
 import fi.hel.haitaton.hanke.getCurrentTimeUTC
@@ -13,11 +15,15 @@ import java.time.ZonedDateTime
 
 object HankeYhteystietoFactory {
 
+    const val defaultYtunnus = "1817548-2"
+
     /** Create a test yhteystieto with values in all fields. */
     fun create(
         id: Int? = 1,
         nimi: String = "Teppo Testihenkilö",
         email: String = teppoEmail,
+        tyyppi: YhteystietoTyyppi = YRITYS,
+        ytunnus: String = defaultYtunnus,
         puhelinnumero: String = "04012345678",
         createdAt: ZonedDateTime? = getCurrentTimeUTC(),
         modifiedAt: ZonedDateTime? = getCurrentTimeUTC(),
@@ -26,6 +32,8 @@ object HankeYhteystietoFactory {
             id = id,
             nimi = nimi,
             email = email,
+            tyyppi = tyyppi,
+            ytunnus = if (tyyppi != YKSITYISHENKILO) ytunnus else null,
             puhelinnumero = puhelinnumero,
             organisaatioNimi = "Organisaatio",
             osasto = "Osasto",
@@ -34,7 +42,6 @@ object HankeYhteystietoFactory {
             modifiedBy = "test7358",
             modifiedAt = modifiedAt,
             rooli = "Isännöitsijä",
-            tyyppi = YRITYS,
             alikontaktit =
                 listOf(Yhteyshenkilo("Ali", "Kontakti", "ali.kontakti@meili.com", "050-4567890"))
         )
@@ -51,6 +58,8 @@ object HankeYhteystietoFactory {
                 contactType = contactType,
                 nimi = "$nimi $contactType",
                 email = "$contactType.$email",
+                tyyppi = tyyppi,
+                ytunnus = ytunnus,
                 puhelinnumero = puhelinnumero,
                 organisaatioNimi = organisaatioNimi,
                 osasto = osasto,
@@ -62,7 +71,6 @@ object HankeYhteystietoFactory {
                 createdAt = createdAt?.toLocalDateTime(),
                 modifiedByUserId = modifiedBy,
                 modifiedAt = modifiedAt?.toLocalDateTime(),
-                tyyppi = tyyppi,
                 hanke = hanke,
             )
         }
@@ -76,6 +84,7 @@ object HankeYhteystietoFactory {
             id = null,
             nimi = "etu$i suku$i",
             email = "email$i",
+            ytunnus = defaultYtunnus,
             puhelinnumero = "010$i$i$i$i$i$i$i",
             organisaatioNimi = "org$i",
             osasto = "osasto$i",

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeYhteystietoFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeYhteystietoFactory.kt
@@ -10,6 +10,7 @@ import fi.hel.haitaton.hanke.domain.YhteystietoTyyppi.YHTEISO
 import fi.hel.haitaton.hanke.domain.YhteystietoTyyppi.YKSITYISHENKILO
 import fi.hel.haitaton.hanke.domain.YhteystietoTyyppi.YRITYS
 import fi.hel.haitaton.hanke.factory.AlluDataFactory.Companion.teppoEmail
+import fi.hel.haitaton.hanke.factory.HankeYhteystietoFactory.defaultYtunnus
 import fi.hel.haitaton.hanke.getCurrentTimeUTC
 import java.time.ZonedDateTime
 
@@ -116,3 +117,8 @@ object HankeYhteystietoFactory {
 
     private fun dummyPhoneNumber(i: Int) = "010$i$i$i$i$i$i$i"
 }
+
+fun MutableList<HankeYhteystieto>.modify(
+    ytunnus: String? = defaultYtunnus,
+    tyyppi: YhteystietoTyyppi? = YRITYS
+) = map { it.copy(ytunnus = ytunnus, tyyppi = tyyppi) }.toMutableList()

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/validation/HankePublicValidatorTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/validation/HankePublicValidatorTest.kt
@@ -3,54 +3,223 @@ package fi.hel.haitaton.hanke.validation
 import assertk.assertThat
 import assertk.assertions.containsExactly
 import assertk.assertions.containsExactlyInAnyOrder
+import assertk.assertions.isEqualTo
+import assertk.assertions.isGreaterThanOrEqualTo
 import fi.hel.haitaton.hanke.Vaihe
 import fi.hel.haitaton.hanke.Yhteyshenkilo
 import fi.hel.haitaton.hanke.domain.Hanke
+import fi.hel.haitaton.hanke.domain.HankeYhteystieto
+import fi.hel.haitaton.hanke.domain.YhteystietoTyyppi
+import fi.hel.haitaton.hanke.domain.YhteystietoTyyppi.YKSITYISHENKILO
+import fi.hel.haitaton.hanke.domain.YhteystietoTyyppi.YRITYS
 import fi.hel.haitaton.hanke.factory.HankeFactory
 import fi.hel.haitaton.hanke.factory.HankeFactory.Companion.withHankealue
 import fi.hel.haitaton.hanke.factory.HankeFactory.Companion.withTormaystarkasteluTulos
 import fi.hel.haitaton.hanke.factory.HankeFactory.Companion.withYhteystiedot
+import fi.hel.haitaton.hanke.factory.HankeYhteystietoFactory.defaultYtunnus
 import fi.hel.haitaton.hanke.touch
+import fi.hel.haitaton.hanke.validation.HankePublicValidator.validateHankeHasMandatoryFields
 import java.util.stream.Stream
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 
 private const val BLANK = "   \t\n\t   "
 
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
-internal class HankePublicValidatorTest {
-    private fun completeHanke() =
-        HankeFactory.create().withHankealue().withYhteystiedot().withTormaystarkasteluTulos()
+class HankePublicValidatorTest {
+
+    companion object {
+        private fun completeHanke() =
+            HankeFactory.create().withHankealue().withYhteystiedot().withTormaystarkasteluTulos()
+
+        @JvmStatic
+        private fun draftHankkeet(): Stream<Arguments> =
+            Stream.of(
+                Arguments.of("nimi", "missing", completeHanke().apply { nimi = null }),
+                Arguments.of("nimi", "empty", completeHanke().apply { nimi = "" }),
+                Arguments.of("nimi", "blank", completeHanke().apply { nimi = BLANK }),
+                Arguments.of("kuvaus", "missing", completeHanke().apply { kuvaus = null }),
+                Arguments.of("kuvaus", "empty", completeHanke().apply { kuvaus = "" }),
+                Arguments.of("kuvaus", "blank", completeHanke().apply { kuvaus = BLANK }),
+                Arguments.of(
+                    "tyomaaKatuosoite",
+                    "missing",
+                    completeHanke().apply { tyomaaKatuosoite = null }
+                ),
+                Arguments.of(
+                    "tyomaaKatuosoite",
+                    "empty",
+                    completeHanke().apply { tyomaaKatuosoite = "" }
+                ),
+                Arguments.of(
+                    "tyomaaKatuosoite",
+                    "blank",
+                    completeHanke().apply { tyomaaKatuosoite = BLANK }
+                ),
+                Arguments.of("vaihe", "missing", completeHanke().apply { vaihe = null }),
+                Arguments.of(
+                    "suunnitteluVaihe",
+                    "missing",
+                    completeHanke().apply {
+                        vaihe = Vaihe.SUUNNITTELU
+                        suunnitteluVaihe = null
+                    }
+                ),
+                Arguments.of("alueet", "empty", completeHanke().apply { alueet = mutableListOf() }),
+                Arguments.of(
+                    "alueet[0].haittaAlkuPvm",
+                    "missing",
+                    completeHanke().apply { alueet[0].haittaAlkuPvm = null }
+                ),
+                Arguments.of(
+                    "alueet[0].haittaLoppuPvm",
+                    "missing",
+                    completeHanke().apply { alueet[0].haittaLoppuPvm = null }
+                ),
+                Arguments.of(
+                    "alueet[0].meluHaitta",
+                    "missing",
+                    completeHanke().apply { alueet[0].meluHaitta = null }
+                ),
+                Arguments.of(
+                    "alueet[0].polyHaitta",
+                    "missing",
+                    completeHanke().apply { alueet[0].polyHaitta = null }
+                ),
+                Arguments.of(
+                    "alueet[0].tarinaHaitta",
+                    "missing",
+                    completeHanke().apply { alueet[0].tarinaHaitta = null }
+                ),
+                Arguments.of(
+                    "alueet[0].kaistaHaitta",
+                    "missing",
+                    completeHanke().apply { alueet[0].kaistaHaitta = null }
+                ),
+                Arguments.of(
+                    "alueet[0].kaistaPituusHaitta",
+                    "missing",
+                    completeHanke().apply { alueet[0].kaistaPituusHaitta = null }
+                ),
+                Arguments.of(
+                    "alueet[0].geometriat",
+                    "missing",
+                    completeHanke().apply { alueet[0].geometriat = null }
+                ),
+                Arguments.of(
+                    "alueet[0].geometriat.featureCollection",
+                    "missing",
+                    completeHanke().apply { alueet[0].geometriat!!.featureCollection = null }
+                ),
+                Arguments.of(
+                    "alueet[0].geometriat.featureCollection.features",
+                    "missing",
+                    completeHanke().apply {
+                        alueet[0].geometriat!!.featureCollection!!.features = null
+                    }
+                ),
+                Arguments.of(
+                    "alueet[0].geometriat.featureCollection.features",
+                    "empty",
+                    completeHanke().apply {
+                        alueet[0].geometriat!!.featureCollection!!.features = listOf()
+                    }
+                ),
+                Arguments.of(
+                    "omistajat",
+                    "empty",
+                    completeHanke().apply { omistajat = mutableListOf() }
+                ),
+                Arguments.of(
+                    "omistajat[0].nimi",
+                    "empty",
+                    completeHanke().apply { omistajat[0].nimi = "" }
+                ),
+                Arguments.of(
+                    "omistajat[0].nimi",
+                    "blank",
+                    completeHanke().apply { omistajat[0].nimi = BLANK }
+                ),
+                Arguments.of(
+                    "omistajat[0].email",
+                    "empty",
+                    completeHanke().apply { omistajat[0].email = "" }
+                ),
+                Arguments.of(
+                    "omistajat[0].email",
+                    "blank",
+                    completeHanke().apply { omistajat[0].email = BLANK }
+                ),
+                Arguments.of(
+                    "rakennuttajat[0].nimi",
+                    "empty",
+                    completeHanke().apply { rakennuttajat[0].nimi = "" }
+                ),
+                Arguments.of(
+                    "rakennuttajat[0].nimi",
+                    "blank",
+                    completeHanke().apply { rakennuttajat[0].nimi = BLANK }
+                ),
+                Arguments.of(
+                    "rakennuttajat[0].email",
+                    "empty",
+                    completeHanke().apply { rakennuttajat[0].email = "" }
+                ),
+                Arguments.of(
+                    "rakennuttajat[0].email",
+                    "blank",
+                    completeHanke().apply { rakennuttajat[0].email = BLANK }
+                ),
+                Arguments.of(
+                    "toteuttajat[0].nimi",
+                    "empty",
+                    completeHanke().apply { toteuttajat[0].nimi = "" }
+                ),
+                Arguments.of(
+                    "toteuttajat[0].nimi",
+                    "blank",
+                    completeHanke().apply { toteuttajat[0].nimi = BLANK }
+                ),
+                Arguments.of(
+                    "toteuttajat[0].email",
+                    "empty",
+                    completeHanke().apply { toteuttajat[0].email = "" }
+                ),
+                Arguments.of(
+                    "toteuttajat[0].email",
+                    "blank",
+                    completeHanke().apply { toteuttajat[0].email = BLANK }
+                ),
+            )
+    }
 
     @Test
-    fun `No errors when hanke has all mandatory fields`() {
-        val result = HankePublicValidator.validateHankeHasMandatoryFields(completeHanke())
+    fun `when hanke has all mandatory fields should return ok`() {
+        val result = validateHankeHasMandatoryFields(completeHanke())
 
         assertTrue(result.isOk())
     }
 
     @Test
-    fun `Empty alikontaktit is ok`() {
+    fun `when alikontaktit empty should return ok`() {
         val hanke = completeHanke().apply { omistajat.first().apply { alikontaktit = emptyList() } }
 
-        val result = HankePublicValidator.validateHankeHasMandatoryFields(hanke)
+        val result = validateHankeHasMandatoryFields(hanke)
 
         assertTrue(result.isOk())
     }
 
     @Test
-    fun `Alikontaktit missing data is not ok`() {
+    fun `when alikontaktit missing data should return not ok`() {
         val hanke =
             completeHanke().apply {
                 omistajat.first().apply { alikontaktit = listOf(Yhteyshenkilo("", "", "", "")) }
             }
 
-        val result = HankePublicValidator.validateHankeHasMandatoryFields(hanke)
+        val result = validateHankeHasMandatoryFields(hanke)
 
         assertFalse(result.isOk())
         assertThat(result.errorPaths())
@@ -63,9 +232,9 @@ internal class HankePublicValidatorTest {
     }
 
     @Test
-    fun `No errors when rakennuttajat missing`() {
+    fun `when rakennuttajat missing should return ok`() {
         val result =
-            HankePublicValidator.validateHankeHasMandatoryFields(
+            validateHankeHasMandatoryFields(
                 completeHanke().apply { rakennuttajat = mutableListOf() }
             )
 
@@ -73,19 +242,76 @@ internal class HankePublicValidatorTest {
     }
 
     @Test
-    fun `No errors when toteuttajat missing`() {
+    fun `when toteuttajat missing should return ok`() {
         val result =
-            HankePublicValidator.validateHankeHasMandatoryFields(
-                completeHanke().apply { toteuttajat = mutableListOf() }
-            )
+            validateHankeHasMandatoryFields(completeHanke().apply { toteuttajat = mutableListOf() })
 
         assertTrue(result.isOk())
     }
 
     @Test
-    fun `All errors when multiple missing fields`() {
+    fun `when ytunnus is present and valid should return ok`() {
+        val hanke = completeHanke()
+
+        val result = validateHankeHasMandatoryFields(hanke)
+
+        val ytunnusCount = hanke.extractYhteystiedot().mapNotNull { it.ytunnus }.count()
+        assertThat(ytunnusCount).isGreaterThanOrEqualTo(1)
+        assertTrue(result.isOk())
+    }
+
+    @Test
+    fun `when ytunnus is present and not valid should return not ok`() {
+        val hanke =
+            completeHanke().apply { rakennuttajat = rakennuttajat.modify(ytunnus = "1580375-3") }
+
+        val result = validateHankeHasMandatoryFields(hanke)
+
+        assertFalse(result.isOk())
+        assertThat(result.errorPaths()).containsExactly("rakennuttajat[0].ytunnus")
+    }
+
+    @Test
+    fun `when tyyppi yksityishenkilo or null and ytunnus is null should return ok`() {
+        val hanke =
+            completeHanke().apply {
+                omistajat = omistajat.modify(ytunnus = null, tyyppi = null)
+                rakennuttajat = rakennuttajat.modify(ytunnus = null, tyyppi = YKSITYISHENKILO)
+                toteuttajat = toteuttajat.modify(ytunnus = null, null)
+                muut = muut.modify(ytunnus = null, YKSITYISHENKILO)
+            }
+
+        val result = validateHankeHasMandatoryFields(hanke)
+
+        val ytunnusCount = hanke.extractYhteystiedot().mapNotNull { it.ytunnus }.count()
+        assertThat(ytunnusCount).isEqualTo(0)
+        assertTrue(result.isOk())
+    }
+
+    @Test
+    fun `when tyyppi is not yksityishenkilo and ytunnus is null should not return ok`() {
+        val hanke = completeHanke().apply { toteuttajat = toteuttajat.modify(ytunnus = null) }
+
+        val result = validateHankeHasMandatoryFields(hanke)
+
+        assertFalse(result.isOk())
+        assertThat(result.errorPaths()).containsExactly("toteuttajat[0].ytunnus")
+    }
+
+    @Test
+    fun `when tyyppi is yksityishenkilo and ytunnus is not null should not return ok`() {
+        val hanke = completeHanke().apply { omistajat = omistajat.modify(tyyppi = YKSITYISHENKILO) }
+
+        val result = validateHankeHasMandatoryFields(hanke)
+
+        assertFalse(result.isOk())
+        assertThat(result.errorPaths()).containsExactly("omistajat[0].ytunnus")
+    }
+
+    @Test
+    fun `when multiple missing fields should return not ok and failed paths`() {
         val result =
-            HankePublicValidator.validateHankeHasMandatoryFields(
+            validateHankeHasMandatoryFields(
                 completeHanke().apply {
                     with(toteuttajat[0]) {
                         nimi = ""
@@ -109,173 +335,21 @@ internal class HankePublicValidatorTest {
 
     @ParameterizedTest(name = "Has error when {0} {1}")
     @MethodSource("draftHankkeet")
-    fun `Error with correct path when hanke is missing a mandatory field`(
+    fun `when hanke missing a mandatory field should return not ok and failed path`(
         path: String,
         case: String,
         hanke: Hanke
     ) {
         case.touch()
 
-        val result = HankePublicValidator.validateHankeHasMandatoryFields(hanke)
+        val result = validateHankeHasMandatoryFields(hanke)
 
         assertFalse(result.isOk())
         assertThat(result.errorPaths()).containsExactly(path)
     }
 
-    private fun draftHankkeet(): Stream<Arguments> =
-        Stream.of(
-            Arguments.of("nimi", "missing", completeHanke().apply { nimi = null }),
-            Arguments.of("nimi", "empty", completeHanke().apply { nimi = "" }),
-            Arguments.of("nimi", "blank", completeHanke().apply { nimi = BLANK }),
-            Arguments.of("kuvaus", "missing", completeHanke().apply { kuvaus = null }),
-            Arguments.of("kuvaus", "empty", completeHanke().apply { kuvaus = "" }),
-            Arguments.of("kuvaus", "blank", completeHanke().apply { kuvaus = BLANK }),
-            Arguments.of(
-                "tyomaaKatuosoite",
-                "missing",
-                completeHanke().apply { tyomaaKatuosoite = null }
-            ),
-            Arguments.of(
-                "tyomaaKatuosoite",
-                "empty",
-                completeHanke().apply { tyomaaKatuosoite = "" }
-            ),
-            Arguments.of(
-                "tyomaaKatuosoite",
-                "blank",
-                completeHanke().apply { tyomaaKatuosoite = BLANK }
-            ),
-            Arguments.of("vaihe", "missing", completeHanke().apply { vaihe = null }),
-            Arguments.of(
-                "suunnitteluVaihe",
-                "missing",
-                completeHanke().apply {
-                    vaihe = Vaihe.SUUNNITTELU
-                    suunnitteluVaihe = null
-                }
-            ),
-            Arguments.of("alueet", "empty", completeHanke().apply { alueet = mutableListOf() }),
-            Arguments.of(
-                "alueet[0].haittaAlkuPvm",
-                "missing",
-                completeHanke().apply { alueet[0].haittaAlkuPvm = null }
-            ),
-            Arguments.of(
-                "alueet[0].haittaLoppuPvm",
-                "missing",
-                completeHanke().apply { alueet[0].haittaLoppuPvm = null }
-            ),
-            Arguments.of(
-                "alueet[0].meluHaitta",
-                "missing",
-                completeHanke().apply { alueet[0].meluHaitta = null }
-            ),
-            Arguments.of(
-                "alueet[0].polyHaitta",
-                "missing",
-                completeHanke().apply { alueet[0].polyHaitta = null }
-            ),
-            Arguments.of(
-                "alueet[0].tarinaHaitta",
-                "missing",
-                completeHanke().apply { alueet[0].tarinaHaitta = null }
-            ),
-            Arguments.of(
-                "alueet[0].kaistaHaitta",
-                "missing",
-                completeHanke().apply { alueet[0].kaistaHaitta = null }
-            ),
-            Arguments.of(
-                "alueet[0].kaistaPituusHaitta",
-                "missing",
-                completeHanke().apply { alueet[0].kaistaPituusHaitta = null }
-            ),
-            Arguments.of(
-                "alueet[0].geometriat",
-                "missing",
-                completeHanke().apply { alueet[0].geometriat = null }
-            ),
-            Arguments.of(
-                "alueet[0].geometriat.featureCollection",
-                "missing",
-                completeHanke().apply { alueet[0].geometriat!!.featureCollection = null }
-            ),
-            Arguments.of(
-                "alueet[0].geometriat.featureCollection.features",
-                "missing",
-                completeHanke().apply { alueet[0].geometriat!!.featureCollection!!.features = null }
-            ),
-            Arguments.of(
-                "alueet[0].geometriat.featureCollection.features",
-                "empty",
-                completeHanke().apply {
-                    alueet[0].geometriat!!.featureCollection!!.features = listOf()
-                }
-            ),
-            Arguments.of(
-                "omistajat",
-                "empty",
-                completeHanke().apply { omistajat = mutableListOf() }
-            ),
-            Arguments.of(
-                "omistajat[0].nimi",
-                "empty",
-                completeHanke().apply { omistajat[0].nimi = "" }
-            ),
-            Arguments.of(
-                "omistajat[0].nimi",
-                "blank",
-                completeHanke().apply { omistajat[0].nimi = BLANK }
-            ),
-            Arguments.of(
-                "omistajat[0].email",
-                "empty",
-                completeHanke().apply { omistajat[0].email = "" }
-            ),
-            Arguments.of(
-                "omistajat[0].email",
-                "blank",
-                completeHanke().apply { omistajat[0].email = BLANK }
-            ),
-            Arguments.of(
-                "rakennuttajat[0].nimi",
-                "empty",
-                completeHanke().apply { rakennuttajat[0].nimi = "" }
-            ),
-            Arguments.of(
-                "rakennuttajat[0].nimi",
-                "blank",
-                completeHanke().apply { rakennuttajat[0].nimi = BLANK }
-            ),
-            Arguments.of(
-                "rakennuttajat[0].email",
-                "empty",
-                completeHanke().apply { rakennuttajat[0].email = "" }
-            ),
-            Arguments.of(
-                "rakennuttajat[0].email",
-                "blank",
-                completeHanke().apply { rakennuttajat[0].email = BLANK }
-            ),
-            Arguments.of(
-                "toteuttajat[0].nimi",
-                "empty",
-                completeHanke().apply { toteuttajat[0].nimi = "" }
-            ),
-            Arguments.of(
-                "toteuttajat[0].nimi",
-                "blank",
-                completeHanke().apply { toteuttajat[0].nimi = BLANK }
-            ),
-            Arguments.of(
-                "toteuttajat[0].email",
-                "empty",
-                completeHanke().apply { toteuttajat[0].email = "" }
-            ),
-            Arguments.of(
-                "toteuttajat[0].email",
-                "blank",
-                completeHanke().apply { toteuttajat[0].email = BLANK }
-            ),
-        )
+    private fun MutableList<HankeYhteystieto>.modify(
+        ytunnus: String? = defaultYtunnus,
+        tyyppi: YhteystietoTyyppi? = YRITYS
+    ) = map { it.copy(ytunnus = ytunnus, tyyppi = tyyppi) }.toMutableList()
 }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/validation/HankePublicValidatorTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/validation/HankePublicValidatorTest.kt
@@ -8,15 +8,12 @@ import assertk.assertions.isGreaterThanOrEqualTo
 import fi.hel.haitaton.hanke.Vaihe
 import fi.hel.haitaton.hanke.Yhteyshenkilo
 import fi.hel.haitaton.hanke.domain.Hanke
-import fi.hel.haitaton.hanke.domain.HankeYhteystieto
-import fi.hel.haitaton.hanke.domain.YhteystietoTyyppi
 import fi.hel.haitaton.hanke.domain.YhteystietoTyyppi.YKSITYISHENKILO
-import fi.hel.haitaton.hanke.domain.YhteystietoTyyppi.YRITYS
 import fi.hel.haitaton.hanke.factory.HankeFactory
 import fi.hel.haitaton.hanke.factory.HankeFactory.Companion.withHankealue
 import fi.hel.haitaton.hanke.factory.HankeFactory.Companion.withTormaystarkasteluTulos
 import fi.hel.haitaton.hanke.factory.HankeFactory.Companion.withYhteystiedot
-import fi.hel.haitaton.hanke.factory.HankeYhteystietoFactory.defaultYtunnus
+import fi.hel.haitaton.hanke.factory.modify
 import fi.hel.haitaton.hanke.touch
 import fi.hel.haitaton.hanke.validation.HankePublicValidator.validateHankeHasMandatoryFields
 import java.util.stream.Stream
@@ -347,9 +344,4 @@ class HankePublicValidatorTest {
         assertFalse(result.isOk())
         assertThat(result.errorPaths()).containsExactly(path)
     }
-
-    private fun MutableList<HankeYhteystieto>.modify(
-        ytunnus: String? = defaultYtunnus,
-        tyyppi: YhteystietoTyyppi? = YRITYS
-    ) = map { it.copy(ytunnus = ytunnus, tyyppi = tyyppi) }.toMutableList()
 }


### PR DESCRIPTION
# Description

Add ytunnus for hanke contacts. 

Ytunnus is required for public hanke, if tyyppi is YRITYS or YHDISTYS.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1931

## Type of change

- [ ] Bug fix 
- [x] New feature 
- [ ] Other

# Instructions for testing
Ytunnus should be saved if it is submitted in the UI. Hanke status will turn public if required fields are present, including y-tunnus.

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 

# Other relevant info
Please describe here if there is e.g. some requirements for this change or
 other info that the tester/user needs to know.