### PR TITLE
HAI-1898 Update Spring Boot to 3.1.4

### DIFF
--- a/services/hanke-service/build.gradle.kts
+++ b/services/hanke-service/build.gradle.kts
@@ -49,7 +49,7 @@ spotless {
 
 plugins {
     val kotlinVersion = "1.9.10"
-    id("org.springframework.boot") version "3.0.11"
+    id("org.springframework.boot") version "3.1.4"
     id("io.spring.dependency-management") version "1.1.3"
     id("com.diffplug.spotless") version "6.21.0"
     kotlin("jvm") version kotlinVersion

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Constants.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Constants.kt
@@ -3,7 +3,7 @@ package fi.hel.haitaton.hanke
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import java.time.ZoneId
+import java.time.ZoneOffset
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 
@@ -17,7 +17,7 @@ val OBJECT_MAPPER =
         this.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
     }
 
-val TZ_UTC: ZoneId = ZoneId.of("UTC")
+val TZ_UTC: ZoneOffset = ZoneOffset.UTC
 
 val DATABASE_TIMESTAMP_FORMAT: DateTimeFormatter =
     DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS")

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/Persistence.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/Persistence.kt
@@ -21,8 +21,8 @@ import java.time.OffsetDateTime
 import java.time.format.DateTimeFormatter
 import java.util.UUID
 import org.hibernate.annotations.Generated
-import org.hibernate.annotations.GenerationTime
 import org.hibernate.annotations.Type
+import org.hibernate.generator.EventType
 import org.springframework.data.jpa.repository.JpaRepository
 
 /**
@@ -52,7 +52,7 @@ data class AuditLogEntryEntity(
 
     /** This will be set by the database. */
     @Column(name = "created_at")
-    @Generated(GenerationTime.INSERT)
+    @Generated(event = [EventType.INSERT])
     val createdAt: OffsetDateTime? = null,
 )
 

--- a/services/hanke-service/src/main/resources/application.properties
+++ b/services/hanke-service/src/main/resources/application.properties
@@ -34,7 +34,7 @@ spring.datasource.password=${HAITATON_PASSWORD:haitaton}
 
 # JPA
 spring.jpa.open-in-view=false
-spring.jpa.database-platform=org.hibernate.dialect.PostgreSQL94Dialect
+spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
 # This makes the database field names to match the entity member names
 spring.jpa.hibernate.naming.physical-strategy=org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
 # Don't log SQL queries. This is the default, but left here to make it easy to enable while developing.

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/ApplicationHistoryFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/ApplicationHistoryFactory.kt
@@ -26,12 +26,12 @@ object ApplicationHistoryFactory {
             events =
                 listOf(
                     createEvent(
-                        eventTime = ZonedDateTime.parse("2022-10-12T15:25:34.981654Z[UTC]"),
+                        eventTime = ZonedDateTime.parse("2022-10-12T15:25:34.981654Z"),
                         newStatus = ApplicationStatus.PENDING,
                         applicationIdentifier = applicationIdentifier,
                     ),
                     createEvent(
-                        eventTime = ZonedDateTime.parse("2023-01-09T14:37:09.135Z[UTC]"),
+                        eventTime = ZonedDateTime.parse("2023-01-09T14:37:09.135Z"),
                         newStatus = ApplicationStatus.PENDING_CLIENT,
                         applicationIdentifier = applicationIdentifier,
                     ),


### PR DESCRIPTION
# Description

- Updates Jackson to 2.15, which changes ZonedDateTime deserialization.
  - 2021-02-01T19:49:04.051348600Z[UTC] will be just 2021-02-01T19:49:04.051348600Z as Z and UTC mean the same thing.
  - I changed TZ_UTC accordingly.
  - See: https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.15#changes-behavior-other

- Version specific dialects are removed from hibernate (see spring.jpa.database-platform).
  - Changed dialect to PostgreSQLDialect
  - See: https://github.com/hibernate/hibernate-orm/blob/6.0/migration-guide.adoc#version-specific-and-spatial-specific-dialects-are-deprecated

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1892

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [x] Other

# Instructions for testing
Please describe tests how this change or new feature can be tested.

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 

# Other relevant info
Please describe here if there is e.g. some requirements for this change or
 other info that the tester/user needs to know.