### PR TITLE
HAI-1896 Create hanke users after allu update and send emails

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceITest.kt
@@ -602,7 +602,6 @@ class ApplicationServiceITest : DatabaseTest() {
         fun `when application is in Allu should initialize access for new contacts`() {
             val cableReport =
                 createCableReportApplicationData(
-                    areas = listOf(aleksanterinpatsas),
                     customerWithContacts = hakijaCustomerContact,
                     contractorWithContacts = suorittajaCustomerContact,
                 )
@@ -613,14 +612,13 @@ class ApplicationServiceITest : DatabaseTest() {
                 )
             fakeSendAllu(applicationRepository.findById(application.id!!).orElseThrow())
             val capturedNotifications = mutableListOf<ApplicationNotificationData>()
-            with(cableReportServiceAllu) {
-                justRun { update(21, any()) }
-                every { getApplicationInformation(any()) } returns createAlluApplicationResponse(21)
-                justRun { addAttachment(21, any()) }
-            }
-            with(emailSenderService) {
-                justRun { sendHankeInvitationEmail(any()) }
-                justRun { sendApplicationNotificationEmail(capture(capturedNotifications)) }
+            justRun { cableReportServiceAllu.update(21, any()) }
+            every { cableReportServiceAllu.getApplicationInformation(any()) } returns
+                createAlluApplicationResponse(21)
+            justRun { cableReportServiceAllu.addAttachment(21, any()) }
+            justRun { emailSenderService.sendHankeInvitationEmail(any()) }
+            justRun {
+                emailSenderService.sendApplicationNotificationEmail(capture(capturedNotifications))
             }
 
             applicationService.updateApplicationData(
@@ -638,16 +636,12 @@ class ApplicationServiceITest : DatabaseTest() {
             assertThat(capturedNotifications)
                 .areValid(application.applicationType, application.hankeTunnus)
             verifySequence {
-                with(cableReportServiceAllu) {
-                    getApplicationInformation(any())
-                    update(21, any())
-                    addAttachment(any(), any())
-                }
+                cableReportServiceAllu.getApplicationInformation(any())
+                cableReportServiceAllu.update(21, any())
+                cableReportServiceAllu.addAttachment(any(), any())
             }
-            with(emailSenderService) {
-                verify(exactly = 3) { sendHankeInvitationEmail(any()) }
-                verify(exactly = 3) { sendApplicationNotificationEmail(any()) }
-            }
+            verify(exactly = 3) { emailSenderService.sendHankeInvitationEmail(any()) }
+            verify(exactly = 3) { emailSenderService.sendApplicationNotificationEmail(any()) }
         }
 
         @Test
@@ -1122,15 +1116,12 @@ class ApplicationServiceITest : DatabaseTest() {
                     USERNAME,
                 )
             val capturedEmails = mutableListOf<ApplicationNotificationData>()
-            with(cableReportServiceAllu) {
-                every { create(any()) } returns 26
-                every { getApplicationInformation(any()) } returns createAlluApplicationResponse(26)
-                justRun { addAttachment(26, any()) }
-            }
-            with(emailSenderService) {
-                justRun { sendHankeInvitationEmail(any()) }
-                justRun { sendApplicationNotificationEmail(capture(capturedEmails)) }
-            }
+            every { cableReportServiceAllu.create(any()) } returns 26
+            every { cableReportServiceAllu.getApplicationInformation(any()) } returns
+                createAlluApplicationResponse(26)
+            justRun { cableReportServiceAllu.addAttachment(26, any()) }
+            justRun { emailSenderService.sendHankeInvitationEmail(any()) }
+            justRun { emailSenderService.sendApplicationNotificationEmail(capture(capturedEmails)) }
 
             applicationService.sendApplication(application.id!!, USERNAME)
 
@@ -1138,16 +1129,12 @@ class ApplicationServiceITest : DatabaseTest() {
             assertThat(capturedEmails)
                 .areValid(application.applicationType, application.hankeTunnus)
             verifySequence {
-                with(cableReportServiceAllu) {
-                    create(any())
-                    addAttachment(any(), any())
-                    getApplicationInformation(any())
-                }
+                cableReportServiceAllu.create(any())
+                cableReportServiceAllu.addAttachment(any(), any())
+                cableReportServiceAllu.getApplicationInformation(any())
             }
-            with(emailSenderService) {
-                verify(exactly = 3) { sendHankeInvitationEmail(any()) }
-                verify(exactly = 3) { sendApplicationNotificationEmail(any()) }
-            }
+            verify(exactly = 3) { emailSenderService.sendHankeInvitationEmail(any()) }
+            verify(exactly = 3) { emailSenderService.sendApplicationNotificationEmail(any()) }
         }
 
         @Test

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceITest.kt
@@ -610,7 +610,7 @@ class ApplicationServiceITest : DatabaseTest() {
                     CableReportWithoutHanke(CABLE_REPORT, cableReport),
                     USERNAME,
                 )
-            fakeSendAllu(applicationRepository.findById(application.id!!).orElseThrow())
+            setAlluFields(applicationRepository.findById(application.id!!).orElseThrow())
             val capturedNotifications = mutableListOf<ApplicationNotificationData>()
             justRun { cableReportServiceAllu.update(21, any()) }
             every { cableReportServiceAllu.getApplicationInformation(any()) } returns
@@ -1815,7 +1815,7 @@ class ApplicationServiceITest : DatabaseTest() {
             applicationData = applicationData
         )
 
-    private fun fakeSendAllu(applicationEntity: ApplicationEntity) {
+    private fun setAlluFields(applicationEntity: ApplicationEntity) {
         applicationRepository.save(
             applicationEntity.copy(
                 alluid = 21,

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceITest.kt
@@ -612,7 +612,7 @@ class ApplicationServiceITest : DatabaseTest() {
                     USERNAME,
                 )
             mockSendAllu(applicationRepository.findById(application.id!!).orElseThrow())
-            val capturedEmails = mutableListOf<ApplicationNotificationData>()
+            val capturedNotifications = mutableListOf<ApplicationNotificationData>()
             with(cableReportServiceAllu) {
                 justRun { update(21, any()) }
                 every { getApplicationInformation(any()) } returns createAlluApplicationResponse(21)
@@ -620,7 +620,7 @@ class ApplicationServiceITest : DatabaseTest() {
             }
             with(emailSenderService) {
                 justRun { sendHankeInvitationEmail(any()) }
-                justRun { sendApplicationNotificationEmail(capture(capturedEmails)) }
+                justRun { sendApplicationNotificationEmail(capture(capturedNotifications)) }
             }
 
             applicationService.updateApplicationData(
@@ -634,8 +634,8 @@ class ApplicationServiceITest : DatabaseTest() {
                 USERNAME
             )
 
-            assertThat(capturedEmails).hasSize(3)
-            assertThat(capturedEmails)
+            assertThat(capturedNotifications).hasSize(3)
+            assertThat(capturedNotifications)
                 .areValid(application.applicationType, application.hankeTunnus)
             verifySequence {
                 with(cableReportServiceAllu) {

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceITest.kt
@@ -611,7 +611,7 @@ class ApplicationServiceITest : DatabaseTest() {
                     CableReportWithoutHanke(CABLE_REPORT, cableReport),
                     USERNAME,
                 )
-            mockSendAllu(applicationRepository.findById(application.id!!).orElseThrow())
+            fakeSendAllu(applicationRepository.findById(application.id!!).orElseThrow())
             val capturedNotifications = mutableListOf<ApplicationNotificationData>()
             with(cableReportServiceAllu) {
                 justRun { update(21, any()) }
@@ -1828,7 +1828,7 @@ class ApplicationServiceITest : DatabaseTest() {
             applicationData = applicationData
         )
 
-    private fun mockSendAllu(applicationEntity: ApplicationEntity) {
+    private fun fakeSendAllu(applicationEntity: ApplicationEntity) {
         applicationRepository.save(
             applicationEntity.copy(
                 alluid = 21,

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceITest.kt
@@ -620,17 +620,15 @@ class ApplicationServiceITest : DatabaseTest() {
             justRun {
                 emailSenderService.sendApplicationNotificationEmail(capture(capturedNotifications))
             }
-
-            applicationService.updateApplicationData(
-                application.id!!,
+            val updatedApplication =
                 cableReport.copy(
                     representativeWithContacts = asianHoitajaCustomerContact,
                     propertyDeveloperWithContacts = rakennuttajaCustomerContact,
                     contractorWithContacts =
                         suorittajaCustomerContact.changeContactEmails("new.mail@foo.fi")
-                ),
-                USERNAME
-            )
+                )
+
+            applicationService.updateApplicationData(application.id!!, updatedApplication, USERNAME)
 
             assertThat(capturedNotifications).hasSize(3)
             assertThat(capturedNotifications)

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceITest.kt
@@ -630,9 +630,15 @@ class ApplicationServiceITest : DatabaseTest() {
 
             applicationService.updateApplicationData(application.id!!, updatedApplication, USERNAME)
 
-            assertThat(capturedNotifications).hasSize(3)
             assertThat(capturedNotifications)
                 .areValid(application.applicationType, application.hankeTunnus)
+            assertThat(capturedNotifications)
+                .extracting { it.recipientEmail }
+                .containsExactlyInAnyOrder(
+                    "new.mail@foo.fi",
+                    asianHoitajaCustomerContact.contacts[0].email,
+                    rakennuttajaCustomerContact.contacts[0].email
+                )
             verifySequence {
                 cableReportServiceAllu.getApplicationInformation(any())
                 cableReportServiceAllu.update(21, any())

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeServiceImpl.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeServiceImpl.kt
@@ -230,7 +230,7 @@ open class HankeServiceImpl(
     private fun anyHakemusProcessingInAllu(hakemukset: List<Application>): Boolean =
         hakemukset.any {
             logger.info { "Hakemus ${it.id} has alluStatus ${it.alluStatus}" }
-            !applicationService.isStillPending(it)
+            !applicationService.isStillPending(it.alluid, it.alluStatus)
         }
 
     private fun initAccessForCreatedHanke(hanke: Hanke, perustaja: Perustaja?, userId: String) {

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationService.kt
@@ -183,7 +183,7 @@ open class ApplicationService(
         // Update the application in Allu, if it's been already uploaded
         if (saved.alluid != null) {
             updateApplicationInAllu(saved)
-            initAccessOnAlluUpdate(saved, previous.applicationData, userId, hanke)
+            provideAccessOnAlluUpdate(saved, previous.applicationData, userId, hanke)
         }
 
         return saved.toApplication().also {
@@ -358,7 +358,7 @@ open class ApplicationService(
         val kayttaja = hankeKayttajaService.getKayttajaByUserId(hanke.id!!, currentUserId)
         val contacts = application.applicationData.typedContacts(omit = kayttaja?.sahkoposti)
 
-        initAccess(
+        provideAccess(
             application = application,
             hanke = hanke,
             currentKayttaja = kayttaja,
@@ -368,7 +368,7 @@ open class ApplicationService(
     }
 
     /** Creates access for new application contacts. Email address used for comparison. */
-    private fun initAccessOnAlluUpdate(
+    private fun provideAccessOnAlluUpdate(
         application: ApplicationEntity,
         previousData: ApplicationData,
         currentUserId: String,
@@ -385,7 +385,7 @@ open class ApplicationService(
         val updatedContacts = application.applicationData.typedContacts(omit = kayttaja?.sahkoposti)
         val newContacts = updatedContacts.subtractByEmail(previousContacts)
 
-        initAccess(
+        provideAccess(
             application = application,
             hanke = hanke,
             currentKayttaja = kayttaja,
@@ -394,7 +394,7 @@ open class ApplicationService(
         )
     }
 
-    private fun initAccess(
+    private fun provideAccess(
         application: ApplicationEntity,
         hanke: HankeEntity,
         currentKayttaja: HankeKayttajaEntity?,

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationService.kt
@@ -132,15 +132,15 @@ open class ApplicationService(
         userId: String,
     ): Application {
         val application = getById(id)
-        val previous = application.toApplication()
+        val previousApplication = application.toApplication()
         logger.info("Updating application id=$id, alluid=${application.alluid}")
 
-        if (previous.applicationData == newApplicationData) {
+        if (previousApplication.applicationData == newApplicationData) {
             logger.info {
                 "Not updating unchanged application data. id=$id, " +
                     "alluid=${application.alluid}, identifier=${application.applicationIdentifier}"
             }
-            return previous
+            return previousApplication
         }
 
         when (application.applicationData) {
@@ -183,12 +183,12 @@ open class ApplicationService(
         // Update the application in Allu, if it's been already uploaded
         if (saved.alluid != null) {
             updateApplicationInAllu(saved)
-            provideAccessOnAlluUpdate(saved, previous.applicationData, userId, hanke)
+            provideAccessOnAlluUpdate(saved, previousApplication.applicationData, userId, hanke)
         }
 
         return saved.toApplication().also {
             logger.info("Updated application id=${it.id}, alluid=${it.alluid}")
-            applicationLoggingService.logUpdate(previous, it, userId)
+            applicationLoggingService.logUpdate(previousApplication, it, userId)
         }
     }
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentService.kt
@@ -92,7 +92,7 @@ class HankeAttachmentService(
 
     private fun ensureRoomForAttachment(hankeId: Int) {
         if (attachmentAmountReached(hankeId)) {
-            logger.warn { "Application $hankeId has reached the allowed amount of attachments." }
+            logger.warn { "Hanke $hankeId has reached the allowed amount of attachments." }
             throw AttachmentInvalidException("Attachment amount limit reached")
         }
     }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/configuration/Configuration.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/configuration/Configuration.kt
@@ -89,6 +89,7 @@ class Configuration {
         permissionService: PermissionService,
         hankeRepository: HankeRepository,
         hankeLoggingService: HankeLoggingService,
+        featureFlags: FeatureFlags,
     ): ApplicationService =
         ApplicationService(
             applicationRepository,
@@ -103,6 +104,7 @@ class Configuration {
             permissionService,
             hankeRepository,
             hankeLoggingService,
+            featureFlags,
         )
 
     @Bean

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/UserContact.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/UserContact.kt
@@ -1,6 +1,10 @@
 package fi.hel.haitaton.hanke.domain
 
 import fi.hel.haitaton.hanke.application.ApplicationContactType
+import fi.hel.haitaton.hanke.application.ApplicationContactType.ASIANHOITAJA
+import fi.hel.haitaton.hanke.application.ApplicationContactType.HAKIJA
+import fi.hel.haitaton.hanke.application.ApplicationContactType.RAKENNUTTAJA
+import fi.hel.haitaton.hanke.application.ApplicationContactType.TYON_SUORITTAJA
 import fi.hel.haitaton.hanke.application.ApplicationData
 import fi.hel.haitaton.hanke.application.CableReportApplicationData
 import fi.hel.haitaton.hanke.application.CustomerWithContacts
@@ -45,22 +49,28 @@ fun ApplicationData.typedContacts(omit: String? = null): Set<ApplicationUserCont
     when (this) {
         is CableReportApplicationData ->
             listOfNotNull(
-                    customerWithContacts.typedContacts(ApplicationContactType.HAKIJA),
-                    contractorWithContacts.typedContacts(ApplicationContactType.TYON_SUORITTAJA),
-                    representativeWithContacts?.typedContacts(ApplicationContactType.ASIANHOITAJA),
-                    propertyDeveloperWithContacts?.typedContacts(
-                        ApplicationContactType.RAKENNUTTAJA
-                    )
+                    customerWithContacts.typedAs(HAKIJA),
+                    contractorWithContacts.typedAs(TYON_SUORITTAJA),
+                    representativeWithContacts?.typedAs(ASIANHOITAJA),
+                    propertyDeveloperWithContacts?.typedAs(RAKENNUTTAJA)
                 )
                 .flatten()
                 .remove(omit)
                 .toSet()
     }
 
+/** Filter contacts whose email does not exist in the other set. */
+fun Set<ApplicationUserContact>.subtractByEmail(
+    other: Set<ApplicationUserContact>
+): Set<ApplicationUserContact> {
+    val otherEmails = other.map { it.email }
+    return filterNot { contact -> contact.email in otherEmails }.toSet()
+}
+
 private fun List<ApplicationUserContact>.remove(email: String?) =
     if (email == null) this else filter { it.email != email }
 
-private fun CustomerWithContacts.typedContacts(
+private fun CustomerWithContacts.typedAs(
     type: ApplicationContactType
 ): List<ApplicationUserContact> =
     contacts.mapNotNull { ApplicationUserContact.from(it.fullName(), it.email, type) }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/gdpr/GdprService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/gdpr/GdprService.kt
@@ -25,7 +25,7 @@ class GdprService(private val applicationService: ApplicationService) {
 
         val (pendingApplications, activeApplications) =
             applicationService.getAllApplicationsCreatedByUser(userId).partition {
-                applicationService.isStillPending(it)
+                applicationService.isStillPending(it.alluid, it.alluStatus)
             }
 
         if (activeApplications.isNotEmpty()) {

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaService.kt
@@ -15,7 +15,6 @@ import fi.hel.haitaton.hanke.email.HankeInvitationData
 import fi.hel.haitaton.hanke.logging.HankeKayttajaLoggingService
 import java.util.UUID
 import mu.KotlinLogging
-import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -31,11 +30,6 @@ class HankeKayttajaService(
     private val logService: HankeKayttajaLoggingService,
     private val emailSenderService: EmailSenderService,
 ) {
-
-    @Transactional(readOnly = true)
-    fun getKayttajaById(kayttajaId: UUID): HankeKayttaja? =
-        hankeKayttajaRepository.findByIdOrNull(kayttajaId)?.toDomain()
-
     @Transactional(readOnly = true)
     fun getKayttajatByHankeId(hankeId: Int): List<HankeKayttajaDto> =
         hankeKayttajaRepository.findByHankeId(hankeId).map { it.toDto() }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaService.kt
@@ -62,9 +62,6 @@ class HankeKayttajaService(
         currentUserId: String,
         currentKayttaja: HankeKayttajaEntity? = null,
     ) {
-        if (featureFlags.isDisabled(Feature.USER_MANAGEMENT)) {
-            return
-        }
         logger.info {
             "Creating users and user tokens for application ${application.id}, alluid=${application.alluid}}"
         }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceTest.kt
@@ -43,9 +43,8 @@ import io.mockk.checkUnnecessaryStub
 import io.mockk.clearAllMocks
 import io.mockk.confirmVerified
 import io.mockk.every
-import io.mockk.impl.annotations.InjectMockKs
-import io.mockk.impl.annotations.MockK
 import io.mockk.justRun
+import io.mockk.mockk
 import io.mockk.verify
 import io.mockk.verifyAll
 import io.mockk.verifySequence
@@ -63,31 +62,44 @@ import org.junit.jupiter.params.provider.CsvSource
 import org.junit.jupiter.params.provider.MethodSource
 import org.springframework.boot.test.system.CapturedOutput
 import org.springframework.boot.test.system.OutputCaptureExtension
-import org.springframework.test.context.junit.jupiter.SpringExtension
 
 private const val USERNAME = "test"
 private const val HANKE_TUNNUS = "HAI-1234"
 
-@ExtendWith(SpringExtension::class)
 class ApplicationServiceTest {
+    private val applicationRepository: ApplicationRepository = mockk()
+    private val hankeRepository: HankeRepository = mockk()
+    private val statusRepository: AlluStatusRepository = mockk()
+    private val geometriatDao: GeometriatDao = mockk()
 
-    @MockK private lateinit var applicationRepository: ApplicationRepository
-    @MockK private lateinit var hankeRepository: HankeRepository
-    @MockK private lateinit var statusRepository: AlluStatusRepository
-    @MockK private lateinit var geometriatDao: GeometriatDao
+    private val cableReportService: CableReportService = mockk()
+    private val permissionService: PermissionService = mockk()
+    private val emailSenderService: EmailSenderService = mockk()
+    private val attachmentService: ApplicationAttachmentService = mockk()
 
-    @MockK private lateinit var cableReportService: CableReportService
-    @MockK private lateinit var permissionService: PermissionService
-    @MockK private lateinit var emailSenderService: EmailSenderService
-    @MockK private lateinit var attachmentService: ApplicationAttachmentService
+    private val disclosureLogService: DisclosureLogService = mockk(relaxUnitFun = true)
+    private val loggingService: ApplicationLoggingService = mockk(relaxUnitFun = true)
+    private val hankeKayttajaService: HankeKayttajaService = mockk(relaxUnitFun = true)
+    private val hankeLoggingService: HankeLoggingService = mockk(relaxUnitFun = true)
 
-    @MockK(relaxUnitFun = true) private lateinit var disclosureLogService: DisclosureLogService
-    @MockK(relaxUnitFun = true) private lateinit var loggingService: ApplicationLoggingService
-    @MockK(relaxUnitFun = true) private lateinit var hankeKayttajaService: HankeKayttajaService
-    @MockK(relaxUnitFun = true) private lateinit var hankeLoggingService: HankeLoggingService
-    @MockK(relaxed = true) private lateinit var featureFlags: FeatureFlags
+    private val featureFlags: FeatureFlags = mockk(relaxed = true)
 
-    @InjectMockKs private lateinit var applicationService: ApplicationService
+    private val applicationService: ApplicationService =
+        ApplicationService(
+            applicationRepository,
+            statusRepository,
+            cableReportService,
+            disclosureLogService,
+            loggingService,
+            hankeKayttajaService,
+            emailSenderService,
+            attachmentService,
+            geometriatDao,
+            permissionService,
+            hankeRepository,
+            hankeLoggingService,
+            featureFlags
+        )
 
     companion object {
         private val applicationData: CableReportApplicationData =

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceTest.kt
@@ -19,6 +19,8 @@ import fi.hel.haitaton.hanke.allu.ApplicationStatus
 import fi.hel.haitaton.hanke.allu.CableReportService
 import fi.hel.haitaton.hanke.asJsonResource
 import fi.hel.haitaton.hanke.attachment.application.ApplicationAttachmentService
+import fi.hel.haitaton.hanke.configuration.Feature
+import fi.hel.haitaton.hanke.configuration.FeatureFlags
 import fi.hel.haitaton.hanke.email.EmailSenderService
 import fi.hel.haitaton.hanke.factory.AlluDataFactory
 import fi.hel.haitaton.hanke.factory.AlluDataFactory.Companion.withContacts
@@ -41,9 +43,11 @@ import io.mockk.checkUnnecessaryStub
 import io.mockk.clearAllMocks
 import io.mockk.confirmVerified
 import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
 import io.mockk.justRun
-import io.mockk.mockk
 import io.mockk.verify
+import io.mockk.verifyAll
 import io.mockk.verifySequence
 import java.time.OffsetDateTime
 import java.util.stream.Stream
@@ -51,7 +55,6 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
@@ -65,37 +68,58 @@ import org.springframework.test.context.junit.jupiter.SpringExtension
 private const val USERNAME = "test"
 private const val HANKE_TUNNUS = "HAI-1234"
 
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ExtendWith(SpringExtension::class)
 class ApplicationServiceTest {
-    private val applicationRepo: ApplicationRepository = mockk()
-    private val statusRepo: AlluStatusRepository = mockk()
-    private val cableReportService: CableReportService = mockk()
-    private val geometriatDao: GeometriatDao = mockk()
-    private val disclosureLogService: DisclosureLogService = mockk(relaxUnitFun = true)
-    private val applicationLoggingService: ApplicationLoggingService = mockk(relaxUnitFun = true)
-    private val hankeRepository: HankeRepository = mockk()
-    private val permissionService: PermissionService = mockk()
-    private val emailSenderService: EmailSenderService = mockk()
-    private val hankeKayttajaService: HankeKayttajaService = mockk(relaxUnitFun = true)
-    private val attachmentService: ApplicationAttachmentService = mockk()
-    private val hankeLoggingService: HankeLoggingService = mockk(relaxUnitFun = true)
 
-    private val applicationService: ApplicationService =
-        ApplicationService(
-            applicationRepo,
-            statusRepo,
-            cableReportService,
-            disclosureLogService,
-            applicationLoggingService,
-            hankeKayttajaService,
-            emailSenderService,
-            attachmentService,
-            geometriatDao,
-            permissionService,
-            hankeRepository,
-            hankeLoggingService,
-        )
+    @MockK private lateinit var applicationRepository: ApplicationRepository
+    @MockK private lateinit var hankeRepository: HankeRepository
+    @MockK private lateinit var statusRepository: AlluStatusRepository
+    @MockK private lateinit var geometriatDao: GeometriatDao
+
+    @MockK private lateinit var cableReportService: CableReportService
+    @MockK private lateinit var permissionService: PermissionService
+    @MockK private lateinit var emailSenderService: EmailSenderService
+    @MockK private lateinit var attachmentService: ApplicationAttachmentService
+
+    @MockK(relaxUnitFun = true) private lateinit var disclosureLogService: DisclosureLogService
+    @MockK(relaxUnitFun = true) private lateinit var loggingService: ApplicationLoggingService
+    @MockK(relaxUnitFun = true) private lateinit var hankeKayttajaService: HankeKayttajaService
+    @MockK(relaxUnitFun = true) private lateinit var hankeLoggingService: HankeLoggingService
+    @MockK(relaxed = true) private lateinit var featureFlags: FeatureFlags
+
+    @InjectMockKs private lateinit var applicationService: ApplicationService
+
+    companion object {
+        private val applicationData: CableReportApplicationData =
+            "/fi/hel/haitaton/hanke/application/applicationData.json".asJsonResource()
+
+        @JvmStatic
+        private fun invalidData(): Stream<Arguments> =
+            Stream.of(
+                Arguments.of(
+                    applicationData.copy(
+                        customerWithContacts =
+                            applicationData.customerWithContacts.copy(
+                                customer =
+                                    applicationData.customerWithContacts.customer.copy(type = null)
+                            )
+                    ),
+                    "applicationData.customerWithContacts.customer.type",
+                ),
+                Arguments.of(
+                    applicationData.copy(endTime = null),
+                    "applicationData.endTime",
+                ),
+                Arguments.of(
+                    applicationData.copy(startTime = null),
+                    "applicationData.startTime",
+                ),
+                Arguments.of(
+                    applicationData.copy(rockExcavation = null),
+                    "applicationData.rockExcavation",
+                ),
+            )
+    }
 
     @BeforeEach
     fun cleanup() {
@@ -106,11 +130,11 @@ class ApplicationServiceTest {
     fun verifyMocks() {
         checkUnnecessaryStub()
         confirmVerified(
-            applicationRepo,
-            statusRepo,
+            applicationRepository,
+            statusRepository,
             cableReportService,
             disclosureLogService,
-            applicationLoggingService,
+            loggingService,
             hankeKayttajaService,
             emailSenderService,
             geometriatDao,
@@ -119,383 +143,392 @@ class ApplicationServiceTest {
         )
     }
 
-    private val applicationData: CableReportApplicationData =
-        "/fi/hel/haitaton/hanke/application/applicationData.json".asJsonResource()
+    @Nested
+    inner class CreateApplication {
+        @Test
+        fun `when valid data should create`() {
+            val application = application()
+            val hanke = hankeEntity()
+            every { applicationRepository.save(any()) } answers
+                {
+                    firstArg<ApplicationEntity>().copy(id = 1)
+                }
+            every { hankeRepository.findByHankeTunnus(HANKE_TUNNUS) } returns hanke
+            every { geometriatDao.validateGeometriat(any()) } returns null
+            every { geometriatDao.isInsideHankeAlueet(1, any()) } returns true
 
-    @Test
-    fun create() {
-        val dto =
-            AlluDataFactory.createApplication(
-                id = null,
-                applicationData = applicationData,
-                hankeTunnus = HANKE_TUNNUS,
-            )
-        every { applicationRepo.save(any()) } answers
-            {
-                val application: ApplicationEntity = firstArg()
-                application.copy(id = 1)
+            val created = applicationService.create(application, USERNAME)
+
+            assertThat(created.id).isEqualTo(1)
+            assertThat(created.alluid).isEqualTo(null)
+            verifySequence {
+                geometriatDao.validateGeometriat(any())
+                hankeRepository.findByHankeTunnus(HANKE_TUNNUS)
+                geometriatDao.isInsideHankeAlueet(1, any())
+                applicationRepository.save(any())
+                loggingService.logCreate(any(), USERNAME)
             }
-        val hanke = HankeEntity(id = 1, hankeTunnus = HANKE_TUNNUS)
-        every { hankeRepository.findByHankeTunnus(HANKE_TUNNUS) } returns hanke
-        every { geometriatDao.validateGeometriat(any()) } returns null
-        every { geometriatDao.isInsideHankeAlueet(1, any()) } returns true
-
-        val created = applicationService.create(dto, USERNAME)
-
-        assertThat(created.id).isEqualTo(1)
-        assertThat(created.alluid).isEqualTo(null)
-        verifySequence {
-            geometriatDao.validateGeometriat(any())
-            hankeRepository.findByHankeTunnus(HANKE_TUNNUS)
-            geometriatDao.isInsideHankeAlueet(1, any())
-            applicationRepo.save(any())
-            applicationLoggingService.logCreate(any(), USERNAME)
-            disclosureLogService wasNot Called
-            cableReportService wasNot Called
-        }
-    }
-
-    @Test
-    fun `create throws exception with invalid geometry`() {
-        val dto =
-            AlluDataFactory.createApplication(
-                id = null,
-                applicationData = applicationData,
-                hankeTunnus = HANKE_TUNNUS
-            )
-        every { geometriatDao.validateGeometriat(any()) } returns
-            GeometriatDao.InvalidDetail(
-                "Self-intersection",
-                """{"type":"Point","coordinates":[25494009.65639264,6679886.142116806]}"""
-            )
-
-        val exception =
-            assertThrows<ApplicationGeometryException> { applicationService.create(dto, USERNAME) }
-
-        assertThat(exception)
-            .hasMessage(
-                """Invalid geometry received when creating a new application for user $USERNAME, reason = Self-intersection, location = {"type":"Point","coordinates":[25494009.65639264,6679886.142116806]}"""
-            )
-        verifySequence { geometriatDao.validateGeometriat(any()) }
-    }
-
-    @Test
-    fun `updateApplicationData saves disclosure logs when updating Allu data`() {
-        val hanke = HankeEntity(id = 1, hankeTunnus = HANKE_TUNNUS)
-        val applicationEntity =
-            AlluDataFactory.createApplicationEntity(
-                id = 3,
-                alluid = 42,
-                userId = USERNAME,
-                applicationData = applicationData,
-                hanke = hanke,
-            )
-        every { applicationRepo.findOneById(3) } returns applicationEntity
-        every { applicationRepo.save(applicationEntity) } returns applicationEntity
-        justRun { cableReportService.update(42, any()) }
-        justRun { cableReportService.addAttachment(42, any()) }
-        every { cableReportService.getApplicationInformation(42) } returns
-            AlluDataFactory.createAlluApplicationResponse(42)
-        every { geometriatDao.validateGeometriat(any()) } returns null
-        every { geometriatDao.isInsideHankeAlueet(1, any()) } returns true
-        every { geometriatDao.calculateCombinedArea(any()) } returns 100f
-        every { geometriatDao.calculateArea(any()) } returns 100f
-        val updatedData = applicationData.copy(rockExcavation = !applicationData.rockExcavation!!)
-
-        applicationService.updateApplicationData(3, updatedData, USERNAME)
-
-        verifySequence {
-            applicationRepo.findOneById(3)
-            geometriatDao.validateGeometriat(any())
-            geometriatDao.isInsideHankeAlueet(1, any())
-            cableReportService.getApplicationInformation(42)
-            // any() here tries to match eq([]) for some reason
-            geometriatDao.calculateCombinedArea(listOf(applicationData.areas?.first()?.geometry!!))
-            geometriatDao.calculateArea(any())
-            cableReportService.update(42, any())
-            disclosureLogService.saveDisclosureLogsForAllu(updatedData, Status.SUCCESS)
-            cableReportService.addAttachment(42, any())
-            applicationRepo.save(applicationEntity)
-            applicationLoggingService.logUpdate(any(), any(), USERNAME)
-        }
-    }
-
-    @Test
-    fun `updateApplicationData throws exception with invalid geometry`() {
-        val applicationEntity =
-            AlluDataFactory.createApplicationEntity(
-                id = 3,
-                alluid = 42,
-                userId = USERNAME,
-                applicationData = applicationData,
-                hanke = HankeEntity(hankeTunnus = HANKE_TUNNUS),
-            )
-        every { applicationRepo.findOneById(3) } returns applicationEntity
-        every { geometriatDao.validateGeometriat(any()) } returns
-            GeometriatDao.InvalidDetail(
-                "Self-intersection",
-                """{"type":"Point","coordinates":[25494009.65639264,6679886.142116806]}"""
-            )
-        val updatedData = applicationData.copy(rockExcavation = !applicationData.rockExcavation!!)
-
-        val exception =
-            assertThrows<ApplicationGeometryException> {
-                applicationService.updateApplicationData(3, updatedData, USERNAME)
+            verifyAll {
+                disclosureLogService wasNot Called
+                cableReportService wasNot Called
             }
+        }
 
-        assertThat(exception)
-            .hasMessage(
-                """Invalid geometry received when updating application for user $USERNAME, id=3, alluid=42, reason = Self-intersection, location = {"type":"Point","coordinates":[25494009.65639264,6679886.142116806]}"""
-            )
-        verifySequence {
-            applicationRepo.findOneById(3)
-            geometriatDao.validateGeometriat(any())
+        @Test
+        fun `when invalid geometry should throw`() {
+            val application = application()
+            every { geometriatDao.validateGeometriat(any()) } returns
+                GeometriatDao.InvalidDetail(
+                    "Self-intersection",
+                    """{"type":"Point","coordinates":[25494009.65639264,6679886.142116806]}"""
+                )
+
+            val exception =
+                assertThrows<ApplicationGeometryException> {
+                    applicationService.create(application, USERNAME)
+                }
+
+            assertThat(exception)
+                .hasMessage(
+                    """Invalid geometry received when creating a new application for user $USERNAME, reason = Self-intersection, location = {"type":"Point","coordinates":[25494009.65639264,6679886.142116806]}"""
+                )
+            verifySequence { geometriatDao.validateGeometriat(any()) }
         }
     }
 
-    @Test
-    fun `sendApplication saves disclosure logs for successful attempts`() {
-        val hankeEntity =
-            HankeEntity(id = 1, nimi = HankeFactory.defaultNimi, hankeTunnus = HANKE_TUNNUS)
-        val applicationEntity =
-            AlluDataFactory.createApplicationEntity(
-                id = 3,
-                alluid = null,
-                userId = USERNAME,
-                applicationData = applicationData,
-                hanke = hankeEntity,
-            )
-        val sender = HankeKayttajaFactory.createEntity()
-        every { applicationRepo.findOneById(3) } returns applicationEntity
-        every { applicationRepo.save(any()) } answers { firstArg() }
-        every { cableReportService.create(any()) } returns 42
-        justRun { cableReportService.addAttachment(42, any()) }
-        every { cableReportService.getApplicationInformation(42) } returns
-            AlluDataFactory.createAlluApplicationResponse(42)
-        every { geometriatDao.calculateCombinedArea(any()) } returns 100f
-        every { geometriatDao.calculateArea(any()) } returns 100f
-        every { geometriatDao.isInsideHankeAlueet(1, any()) } returns true
-        justRun { attachmentService.sendInitialAttachments(42, any()) }
-        every { hankeKayttajaService.getKayttajaByUserId(1, USERNAME) } returns sender
-        justRun { emailSenderService.sendApplicationNotificationEmail(any()) }
+    @Nested
+    inner class UpdateApplication {
+        @Test
+        fun `when update Allu data should save disclosure logs`() {
+            val hanke = hankeEntity()
+            val applicationEntity = applicationEntity(alluId = 42, hanke = hanke)
+            val sender = HankeKayttajaFactory.createEntity()
+            every { applicationRepository.findOneById(3) } returns applicationEntity
+            every { applicationRepository.save(applicationEntity) } returns applicationEntity
+            justRun { cableReportService.update(42, any()) }
+            justRun { cableReportService.addAttachment(42, any()) }
+            every { cableReportService.getApplicationInformation(42) } returns alluResponse()
+            every { geometriatDao.validateGeometriat(any()) } returns null
+            every { geometriatDao.isInsideHankeAlueet(1, any()) } returns true
+            every { geometriatDao.calculateCombinedArea(any()) } returns 100f
+            every { geometriatDao.calculateArea(any()) } returns 100f
+            every { hankeKayttajaService.getKayttajaByUserId(1, USERNAME) } returns sender
+            val updatedData =
+                applicationData.copy(rockExcavation = !applicationData.rockExcavation!!)
 
-        applicationService.sendApplication(3, USERNAME)
+            applicationService.updateApplicationData(3, updatedData, USERNAME)
 
-        val expectedApplication = applicationData.copy(pendingOnClient = false)
-        verifySequence {
-            applicationRepo.findOneById(3)
-            geometriatDao.isInsideHankeAlueet(1, any())
-            geometriatDao.calculateCombinedArea(any())
-            geometriatDao.calculateArea(any())
-            cableReportService.create(any())
-            disclosureLogService.saveDisclosureLogsForAllu(expectedApplication, Status.SUCCESS)
-            cableReportService.addAttachment(42, any())
-            attachmentService.sendInitialAttachments(42, any())
-            cableReportService.getApplicationInformation(42)
-            hankeKayttajaService.getKayttajaByUserId(1, USERNAME)
-            hankeKayttajaService.saveNewTokensFromApplication(
-                applicationEntity,
-                hankeEntity.id!!,
-                hankeEntity.hankeTunnus!!,
-                hankeEntity.nimi!!,
-                USERNAME,
-                sender
-            )
-            emailSenderService.sendApplicationNotificationEmail(any())
-            emailSenderService.sendApplicationNotificationEmail(any())
-            applicationRepo.save(any())
-        }
-    }
-
-    @Test
-    fun `sendApplication saves disclosure logs for failed attempts`() {
-        val hankeEntity =
-            HankeEntity(hankeTunnus = HANKE_TUNNUS, id = 1, nimi = HankeFactory.defaultNimi)
-        val applicationEntity =
-            AlluDataFactory.createApplicationEntity(
-                id = 3,
-                alluid = null,
-                userId = USERNAME,
-                applicationData = applicationData,
-                hanke = hankeEntity,
-            )
-        every { applicationRepo.findOneById(3) } returns applicationEntity
-        every { geometriatDao.calculateCombinedArea(any()) } returns 100f
-        every { geometriatDao.calculateArea(any()) } returns 100f
-        every { cableReportService.create(any()) } throws AlluException(listOf())
-        every { geometriatDao.isInsideHankeAlueet(1, any()) } returns true
-
-        assertThrows<AlluException> { applicationService.sendApplication(3, USERNAME) }
-
-        val expectedApplication = applicationData.copy(pendingOnClient = false)
-        verifySequence {
-            hankeKayttajaService wasNot Called
-            applicationRepo.findOneById(3)
-            geometriatDao.isInsideHankeAlueet(1, any())
-            geometriatDao.calculateCombinedArea(any())
-            geometriatDao.calculateArea(any())
-            cableReportService.create(any())
-            disclosureLogService.saveDisclosureLogsForAllu(
-                expectedApplication,
-                Status.FAILED,
-                ALLU_APPLICATION_ERROR_MSG
-            )
-        }
-    }
-
-    @Test
-    fun `sendApplication doesn't save disclosure logs for login errors`() {
-        val hankeEntity =
-            HankeEntity(hankeTunnus = HANKE_TUNNUS, id = 1, nimi = HankeFactory.defaultNimi)
-        val applicationEntity =
-            AlluDataFactory.createApplicationEntity(
-                id = 3,
-                alluid = null,
-                userId = USERNAME,
-                applicationData = applicationData,
-                hanke = hankeEntity,
-            )
-        assertThat(applicationEntity.applicationData.areas).isNotNull().isNotEmpty()
-        every { applicationRepo.findOneById(3) } returns applicationEntity
-        every { geometriatDao.calculateCombinedArea(any()) } returns 500f
-        every { geometriatDao.calculateArea(any()) } returns 500f
-        every { geometriatDao.isInsideHankeAlueet(any(), any()) } returns true
-        every { cableReportService.create(any()) } throws AlluLoginException(RuntimeException())
-
-        assertThrows<AlluLoginException> { applicationService.sendApplication(3, USERNAME) }
-
-        verifySequence {
-            disclosureLogService wasNot called
-            applicationRepo.findOneById(3)
-            geometriatDao.isInsideHankeAlueet(any(), any())
-            geometriatDao.calculateCombinedArea(any())
-            geometriatDao.calculateArea(any())
-            cableReportService.create(any())
-        }
-    }
-
-    @ParameterizedTest
-    @CsvSource("true,Louhitaan", "false,Ei louhita")
-    fun `sendApplication adds rock excavation information to work description`(
-        rockExcavation: Boolean,
-        expectedSuffix: String
-    ) {
-        val hankeEntity =
-            HankeEntity(hankeTunnus = HANKE_TUNNUS, id = 1, nimi = HankeFactory.defaultNimi)
-        val applicationEntity =
-            AlluDataFactory.createApplicationEntity(
-                id = 3,
-                alluid = null,
-                userId = USERNAME,
-                applicationData = applicationData.copy(rockExcavation = rockExcavation),
-                hanke = hankeEntity,
-            )
-        val sender = HankeKayttajaFactory.createEntity()
-        every { applicationRepo.findOneById(3) } returns applicationEntity
-        every { applicationRepo.save(any()) } answers { firstArg() }
-        every { geometriatDao.calculateCombinedArea(any()) } returns 100f
-        every { geometriatDao.calculateArea(any()) } returns 100f
-        every { geometriatDao.isInsideHankeAlueet(1, any()) } returns true
-        every { cableReportService.create(any()) } returns 852
-        justRun { cableReportService.addAttachment(852, any()) }
-        every { cableReportService.getApplicationInformation(852) } returns
-            AlluDataFactory.createAlluApplicationResponse(852)
-        justRun { attachmentService.sendInitialAttachments(852, any()) }
-        every { hankeKayttajaService.getKayttajaByUserId(1, USERNAME) } returns sender
-        justRun { emailSenderService.sendApplicationNotificationEmail(any()) }
-
-        applicationService.sendApplication(3, USERNAME)
-
-        val expectedApplicationData =
-            applicationData.copy(pendingOnClient = false, rockExcavation = rockExcavation)
-        val expectedAlluData =
-            expectedApplicationData
-                .toAlluData(HANKE_TUNNUS)
-                .copy(workDescription = applicationData.workDescription + "\n" + expectedSuffix)
-        verifySequence {
-            applicationRepo.findOneById(3)
-            geometriatDao.isInsideHankeAlueet(1, any())
-            geometriatDao.calculateCombinedArea(any())
-            geometriatDao.calculateArea(any())
-            cableReportService.create(expectedAlluData)
-            disclosureLogService.saveDisclosureLogsForAllu(expectedApplicationData, Status.SUCCESS)
-            cableReportService.addAttachment(852, any())
-            cableReportService.getApplicationInformation(852)
-            hankeKayttajaService.getKayttajaByUserId(1, USERNAME)
-            hankeKayttajaService.saveNewTokensFromApplication(
-                any(),
-                hankeEntity.id!!,
-                hankeEntity.hankeTunnus!!,
-                hankeEntity.nimi!!,
-                USERNAME,
-                sender
-            )
-            emailSenderService.sendApplicationNotificationEmail(any())
-            emailSenderService.sendApplicationNotificationEmail(any())
-            applicationRepo.save(any())
-        }
-    }
-
-    @ParameterizedTest(name = "{1} {2}")
-    @MethodSource("invalidApplicationData")
-    fun `sendApplication with invalid data doesn't send application to Allu`(
-        applicationData: ApplicationData,
-        path: String,
-    ) {
-        val hankeEntity =
-            HankeEntity(hankeTunnus = HANKE_TUNNUS, id = 1, nimi = HankeFactory.defaultNimi)
-        val applicationEntity =
-            AlluDataFactory.createApplicationEntity(
-                id = 3,
-                alluid = null,
-                userId = USERNAME,
-                applicationData = applicationData,
-                hanke = hankeEntity,
-            )
-        every { applicationRepo.findOneById(3) } returns applicationEntity
-        every { geometriatDao.isInsideHankeAlueet(1, any()) } returns true
-
-        assertFailure { applicationService.sendApplication(3, USERNAME) }
-            .all {
-                hasClass(InvalidApplicationDataException::class)
-                hasMessage("Application contains invalid data. Errors at paths: $path")
+            verifySequence {
+                applicationRepository.findOneById(3)
+                geometriatDao.validateGeometriat(any())
+                geometriatDao.isInsideHankeAlueet(1, any())
+                cableReportService.getApplicationInformation(42)
+                applicationRepository.save(applicationEntity)
+                geometriatDao.calculateCombinedArea(
+                    listOf(applicationData.areas?.first()?.geometry!!)
+                )
+                geometriatDao.calculateArea(any())
+                cableReportService.update(42, any())
+                disclosureLogService.saveDisclosureLogsForAllu(updatedData, Status.SUCCESS)
+                cableReportService.addAttachment(42, any())
+                hankeKayttajaService.getKayttajaByUserId(1, USERNAME)
+                hankeKayttajaService.saveNewTokensFromApplication(
+                    applicationEntity,
+                    1,
+                    HANKE_TUNNUS,
+                    HankeFactory.defaultNimi,
+                    USERNAME,
+                    sender
+                )
+                loggingService.logUpdate(any(), any(), USERNAME)
             }
+        }
 
-        verifySequence {
-            applicationRepo.findOneById(3)
-            geometriatDao.isInsideHankeAlueet(1, any())
-            cableReportService wasNot Called
-            disclosureLogService wasNot Called
-            hankeKayttajaService wasNot Called
-            applicationLoggingService wasNot Called
+        @Test
+        fun `when user management disabled should not create tokens`() {
+            val hanke = hankeEntity(generated = true)
+            val applicationEntity = applicationEntity(alluId = 42, hanke = hanke)
+            val dataupdate = applicationData.copy(name = "New name")
+            every { applicationRepository.findOneById(3) } returns applicationEntity
+            every { geometriatDao.validateGeometriat(any()) } returns null
+            every { cableReportService.getApplicationInformation(42) } returns alluResponse()
+            every { applicationRepository.save(applicationEntity) } returns applicationEntity
+            every { geometriatDao.calculateCombinedArea(any()) } returns 100f
+            every { geometriatDao.calculateArea(any()) } returns 100f
+            justRun { cableReportService.update(42, any()) }
+            justRun { cableReportService.addAttachment(42, any()) }
+            every { featureFlags.isDisabled(Feature.USER_MANAGEMENT) } returns true
+
+            applicationService.updateApplicationData(
+                id = 3,
+                newApplicationData = dataupdate,
+                userId = USERNAME
+            )
+
+            verifySequence {
+                applicationRepository.findOneById(3)
+                geometriatDao.validateGeometriat(any())
+                cableReportService.getApplicationInformation(42)
+                applicationRepository.save(any())
+                geometriatDao.calculateCombinedArea(any())
+                geometriatDao.calculateArea(any())
+                cableReportService.update(42, any())
+                disclosureLogService.saveDisclosureLogsForAllu(any(), any())
+                cableReportService.addAttachment(42, any())
+                loggingService.logUpdate(any(), any(), USERNAME)
+            }
+            verifyAll {
+                hankeKayttajaService wasNot Called
+                emailSenderService wasNot Called
+            }
+        }
+
+        @Test
+        fun `when invalid geometry updateApplicationData should throw`() {
+            val applicationEntity = applicationEntity(alluId = 42, hanke = hankeEntity())
+            every { applicationRepository.findOneById(3) } returns applicationEntity
+            every { geometriatDao.validateGeometriat(any()) } returns
+                GeometriatDao.InvalidDetail(
+                    "Self-intersection",
+                    """{"type":"Point","coordinates":[25494009.65639264,6679886.142116806]}"""
+                )
+            val updatedData =
+                applicationData.copy(rockExcavation = !applicationData.rockExcavation!!)
+
+            val exception =
+                assertThrows<ApplicationGeometryException> {
+                    applicationService.updateApplicationData(3, updatedData, USERNAME)
+                }
+
+            assertThat(exception)
+                .hasMessage(
+                    """Invalid geometry received when updating application for user $USERNAME, id=3, alluid=42, reason = Self-intersection, location = {"type":"Point","coordinates":[25494009.65639264,6679886.142116806]}"""
+                )
+            verifySequence {
+                applicationRepository.findOneById(3)
+                geometriatDao.validateGeometriat(any())
+            }
         }
     }
 
-    private fun invalidApplicationData(): Stream<Arguments> {
-        return Stream.of(
-            Arguments.of(
-                applicationData.copy(
-                    customerWithContacts =
-                        applicationData.customerWithContacts.copy(
-                            customer =
-                                applicationData.customerWithContacts.customer.copy(type = null)
-                        )
-                ),
-                "applicationData.customerWithContacts.customer.type",
-            ),
-            Arguments.of(
-                applicationData.copy(endTime = null),
-                "applicationData.endTime",
-            ),
-            Arguments.of(
-                applicationData.copy(startTime = null),
-                "applicationData.startTime",
-            ),
-            Arguments.of(
-                applicationData.copy(rockExcavation = null),
-                "applicationData.rockExcavation",
-            ),
-        )
+    @Nested
+    inner class SendApplication {
+        @Test
+        fun `when successful should save disclosure logs`() {
+            val hankeEntity = hankeEntity()
+            val applicationEntity = applicationEntity(hanke = hankeEntity)
+            val sender = HankeKayttajaFactory.createEntity()
+            every { applicationRepository.findOneById(3) } returns applicationEntity
+            every { applicationRepository.save(any()) } answers { firstArg() }
+            every { cableReportService.create(any()) } returns 42
+            justRun { cableReportService.addAttachment(42, any()) }
+            every { cableReportService.getApplicationInformation(42) } returns alluResponse()
+            every { geometriatDao.calculateCombinedArea(any()) } returns 100f
+            every { geometriatDao.calculateArea(any()) } returns 100f
+            every { geometriatDao.isInsideHankeAlueet(1, any()) } returns true
+            justRun { attachmentService.sendInitialAttachments(42, any()) }
+            every { hankeKayttajaService.getKayttajaByUserId(1, USERNAME) } returns sender
+            justRun { emailSenderService.sendApplicationNotificationEmail(any()) }
+
+            applicationService.sendApplication(3, USERNAME)
+
+            val expectedApplication = applicationData.copy(pendingOnClient = false)
+            verifySequence {
+                applicationRepository.findOneById(3)
+                geometriatDao.isInsideHankeAlueet(1, any())
+                geometriatDao.calculateCombinedArea(any())
+                geometriatDao.calculateArea(any())
+                cableReportService.create(any())
+                disclosureLogService.saveDisclosureLogsForAllu(expectedApplication, Status.SUCCESS)
+                cableReportService.addAttachment(42, any())
+                attachmentService.sendInitialAttachments(42, any())
+                cableReportService.getApplicationInformation(42)
+                hankeKayttajaService.getKayttajaByUserId(1, USERNAME)
+                hankeKayttajaService.saveNewTokensFromApplication(
+                    applicationEntity,
+                    hankeEntity.id!!,
+                    hankeEntity.hankeTunnus!!,
+                    hankeEntity.nimi!!,
+                    USERNAME,
+                    sender
+                )
+                emailSenderService.sendApplicationNotificationEmail(any())
+                emailSenderService.sendApplicationNotificationEmail(any())
+                applicationRepository.save(any())
+            }
+        }
+
+        @Test
+        fun `when sending fails should save disclosure logs for attempt`() {
+            val hankeEntity = hankeEntity()
+            val applicationEntity = applicationEntity(hanke = hankeEntity)
+            every { applicationRepository.findOneById(3) } returns applicationEntity
+            every { geometriatDao.calculateCombinedArea(any()) } returns 100f
+            every { geometriatDao.calculateArea(any()) } returns 100f
+            every { cableReportService.create(any()) } throws AlluException(listOf())
+            every { geometriatDao.isInsideHankeAlueet(1, any()) } returns true
+
+            assertThrows<AlluException> { applicationService.sendApplication(3, USERNAME) }
+
+            val expectedApplication = applicationData.copy(pendingOnClient = false)
+            verifySequence {
+                applicationRepository.findOneById(3)
+                geometriatDao.isInsideHankeAlueet(1, any())
+                geometriatDao.calculateCombinedArea(any())
+                geometriatDao.calculateArea(any())
+                cableReportService.create(any())
+                disclosureLogService.saveDisclosureLogsForAllu(
+                    expectedApplication,
+                    Status.FAILED,
+                    ALLU_APPLICATION_ERROR_MSG
+                )
+            }
+            verify { hankeKayttajaService wasNot Called }
+        }
+
+        @Test
+        fun `when login error should not save disclosure logs`() {
+            val hankeEntity = hankeEntity()
+            val applicationEntity = applicationEntity(hanke = hankeEntity)
+            assertThat(applicationEntity.applicationData.areas).isNotNull().isNotEmpty()
+            every { applicationRepository.findOneById(3) } returns applicationEntity
+            every { geometriatDao.calculateCombinedArea(any()) } returns 500f
+            every { geometriatDao.calculateArea(any()) } returns 500f
+            every { geometriatDao.isInsideHankeAlueet(any(), any()) } returns true
+            every { cableReportService.create(any()) } throws AlluLoginException(RuntimeException())
+
+            assertThrows<AlluLoginException> { applicationService.sendApplication(3, USERNAME) }
+
+            verifySequence {
+                applicationRepository.findOneById(3)
+                geometriatDao.isInsideHankeAlueet(any(), any())
+                geometriatDao.calculateCombinedArea(any())
+                geometriatDao.calculateArea(any())
+                cableReportService.create(any())
+            }
+            verify { disclosureLogService wasNot called }
+        }
+
+        @ParameterizedTest
+        @CsvSource("true,Louhitaan", "false,Ei louhita")
+        fun `when sending should add rock excavation information to work description`(
+            rockExcavation: Boolean,
+            expectedSuffix: String
+        ) {
+            val hankeEntity = hankeEntity()
+            val applicationEntity =
+                applicationEntity(
+                    data = applicationData.copy(rockExcavation = rockExcavation),
+                    hanke = hankeEntity
+                )
+            val sender = HankeKayttajaFactory.createEntity()
+            every { applicationRepository.findOneById(3) } returns applicationEntity
+            every { applicationRepository.save(any()) } answers { firstArg() }
+            every { geometriatDao.calculateCombinedArea(any()) } returns 100f
+            every { geometriatDao.calculateArea(any()) } returns 100f
+            every { geometriatDao.isInsideHankeAlueet(1, any()) } returns true
+            every { cableReportService.create(any()) } returns 852
+            justRun { cableReportService.addAttachment(852, any()) }
+            every { cableReportService.getApplicationInformation(852) } returns alluResponse(852)
+            justRun { attachmentService.sendInitialAttachments(852, any()) }
+            every { hankeKayttajaService.getKayttajaByUserId(1, USERNAME) } returns sender
+            justRun { emailSenderService.sendApplicationNotificationEmail(any()) }
+
+            applicationService.sendApplication(3, USERNAME)
+
+            val expectedApplicationData =
+                applicationData.copy(pendingOnClient = false, rockExcavation = rockExcavation)
+            val expectedAlluData =
+                expectedApplicationData
+                    .toAlluData(HANKE_TUNNUS)
+                    .copy(workDescription = applicationData.workDescription + "\n" + expectedSuffix)
+            verifySequence {
+                applicationRepository.findOneById(3)
+                geometriatDao.isInsideHankeAlueet(1, any())
+                geometriatDao.calculateCombinedArea(any())
+                geometriatDao.calculateArea(any())
+                cableReportService.create(expectedAlluData)
+                disclosureLogService.saveDisclosureLogsForAllu(
+                    expectedApplicationData,
+                    Status.SUCCESS
+                )
+                cableReportService.addAttachment(852, any())
+                cableReportService.getApplicationInformation(852)
+                hankeKayttajaService.getKayttajaByUserId(1, USERNAME)
+                hankeKayttajaService.saveNewTokensFromApplication(
+                    any(),
+                    hankeEntity.id!!,
+                    hankeEntity.hankeTunnus!!,
+                    hankeEntity.nimi!!,
+                    USERNAME,
+                    sender
+                )
+                emailSenderService.sendApplicationNotificationEmail(any())
+                emailSenderService.sendApplicationNotificationEmail(any())
+                applicationRepository.save(any())
+            }
+        }
+
+        @ParameterizedTest(name = "{1} {2}")
+        @MethodSource("fi.hel.haitaton.hanke.application.ApplicationServiceTest#invalidData")
+        fun `when invalid data should not send application`(
+            applicationData: ApplicationData,
+            path: String,
+        ) {
+            val hankeEntity = hankeEntity()
+            val applicationEntity = applicationEntity(data = applicationData, hanke = hankeEntity)
+            every { applicationRepository.findOneById(3) } returns applicationEntity
+            every { geometriatDao.isInsideHankeAlueet(1, any()) } returns true
+
+            assertFailure { applicationService.sendApplication(3, USERNAME) }
+                .all {
+                    hasClass(InvalidApplicationDataException::class)
+                    hasMessage("Application contains invalid data. Errors at paths: $path")
+                }
+
+            verifySequence {
+                applicationRepository.findOneById(3)
+                geometriatDao.isInsideHankeAlueet(1, any())
+            }
+            verifyAll {
+                cableReportService wasNot Called
+                disclosureLogService wasNot Called
+                hankeKayttajaService wasNot Called
+                loggingService wasNot Called
+            }
+        }
+
+        @Test
+        fun `when user management disabled should not create tokens`() {
+            val hankeEntity = hankeEntity(generated = true)
+            val applicationEntity = applicationEntity(hanke = hankeEntity)
+            every { applicationRepository.findOneById(3) } returns applicationEntity
+            every { applicationRepository.save(applicationEntity) } returns applicationEntity
+            every { geometriatDao.calculateCombinedArea(any()) } returns 100f
+            every { geometriatDao.calculateArea(any()) } returns 100f
+            every { cableReportService.getApplicationInformation(42) } returns alluResponse()
+            every { cableReportService.create(any()) } returns 42
+            justRun { cableReportService.addAttachment(42, any()) }
+            every { featureFlags.isDisabled(Feature.USER_MANAGEMENT) } returns true
+            justRun { attachmentService.sendInitialAttachments(42, any()) }
+
+            applicationService.sendApplication(id = 3, userId = USERNAME)
+
+            verifySequence {
+                applicationRepository.findOneById(3)
+                geometriatDao.calculateCombinedArea(any())
+                geometriatDao.calculateArea(any())
+                cableReportService.create(any())
+                disclosureLogService.saveDisclosureLogsForAllu(any(), any())
+                cableReportService.addAttachment(42, any())
+                cableReportService.getApplicationInformation(42)
+                applicationRepository.save(any())
+            }
+            verifyAll {
+                hankeKayttajaService wasNot Called
+                emailSenderService wasNot Called
+            }
+        }
     }
 
     @Nested
@@ -510,7 +543,8 @@ class ApplicationServiceTest {
 
         @Test
         fun `sends email to the orderer when application gets a decision`() {
-            every { applicationRepo.getOneByAlluid(42) } returns applicationEntity()
+            every { applicationRepository.getOneByAlluid(42) } returns
+                applicationEntityWithCustomer()
             justRun {
                 emailSenderService.sendJohtoselvitysCompleteEmail(
                     receiver,
@@ -518,31 +552,32 @@ class ApplicationServiceTest {
                     identifier
                 )
             }
-            every { applicationRepo.save(any()) } answers { firstArg() }
-            every { statusRepo.getReferenceById(1) } returns AlluStatus(1, updateTime)
-            every { statusRepo.save(any()) } answers { firstArg() }
+            every { applicationRepository.save(any()) } answers { firstArg() }
+            every { statusRepository.getReferenceById(1) } returns AlluStatus(1, updateTime)
+            every { statusRepository.save(any()) } answers { firstArg() }
 
             applicationService.handleApplicationUpdates(historiesWithDecision(), updateTime)
 
             verifySequence {
-                applicationRepo.getOneByAlluid(42)
+                applicationRepository.getOneByAlluid(42)
                 emailSenderService.sendJohtoselvitysCompleteEmail(
                     receiver,
                     applicationId,
                     identifier
                 )
-                applicationRepo.save(any())
-                statusRepo.getReferenceById(1)
-                statusRepo.save(any())
+                applicationRepository.save(any())
+                statusRepository.getReferenceById(1)
+                statusRepository.save(any())
             }
         }
 
         @Test
         fun `doesn't send email when status is not decision`() {
-            every { applicationRepo.getOneByAlluid(42) } returns applicationEntity()
-            every { applicationRepo.save(any()) } answers { firstArg() }
-            every { statusRepo.getReferenceById(1) } returns AlluStatus(1, updateTime)
-            every { statusRepo.save(any()) } answers { firstArg() }
+            every { applicationRepository.getOneByAlluid(42) } returns
+                applicationEntityWithCustomer()
+            every { applicationRepository.save(any()) } answers { firstArg() }
+            every { statusRepository.getReferenceById(1) } returns AlluStatus(1, updateTime)
+            every { statusRepository.save(any()) } answers { firstArg() }
             val histories =
                 listOf(
                     ApplicationHistoryFactory.create(
@@ -557,88 +592,88 @@ class ApplicationServiceTest {
             applicationService.handleApplicationUpdates(histories, updateTime)
 
             verifySequence {
-                applicationRepo.getOneByAlluid(42)
-                applicationRepo.save(any())
-                statusRepo.getReferenceById(1)
-                statusRepo.save(any())
+                applicationRepository.getOneByAlluid(42)
+                applicationRepository.save(any())
+                statusRepository.getReferenceById(1)
+                statusRepository.save(any())
             }
             verify { emailSenderService wasNot Called }
         }
 
         @Test
         fun `logs error when there are no receivers`(output: CapturedOutput) {
-            every { applicationRepo.getOneByAlluid(42) } returns
-                applicationEntity()
+            every { applicationRepository.getOneByAlluid(42) } returns
+                applicationEntityWithCustomer()
                     .withCustomer(
                         AlluDataFactory.createCompanyCustomer()
                             .withContacts(AlluDataFactory.createContact(orderer = false))
                     )
-            every { applicationRepo.save(any()) } answers { firstArg() }
-            every { statusRepo.getReferenceById(1) } returns AlluStatus(1, updateTime)
-            every { statusRepo.save(any()) } answers { firstArg() }
+            every { applicationRepository.save(any()) } answers { firstArg() }
+            every { statusRepository.getReferenceById(1) } returns AlluStatus(1, updateTime)
+            every { statusRepository.save(any()) } answers { firstArg() }
 
             applicationService.handleApplicationUpdates(historiesWithDecision(), updateTime)
 
             assertThat(output)
                 .contains("No receivers found for decision ready email, not sending any.")
             verifySequence {
-                applicationRepo.getOneByAlluid(42)
-                applicationRepo.save(any())
-                statusRepo.getReferenceById(1)
-                statusRepo.save(any())
+                applicationRepository.getOneByAlluid(42)
+                applicationRepository.save(any())
+                statusRepository.getReferenceById(1)
+                statusRepository.save(any())
             }
             verify { emailSenderService wasNot Called }
         }
 
         @Test
         fun `logs error if hanketunnus is null`(output: CapturedOutput) {
-            every { applicationRepo.getOneByAlluid(42) } returns
-                applicationEntity().withHanke(HankeEntity(id = 1, hankeTunnus = null))
-            every { applicationRepo.save(any()) } answers { firstArg() }
-            every { statusRepo.getReferenceById(1) } returns AlluStatus(1, updateTime)
-            every { statusRepo.save(any()) } answers { firstArg() }
+            every { applicationRepository.getOneByAlluid(42) } returns
+                applicationEntityWithCustomer().withHanke(HankeEntity(id = 1, hankeTunnus = null))
+            every { applicationRepository.save(any()) } answers { firstArg() }
+            every { statusRepository.getReferenceById(1) } returns AlluStatus(1, updateTime)
+            every { statusRepository.save(any()) } answers { firstArg() }
 
             applicationService.handleApplicationUpdates(historiesWithDecision(), updateTime)
 
             assertThat(output)
                 .contains("Can't send decision ready emails, because hankeTunnus is null.")
             verifySequence {
-                applicationRepo.getOneByAlluid(42)
-                applicationRepo.save(any())
-                statusRepo.getReferenceById(1)
-                statusRepo.save(any())
+                applicationRepository.getOneByAlluid(42)
+                applicationRepository.save(any())
+                statusRepository.getReferenceById(1)
+                statusRepository.save(any())
             }
             verify { emailSenderService wasNot Called }
         }
 
         @Test
         fun `logs error if receiver email is null`(output: CapturedOutput) {
-            every { applicationRepo.getOneByAlluid(42) } returns
-                applicationEntity()
+            every { applicationRepository.getOneByAlluid(42) } returns
+                applicationEntityWithCustomer()
                     .withCustomer(
                         AlluDataFactory.createCompanyCustomer()
                             .withContacts(
                                 AlluDataFactory.createContact(orderer = true, email = null)
                             )
                     )
-            every { applicationRepo.save(any()) } answers { firstArg() }
-            every { statusRepo.getReferenceById(1) } returns AlluStatus(1, updateTime)
-            every { statusRepo.save(any()) } answers { firstArg() }
+            every { applicationRepository.save(any()) } answers { firstArg() }
+            every { statusRepository.getReferenceById(1) } returns AlluStatus(1, updateTime)
+            every { statusRepository.save(any()) } answers { firstArg() }
 
             applicationService.handleApplicationUpdates(historiesWithDecision(), updateTime)
 
             assertThat(output)
                 .contains("Can't send decision ready email, because contact email is null.")
             verifySequence {
-                applicationRepo.getOneByAlluid(42)
-                applicationRepo.save(any())
-                statusRepo.getReferenceById(1)
-                statusRepo.save(any())
+                applicationRepository.getOneByAlluid(42)
+                applicationRepository.save(any())
+                statusRepository.getReferenceById(1)
+                statusRepository.save(any())
             }
             verify { emailSenderService wasNot Called }
         }
 
-        private fun applicationEntity() =
+        private fun applicationEntityWithCustomer() =
             AlluDataFactory.createApplicationEntity(
                     id = applicationId,
                     alluid = alluid,
@@ -659,4 +694,39 @@ class ApplicationServiceTest {
                 ),
             )
     }
+
+    private fun application(id: Long? = null) =
+        AlluDataFactory.createApplication(
+            id = id,
+            applicationData = applicationData,
+            hankeTunnus = HANKE_TUNNUS,
+        )
+
+    private fun applicationEntity(
+        id: Long? = 3,
+        alluId: Int? = null,
+        data: ApplicationData = applicationData,
+        hanke: HankeEntity
+    ) =
+        AlluDataFactory.createApplicationEntity(
+            id = id,
+            alluid = alluId,
+            userId = USERNAME,
+            applicationData = data,
+            hanke = hanke,
+        )
+
+    private fun hankeEntity(
+        id: Int? = 1,
+        nimi: String? = HankeFactory.defaultNimi,
+        generated: Boolean = false
+    ) =
+        HankeEntity(
+            id = id,
+            hankeTunnus = HANKE_TUNNUS,
+            nimi = nimi,
+            generated = generated,
+        )
+
+    private fun alluResponse(id: Int = 42) = AlluDataFactory.createAlluApplicationResponse(id = id)
 }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/domain/UserContactTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/domain/UserContactTest.kt
@@ -1,13 +1,24 @@
 package fi.hel.haitaton.hanke.domain
 
+import assertk.all
 import assertk.assertThat
 import assertk.assertions.containsExactlyInAnyOrder
+import assertk.assertions.extracting
+import assertk.assertions.hasSize
+import assertk.assertions.isEmpty
 import assertk.assertions.isEqualTo
+import assertk.assertions.isNotEqualTo
 import assertk.assertions.isNull
+import assertk.assertions.prop
 import fi.hel.haitaton.hanke.application.ApplicationContactType.HAKIJA
+import fi.hel.haitaton.hanke.application.ApplicationContactType.RAKENNUTTAJA
+import fi.hel.haitaton.hanke.application.ApplicationContactType.TYON_SUORITTAJA
+import fi.hel.haitaton.hanke.application.Contact
+import fi.hel.haitaton.hanke.application.CustomerWithContacts
+import fi.hel.haitaton.hanke.factory.AlluDataFactory
 import fi.hel.haitaton.hanke.factory.AlluDataFactory.Companion.asianHoitajaCustomerContact
 import fi.hel.haitaton.hanke.factory.AlluDataFactory.Companion.asianhoitajaApplicationContact
-import fi.hel.haitaton.hanke.factory.AlluDataFactory.Companion.createCableReportApplicationData
+import fi.hel.haitaton.hanke.factory.AlluDataFactory.Companion.createContact
 import fi.hel.haitaton.hanke.factory.AlluDataFactory.Companion.hakijaApplicationContact
 import fi.hel.haitaton.hanke.factory.AlluDataFactory.Companion.hakijaCustomerContact
 import fi.hel.haitaton.hanke.factory.AlluDataFactory.Companion.rakennuttajaApplicationContact
@@ -15,7 +26,8 @@ import fi.hel.haitaton.hanke.factory.AlluDataFactory.Companion.rakennuttajaCusto
 import fi.hel.haitaton.hanke.factory.AlluDataFactory.Companion.suorittajaApplicationContact
 import fi.hel.haitaton.hanke.factory.AlluDataFactory.Companion.suorittajaCustomerContact
 import fi.hel.haitaton.hanke.factory.AlluDataFactory.Companion.teppoEmail
-import fi.hel.haitaton.hanke.factory.HankeKayttajaFactory
+import fi.hel.haitaton.hanke.factory.AlluDataFactory.Companion.withContact
+import fi.hel.haitaton.hanke.factory.AlluDataFactory.Companion.withContacts
 import fi.hel.haitaton.hanke.factory.TEPPO_TESTI
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -60,13 +72,7 @@ class UserContactTest {
 
         @Test
         fun `typedContacts when all types are present should return all as typed`() {
-            val applicationData =
-                createCableReportApplicationData(
-                    customerWithContacts = hakijaCustomerContact,
-                    contractorWithContacts = suorittajaCustomerContact,
-                    representativeWithContacts = asianHoitajaCustomerContact,
-                    propertyDeveloperWithContacts = rakennuttajaCustomerContact
-                )
+            val applicationData = cableReport()
 
             val result = applicationData.typedContacts()
 
@@ -82,9 +88,11 @@ class UserContactTest {
         @Test
         fun `typedContacts when not all types present should return existing as typed`() {
             val applicationData =
-                createCableReportApplicationData(
-                    customerWithContacts = hakijaCustomerContact,
-                    contractorWithContacts = suorittajaCustomerContact
+                cableReport(
+                    customer = hakijaCustomerContact,
+                    contractor = suorittajaCustomerContact,
+                    representative = null,
+                    developer = null
                 )
 
             val result = applicationData.typedContacts()
@@ -96,27 +104,21 @@ class UserContactTest {
         @Test
         fun `typedContacts when omitted present filters out given contact`() {
             val applicationData =
-                createCableReportApplicationData(
-                    customerWithContacts = hakijaCustomerContact,
-                    contractorWithContacts = suorittajaCustomerContact
+                cableReport(
+                    customer = hakijaCustomerContact,
+                    contractor = suorittajaCustomerContact,
+                    representative = null,
+                    developer = null
                 )
-            val kayttaja =
-                HankeKayttajaFactory.createEntity(sahkoposti = suorittajaApplicationContact.email)
 
-            val result = applicationData.typedContacts(omit = kayttaja.sahkoposti)
+            val result = applicationData.typedContacts(omit = suorittajaApplicationContact.email)
 
             assertThat(result).containsExactlyInAnyOrder(hakijaApplicationContact)
         }
 
         @Test
         fun `typedContacts when omitted is null does no filtering`() {
-            val applicationData =
-                createCableReportApplicationData(
-                    customerWithContacts = hakijaCustomerContact,
-                    contractorWithContacts = suorittajaCustomerContact,
-                    representativeWithContacts = asianHoitajaCustomerContact,
-                    propertyDeveloperWithContacts = rakennuttajaCustomerContact
-                )
+            val applicationData = cableReport()
 
             val result = applicationData.typedContacts(omit = null)
 
@@ -128,5 +130,103 @@ class UserContactTest {
                     rakennuttajaApplicationContact
                 )
         }
+
+        @Test
+        fun `subtractByEmail when same data should return empty set`() {
+            val oldContacts = cableReport().typedContacts()
+            val updatedContacts = cableReport().typedContacts()
+
+            val result = updatedContacts.subtractByEmail(oldContacts)
+
+            assertThat(result).isEmpty()
+        }
+
+        @Test
+        fun `subtractByEmail when customer changes and has new contact should return the new contact`() {
+            val oldContacts = cableReport().typedContacts()
+            val updatedContacts = cableReport(contractor = person()).typedContacts()
+
+            val result = updatedContacts.subtractByEmail(oldContacts)
+
+            assertThat(result).hasSize(1)
+            assertThat(result.first()).all {
+                prop(ApplicationUserContact::name).isEqualTo(TEPPO_TESTI)
+                prop(ApplicationUserContact::email).isEqualTo(teppoEmail)
+                prop(ApplicationUserContact::type).isEqualTo(TYON_SUORITTAJA)
+            }
+        }
+
+        @Test
+        fun `subtractByEmail when customer changes but contact email is same should return empty set`() {
+            val oldApplication = cableReport(representative = company())
+            val updatedApplication = cableReport(representative = person())
+
+            val result =
+                updatedApplication.typedContacts().subtractByEmail(oldApplication.typedContacts())
+
+            assertThat(updatedApplication.customersWithContacts())
+                .isNotEqualTo(oldApplication.customersWithContacts())
+            assertThat(result).isEmpty()
+        }
+
+        @Test
+        fun `subtractByEmail when customer has added new contact should return the new contact`() {
+            val oldApplication = cableReport()
+            val updatedApplication =
+                cableReport(developer = oldApplication.propertyDeveloperWithContacts.plusContact())
+
+            val result =
+                updatedApplication.typedContacts().subtractByEmail(oldApplication.typedContacts())
+
+            assertThat(result).hasSize(1)
+            assertThat(result.first()).all {
+                prop(ApplicationUserContact::name).isEqualTo(TEPPO_TESTI)
+                prop(ApplicationUserContact::email).isEqualTo(teppoEmail)
+                prop(ApplicationUserContact::type).isEqualTo(RAKENNUTTAJA)
+            }
+        }
+
+        @Test
+        fun `subtractByEmail when customer several new contacts should return them`() {
+            val oldApplication = cableReport(representative = null)
+            val updatedApplication =
+                cableReport(
+                    representative =
+                        AlluDataFactory.createCompanyCustomer()
+                            .withContacts(
+                                createContact(email = "first"),
+                                createContact(email = "second"),
+                                createContact(email = "third")
+                            )
+                )
+
+            val result =
+                updatedApplication.typedContacts().subtractByEmail(oldApplication.typedContacts())
+
+            assertThat(result).hasSize(3)
+            assertThat(result)
+                .extracting { it.email }
+                .containsExactlyInAnyOrder("first", "second", "third")
+        }
     }
+
+    private fun person() = AlluDataFactory.createPersonCustomer().withContact()
+
+    private fun company() = AlluDataFactory.createCompanyCustomer().withContact()
+
+    private fun cableReport(
+        customer: CustomerWithContacts = hakijaCustomerContact,
+        contractor: CustomerWithContacts = suorittajaCustomerContact,
+        representative: CustomerWithContacts? = asianHoitajaCustomerContact,
+        developer: CustomerWithContacts? = rakennuttajaCustomerContact
+    ) =
+        AlluDataFactory.createCableReportApplicationData(
+            customerWithContacts = customer,
+            contractorWithContacts = contractor,
+            representativeWithContacts = representative,
+            propertyDeveloperWithContacts = developer
+        )
+
+    private fun CustomerWithContacts?.plusContact(contact: Contact = createContact()) =
+        this?.copy(contacts = contacts.plus(contact))
 }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/AlluDataFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/AlluDataFactory.kt
@@ -42,6 +42,7 @@ class AlluDataFactory(
                 "timo.työnsuorittaja@mail.com",
                 "anssi.asianhoitaja@mail.com",
                 "rane.rakennuttaja@mail.com",
+                "new.mail@foo.fi",
             )
 
         fun createPostalAddress(


### PR DESCRIPTION
# Description

When application is updated after initial send, create tokens for new contacts and send notification emails. A contact with an email address that was not present in the previous application is considered a new contact.

Additional: 
- Change application update operation so that application is saved, and the saved data is then sent to Allu (this feels a bit more logical order of operations at least for me).
- Add feature flags to prevent token creations and related emails on applications in production.
- Fix typo in hanke attachment service.
- Refactor ApplicationServiceTest class to use nested classes / have some structure.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1896

## Type of change

- [ ] Bug fix 
- [x] New feature 
- [ ] Other

# Instructions for testing
1. Send johtoselvitys to Allu.
2. Modify contacts after send. New email addresses have access to hanke and receive emails about hanke and application.

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 

# Other relevant info
Please describe here if there is e.g. some requirements for this change or
 other info that the tester/user needs to know.