### PR TITLE
HAI-1970 Add decision downloads to audit logs

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
@@ -1618,11 +1618,11 @@ class HankeServiceITests : DatabaseTest() {
 
     private fun expectedYhteyshenkilot(i: Int) =
         """[{
-            | "etunimi": "yhteys-etu$i",
-            | "sukunimi": "yhteys-suku$i",
-            | "email": "yhteys-email$i",
-            | "puhelinnumero": "010$i$i$i$i$i$i$i"
-            | }]""".trimMargin()
+             "etunimi": "yhteys-etu$i",
+             "sukunimi": "yhteys-suku$i",
+             "email": "yhteys-email$i",
+             "puhelinnumero": "010$i$i$i$i$i$i$i"
+            }]"""
 
     /**
      * Fills a new Hanke domain object with test values and returns it. The audit and id/tunnus

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/gdpr/GdprControllerITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/gdpr/GdprControllerITests.kt
@@ -125,7 +125,7 @@ class GdprControllerITests(@Autowired var mockMvc: MockMvc) {
                     }
                   }
                 ]
-              }""".trimIndent()
+              }"""
 
             get()
                 .andExpect(MockMvcResultMatchers.status().`is`(500))
@@ -186,7 +186,7 @@ class GdprControllerITests(@Autowired var mockMvc: MockMvc) {
                   }
                 ]
               }
-            """.trimIndent()
+            """
 
             get()
                 .andExpect(MockMvcResultMatchers.status().isOk)
@@ -320,7 +320,7 @@ class GdprControllerITests(@Autowired var mockMvc: MockMvc) {
                     }
                   ]
                 }
-            """.trimIndent()
+            """
 
             delete(dryRun)
                 .andExpect(MockMvcResultMatchers.status().isForbidden)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/Application.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/Application.kt
@@ -8,7 +8,7 @@ enum class ApplicationType {
 }
 
 /** Interface to enable Application and CableReportWithoutHanke handling equivalently. */
-interface BaseApplication {
+sealed interface BaseApplication {
     val applicationType: ApplicationType
     val applicationData: ApplicationData
 }
@@ -21,7 +21,17 @@ data class Application(
     override val applicationType: ApplicationType,
     override val applicationData: ApplicationData,
     val hankeTunnus: String,
-) : HasId<Long>, BaseApplication
+) : HasId<Long>, BaseApplication {
+    fun toMetadata() =
+        ApplicationMetaData(
+            id!!,
+            alluid,
+            alluStatus,
+            applicationIdentifier,
+            applicationType,
+            hankeTunnus
+        )
+}
 
 /** Creation of an application without hanke is enabled for cable reports. */
 data class CableReportWithoutHanke(
@@ -39,3 +49,13 @@ data class CableReportWithoutHanke(
             hankeTunnus = hankeTunnus,
         )
 }
+
+/** Without application data, just the identifiers and metadata. */
+data class ApplicationMetaData(
+    override val id: Long,
+    val alluid: Int?,
+    val alluStatus: ApplicationStatus?,
+    val applicationIdentifier: String?,
+    val applicationType: ApplicationType,
+    val hankeTunnus: String,
+) : HasId<Long>

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationController.kt
@@ -275,7 +275,11 @@ class ApplicationController(
     )
     @PreAuthorize("@applicationAuthorizer.authorizeApplicationId(#id, 'VIEW')")
     fun downloadDecision(@PathVariable(name = "id") id: Long): ResponseEntity<ByteArray> {
-        val (filename, pdfBytes) = applicationService.downloadDecision(id, currentUserId())
+        val userId = currentUserId()
+        val (filename, pdfBytes) = applicationService.downloadDecision(id, userId)
+        val application = applicationService.getApplicationById(id)
+        disclosureLogService.saveDisclosureLogsForDecision(application.toMetadata(), userId)
+
         val headers = HttpHeaders()
         headers.add("Content-Disposition", "inline; filename=$filename.pdf")
         return ResponseEntity.ok().headers(headers).contentType(APPLICATION_PDF).body(pdfBytes)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/AuditLogEntry.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/AuditLogEntry.kt
@@ -46,6 +46,7 @@ enum class ObjectType {
     APPLICATION,
     ALLU_CONTACT,
     ALLU_CUSTOMER,
+    DECISION,
     GDPR_RESPONSE,
     HANKE,
     HANKE_KAYTTAJA,
@@ -71,7 +72,6 @@ data class AuditLogEntry(
     val objectBefore: String? = null,
     val objectAfter: String? = null,
 ) {
-    // TODO: There will be a centralized place for object mappers. This should be moved there.
     fun toEntity(dateTime: OffsetDateTime, ipAddress: String?): AuditLogEntryEntity =
         AuditLogEntryEntity(
             message =

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/DisclosureLogService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/DisclosureLogService.kt
@@ -49,7 +49,7 @@ class DisclosureLogService(private val auditLogService: AuditLogService) {
     }
 
     /**
-     * Save disclosure logs for when a user downloads a decision.We don't know what information is
+     * Save disclosure logs for when a user downloads a decision. We don't know what information is
      * inside the PDF, but we can log the meta information about the decision (or application).
      *
      * Decisions contain private information, so their reads need to be logged.

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/DisclosureLogService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/DisclosureLogService.kt
@@ -3,6 +3,7 @@ package fi.hel.haitaton.hanke.logging
 import fi.hel.haitaton.hanke.allu.CustomerType
 import fi.hel.haitaton.hanke.application.Application
 import fi.hel.haitaton.hanke.application.ApplicationData
+import fi.hel.haitaton.hanke.application.ApplicationMetaData
 import fi.hel.haitaton.hanke.application.CableReportApplicationData
 import fi.hel.haitaton.hanke.application.Contact
 import fi.hel.haitaton.hanke.application.Customer
@@ -29,7 +30,7 @@ class DisclosureLogService(private val auditLogService: AuditLogService) {
      */
     fun saveDisclosureLogsForProfiili(userId: String, gdprInfo: CollectionNode) {
         val entry = disclosureLogEntry(ObjectType.GDPR_RESPONSE, userId, gdprInfo)
-        saveDisclosureLogs(PROFIILI_AUDIT_LOG_USERID, UserRole.SERVICE, listOf(entry))
+        saveDisclosureLog(PROFIILI_AUDIT_LOG_USERID, UserRole.SERVICE, entry)
     }
 
     /**
@@ -45,6 +46,17 @@ class DisclosureLogService(private val auditLogService: AuditLogService) {
             auditLogEntriesForCustomers(listOf(application), status, failureDescription) +
                 auditLogEntriesForContacts(listOf(application), status, failureDescription)
         saveDisclosureLogs(ALLU_AUDIT_LOG_USERID, UserRole.SERVICE, entries)
+    }
+
+    /**
+     * Save disclosure logs for when a user downloads a decision.We don't know what information is
+     * inside the PDF, but we can log the meta information about the decision (or application).
+     *
+     * Decisions contain private information, so their reads need to be logged.
+     */
+    fun saveDisclosureLogsForDecision(metaData: ApplicationMetaData, userId: String) {
+        val entry = disclosureLogEntry(ObjectType.DECISION, metaData.id, metaData)
+        saveDisclosureLog(userId, UserRole.USER, entry)
     }
 
     /**
@@ -183,6 +195,9 @@ class DisclosureLogService(private val auditLogService: AuditLogService) {
             objectId = objectId?.toString(),
             objectBefore = objectBefore.toJsonString()
         )
+
+    private fun saveDisclosureLog(userId: String, userRole: UserRole, entry: AuditLogEntry) =
+        auditLogService.create(entry.copy(userId = userId, userRole = userRole))
 
     private fun saveDisclosureLogs(
         userId: String,

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/TestExtensions.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/TestExtensions.kt
@@ -28,6 +28,12 @@ fun String.getResourceAsBytes(): ByteArray = this.getResource().readBytes()
 inline fun <reified T> String.parseJson(): T = OBJECT_MAPPER.readValue(this)
 
 /**
+ * Deserialize the string to a JSON node and then serialize it back to a string, effectively
+ * normalizing its formatting.
+ */
+fun String.reformatJson(): String = OBJECT_MAPPER.readTree(this).toJsonString()
+
+/**
  * Find all audit logs for a specific object type. Getting all and filtering would obviously not be
  * acceptable in production, but in tests we usually have a very limited number of entities at any
  * one test.

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/logging/DisclosureLogServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/logging/DisclosureLogServiceTest.kt
@@ -1,5 +1,6 @@
 package fi.hel.haitaton.hanke.logging
 
+import fi.hel.haitaton.hanke.allu.ApplicationStatus
 import fi.hel.haitaton.hanke.allu.CustomerType
 import fi.hel.haitaton.hanke.application.Contact
 import fi.hel.haitaton.hanke.application.Customer
@@ -26,6 +27,7 @@ import io.mockk.verify
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
@@ -76,17 +78,15 @@ internal class DisclosureLogServiceTest {
             |}"""
                 .trimMargin()
                 .replace("\n", "")
-        val expectedEntries =
-            listOf(
-                AuditLogEntryFactory.createReadEntry(
-                    userId = PROFIILI_AUDIT_LOG_USERID,
-                    userRole = UserRole.SERVICE,
-                    objectType = ObjectType.GDPR_RESPONSE,
-                    objectId = userId,
-                    objectBefore = expectedObject
-                )
+        val expectedEntry =
+            AuditLogEntryFactory.createReadEntry(
+                userId = PROFIILI_AUDIT_LOG_USERID,
+                userRole = UserRole.SERVICE,
+                objectType = ObjectType.GDPR_RESPONSE,
+                objectId = userId,
+                objectBefore = expectedObject
             )
-        verify { auditLogService.createAll(match(containsAll(expectedEntries))) }
+        verify { auditLogService.create(expectedEntry) }
     }
 
     @Test
@@ -365,6 +365,43 @@ internal class DisclosureLogServiceTest {
         disclosureLogService.saveDisclosureLogsForApplications(listOf(), userId)
 
         verify { auditLogService wasNot Called }
+    }
+
+    @Nested
+    inner class SaveDisclosureLogsForDecision {
+        @Test
+        fun `saves log with application details but decision type`() {
+            val application =
+                AlluDataFactory.createApplication(
+                    alluid = 2,
+                    alluStatus = ApplicationStatus.DECISION,
+                    applicationIdentifier = "JS2300050-2"
+                )
+            val expectedObject =
+                """
+                {
+                  "id": ${application.id},
+                  "alluid": ${application.alluid},
+                  "alluStatus": "${application.alluStatus}",
+                  "applicationIdentifier": "${application.applicationIdentifier}",
+                  "applicationType": "${application.applicationType}",
+                  "hankeTunnus": "${application.hankeTunnus}"
+                }"""
+                    .trimIndent()
+                    .replace("\n", "")
+                    .replace(" ", "")
+            val expectedLog =
+                AuditLogEntryFactory.createReadEntry(
+                    userId,
+                    objectType = ObjectType.DECISION,
+                    objectId = application.id!!,
+                    objectBefore = expectedObject
+                )
+
+            disclosureLogService.saveDisclosureLogsForDecision(application.toMetadata(), userId)
+
+            verify { auditLogService.create(expectedLog) }
+        }
     }
 
     private fun containsAll(

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/logging/DisclosureLogServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/logging/DisclosureLogServiceTest.kt
@@ -371,21 +371,27 @@ internal class DisclosureLogServiceTest {
     inner class SaveDisclosureLogsForDecision {
         @Test
         fun `saves log with application details but decision type`() {
+            val applicationId = 42L
+            val alluId = 2
+            val alluStatus = ApplicationStatus.DECISION
+            val applicationIdentifier = "JS2300050-2"
             val application =
                 AlluDataFactory.createApplication(
-                    alluid = 2,
-                    alluStatus = ApplicationStatus.DECISION,
-                    applicationIdentifier = "JS2300050-2"
+                    id = applicationId,
+                    alluid = alluId,
+                    alluStatus = alluStatus,
+                    applicationIdentifier = applicationIdentifier,
+                    hankeTunnus = hankeTunnus
                 )
             val expectedObject =
                 """
                 {
-                  "id": ${application.id},
-                  "alluid": ${application.alluid},
-                  "alluStatus": "${application.alluStatus}",
-                  "applicationIdentifier": "${application.applicationIdentifier}",
-                  "applicationType": "${application.applicationType}",
-                  "hankeTunnus": "${application.hankeTunnus}"
+                  "id": $applicationId,
+                  "alluid": $alluId,
+                  "alluStatus": "$alluStatus",
+                  "applicationIdentifier": "$applicationIdentifier",
+                  "applicationType": "CABLE_REPORT",
+                  "hankeTunnus": "$hankeTunnus"
                 }"""
                     .trimIndent()
                     .replace("\n", "")

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/logging/DisclosureLogServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/logging/DisclosureLogServiceTest.kt
@@ -17,6 +17,7 @@ import fi.hel.haitaton.hanke.factory.HankeKayttajaFactory
 import fi.hel.haitaton.hanke.factory.HankeYhteystietoFactory
 import fi.hel.haitaton.hanke.gdpr.CollectionNode
 import fi.hel.haitaton.hanke.gdpr.StringNode
+import fi.hel.haitaton.hanke.reformatJson
 import fi.hel.haitaton.hanke.toJsonString
 import io.mockk.Called
 import io.mockk.checkUnnecessaryStub
@@ -68,16 +69,14 @@ internal class DisclosureLogServiceTest {
 
         val expectedObject =
             """
-            |{"key":"user","children":
-              |[
-                |{"key":"id","value":"4f15afe1-51dc-4015-bb66-3a536295abea"},
-                |{"key":"nimi","value":"Teppo Testihenkilö"},
-                |{"key":"sahkoposti","value":"teppo@example.test"},
-                |{"key":"puhelin","value":"04012345678"}
-              |]
-            |}"""
-                .trimMargin()
-                .replace("\n", "")
+            {"key":"user","children":
+              [
+                {"key":"id","value":"4f15afe1-51dc-4015-bb66-3a536295abea"},
+                {"key":"nimi","value":"Teppo Testihenkilö"},
+                {"key":"sahkoposti","value":"teppo@example.test"},
+                {"key":"puhelin","value":"04012345678"}
+              ]
+            }""".reformatJson()
         val expectedEntry =
             AuditLogEntryFactory.createReadEntry(
                 userId = PROFIILI_AUDIT_LOG_USERID,
@@ -384,18 +383,14 @@ internal class DisclosureLogServiceTest {
                     hankeTunnus = hankeTunnus
                 )
             val expectedObject =
-                """
-                {
+                """{
                   "id": $applicationId,
                   "alluid": $alluId,
                   "alluStatus": "$alluStatus",
                   "applicationIdentifier": "$applicationIdentifier",
                   "applicationType": "CABLE_REPORT",
                   "hankeTunnus": "$hankeTunnus"
-                }"""
-                    .trimIndent()
-                    .replace("\n", "")
-                    .replace(" ", "")
+                }""".reformatJson()
             val expectedLog =
                 AuditLogEntryFactory.createReadEntry(
                     userId,


### PR DESCRIPTION
# Description

Decisions contain personal information, so we need to log who we give what information to.

We can't read the personal information from inside the PDF decision, but we can log the metadata about the decision, which is the same as metadata about the application. This shows the exact version of the decision (in applicationIdentifier), which can then be (manually) matched against the content of the file if necessary.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1970

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
Download a decision. The audit log should appear in the audit_logs table.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 