### PR TITLE
HAI-1971 Add role information to application contact audit logs

### DIFF
--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationData.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationData.kt
@@ -84,6 +84,14 @@ data class CableReportApplicationData(
             representativeWithContacts
         )
 
+    fun customersByRole(): List<Pair<ApplicationContactType, CustomerWithContacts>> =
+        listOfNotNull(
+            ApplicationContactType.HAKIJA to customerWithContacts,
+            ApplicationContactType.TYON_SUORITTAJA to contractorWithContacts,
+            representativeWithContacts?.let { ApplicationContactType.ASIANHOITAJA to it },
+            propertyDeveloperWithContacts?.let { ApplicationContactType.RAKENNUTTAJA to it },
+        )
+
     fun findOrderer(): Contact? =
         customersWithContacts().flatMap { it.contacts }.find { it.orderer }
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/UserContact.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/UserContact.kt
@@ -45,8 +45,7 @@ fun ApplicationData.typedContacts(omit: String? = null): Set<ApplicationUserCont
     when (this) {
         is CableReportApplicationData ->
             customersByRole()
-                .map { (role, customer) -> customer.typedAs(role) }
-                .flatten()
+                .flatMap { (role, customer) -> customer.contactsTypedAs(role) }
                 .remove(omit)
                 .toSet()
     }
@@ -62,7 +61,7 @@ fun Set<ApplicationUserContact>.subtractByEmail(
 private fun List<ApplicationUserContact>.remove(email: String?) =
     if (email == null) this else filter { it.email != email }
 
-private fun CustomerWithContacts.typedAs(
+private fun CustomerWithContacts.contactsTypedAs(
     type: ApplicationContactType
 ): List<ApplicationUserContact> =
     contacts.mapNotNull { ApplicationUserContact.from(it.fullName(), it.email, type) }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/UserContact.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/UserContact.kt
@@ -1,10 +1,6 @@
 package fi.hel.haitaton.hanke.domain
 
 import fi.hel.haitaton.hanke.application.ApplicationContactType
-import fi.hel.haitaton.hanke.application.ApplicationContactType.ASIANHOITAJA
-import fi.hel.haitaton.hanke.application.ApplicationContactType.HAKIJA
-import fi.hel.haitaton.hanke.application.ApplicationContactType.RAKENNUTTAJA
-import fi.hel.haitaton.hanke.application.ApplicationContactType.TYON_SUORITTAJA
 import fi.hel.haitaton.hanke.application.ApplicationData
 import fi.hel.haitaton.hanke.application.CableReportApplicationData
 import fi.hel.haitaton.hanke.application.CustomerWithContacts
@@ -48,12 +44,8 @@ data class ApplicationUserContact(
 fun ApplicationData.typedContacts(omit: String? = null): Set<ApplicationUserContact> =
     when (this) {
         is CableReportApplicationData ->
-            listOfNotNull(
-                    customerWithContacts.typedAs(HAKIJA),
-                    contractorWithContacts.typedAs(TYON_SUORITTAJA),
-                    representativeWithContacts?.typedAs(ASIANHOITAJA),
-                    propertyDeveloperWithContacts?.typedAs(RAKENNUTTAJA)
-                )
+            customersByRole()
+                .map { (role, customer) -> customer.typedAs(role) }
                 .flatten()
                 .remove(omit)
                 .toSet()

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/AuditLogEntryFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/AuditLogEntryFactory.kt
@@ -1,9 +1,12 @@
 package fi.hel.haitaton.hanke.factory
 
+import fi.hel.haitaton.hanke.application.ApplicationContactType
 import fi.hel.haitaton.hanke.application.Contact
 import fi.hel.haitaton.hanke.application.Customer
 import fi.hel.haitaton.hanke.domain.Hanke
 import fi.hel.haitaton.hanke.logging.AuditLogEntry
+import fi.hel.haitaton.hanke.logging.ContactWithRole
+import fi.hel.haitaton.hanke.logging.CustomerWithRole
 import fi.hel.haitaton.hanke.logging.ObjectType
 import fi.hel.haitaton.hanke.logging.Operation
 import fi.hel.haitaton.hanke.logging.Status
@@ -37,18 +40,26 @@ object AuditLogEntryFactory {
             createReadEntry(objectId = it.id!!, objectBefore = it.toJsonString())
         }
 
-    fun createReadEntryForContact(applicationId: Long, contact: Contact): AuditLogEntry =
+    fun createReadEntryForContact(
+        applicationId: Long,
+        contact: Contact,
+        role: ApplicationContactType = ApplicationContactType.HAKIJA,
+    ): AuditLogEntry =
         createReadEntry(
             objectId = applicationId,
             objectType = ObjectType.APPLICATION_CONTACT,
-            objectBefore = contact.toJsonString()
+            objectBefore = ContactWithRole(role, contact).toJsonString()
         )
 
-    fun createReadEntryForCustomer(applicationId: Long, customer: Customer): AuditLogEntry =
+    fun createReadEntryForCustomer(
+        applicationId: Long,
+        customer: Customer,
+        role: ApplicationContactType = ApplicationContactType.HAKIJA,
+    ): AuditLogEntry =
         createReadEntry(
             objectId = applicationId,
             objectType = ObjectType.APPLICATION_CUSTOMER,
-            objectBefore = customer.toJsonString()
+            objectBefore = CustomerWithRole(role, customer).toJsonString()
         )
 
     fun createReadEntryForHankeKayttajat(kayttajat: List<HankeKayttajaDto>): List<AuditLogEntry> =


### PR DESCRIPTION
# Description

It's potentially useful to have the roles of the application contacts in the audit logs. This needs some extra work since the role is determined by the context, not the actual Customer / Contact objects.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1971

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [X] Other

# Instructions for testing
Open an application and check the audit_logs table.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 
