### PR TITLE
HAI-1893 Make nimi always mandatory in Hanke

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ effects of projects taking place within the urban area.
 Building the service with both unit and integration tests:
 
 ```
-$ ./gradlew :services:hanke-service:clean :services:hanke-service:build :services:hanke-service:integrationTest
+$ ./gradlew :services:hanke-service:clean :services:hanke-service:check
 ```
 
 Starting the application/services can be done afterwards with command line at haitaton-backend root directory:

--- a/githooks/pre-push.d/build
+++ b/githooks/pre-push.d/build
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-./gradlew build integrationTest
+./gradlew check

--- a/services/hanke-service/build.gradle.kts
+++ b/services/hanke-service/build.gradle.kts
@@ -136,6 +136,7 @@ tasks {
         testClassesDirs = sourceSets["integrationTest"].output.classesDirs
         classpath = sourceSets["integrationTest"].runtimeClasspath
         shouldRunAfter("test")
+        shouldRunAfter("spotlessCheck")
         outputs.upToDateWhen { false }
         testLogging {
             events("skipped", "failed")
@@ -162,3 +163,5 @@ tasks.register("installGitHook", Copy::class) {
 }
 
 tasks.named("build") { dependsOn(tasks.named("installGitHook")) }
+
+tasks.named("check") { dependsOn(tasks.named("integrationTest")) }

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
@@ -1533,7 +1533,7 @@ class HankeServiceITests : DatabaseTest() {
     }
 
     private fun initHankeWithHakemus(alluId: Int): HankeEntity {
-        val hanke = hankeRepository.save(HankeEntity(hankeTunnus = "HAI23-1"))
+        val hanke = hankeFactory.saveMinimal(hankeTunnus = "HAI23-1")
         val application =
             applicationRepository.save(
                 AlluDataFactory.createApplicationEntity(

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaServiceITest.kt
@@ -305,7 +305,7 @@ class HankeKayttajaServiceITest : DatabaseTest() {
                 application,
                 hanke.id!!,
                 hanke.hankeTunnus!!,
-                hanke.nimi!!,
+                hanke.nimi,
                 USERNAME,
                 HankeKayttajaFactory.createEntity()
             )
@@ -343,7 +343,7 @@ class HankeKayttajaServiceITest : DatabaseTest() {
                 application,
                 hanke.id!!,
                 hanke.hankeTunnus!!,
-                hanke.nimi!!,
+                hanke.nimi,
                 USERNAME
             )
 
@@ -381,7 +381,7 @@ class HankeKayttajaServiceITest : DatabaseTest() {
                 application,
                 hanke.id!!,
                 hanke.hankeTunnus!!,
-                hanke.nimi!!,
+                hanke.nimi,
                 USERNAME,
                 currentKayttaja = null
             )
@@ -416,7 +416,7 @@ class HankeKayttajaServiceITest : DatabaseTest() {
                 applicationEntity,
                 hanke.id!!,
                 hanke.hankeTunnus!!,
-                hanke.nimi!!,
+                hanke.nimi,
                 USERNAME,
                 inviter
             )
@@ -466,7 +466,7 @@ class HankeKayttajaServiceITest : DatabaseTest() {
                 application,
                 hanke.id!!,
                 hanke.hankeTunnus!!,
-                hanke.nimi!!,
+                hanke.nimi,
                 USERNAME
             )
 
@@ -512,7 +512,7 @@ class HankeKayttajaServiceITest : DatabaseTest() {
                 application,
                 hanke.id!!,
                 hanke.hankeTunnus!!,
-                hanke.nimi!!,
+                hanke.nimi,
                 USERNAME
             )
 
@@ -560,7 +560,7 @@ class HankeKayttajaServiceITest : DatabaseTest() {
                 application,
                 hanke.id!!,
                 hanke.hankeTunnus!!,
-                hanke.nimi!!,
+                hanke.nimi,
                 USERNAME
             )
 
@@ -600,7 +600,7 @@ class HankeKayttajaServiceITest : DatabaseTest() {
                 application,
                 hanke.id!!,
                 hanke.hankeTunnus!!,
-                hanke.nimi!!,
+                hanke.nimi,
                 USERNAME
             )
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeServiceImpl.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeServiceImpl.kt
@@ -109,7 +109,7 @@ open class HankeServiceImpl(
     private fun createHankeInternal(hanke: Hanke, perustaja: Perustaja?): Hanke {
         val userId = currentUserId()
 
-        val entity = HankeEntity()
+        val entity = HankeEntity(nimi = hanke.nimi)
         val loggingEntryHolder = prepareLogging(entity)
 
         // Create a new hanketunnus for it and save it:
@@ -453,7 +453,7 @@ open class HankeServiceImpl(
      */
     private fun copyNonNullHankeFieldsToEntity(hanke: Hanke, entity: HankeEntity) {
         hanke.onYKTHanke?.let { entity.onYKTHanke = hanke.onYKTHanke }
-        hanke.nimi?.let { entity.nimi = hanke.nimi }
+        entity.nimi = hanke.nimi
         hanke.kuvaus?.let { entity.kuvaus = hanke.kuvaus }
         entity.generated = hanke.generated
         hanke.vaihe?.let { entity.vaihe = hanke.vaihe }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Persistence.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Persistence.kt
@@ -122,7 +122,7 @@ enum class Haitta13 {
 class HankeEntity(
     @Enumerated(EnumType.STRING) var status: HankeStatus = HankeStatus.DRAFT,
     var hankeTunnus: String? = null,
-    var nimi: String? = null,
+    var nimi: String,
     var kuvaus: String? = null,
     @Enumerated(EnumType.STRING) var vaihe: Vaihe? = null,
     @Enumerated(EnumType.STRING) var suunnitteluVaihe: SuunnitteluVaihe? = null,

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationService.kt
@@ -405,7 +405,7 @@ open class ApplicationService(
             application = application,
             hankeId = hanke.id!!,
             hankeTunnus = hanke.hankeTunnus!!,
-            hankeNimi = hanke.nimi!!,
+            hankeNimi = hanke.nimi,
             currentUserId = currentUserId,
             currentKayttaja = currentKayttaja
         )

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/Hanke.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/Hanke.kt
@@ -38,7 +38,7 @@ data class Hanke(
     //
     @JsonView(ChangeLogView::class)
     @field:Schema(description = "Name of the Hanke, must not be blank")
-    var nimi: String?,
+    var nimi: String,
     //
     @JsonView(ChangeLogView::class)
     @field:Schema(description = "Description of the Hanke contents ")

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/PublicHanke.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/PublicHanke.kt
@@ -89,7 +89,7 @@ fun hankeToPublic(hanke: Hanke): PublicHanke {
     return PublicHanke(
         hanke.id!!,
         hanke.hankeTunnus!!,
-        hanke.nimi!!,
+        hanke.nimi,
         hanke.kuvaus!!,
         hanke.alkuPvm!!,
         hanke.loppuPvm!!,

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaController.kt
@@ -221,7 +221,7 @@ Responds with information about the activated user and the hanke associated with
             )
 
         val hanke = hankeService.loadHankeById(kayttaja.hankeId)!!
-        return TunnistautuminenResponse(kayttaja.id, hanke.hankeTunnus!!, hanke.nimi!!)
+        return TunnistautuminenResponse(kayttaja.id, hanke.hankeTunnus!!, hanke.nimi)
     }
 
     @PostMapping("/kayttajat/{kayttajaId}/kutsu")

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaService.kt
@@ -95,7 +95,7 @@ class HankeKayttajaService(
 
         val hankeId = hanke.id ?: throw HankeArgumentException("Hanke without id")
         val hankeTunnus = hanke.hankeTunnus ?: throw HankeArgumentException("Hanke without tunnus")
-        val hankeNimi = hanke.nimi ?: throw HankeArgumentException("Hanke without name")
+        val hankeNimi = hanke.nimi
 
         val contacts =
             hanke
@@ -205,7 +205,7 @@ class HankeKayttajaService(
 
         recreateTunniste(kayttaja, currentUserId)
         val hanke = hankeRepository.getReferenceById(kayttaja.hankeId)
-        sendHankeInvitation(hanke.hankeTunnus!!, hanke.nimi!!, inviter, kayttaja)
+        sendHankeInvitation(hanke.hankeTunnus!!, hanke.nimi, inviter, kayttaja)
     }
 
     /** Check that every user an update was requested for was found as a user of the hanke. */

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaService.kt
@@ -95,7 +95,6 @@ class HankeKayttajaService(
 
         val hankeId = hanke.id ?: throw HankeArgumentException("Hanke without id")
         val hankeTunnus = hanke.hankeTunnus ?: throw HankeArgumentException("Hanke without tunnus")
-        val hankeNimi = hanke.nimi
 
         val contacts =
             hanke
@@ -105,7 +104,7 @@ class HankeKayttajaService(
 
         val inviter = getKayttajaByUserId(hankeId, userId)
         filterNewContacts(hankeId, contacts).forEach { contact ->
-            createTunnisteAndKayttaja(hankeId, hankeTunnus, hankeNimi, inviter, contact, userId)
+            createTunnisteAndKayttaja(hankeId, hankeTunnus, hanke.nimi, inviter, contact, userId)
         }
     }
 

--- a/services/hanke-service/src/main/resources/db/changelog/changesets/050-make-nimi-mandatory-in-hanke.yml
+++ b/services/hanke-service/src/main/resources/db/changelog/changesets/050-make-nimi-mandatory-in-hanke.yml
@@ -1,0 +1,11 @@
+databaseChangeLog:
+  - changeSet:
+      id: 050-make-nimi-mandatory-in-hanke
+      author: Topias Heinonen
+      changes:
+        - addNotNullConstraint:
+            tableName: hanke
+            columnName: nimi
+            # There shouldn't be unnamed hanke, but let's add a default name
+            # just in case, instead of failing to start.
+            defaultNullValue: "Unnamed"

--- a/services/hanke-service/src/main/resources/db/changelog/changesets/050-make-nimi-mandatory-in-hanke.yml
+++ b/services/hanke-service/src/main/resources/db/changelog/changesets/050-make-nimi-mandatory-in-hanke.yml
@@ -6,6 +6,3 @@ databaseChangeLog:
         - addNotNullConstraint:
             tableName: hanke
             columnName: nimi
-            # There shouldn't be unnamed hanke, but let's add a default name
-            # just in case, instead of failing to start.
-            defaultNullValue: "Unnamed"

--- a/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -127,3 +127,5 @@ databaseChangeLog:
       file: db/changelog/changesets/048-add-y-tunnus-to-hankeyhteystieto.yml
   - include:
       file: db/changelog/changesets/049-add-bus-and-tram-indexes.sql
+  - include:
+      file: db/changelog/changesets/050-make-nimi-mandatory-in-hanke.yml

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeFactory.kt
@@ -40,7 +40,7 @@ class HankeFactory(
      * Needs a mock user set up, since `hankeService.createHanke` calls currentUserId() directly.
      */
     fun save(
-        nimi: String? = defaultNimi,
+        nimi: String = defaultNimi,
         vaihe: Vaihe? = Vaihe.OHJELMOINTI,
         suunnitteluVaihe: SuunnitteluVaihe? = null,
     ) =
@@ -59,7 +59,7 @@ class HankeFactory(
      * even though we want to return the entity, not the domain object.
      */
     fun saveEntity(
-        nimi: String? = defaultNimi,
+        nimi: String = defaultNimi,
         vaihe: Vaihe? = Vaihe.OHJELMOINTI,
         suunnitteluVaihe: SuunnitteluVaihe? = null,
     ): HankeEntity {
@@ -71,8 +71,12 @@ class HankeFactory(
 
     fun saveMinimal(
         hankeTunnus: String = hanketunnusService.newHanketunnus(),
-        nimi: String? = null
-    ): HankeEntity = hankeRepository.save(HankeEntity(hankeTunnus = hankeTunnus, nimi = nimi))
+        nimi: String = defaultNimi,
+        generated: Boolean = false,
+    ): HankeEntity =
+        hankeRepository.save(
+            HankeEntity(hankeTunnus = hankeTunnus, nimi = nimi, generated = generated)
+        )
 
     fun saveSeveralMinimal(n: Int): List<HankeEntity> = (1..n).map { saveMinimal() }
 
@@ -106,7 +110,7 @@ class HankeFactory(
         fun create(
             id: Int? = defaultId,
             hankeTunnus: String? = defaultHankeTunnus,
-            nimi: String? = defaultNimi,
+            nimi: String = defaultNimi,
             vaihe: Vaihe? = Vaihe.OHJELMOINTI,
             suunnitteluVaihe: SuunnitteluVaihe? = null,
             version: Int? = 1,
@@ -129,6 +133,13 @@ class HankeFactory(
                 null,
                 hankeStatus,
             )
+
+        fun createMinimalEntity(
+            id: Int? = defaultId,
+            hankeTunnus: String? = defaultHankeTunnus,
+            nimi: String = defaultNimi,
+            generated: Boolean = false,
+        ) = HankeEntity(id = id, hankeTunnus = hankeTunnus, nimi = nimi, generated = generated)
 
         fun createEntity(mockId: Int = 1): HankeEntity =
             HankeEntity(

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/validation/HankePublicValidatorTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/validation/HankePublicValidatorTest.kt
@@ -35,7 +35,6 @@ class HankePublicValidatorTest {
         @JvmStatic
         private fun draftHankkeet(): Stream<Arguments> =
             Stream.of(
-                Arguments.of("nimi", "missing", completeHanke().apply { nimi = null }),
                 Arguments.of("nimi", "empty", completeHanke().apply { nimi = "" }),
                 Arguments.of("nimi", "blank", completeHanke().apply { nimi = BLANK }),
                 Arguments.of("kuvaus", "missing", completeHanke().apply { kuvaus = null }),

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/validation/HankeValidatorTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/validation/HankeValidatorTest.kt
@@ -71,15 +71,6 @@ class HankeValidatorTest {
     }
 
     @Test
-    fun `fails if nimi is missing`() {
-        val hanke = HankeFactory.create(nimi = null)
-
-        assertThat(hankeValidator.isValid(hanke, context)).isFalse()
-
-        verifyError(HankeError.HAI1002, "nimi")
-    }
-
-    @Test
     fun `fails if nimi is empty`() {
         val hanke = HankeFactory.create(nimi = "")
 


### PR DESCRIPTION
# Description

Name is one of the few things we require every hanke to have from the first draft. There needs to be a name for the hanke to distinguish it from other hanke.

Since every hanke must have a name, we can make the associated field non-nullable. This simplifies code referring to the name.

Also, make the `check` Gradle task depend on the `integrationTest` task. This way, we can run `./gradlew check` instead of `./gradlew build integrationTest`.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1893

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [X] Other