### PR TITLE
HAI-1893 Add a new DTO class for hanke creation

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeControllerITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeControllerITests.kt
@@ -7,7 +7,6 @@ import fi.hel.haitaton.hanke.factory.DateFactory
 import fi.hel.haitaton.hanke.factory.HankeFactory
 import fi.hel.haitaton.hanke.factory.HankeFactory.Companion.withGeneratedOmistaja
 import fi.hel.haitaton.hanke.factory.HankeFactory.Companion.withTormaystarkasteluTulos
-import fi.hel.haitaton.hanke.factory.HankeFactory.Companion.withYhteystiedot
 import fi.hel.haitaton.hanke.geometria.Geometriat
 import fi.hel.haitaton.hanke.logging.DisclosureLogService
 import fi.hel.haitaton.hanke.permissions.PermissionCode
@@ -366,22 +365,6 @@ class HankeControllerITests(@Autowired override val mockMvc: MockMvc) : Controll
             verifySequence {
                 hankeService.createHanke(any())
                 disclosureLogService.saveDisclosureLogsForHanke(createdHanke, USERNAME)
-            }
-        }
-
-        @Test
-        fun `Sanitize hanke input and return 200`() {
-            val hanke = HankeFactory.create().withYhteystiedot().apply { generated = true }
-            val expectedServiceArgument =
-                HankeFactory.create(id = null).withYhteystiedot().apply { generated = false }
-            every { hankeService.createHanke(expectedServiceArgument) } returns
-                expectedServiceArgument
-
-            post(url, hanke).andExpect(status().isOk)
-
-            verifySequence {
-                hankeService.createHanke(expectedServiceArgument)
-                disclosureLogService.saveDisclosureLogsForHanke(any(), any())
             }
         }
 

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceITest.kt
@@ -294,7 +294,7 @@ class ApplicationServiceITest : DatabaseTest() {
 
         @Test
         fun `when application area is outside hankealue should throw`() {
-            val hanke = hankeService.createHanke(HankeFactory.create().withHankealue())
+            val hanke = hankeFactory.createRequest().withHankealue().save()
             val cableReportApplicationData =
                 createCableReportApplicationData(areas = listOf(havisAmanda))
             val newApplication =
@@ -916,7 +916,7 @@ class ApplicationServiceITest : DatabaseTest() {
 
         @Test
         fun `when application area outside hankealue should throw`() {
-            val hanke = hankeService.createHanke(HankeFactory.create().withHankealue())
+            val hanke = hankeFactory.createRequest().withHankealue().save()
             val hankeEntity = hankeRepository.getReferenceById(hanke.id!!)
             val application =
                 alluDataFactory.saveApplicationEntity(USERNAME, hanke = hankeEntity) {
@@ -1254,7 +1254,7 @@ class ApplicationServiceITest : DatabaseTest() {
 
         @Test
         fun `Throws an exception when application area is outside hankealue`() {
-            val hanke = hankeService.createHanke(HankeFactory.create().withHankealue())
+            val hanke = hankeFactory.createRequest().withHankealue().save()
             val hankeEntity = hankeRepository.getReferenceById(hanke.id!!)
             val application =
                 alluDataFactory.saveApplicationEntity(USERNAME, hanke = hankeEntity) {

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentServiceITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentServiceITests.kt
@@ -69,7 +69,7 @@ class HankeAttachmentServiceITests : DatabaseTest() {
     fun `getMetadataList should return related metadata list`() {
         mockWebServer.enqueue(response(body(results = successResult())))
         mockWebServer.enqueue(response(body(results = successResult())))
-        val hanke = hankeService.createHanke(HankeFactory.create())
+        val hanke = hankeFactory.save()
         (1..2).forEach { _ ->
             hankeAttachmentService.addAttachment(
                 hankeTunnus = hanke.hankeTunnus!!,
@@ -93,7 +93,7 @@ class HankeAttachmentServiceITests : DatabaseTest() {
     fun `getContent when status is OK should succeed`() {
         mockWebServer.enqueue(response(body(results = successResult())))
         val file = testFile()
-        val hanke = hankeService.createHanke(HankeFactory.create())
+        val hanke = hankeFactory.save()
         val attachment = hankeAttachmentService.addAttachment(hanke.hankeTunnus!!, file)
 
         val result = hankeAttachmentService.getContent(hanke.hankeTunnus!!, attachment.id)
@@ -107,8 +107,8 @@ class HankeAttachmentServiceITests : DatabaseTest() {
     fun `getContent when attachment is not in requested hanke should throw`() {
         mockWebServer.enqueue(response(body(results = successResult())))
         mockWebServer.enqueue(response(body(results = successResult())))
-        val firstHanke = hankeService.createHanke(HankeFactory.create())
-        val secondHanke = hankeService.createHanke(HankeFactory.create())
+        val firstHanke = hankeFactory.save()
+        val secondHanke = hankeFactory.save()
         hankeAttachmentService.addAttachment(
             hankeTunnus = firstHanke.hankeTunnus!!,
             attachment = testFile(),
@@ -130,7 +130,7 @@ class HankeAttachmentServiceITests : DatabaseTest() {
     @Test
     fun `addAttachment when valid input returns metadata of saved attachment`() {
         mockWebServer.enqueue(response(body(results = successResult())))
-        val hanke = hankeService.createHanke(HankeFactory.create())
+        val hanke = hankeFactory.save()
 
         val result = hankeAttachmentService.addAttachment(hanke.hankeTunnus!!, testFile())
 
@@ -154,7 +154,7 @@ class HankeAttachmentServiceITests : DatabaseTest() {
     @Test
     fun `addAttachment with special characters in filename sanitizes filename`() {
         mockWebServer.enqueue(response(body(results = successResult())))
-        val hanke = hankeService.createHanke(HankeFactory.create())
+        val hanke = hankeFactory.save()
 
         val result =
             hankeAttachmentService.addAttachment(
@@ -199,7 +199,7 @@ class HankeAttachmentServiceITests : DatabaseTest() {
 
     @Test
     fun `addAttachment when content type not supported should throw`() {
-        val hanke = hankeService.createHanke(HankeFactory.create())
+        val hanke = hankeFactory.save()
         val invalidFilename = "hello.html"
 
         val ex =
@@ -218,7 +218,7 @@ class HankeAttachmentServiceITests : DatabaseTest() {
     @Test
     fun `addAttachment when scan fails should throw`() {
         mockWebServer.enqueue(response(body(results = failResult())))
-        val hanke = hankeService.createHanke(HankeFactory.create())
+        val hanke = hankeFactory.save()
 
         val exception =
             assertThrows<AttachmentInvalidException> {
@@ -233,7 +233,7 @@ class HankeAttachmentServiceITests : DatabaseTest() {
     @Test
     fun `deleteAttachment when valid input should succeed`() {
         mockWebServer.enqueue(response(body(results = successResult())))
-        val hanke = hankeService.createHanke(HankeFactory.create())
+        val hanke = hankeFactory.save()
         val attachment = hankeAttachmentService.addAttachment(hanke.hankeTunnus!!, testFile())
         val attachmentId = attachment.id
         assertThat(hankeAttachmentRepository.findById(attachmentId)).isPresent()

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaServiceITest.kt
@@ -123,9 +123,8 @@ class HankeKayttajaServiceITest : DatabaseTest() {
 
         @Test
         fun `Returns users from correct hanke only`() {
-            val hankeToFind =
-                hankeFactory.save(HankeFactory.create().withYhteystiedot { id = null })
-            hankeFactory.save(HankeFactory.create().withYhteystiedot { id = null })
+            val hankeToFind = hankeFactory.createRequest().withYhteystiedot().save()
+            hankeFactory.createRequest().withYhteystiedot().save()
 
             val result: List<HankeKayttajaDto> =
                 hankeKayttajaService.getKayttajatByHankeId(hankeToFind.id!!)
@@ -135,8 +134,7 @@ class HankeKayttajaServiceITest : DatabaseTest() {
 
         @Test
         fun `Returns data matching to the saved entity`() {
-            val hanke =
-                hankeFactory.save(HankeFactory.create().withGeneratedOmistaja(1) { id = null })
+            val hanke = hankeFactory.createRequest().withGeneratedOmistaja(1).save()
 
             val result: List<HankeKayttajaDto> =
                 hankeKayttajaService.getKayttajatByHankeId(hanke.id!!)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeController.kt
@@ -1,6 +1,7 @@
 package fi.hel.haitaton.hanke
 
 import fi.hel.haitaton.hanke.application.ApplicationsResponse
+import fi.hel.haitaton.hanke.domain.CreateHankeRequest
 import fi.hel.haitaton.hanke.domain.Hanke
 import fi.hel.haitaton.hanke.logging.DisclosureLogService
 import fi.hel.haitaton.hanke.permissions.PermissionCode
@@ -167,20 +168,13 @@ When Hanke is created:
             ]
     )
     @PreAuthorize("@featureService.isEnabled('HANKE_EDITING')")
-    fun createHanke(@ValidHanke @RequestBody hanke: Hanke?): Hanke {
-        if (hanke == null) {
-            throw HankeArgumentException("No hanke given when creating hanke")
-        }
-
-        hanke.id = null
-        hanke.generated = false
-
-        val userId = currentUserId()
-        logger.info { "Creating Hanke for user $userId: ${hanke.toLogString()} " }
+    fun createHanke(@ValidHanke @RequestBody hanke: CreateHankeRequest): Hanke {
+        logger.info { "Creating Hanke..." }
 
         val createdHanke = hankeService.createHanke(hanke)
 
-        disclosureLogService.saveDisclosureLogsForHanke(createdHanke, userId)
+        disclosureLogService.saveDisclosureLogsForHanke(createdHanke, currentUserId())
+        logger.info { "Created Hanke ${createdHanke.hankeTunnus}." }
         return createdHanke
     }
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeService.kt
@@ -2,6 +2,7 @@ package fi.hel.haitaton.hanke
 
 import fi.hel.haitaton.hanke.application.Application
 import fi.hel.haitaton.hanke.application.CableReportWithoutHanke
+import fi.hel.haitaton.hanke.domain.CreateHankeRequest
 import fi.hel.haitaton.hanke.domain.Hanke
 
 interface HankeService {
@@ -12,7 +13,7 @@ interface HankeService {
 
     fun getHankeApplications(hankeTunnus: String): List<Application>
 
-    fun createHanke(hanke: Hanke): Hanke
+    fun createHanke(request: CreateHankeRequest): Hanke
 
     fun generateHankeWithApplication(
         cableReport: CableReportWithoutHanke,

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/configuration/Configuration.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/configuration/Configuration.kt
@@ -120,7 +120,6 @@ class Configuration {
         auditLogService: AuditLogService,
         hankeLoggingService: HankeLoggingService,
         applicationService: ApplicationService,
-        permissionService: PermissionService,
         hankeKayttajaService: HankeKayttajaService,
     ): HankeService =
         HankeServiceImpl(

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/BaseHanke.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/BaseHanke.kt
@@ -1,0 +1,31 @@
+package fi.hel.haitaton.hanke.domain
+
+import fi.hel.haitaton.hanke.ContactType
+import fi.hel.haitaton.hanke.SuunnitteluVaihe
+import fi.hel.haitaton.hanke.Vaihe
+
+interface BaseHanke : HasYhteystiedot {
+    val nimi: String
+    val vaihe: Vaihe?
+    val suunnitteluVaihe: SuunnitteluVaihe?
+    val alueet: List<Hankealue>?
+    val tyomaaKatuosoite: String?
+}
+
+interface HasYhteystiedot {
+    val omistajat: List<HankeYhteystieto>?
+    val rakennuttajat: List<HankeYhteystieto>?
+    val toteuttajat: List<HankeYhteystieto>?
+    val muut: List<HankeYhteystieto>?
+
+    fun extractYhteystiedot(): List<HankeYhteystieto> =
+        listOfNotNull(omistajat, rakennuttajat, toteuttajat, muut).flatten()
+
+    fun yhteystiedotByType(): Map<ContactType, List<HankeYhteystieto>> =
+        mapOf(
+            ContactType.OMISTAJA to (omistajat ?: listOf()),
+            ContactType.RAKENNUTTAJA to (rakennuttajat ?: listOf()),
+            ContactType.TOTEUTTAJA to (toteuttajat ?: listOf()),
+            ContactType.MUU to (muut ?: listOf()),
+        )
+}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/CreateHankeRequest.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/CreateHankeRequest.kt
@@ -1,0 +1,63 @@
+package fi.hel.haitaton.hanke.domain
+
+import fi.hel.haitaton.hanke.SuunnitteluVaihe
+import fi.hel.haitaton.hanke.TyomaaTyyppi
+import fi.hel.haitaton.hanke.Vaihe
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class CreateHankeRequest(
+    @field:Schema(
+        description = "Name of the project, must not be blank.",
+        maxLength = 100,
+    )
+    override val nimi: String,
+    @field:Schema(
+        description = "Shared Public Utility Site (Yhteinen kunnallistekninen työmaa). Optional.",
+    )
+    val onYKTHanke: Boolean? = null,
+    @field:Schema(
+        description =
+            "Description of the project and the work done during it. Required for the project to be published.",
+    )
+    val kuvaus: String? = null,
+    @field:Schema(
+        description = "Current stage of the project. Required for the hanke to be published.",
+    )
+    override val vaihe: Vaihe? = null,
+    @field:Schema(
+        description = "Current planning stage, must be defined if vaihe = SUUNNITTELU",
+    )
+    override val suunnitteluVaihe: SuunnitteluVaihe? = null,
+    @field:Schema(
+        description =
+            "Project owners, contact information. At least one is required for the hanke to be published.",
+    )
+    override val omistajat: List<HankeYhteystieto>? = null,
+    @field:Schema(
+        description =
+            "Property developers, contact information. Not required for the hanke to be published.",
+    )
+    override val rakennuttajat: List<HankeYhteystieto>? = null,
+    @field:Schema(
+        description = "Executor of the work. Not required for the hanke to be published.",
+    )
+    override val toteuttajat: List<HankeYhteystieto>? = null,
+    @field:Schema(
+        description = "Other contacts. Not required for the hanke to be published.",
+    )
+    override val muut: List<HankeYhteystieto>? = null,
+    @field:Schema(
+        description = "Work site street address. Required for the hanke to be published.",
+        maxLength = 2000,
+    )
+    override val tyomaaKatuosoite: String? = null,
+    @field:Schema(
+        description = "Work site types. Not required for the hanke to be published.",
+    )
+    val tyomaaTyyppi: Set<TyomaaTyyppi>? = null,
+    @field:Schema(
+        description =
+            "Hanke areas data. At least one alue is required for the hanke to be published.",
+    )
+    override val alueet: List<Hankealue>? = null,
+) : BaseHanke

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/Hankealue.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/Hankealue.kt
@@ -8,6 +8,7 @@ import fi.hel.haitaton.hanke.TodennakoinenHaittaPaaAjoRatojenKaistajarjestelyihi
 import fi.hel.haitaton.hanke.geometria.Geometriat
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.ZonedDateTime
+import java.time.temporal.ChronoUnit
 
 /** NOTE Remember to update PublicHankealue after changes */
 @JsonView(ChangeLogView::class)
@@ -45,3 +46,24 @@ data class Hankealue(
     //
     @field:Schema(description = "Area name") var nimi: String? = null,
 ) : HasId<Int>
+
+fun List<Hankealue>.alkuPvm(): ZonedDateTime? = mapNotNull { it.haittaAlkuPvm }.minOfOrNull { it }
+
+fun List<Hankealue>.loppuPvm(): ZonedDateTime? = mapNotNull { it.haittaLoppuPvm }.maxOfOrNull { it }
+
+fun List<Hankealue>.kaistaHaitat(): Set<TodennakoinenHaittaPaaAjoRatojenKaistajarjestelyihin> {
+    return mapNotNull { it.kaistaHaitta }.toSet()
+}
+
+fun List<Hankealue>.kaistaPituusHaitat(): Set<KaistajarjestelynPituus> {
+    return mapNotNull { it.kaistaPituusHaitta }.toSet()
+}
+
+fun List<Hankealue>.geometriat(): List<Geometriat> = mapNotNull { it.geometriat }
+
+fun List<Hankealue>.haittaAjanKestoDays(): Int? =
+    if (alkuPvm() != null && loppuPvm() != null) {
+        ChronoUnit.DAYS.between(alkuPvm(), loppuPvm()).toInt() + 1
+    } else {
+        null
+    }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/validation/Validators.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/validation/Validators.kt
@@ -87,6 +87,7 @@ class ValidationResult
 private constructor(private val errorPaths: MutableList<String> = mutableListOf()) {
 
     fun errorPaths(): List<String> = errorPaths
+
     fun isOk() = errorPaths.isEmpty()
 
     fun and(f: () -> ValidationResult): ValidationResult {
@@ -117,5 +118,14 @@ private constructor(private val errorPaths: MutableList<String> = mutableListOf(
         fun success() = ValidationResult()
 
         fun failure(errorPath: String) = ValidationResult(mutableListOf(errorPath))
+
+        fun <T> whenNotNull(value: T?, f: (T) -> ValidationResult): ValidationResult =
+            success().whenNotNull(value, f)
+
+        fun <T> allIn(
+            values: Collection<T>,
+            path: String,
+            f: (T, String) -> ValidationResult,
+        ): ValidationResult = success().andAllIn(values, path, f)
     }
 }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/HankeMapperTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/HankeMapperTest.kt
@@ -92,7 +92,7 @@ class HankeMapperTest {
                 hankeId = hankeId,
                 haittaAlkuPvm = DateFactory.getStartDatetime().toLocalDate().atStartOfDay(TZ_UTC),
                 haittaLoppuPvm = DateFactory.getEndDatetime().toLocalDate().atStartOfDay(TZ_UTC),
-                geometriat = geometry.apply { resetFeatureProperties(hankeTunnus) },
+                geometriat = geometry.apply { resetFeatureProperties(hankeTunnus!!) },
             )
         )
 }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/AlluDataFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/AlluDataFactory.kt
@@ -185,7 +185,7 @@ class AlluDataFactory(
             propertyDeveloperWithContacts: CustomerWithContacts? = null,
             rockExcavation: Boolean = false,
             postalAddress: PostalAddress? = null,
-        ) =
+        ): CableReportApplicationData =
             CableReportApplicationData(
                 applicationType = ApplicationType.CABLE_REPORT,
                 name = name,
@@ -228,6 +228,7 @@ class AlluDataFactory(
                         customerWithContacts = customer
                     )
             )
+
         fun Application.withCustomerContacts(vararg contacts: Contact): Application =
             this.withCustomer(
                 (applicationData as CableReportApplicationData)
@@ -241,13 +242,14 @@ class AlluDataFactory(
             city: String = "Helsinki",
         ) = this.copy(postalAddress = PostalAddress(StreetAddress(streetAddress), postalCode, city))
 
-        fun cableReportWithoutHanke(): CableReportWithoutHanke =
-            with(createApplication()) {
-                CableReportWithoutHanke(
-                    applicationType,
-                    applicationData as CableReportApplicationData
-                )
-            }
+        fun CableReportApplicationData.withArea(name: String, geometry: Polygon) =
+            this.copy(areas = (areas ?: listOf()) + ApplicationArea(name, geometry))
+
+        fun cableReportWithoutHanke(
+            applicationData: CableReportApplicationData = createCableReportApplicationData(),
+            applicationType: ApplicationType = ApplicationType.CABLE_REPORT,
+            f: CableReportApplicationData.() -> CableReportApplicationData = { this },
+        ): CableReportWithoutHanke = CableReportWithoutHanke(applicationType, applicationData.f())
 
         fun createApplications(
             n: Long,

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/CreateHankeRequestBuilder.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/CreateHankeRequestBuilder.kt
@@ -1,0 +1,49 @@
+package fi.hel.haitaton.hanke.factory
+
+import fi.hel.haitaton.hanke.HankeService
+import fi.hel.haitaton.hanke.TyomaaTyyppi
+import fi.hel.haitaton.hanke.domain.CreateHankeRequest
+import fi.hel.haitaton.hanke.domain.Hanke
+import fi.hel.haitaton.hanke.domain.Hankealue
+
+data class CreateHankeRequestBuilder(
+    private val hankeService: HankeService?,
+    private val request: CreateHankeRequest,
+) {
+    fun save(): Hanke = hankeService!!.createHanke(request)
+
+    fun build(): CreateHankeRequest = request
+
+    fun withRequest(f: CreateHankeRequest.() -> CreateHankeRequest) = copy(request = request.f())
+
+    fun withYhteystiedot(): CreateHankeRequestBuilder = withRequest {
+        copy(
+            omistajat = listOf(HankeYhteystietoFactory.createDifferentiated(1, id = null)),
+            rakennuttajat = listOf(HankeYhteystietoFactory.createDifferentiated(2, id = null)),
+            toteuttajat = listOf(HankeYhteystietoFactory.createDifferentiated(3, id = null)),
+            muut = listOf(HankeYhteystietoFactory.createDifferentiated(4, id = null)),
+        )
+    }
+
+    fun withGeneratedOmistaja(i: Int = 1) = withGeneratedOmistajat(i)
+
+    fun withGeneratedOmistajat(vararg discriminators: Int) = withRequest {
+        copy(
+            omistajat =
+                HankeYhteystietoFactory.createDifferentiated(discriminators.toList()) { id = null }
+        )
+    }
+
+    fun withGeneratedRakennuttaja(i: Int = 1) = withRequest {
+        copy(rakennuttajat = listOf(HankeYhteystietoFactory.createDifferentiated(i, id = null)))
+    }
+
+    fun withHankealue(alue: Hankealue = HankealueFactory.create(id = null, hankeId = null)) =
+        withRequest {
+            copy(
+                alueet = (this.alueet ?: listOf()) + alue,
+                tyomaaKatuosoite = "Testikatu 1",
+                tyomaaTyyppi = setOf(TyomaaTyyppi.VESI, TyomaaTyyppi.MUU)
+            )
+        }
+}

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeFactory.kt
@@ -16,6 +16,7 @@ import fi.hel.haitaton.hanke.TyomaaTyyppi
 import fi.hel.haitaton.hanke.Vaihe
 import fi.hel.haitaton.hanke.Vaihe.SUUNNITTELU
 import fi.hel.haitaton.hanke.application.CableReportWithoutHanke
+import fi.hel.haitaton.hanke.domain.CreateHankeRequest
 import fi.hel.haitaton.hanke.domain.Hanke
 import fi.hel.haitaton.hanke.domain.HankeYhteystieto
 import fi.hel.haitaton.hanke.domain.Perustaja
@@ -43,12 +44,16 @@ class HankeFactory(
         nimi: String = defaultNimi,
         vaihe: Vaihe? = Vaihe.OHJELMOINTI,
         suunnitteluVaihe: SuunnitteluVaihe? = null,
+        tyomaaKatuosoite: String? = null,
+        tyomaaTyyppi: Set<TyomaaTyyppi>? = null,
     ) =
         hankeService.createHanke(
-            create(
+            CreateHankeRequest(
                 nimi = nimi,
                 vaihe = vaihe,
                 suunnitteluVaihe = suunnitteluVaihe,
+                tyomaaKatuosoite = tyomaaKatuosoite,
+                tyomaaTyyppi = tyomaaTyyppi,
             )
         )
 
@@ -66,8 +71,6 @@ class HankeFactory(
         val hanke = save(nimi, vaihe, suunnitteluVaihe)
         return hankeRepository.getReferenceById(hanke.id!!)
     }
-
-    fun save(hanke: Hanke) = hankeService.createHanke(hanke)
 
     fun saveMinimal(
         hankeTunnus: String = hanketunnusService.newHanketunnus(),
@@ -88,6 +91,26 @@ class HankeFactory(
         val application = hankeService.generateHankeWithApplication(cableReportWithoutHanke, userId)
         return hankeService.loadHanke(application.hankeTunnus)!!
     }
+
+    fun createRequest(
+        nimi: String = defaultNimi,
+        onYKTHanke: Boolean? = true,
+        kuvaus: String? = defaultKuvaus,
+        vaihe: Vaihe? = Vaihe.OHJELMOINTI,
+        suunnitteluVaihe: SuunnitteluVaihe? = null,
+        tyomaaKatuosoite: String? = null,
+        tyomaaTyyppi: Set<TyomaaTyyppi>? = null,
+    ) =
+        Companion.createRequest(
+                nimi,
+                onYKTHanke,
+                kuvaus,
+                vaihe,
+                suunnitteluVaihe,
+                tyomaaKatuosoite,
+                tyomaaTyyppi,
+            )
+            .copy(hankeService = hankeService)
 
     companion object {
 
@@ -175,6 +198,28 @@ class HankeFactory(
                         )
                     tormaystarkasteluTulokset = mutableListOf(tormaysTarkastelu(hankeEntity = this))
                 }
+
+        fun createRequest(
+            nimi: String = defaultNimi,
+            onYKTHanke: Boolean? = true,
+            kuvaus: String? = defaultKuvaus,
+            vaihe: Vaihe? = Vaihe.OHJELMOINTI,
+            suunnitteluVaihe: SuunnitteluVaihe? = null,
+            tyomaaKatuosoite: String? = null,
+            tyomaaTyyppi: Set<TyomaaTyyppi>? = null,
+        ): CreateHankeRequestBuilder =
+            CreateHankeRequestBuilder(
+                null,
+                CreateHankeRequest(
+                    nimi = nimi,
+                    onYKTHanke = onYKTHanke,
+                    kuvaus = kuvaus,
+                    vaihe = vaihe,
+                    suunnitteluVaihe = suunnitteluVaihe,
+                    tyomaaKatuosoite = tyomaaKatuosoite,
+                    tyomaaTyyppi = tyomaaTyyppi
+                )
+            )
 
         /**
          * Add a hankealue with haitat to a test Hanke.

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeYhteystietoFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeYhteystietoFactory.kt
@@ -80,9 +80,9 @@ object HankeYhteystietoFactory {
      * Create a new Yhteystieto with values differentiated by the given integer. The audit and id
      * fields are left null.
      */
-    fun createDifferentiated(i: Int): HankeYhteystieto {
+    fun createDifferentiated(i: Int, id: Int? = i): HankeYhteystieto {
         return HankeYhteystieto(
-            id = i,
+            id = id,
             nimi = "etu$i suku$i",
             email = "email$i",
             ytunnus = defaultYtunnus,


### PR DESCRIPTION
# Description

Add a new DTO class for creating hanke. It only has the fields that the user can decide directly. I.e. the DTO doesn't have any fields that are generated or calculated from other fields. This means there's no need to sanitize its contents or select which fields should be read. It also means the OpenAPI documentation is a lot more relevant.

Using the same request for the creation of the entity enables us to make many fields in the ubiquitous Hanke class non-nullable. This is not done in this PR, however.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1893

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [X] Other

# Instructions for testing
1. Create a hanke.
2. It should work.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 