### PR TITLE
HAI-1893 Make hanketunnus mandatory

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
@@ -267,7 +267,7 @@ class HankeServiceITests : DatabaseTest() {
 
         val hanke = hankeService.createHanke(request)
 
-        val hankeEntity = hankeRepository.findByHankeTunnus(hanke.hankeTunnus!!)!!
+        val hankeEntity = hankeRepository.findByHankeTunnus(hanke.hankeTunnus)!!
         assertThat(hankeEntity.perustaja).isNull()
         assertThat(hankeKayttajaRepository.findAll()).isEmpty()
         assertThat(kayttajaTunnisteRepository.findAll()).isEmpty()
@@ -326,7 +326,7 @@ class HankeServiceITests : DatabaseTest() {
     fun `getHankeApplications return applications`() {
         val hanke = initHankeWithHakemus(123)
 
-        val result = hankeService.getHankeApplications(hanke.hankeTunnus!!)
+        val result = hankeService.getHankeApplications(hanke.hankeTunnus)
 
         val expectedHakemus = applicationRepository.findAll().first().toDomainObject()
         assertThat(result).hasSameElementsAs(listOf(expectedHakemus))
@@ -347,7 +347,7 @@ class HankeServiceITests : DatabaseTest() {
     fun `getHankeApplications when no hakemukset returns an empty list`() {
         val hankeInitial = hankeFactory.save()
 
-        val result = hankeService.getHankeApplications(hankeInitial.hankeTunnus!!)
+        val result = hankeService.getHankeApplications(hankeInitial.hankeTunnus)
 
         assertThat(result).isEmpty()
     }
@@ -444,7 +444,7 @@ class HankeServiceITests : DatabaseTest() {
         assertThat(returnedHanke2.rakennuttajat[0].id).isNotEqualTo(returnedHanke2.omistajat[1].id)
 
         // Use loadHanke and check it returns the same data:
-        val returnedHanke3 = hankeService.loadHanke(returnedHanke2.hankeTunnus!!)
+        val returnedHanke3 = hankeService.loadHanke(returnedHanke2.hankeTunnus)
         // General checks (because using another API action)
         assertThat(returnedHanke3).isNotNull
         assertThat(returnedHanke3).isNotSameAs(returnedHanke)
@@ -509,7 +509,7 @@ class HankeServiceITests : DatabaseTest() {
         assertThat(returnedHanke2.omistajat[1].nimi).isEqualTo(NAME_SOMETHING)
 
         // Use loadHanke and check it returns the same data:
-        val returnedHanke3 = hankeService.loadHanke(returnedHanke2.hankeTunnus!!)
+        val returnedHanke3 = hankeService.loadHanke(returnedHanke2.hankeTunnus)
         // General checks (because using another API action)
         assertThat(returnedHanke3).isNotNull
         assertThat(returnedHanke3).isNotSameAs(returnedHanke)
@@ -571,7 +571,7 @@ class HankeServiceITests : DatabaseTest() {
         assertThat(returnedHanke2.omistajat[0].nimi).isEqualTo(NAME_1)
 
         // Use loadHanke and check it returns the same data:
-        val returnedHanke3 = hankeService.loadHanke(returnedHanke2.hankeTunnus!!)
+        val returnedHanke3 = hankeService.loadHanke(returnedHanke2.hankeTunnus)
         // General checks (because using another API action)
         assertThat(returnedHanke3).isNotNull
         assertThat(returnedHanke3).isNotSameAs(returnedHanke)
@@ -628,7 +628,7 @@ class HankeServiceITests : DatabaseTest() {
         assertThat(returnedHanke2.omistajat[0].nimi).isEqualTo(NAME_1)
 
         // Use loadHanke and check it returns the same data:
-        val returnedHanke3 = hankeService.loadHanke(returnedHanke2.hankeTunnus!!)
+        val returnedHanke3 = hankeService.loadHanke(returnedHanke2.hankeTunnus)
         // General checks (because using another API action)
         assertThat(returnedHanke3).isNotNull
         assertThat(returnedHanke3).isNotSameAs(returnedHanke)
@@ -680,7 +680,7 @@ class HankeServiceITests : DatabaseTest() {
         val ytid2 = returnedHanke2.omistajat[0].id
 
         // Use loadHanke and check it also returns only one entry
-        val returnedHanke3 = hankeService.loadHanke(returnedHanke2.hankeTunnus!!)
+        val returnedHanke3 = hankeService.loadHanke(returnedHanke2.hankeTunnus)
         // General checks (because using another API action)
         assertThat(returnedHanke3).isNotNull
         assertThat(returnedHanke3).isNotSameAs(returnedHanke)
@@ -843,7 +843,7 @@ class HankeServiceITests : DatabaseTest() {
         hankeRepository.save(hankeEntity)
 
         // Try to update the yhteystieto. It should fail and add a new log entry.
-        val hankeWithLockedYT = hankeService.loadHanke(hanke.hankeTunnus!!)
+        val hankeWithLockedYT = hankeService.loadHanke(hanke.hankeTunnus)
         hankeWithLockedYT!!.rakennuttajat[0].nimi = "Muhaha-Evil-Change"
 
         assertThatExceptionOfType(HankeYhteystietoProcessingRestrictedException::class.java)
@@ -900,7 +900,7 @@ class HankeServiceITests : DatabaseTest() {
         assertThat(auditLogEvents[2].target.objectAfter).isNull()
 
         // Check that both yhteystietos still exist and the values have not gotten changed.
-        val returnedHankeAfterBlockedActions = hankeService.loadHanke(hanke.hankeTunnus!!)
+        val returnedHankeAfterBlockedActions = hankeService.loadHanke(hanke.hankeTunnus)
         val rakennuttajat = returnedHankeAfterBlockedActions!!.rakennuttajat
         assertThat(rakennuttajat).hasSize(1)
         assertThat(rakennuttajat[0].nimi).isEqualTo(NAME_2)
@@ -913,7 +913,7 @@ class HankeServiceITests : DatabaseTest() {
         hankeRepository.save(hankeEntity)
 
         // Updating the yhteystieto should now work:
-        val hankeWithUnlockedYT = hankeService.loadHanke(hanke.hankeTunnus!!)
+        val hankeWithUnlockedYT = hankeService.loadHanke(hanke.hankeTunnus)
         hankeWithUnlockedYT!!.rakennuttajat[0].nimi = "Hopefully-Not-Evil-Change"
         val finalHanke = hankeService.updateHanke(hankeWithUnlockedYT)
 
@@ -1124,7 +1124,7 @@ class HankeServiceITests : DatabaseTest() {
         assertThat(alue.polyHaitta).isEqualTo(Haitta13.KOLME)
         assertThat(alue.tarinaHaitta).isEqualTo(Haitta13.KOLME)
         assertThat(alue.geometriat).isNotNull
-        val hankeFromDb = hankeService.loadHanke(hanke.hankeTunnus!!)
+        val hankeFromDb = hankeService.loadHanke(hanke.hankeTunnus)
         assertThat(hankeFromDb?.alueet).hasSize(1)
         assertThat(hankealueCount()).isEqualTo(1)
         assertThat(geometriatCount()).isEqualTo(1)
@@ -1137,7 +1137,7 @@ class HankeServiceITests : DatabaseTest() {
         assertEquals(0, auditLogRepository.count())
         TestUtils.addMockedRequestIp()
 
-        hankeService.deleteHanke(hanke.hankeTunnus!!, "testUser")
+        hankeService.deleteHanke(hanke.hankeTunnus, "testUser")
 
         val hankeLogs = auditLogRepository.findByType(ObjectType.HANKE)
         assertEquals(1, hankeLogs.size)
@@ -1176,7 +1176,7 @@ class HankeServiceITests : DatabaseTest() {
         assertEquals(0, auditLogRepository.count())
         TestUtils.addMockedRequestIp()
 
-        hankeService.deleteHanke(hanke.hankeTunnus!!, "testUser")
+        hankeService.deleteHanke(hanke.hankeTunnus, "testUser")
 
         val logs = auditLogRepository.findByType(ObjectType.YHTEYSTIETO)
         assertEquals(4, logs.size)
@@ -1228,7 +1228,7 @@ class HankeServiceITests : DatabaseTest() {
     fun `deleteHanke hanke when no hakemus should delete hanke`() {
         val hanke = hankeFactory.save()
 
-        hankeService.deleteHanke(hanke.hankeTunnus!!, USER_NAME)
+        hankeService.deleteHanke(hanke.hankeTunnus, USER_NAME)
 
         assertThat(hankeRepository.findByIdOrNull(hanke.id)).isNull()
     }
@@ -1242,7 +1242,7 @@ class HankeServiceITests : DatabaseTest() {
         justRun { cableReportService.cancel(hakemusAlluId) }
         every { cableReportService.sendSystemComment(hakemusAlluId, any()) } returns 1324
 
-        hankeService.deleteHanke(hanke.hankeTunnus!!, USER_NAME)
+        hankeService.deleteHanke(hanke.hankeTunnus, USER_NAME)
 
         assertThat(hankeRepository.findByIdOrNull(hanke.id)).isNull()
         verifySequence {
@@ -1261,7 +1261,7 @@ class HankeServiceITests : DatabaseTest() {
             AlluDataFactory.createAlluApplicationResponse(status = ApplicationStatus.HANDLING)
 
         assertThrows<HankeAlluConflictException> {
-            hankeService.deleteHanke(hanke.hankeTunnus!!, USER_NAME)
+            hankeService.deleteHanke(hanke.hankeTunnus, USER_NAME)
         }
 
         assertThat(hankeRepository.findByIdOrNull(hanke.id)).isNotNull
@@ -1270,7 +1270,7 @@ class HankeServiceITests : DatabaseTest() {
 
     @Test
     fun `deleteHanke when hanke has users should remove users and tokens`() {
-        val hanketunnus = hankeFactory.createRequest().withYhteystiedot().save().hankeTunnus!!
+        val hanketunnus = hankeFactory.createRequest().withYhteystiedot().save().hankeTunnus
         assertk.assertThat(hankeKayttajaRepository.findAll()).hasSize(4)
         assertk.assertThat(kayttajaTunnisteRepository.findAll()).hasSize(4)
 
@@ -1443,7 +1443,7 @@ class HankeServiceITests : DatabaseTest() {
         val templateData =
             TemplateData(
                 updatedHanke.id!!,
-                updatedHanke.hankeTunnus!!,
+                updatedHanke.hankeTunnus,
                 updatedHanke.alueet[0].id,
                 updatedHanke.alueet[0].geometriat?.id,
                 hankeVersion = 1,
@@ -1536,7 +1536,7 @@ class HankeServiceITests : DatabaseTest() {
                 applicationIdentifier,
                 applicationType,
                 applicationData,
-                hanke.hankeTunnus ?: ""
+                hanke.hankeTunnus,
             )
         }
 
@@ -1582,7 +1582,7 @@ class HankeServiceITests : DatabaseTest() {
         val templateData =
             TemplateData(
                 hanke.id!!,
-                hanke.hankeTunnus!!,
+                hanke.hankeTunnus,
                 alue?.id,
                 alue?.geometriat?.id,
                 geometriaVersion,

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceITest.kt
@@ -177,7 +177,7 @@ class ApplicationServiceITest : DatabaseTest() {
                 applicationService.create(
                     createApplication(
                         id = null,
-                        hankeTunnus = hanke.hankeTunnus!!,
+                        hankeTunnus = hanke.hankeTunnus,
                         applicationData = dataWithoutAreas
                     ),
                     USERNAME
@@ -224,7 +224,7 @@ class ApplicationServiceITest : DatabaseTest() {
                 createApplication(
                     id = givenId,
                     applicationData = cableReportApplicationData,
-                    hankeTunnus = hanke.hankeTunnus!!,
+                    hankeTunnus = hanke.hankeTunnus,
                 )
             assertTrue(cableReportApplicationData.pendingOnClient)
 
@@ -261,7 +261,7 @@ class ApplicationServiceITest : DatabaseTest() {
                 createApplication(
                     id = givenId,
                     applicationData = cableReportApplicationData,
-                    hankeTunnus = hanke.hankeTunnus!!,
+                    hankeTunnus = hanke.hankeTunnus,
                 )
 
             val response = applicationService.create(newApplication, USERNAME)
@@ -300,7 +300,7 @@ class ApplicationServiceITest : DatabaseTest() {
             val newApplication =
                 createApplication(
                     id = null,
-                    hankeTunnus = hanke.hankeTunnus!!,
+                    hankeTunnus = hanke.hankeTunnus,
                     applicationData = cableReportApplicationData
                 )
 
@@ -327,7 +327,7 @@ class ApplicationServiceITest : DatabaseTest() {
                 applicationService.create(
                     createApplication(
                         id = null,
-                        hankeTunnus = hanke.hankeTunnus!!,
+                        hankeTunnus = hanke.hankeTunnus,
                         applicationData = dataWithoutAreas
                     ),
                     USERNAME
@@ -1408,7 +1408,7 @@ class ApplicationServiceITest : DatabaseTest() {
                 applicationService.create(
                     createApplication(
                         id = null,
-                        hankeTunnus = hanke.hankeTunnus!!,
+                        hankeTunnus = hanke.hankeTunnus,
                         applicationData = dataWithoutAreas
                     ),
                     USERNAME
@@ -1516,7 +1516,7 @@ class ApplicationServiceITest : DatabaseTest() {
 
             assertThat(result).isEqualTo(ApplicationDeletionResultDto(hankeDeleted = false))
             assertThat(applicationRepository.findAll()).isEmpty()
-            assertThat(hankeRepository.findByHankeTunnus(hanke.hankeTunnus!!)).isNotNull()
+            assertThat(hankeRepository.findByHankeTunnus(hanke.hankeTunnus)).isNotNull()
             verify { cableReportServiceAllu wasNot Called }
         }
 
@@ -1537,7 +1537,7 @@ class ApplicationServiceITest : DatabaseTest() {
             assertThat(result).isEqualTo(ApplicationDeletionResultDto(hankeDeleted = false))
             assertThat(applicationRepository.findAll()).hasSize(1)
             assertThat(applicationRepository.findById(application2.id!!)).isPresent()
-            assertThat(hankeRepository.findByHankeTunnus(hanke.hankeTunnus!!)).isNotNull()
+            assertThat(hankeRepository.findByHankeTunnus(hanke.hankeTunnus)).isNotNull()
             verify { cableReportServiceAllu wasNot Called }
         }
     }

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/geometria/GeometriatServiceImplITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/geometria/GeometriatServiceImplITest.kt
@@ -56,7 +56,7 @@ internal class GeometriatServiceImplITest : DatabaseTest() {
                 .createRequest()
                 .withHankealue(HankealueFactory.createMinimal(geometriat = geometriat))
                 .save()
-                .hankeTunnus!!
+                .hankeTunnus
 
         // NOTE: the local Hanke instance has not been updated by the above call. Need to reload
         // the hanke to check that the flag changed to true:

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaServiceITest.kt
@@ -45,7 +45,6 @@ import fi.hel.haitaton.hanke.factory.AlluDataFactory.Companion.withContact
 import fi.hel.haitaton.hanke.factory.AlluDataFactory.Companion.withContacts
 import fi.hel.haitaton.hanke.factory.HankeFactory
 import fi.hel.haitaton.hanke.factory.HankeFactory.Companion.defaultNimi
-import fi.hel.haitaton.hanke.factory.HankeFactory.Companion.withGeneratedOmistaja
 import fi.hel.haitaton.hanke.factory.HankeFactory.Companion.withYhteystiedot
 import fi.hel.haitaton.hanke.factory.HankeKayttajaFactory
 import fi.hel.haitaton.hanke.factory.HankeYhteystietoFactory
@@ -302,7 +301,7 @@ class HankeKayttajaServiceITest : DatabaseTest() {
             hankeKayttajaService.saveNewTokensFromApplication(
                 application,
                 hanke.id!!,
-                hanke.hankeTunnus!!,
+                hanke.hankeTunnus,
                 hanke.nimi,
                 USERNAME,
                 HankeKayttajaFactory.createEntity()
@@ -340,7 +339,7 @@ class HankeKayttajaServiceITest : DatabaseTest() {
             hankeKayttajaService.saveNewTokensFromApplication(
                 application,
                 hanke.id!!,
-                hanke.hankeTunnus!!,
+                hanke.hankeTunnus,
                 hanke.nimi,
                 USERNAME
             )
@@ -378,7 +377,7 @@ class HankeKayttajaServiceITest : DatabaseTest() {
             hankeKayttajaService.saveNewTokensFromApplication(
                 application,
                 hanke.id!!,
-                hanke.hankeTunnus!!,
+                hanke.hankeTunnus,
                 hanke.nimi,
                 USERNAME,
                 currentKayttaja = null
@@ -413,7 +412,7 @@ class HankeKayttajaServiceITest : DatabaseTest() {
             hankeKayttajaService.saveNewTokensFromApplication(
                 applicationEntity,
                 hanke.id!!,
-                hanke.hankeTunnus!!,
+                hanke.hankeTunnus,
                 hanke.nimi,
                 USERNAME,
                 inviter
@@ -463,7 +462,7 @@ class HankeKayttajaServiceITest : DatabaseTest() {
             hankeKayttajaService.saveNewTokensFromApplication(
                 application,
                 hanke.id!!,
-                hanke.hankeTunnus!!,
+                hanke.hankeTunnus,
                 hanke.nimi,
                 USERNAME
             )
@@ -509,7 +508,7 @@ class HankeKayttajaServiceITest : DatabaseTest() {
             hankeKayttajaService.saveNewTokensFromApplication(
                 application,
                 hanke.id!!,
-                hanke.hankeTunnus!!,
+                hanke.hankeTunnus,
                 hanke.nimi,
                 USERNAME
             )
@@ -557,7 +556,7 @@ class HankeKayttajaServiceITest : DatabaseTest() {
             hankeKayttajaService.saveNewTokensFromApplication(
                 application,
                 hanke.id!!,
-                hanke.hankeTunnus!!,
+                hanke.hankeTunnus,
                 hanke.nimi,
                 USERNAME
             )
@@ -597,7 +596,7 @@ class HankeKayttajaServiceITest : DatabaseTest() {
             hankeKayttajaService.saveNewTokensFromApplication(
                 application,
                 hanke.id!!,
-                hanke.hankeTunnus!!,
+                hanke.hankeTunnus,
                 hanke.nimi,
                 USERNAME
             )
@@ -707,7 +706,7 @@ class HankeKayttajaServiceITest : DatabaseTest() {
                 inv.transform { it.inviterEmail }.isEqualTo(teppoEmail)
                 inv.transform { it.recipientEmail }
                     .isIn("yhteys-email1", "yhteys-email2", "yhteys-email3", "yhteys-email4")
-                inv.transform { it.hankeTunnus }.isEqualTo(hanke.hankeTunnus!!)
+                inv.transform { it.hankeTunnus }.isEqualTo(hanke.hankeTunnus)
                 inv.transform { it.hankeNimi }.isEqualTo(defaultApplicationName)
                 inv.transform { it.invitationToken }.isNotEmpty()
             }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeController.kt
@@ -168,10 +168,10 @@ When Hanke is created:
             ]
     )
     @PreAuthorize("@featureService.isEnabled('HANKE_EDITING')")
-    fun createHanke(@ValidHanke @RequestBody hanke: CreateHankeRequest): Hanke {
+    fun createHanke(@ValidHanke @RequestBody request: CreateHankeRequest): Hanke {
         logger.info { "Creating Hanke..." }
 
-        val createdHanke = hankeService.createHanke(hanke)
+        val createdHanke = hankeService.createHanke(request)
 
         disclosureLogService.saveDisclosureLogsForHanke(createdHanke, currentUserId())
         logger.info { "Created Hanke ${createdHanke.hankeTunnus}." }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Persistence.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Persistence.kt
@@ -121,7 +121,7 @@ enum class Haitta13 {
 @Table(name = "hanke")
 class HankeEntity(
     @Enumerated(EnumType.STRING) var status: HankeStatus = HankeStatus.DRAFT,
-    var hankeTunnus: String? = null,
+    val hankeTunnus: String,
     var nimi: String,
     var kuvaus: String? = null,
     @Enumerated(EnumType.STRING) var vaihe: Vaihe? = null,
@@ -225,7 +225,7 @@ class HankeEntity(
 
     override fun hashCode(): Int {
         var result = status.hashCode()
-        result = 31 * result + (hankeTunnus?.hashCode() ?: 0)
+        result = 31 * result + hankeTunnus.hashCode()
         result = 31 * result + (id ?: 0)
         return result
     }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationEntity.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationEntity.kt
@@ -35,9 +35,9 @@ data class ApplicationEntity(
             applicationIdentifier,
             applicationType,
             applicationData,
-            hanke.hankeTunnus!!,
+            hanke.hankeTunnus,
         )
 
     /** An application must belong to a Hanke. Thus, hankeTunnus must be present. */
-    fun hankeTunnus(): String = hanke.hankeTunnus!!
+    fun hankeTunnus(): String = hanke.hankeTunnus
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationService.kt
@@ -404,7 +404,7 @@ open class ApplicationService(
         hankeKayttajaService.saveNewTokensFromApplication(
             application = application,
             hankeId = hanke.id!!,
-            hankeTunnus = hanke.hankeTunnus!!,
+            hankeTunnus = hanke.hankeTunnus,
             hankeNimi = hanke.nimi,
             currentUserId = currentUserId,
             currentKayttaja = currentKayttaja
@@ -412,7 +412,7 @@ open class ApplicationService(
 
         contacts.forEach {
             notifyOnApplication(
-                hanke.hankeTunnus!!,
+                hanke.hankeTunnus,
                 application.applicationIdentifier!!,
                 application.applicationType,
                 currentKayttaja,
@@ -536,18 +536,6 @@ open class ApplicationService(
             return
         }
         logger.info { "Sending application ready emails to ${receivers.size} receivers" }
-
-        // Check even things that should never be null, because NPE here would cause the
-        // scheduled check to repeat the error every minute indefinitely, without giving
-        // other applications a chance to get their statuses checked.
-        val hankeTunnus = application.hanke.hankeTunnus
-        if (hankeTunnus == null) {
-            logger.error {
-                "Can't send decision ready emails, because hankeTunnus is null. " +
-                    "applicationId=${application.id}, applicationIdentifier=$applicationIdentifier"
-            }
-            return
-        }
 
         receivers.forEach {
             sendDecisionReadyEmail(it.email, applicationIdentifier, application.id)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/common/AttachmentEntity.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/common/AttachmentEntity.kt
@@ -67,7 +67,7 @@ class HankeAttachmentEntity(
             id = id!!,
             fileName = fileName,
             createdAt = createdAt,
-            hankeTunnus = hanke.hankeTunnus!!,
+            hankeTunnus = hanke.hankeTunnus,
             createdByUserId = createdByUserId,
         )
     }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/Hanke.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/Hanke.kt
@@ -25,7 +25,7 @@ data class Hanke(
         description = "Hanke identity for external purposes, set by the service",
         example = "HAI24-123"
     )
-    var hankeTunnus: String?,
+    val hankeTunnus: String,
     //
     @JsonView(ChangeLogView::class)
     @field:Schema(description = "Yhteinen kunnallistekninen työmaa")

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/PublicHanke.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/PublicHanke.kt
@@ -88,7 +88,7 @@ fun hankeToPublic(hanke: Hanke): PublicHanke {
 
     return PublicHanke(
         hanke.id!!,
-        hanke.hankeTunnus!!,
+        hanke.hankeTunnus,
         hanke.nimi,
         hanke.kuvaus!!,
         hanke.alkuPvm!!,

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaController.kt
@@ -221,7 +221,7 @@ Responds with information about the activated user and the hanke associated with
             )
 
         val hanke = hankeService.loadHankeById(kayttaja.hankeId)!!
-        return TunnistautuminenResponse(kayttaja.id, hanke.hankeTunnus!!, hanke.nimi)
+        return TunnistautuminenResponse(kayttaja.id, hanke.hankeTunnus, hanke.nimi)
     }
 
     @PostMapping("/kayttajat/{kayttajaId}/kutsu")

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaService.kt
@@ -94,7 +94,6 @@ class HankeKayttajaService(
         }
 
         val hankeId = hanke.id ?: throw HankeArgumentException("Hanke without id")
-        val hankeTunnus = hanke.hankeTunnus ?: throw HankeArgumentException("Hanke without tunnus")
 
         val contacts =
             hanke
@@ -104,7 +103,14 @@ class HankeKayttajaService(
 
         val inviter = getKayttajaByUserId(hankeId, userId)
         filterNewContacts(hankeId, contacts).forEach { contact ->
-            createTunnisteAndKayttaja(hankeId, hankeTunnus, hanke.nimi, inviter, contact, userId)
+            createTunnisteAndKayttaja(
+                hankeId,
+                hanke.hankeTunnus,
+                hanke.nimi,
+                inviter,
+                contact,
+                userId
+            )
         }
     }
 
@@ -204,7 +210,7 @@ class HankeKayttajaService(
 
         recreateTunniste(kayttaja, currentUserId)
         val hanke = hankeRepository.getReferenceById(kayttaja.hankeId)
-        sendHankeInvitation(hanke.hankeTunnus!!, hanke.nimi, inviter, kayttaja)
+        sendHankeInvitation(hanke.hankeTunnus, hanke.nimi, inviter, kayttaja)
     }
 
     /** Check that every user an update was requested for was found as a user of the hanke. */

--- a/services/hanke-service/src/main/resources/db/changelog/changesets/051-make-hanketunnus-mandatory-in-hanke.yml
+++ b/services/hanke-service/src/main/resources/db/changelog/changesets/051-make-hanketunnus-mandatory-in-hanke.yml
@@ -1,0 +1,8 @@
+databaseChangeLog:
+  - changeSet:
+      id: 051-make-hanketunnus-mandatory-in-hanke
+      author: Topias Heinonen
+      changes:
+        - addNotNullConstraint:
+            tableName: hanke
+            columnName: hanketunnus

--- a/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -129,3 +129,5 @@ databaseChangeLog:
       file: db/changelog/changesets/049-add-bus-and-tram-indexes.sql
   - include:
       file: db/changelog/changesets/050-make-nimi-mandatory-in-hanke.yml
+  - include:
+      file: db/changelog/changesets/051-make-hanketunnus-mandatory-in-hanke.yml

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/HankeMapperTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/HankeMapperTest.kt
@@ -86,13 +86,13 @@ class HankeMapperTest {
             ?.modifiedAt
             ?.let { ZonedDateTime.of(it, TZ_UTC) }
 
-    private fun expectedAlueet(hankeId: Int?, hankeTunnus: String?) =
+    private fun expectedAlueet(hankeId: Int?, hankeTunnus: String) =
         listOf(
             HankealueFactory.create(
                 hankeId = hankeId,
                 haittaAlkuPvm = DateFactory.getStartDatetime().toLocalDate().atStartOfDay(TZ_UTC),
                 haittaLoppuPvm = DateFactory.getEndDatetime().toLocalDate().atStartOfDay(TZ_UTC),
-                geometriat = geometry.apply { resetFeatureProperties(hankeTunnus!!) },
+                geometriat = geometry.apply { resetFeatureProperties(hankeTunnus) },
             )
         )
 }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceTest.kt
@@ -25,7 +25,6 @@ import fi.hel.haitaton.hanke.email.EmailSenderService
 import fi.hel.haitaton.hanke.factory.AlluDataFactory
 import fi.hel.haitaton.hanke.factory.AlluDataFactory.Companion.withContacts
 import fi.hel.haitaton.hanke.factory.AlluDataFactory.Companion.withCustomer
-import fi.hel.haitaton.hanke.factory.AlluDataFactory.Companion.withHanke
 import fi.hel.haitaton.hanke.factory.ApplicationHistoryFactory
 import fi.hel.haitaton.hanke.factory.HankeFactory
 import fi.hel.haitaton.hanke.factory.HankeKayttajaFactory
@@ -367,7 +366,7 @@ class ApplicationServiceTest {
                 hankeKayttajaService.saveNewTokensFromApplication(
                     applicationEntity,
                     hankeEntity.id!!,
-                    hankeEntity.hankeTunnus!!,
+                    hankeEntity.hankeTunnus,
                     hankeEntity.nimi,
                     USERNAME,
                     sender
@@ -481,7 +480,7 @@ class ApplicationServiceTest {
                 hankeKayttajaService.saveNewTokensFromApplication(
                     any(),
                     hankeEntity.id!!,
-                    hankeEntity.hankeTunnus!!,
+                    hankeEntity.hankeTunnus,
                     hankeEntity.nimi,
                     USERNAME,
                     sender
@@ -640,28 +639,6 @@ class ApplicationServiceTest {
 
             assertThat(output)
                 .contains("No receivers found for decision ready email, not sending any.")
-            verifySequence {
-                applicationRepository.getOneByAlluid(42)
-                applicationRepository.save(any())
-                statusRepository.getReferenceById(1)
-                statusRepository.save(any())
-            }
-            verify { emailSenderService wasNot Called }
-        }
-
-        @Test
-        fun `logs error if hanketunnus is null`(output: CapturedOutput) {
-            every { applicationRepository.getOneByAlluid(42) } returns
-                applicationEntityWithCustomer()
-                    .withHanke(HankeFactory.createMinimalEntity(id = 1, hankeTunnus = null))
-            every { applicationRepository.save(any()) } answers { firstArg() }
-            every { statusRepository.getReferenceById(1) } returns AlluStatus(1, updateTime)
-            every { statusRepository.save(any()) } answers { firstArg() }
-
-            applicationService.handleApplicationUpdates(historiesWithDecision(), updateTime)
-
-            assertThat(output)
-                .contains("Can't send decision ready emails, because hankeTunnus is null.")
             verifySequence {
                 applicationRepository.getOneByAlluid(42)
                 applicationRepository.save(any())

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/AlluDataFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/AlluDataFactory.kt
@@ -305,11 +305,6 @@ class AlluDataFactory(
                 hanke = hanke,
             )
 
-        fun ApplicationEntity.withHanke(hanke: HankeEntity): ApplicationEntity {
-            this.hanke = hanke
-            return this
-        }
-
         fun createAlluApplicationResponse(
             id: Int = 42,
             status: ApplicationStatus = ApplicationStatus.PENDING

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/CreateHankeRequestBuilder.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/CreateHankeRequestBuilder.kt
@@ -4,6 +4,7 @@ import fi.hel.haitaton.hanke.HankeService
 import fi.hel.haitaton.hanke.TyomaaTyyppi
 import fi.hel.haitaton.hanke.domain.CreateHankeRequest
 import fi.hel.haitaton.hanke.domain.Hanke
+import fi.hel.haitaton.hanke.domain.HankeYhteystieto
 import fi.hel.haitaton.hanke.domain.Hankealue
 
 data class CreateHankeRequestBuilder(
@@ -16,12 +17,14 @@ data class CreateHankeRequestBuilder(
 
     fun withRequest(f: CreateHankeRequest.() -> CreateHankeRequest) = copy(request = request.f())
 
-    fun withYhteystiedot(): CreateHankeRequestBuilder = withRequest {
+    fun withYhteystiedot(
+        mutator: HankeYhteystieto.() -> Unit = { id = null }
+    ): CreateHankeRequestBuilder = withRequest {
         copy(
-            omistajat = listOf(HankeYhteystietoFactory.createDifferentiated(1, id = null)),
-            rakennuttajat = listOf(HankeYhteystietoFactory.createDifferentiated(2, id = null)),
-            toteuttajat = listOf(HankeYhteystietoFactory.createDifferentiated(3, id = null)),
-            muut = listOf(HankeYhteystietoFactory.createDifferentiated(4, id = null)),
+            omistajat = listOf(HankeYhteystietoFactory.createDifferentiated(1).apply(mutator)),
+            rakennuttajat = listOf(HankeYhteystietoFactory.createDifferentiated(2).apply(mutator)),
+            toteuttajat = listOf(HankeYhteystietoFactory.createDifferentiated(3).apply(mutator)),
+            muut = listOf(HankeYhteystietoFactory.createDifferentiated(4).apply(mutator)),
         )
     }
 

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeFactory.kt
@@ -132,7 +132,7 @@ class HankeFactory(
          */
         fun create(
             id: Int? = defaultId,
-            hankeTunnus: String? = defaultHankeTunnus,
+            hankeTunnus: String = defaultHankeTunnus,
             nimi: String = defaultNimi,
             vaihe: Vaihe? = Vaihe.OHJELMOINTI,
             suunnitteluVaihe: SuunnitteluVaihe? = null,
@@ -159,7 +159,7 @@ class HankeFactory(
 
         fun createMinimalEntity(
             id: Int? = defaultId,
-            hankeTunnus: String? = defaultHankeTunnus,
+            hankeTunnus: String = defaultHankeTunnus,
             nimi: String = defaultNimi,
             generated: Boolean = false,
         ) = HankeEntity(id = id, hankeTunnus = hankeTunnus, nimi = nimi, generated = generated)

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeIdentifierFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeIdentifierFactory.kt
@@ -13,4 +13,4 @@ object HankeIdentifierFactory {
 data class TestHankeIdentifier(override val id: Int, override val hankeTunnus: String) :
     HankeIdentifier
 
-fun Hanke.identifier(): HankeIdentifier = TestHankeIdentifier(id!!, hankeTunnus!!)
+fun Hanke.identifier(): HankeIdentifier = TestHankeIdentifier(id!!, hankeTunnus)


### PR DESCRIPTION
# Description

Make hanketunnus mandatory, i.e. non-nullable, in both Hanke and HankeEntity. Now that there's a separate class for hanke creation, hanketunnus is always defined when these classes come into play.

Also, rewrite controller tests for hanke creation. Change them to use the HAnkeCreateRequest instead of just Hanke, but add one test that documents what happens when the endpoint is called with a full Hanke object. Some tests that didn't really test any functionality were removed.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1893

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [X] Other