### PR TITLE
HAI-1893 Make id mandatory in Hanke and HankeEntity

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
@@ -154,9 +154,9 @@ class HankeServiceITests : DatabaseTest() {
         fun `returns hanke if hanke exists`() {
             val hanke = hankeFactory.save()
 
-            val response = hankeService.loadHankeById(hanke.id!!)
+            val response = hankeService.loadHankeById(hanke.id)
 
-            assertk.assertThat(response).isNotNull().prop(Hanke::id).isEqualTo(hanke.id!!)
+            assertk.assertThat(response).isNotNull().prop(Hanke::id).isEqualTo(hanke.id)
         }
     }
 
@@ -181,12 +181,10 @@ class HankeServiceITests : DatabaseTest() {
 
         // Verify privileges
         PermissionCode.entries.forEach {
-            assertThat(permissionService.hasPermission(returnedHanke.id!!, USER_NAME, it)).isTrue()
+            assertThat(permissionService.hasPermission(returnedHanke.id, USER_NAME, it)).isTrue()
         }
-        // Check the return object in general:
-        assertThat(returnedHanke).isNotNull
-        assertThat(returnedHanke).isNotSameAs(request)
-        assertThat(returnedHanke.id).isNotNull
+        // Check the ID is reassigned by the DB:
+        assertThat(returnedHanke.id).isNotEqualTo(0)
         // Check the fields:
         // Note, "pvm" values should have become truncated to begin of the day
         val expectedDateAlku = // nextyear.2.20 00:00:00Z
@@ -285,11 +283,6 @@ class HankeServiceITests : DatabaseTest() {
         // Call create and get the return object:
         val returnedHanke = hankeService.createHanke(request)
 
-        // Check the return object in general:
-        assertThat(returnedHanke).isNotNull
-        assertThat(returnedHanke).isNotSameAs(request)
-        assertThat(returnedHanke.id).isNotNull
-
         // Check status:
         assertThat(returnedHanke.status).isEqualTo(HankeStatus.DRAFT)
 
@@ -301,9 +294,7 @@ class HankeServiceITests : DatabaseTest() {
         val returnedHanke2 = hankeService.updateHanke(returnedHanke)
 
         // Check the return object in general:
-        assertThat(returnedHanke2).isNotNull
         assertThat(returnedHanke2).isNotSameAs(returnedHanke)
-        assertThat(returnedHanke2.id).isNotNull
 
         // Check that status changed now with full data available:
         assertThat(returnedHanke2.status).isEqualTo(HankeStatus.PUBLIC)
@@ -393,13 +384,9 @@ class HankeServiceITests : DatabaseTest() {
         // Also tests how update affects audit fields.
 
         // Setup Hanke with one Yhteystieto:
-        val hanke = HankeFactory.createRequest().withGeneratedOmistaja(1).build()
+        val request = HankeFactory.createRequest().withGeneratedOmistaja(1).build()
 
-        // Call create, get the return object, and make some general checks:
-        val returnedHanke = hankeService.createHanke(hanke)
-        assertThat(returnedHanke).isNotNull
-        assertThat(returnedHanke).isNotSameAs(hanke)
-        assertThat(returnedHanke.id).isNotNull
+        val returnedHanke = hankeService.createHanke(request)
         // Check and record the Yhteystieto's id
         assertThat(returnedHanke.omistajat).hasSize(1)
         assertThat(returnedHanke.omistajat[0].id).isNotNull
@@ -414,10 +401,7 @@ class HankeServiceITests : DatabaseTest() {
 
         // Call update, get the returned object, make some general checks:
         val returnedHanke2 = hankeService.updateHanke(returnedHanke)
-        assertThat(returnedHanke2).isNotNull
-        assertThat(returnedHanke2).isNotSameAs(hanke)
         assertThat(returnedHanke2).isNotSameAs(returnedHanke)
-        assertThat(returnedHanke2.id).isNotNull
 
         // A small side-check here for audit and version fields handling on update:
         assertThat(returnedHanke2.version).isEqualTo(1)
@@ -449,10 +433,9 @@ class HankeServiceITests : DatabaseTest() {
         assertThat(returnedHanke3).isNotNull
         assertThat(returnedHanke3).isNotSameAs(returnedHanke)
         assertThat(returnedHanke3).isNotSameAs(returnedHanke2)
-        assertThat(returnedHanke3!!.id).isNotNull
 
         // Check that the returned hanke has the same 3 Yhteystietos:
-        assertThat(returnedHanke3.omistajat).hasSize(2)
+        assertThat(returnedHanke3!!.omistajat).hasSize(2)
         assertThat(returnedHanke3.rakennuttajat).hasSize(1)
         assertThat(returnedHanke3.omistajat[0].id).isEqualTo(ytid)
         assertThat(returnedHanke3.omistajat[0].nimi).isEqualTo(NAME_1)
@@ -477,10 +460,7 @@ class HankeServiceITests : DatabaseTest() {
         // Setup Hanke with two Yhteystietos in the same group:
         val request = HankeFactory.createRequest().withGeneratedOmistajat(1, 2).build()
 
-        // Call create, get the return object, and make some general checks:
         val returnedHanke = hankeService.createHanke(request)
-        assertThat(returnedHanke).isNotNull
-        assertThat(returnedHanke.id).isNotNull
         // Check and record the Yhteystieto ids, and to-be-changed field's value
         assertThat(returnedHanke.omistajat).hasSize(2)
         assertThat(returnedHanke.omistajat[0].id).isNotNull
@@ -497,9 +477,7 @@ class HankeServiceITests : DatabaseTest() {
 
         // Call update, get the returned object, make some general checks:
         val returnedHanke2 = hankeService.updateHanke(returnedHanke)
-        assertThat(returnedHanke2).isNotNull
         assertThat(returnedHanke2).isNotSameAs(returnedHanke)
-        assertThat(returnedHanke2.id).isNotNull
 
         // Check that both entries kept their ids, and the only change is where expected
         assertThat(returnedHanke2.omistajat).hasSize(2)
@@ -514,10 +492,9 @@ class HankeServiceITests : DatabaseTest() {
         assertThat(returnedHanke3).isNotNull
         assertThat(returnedHanke3).isNotSameAs(returnedHanke)
         assertThat(returnedHanke3).isNotSameAs(returnedHanke2)
-        assertThat(returnedHanke3!!.id).isNotNull
 
         // Check that the returned hanke has the same 2 Yhteystietos:
-        assertThat(returnedHanke3.omistajat).hasSize(2)
+        assertThat(returnedHanke3!!.omistajat).hasSize(2)
         assertThat(returnedHanke3.omistajat[0].id).isEqualTo(ytid1)
         assertThat(returnedHanke3.omistajat[1].id).isEqualTo(ytid2)
         assertThat(returnedHanke3.omistajat[0].nimi).isEqualTo(NAME_1)
@@ -541,9 +518,6 @@ class HankeServiceITests : DatabaseTest() {
 
         // Call create, get the return object, and make some general checks:
         val returnedHanke = hankeService.createHanke(request)
-        assertThat(returnedHanke).isNotNull
-        assertThat(returnedHanke).isNotSameAs(request)
-        assertThat(returnedHanke.id).isNotNull
         // Check and record the Yhteystieto ids:
         assertThat(returnedHanke.omistajat).hasSize(2)
         assertThat(returnedHanke.omistajat[0].id).isNotNull
@@ -559,10 +533,7 @@ class HankeServiceITests : DatabaseTest() {
 
         // Call update, get the returned object, make some general checks:
         val returnedHanke2 = hankeService.updateHanke(returnedHanke)
-        assertThat(returnedHanke2).isNotNull
-        assertThat(returnedHanke2).isNotSameAs(request)
         assertThat(returnedHanke2).isNotSameAs(returnedHanke)
-        assertThat(returnedHanke2.id).isNotNull
 
         // Check that one yhteystieto got removed, the first one remaining, and its fields not
         // affected:
@@ -576,10 +547,9 @@ class HankeServiceITests : DatabaseTest() {
         assertThat(returnedHanke3).isNotNull
         assertThat(returnedHanke3).isNotSameAs(returnedHanke)
         assertThat(returnedHanke3).isNotSameAs(returnedHanke2)
-        assertThat(returnedHanke3!!.id).isNotNull
 
         // Check that the returned hanke has the same Yhteystieto:
-        assertThat(returnedHanke3.omistajat).hasSize(1)
+        assertThat(returnedHanke3!!.omistajat).hasSize(1)
         assertThat(returnedHanke3.omistajat[0].id).isEqualTo(ytid1)
         assertThat(returnedHanke3.omistajat[0].nimi).isEqualTo(NAME_1)
     }
@@ -593,10 +563,8 @@ class HankeServiceITests : DatabaseTest() {
                 .withGeneratedRakennuttaja(1)
                 .build()
 
-        // Call create, get the return object, and make some general checks:
         val returnedHanke = hankeService.createHanke(request)
-        assertThat(returnedHanke).isNotNull
-        assertThat(returnedHanke.id).isNotNull
+
         // Check and record the Yhteystieto ids, and that the ids are different:
         assertThat(returnedHanke.omistajat).hasSize(1)
         assertThat(returnedHanke.omistajat[0].id).isNotNull
@@ -615,13 +583,10 @@ class HankeServiceITests : DatabaseTest() {
 
         // Call update, get the returned object, make some general checks:
         val returnedHanke2 = hankeService.updateHanke(returnedHanke)
-        assertThat(returnedHanke2).isNotNull
         assertThat(returnedHanke2).isNotSameAs(returnedHanke)
-        assertThat(returnedHanke2.id).isNotNull
 
         // Check that rakennuttaja-yhteystieto got removed, the first one remaining, and its fields
-        // not
-        // affected:
+        // not affected:
         assertThat(returnedHanke2.rakennuttajat).hasSize(0)
         assertThat(returnedHanke2.omistajat).hasSize(1)
         assertThat(returnedHanke2.omistajat[0].id).isEqualTo(ytid1)
@@ -633,10 +598,9 @@ class HankeServiceITests : DatabaseTest() {
         assertThat(returnedHanke3).isNotNull
         assertThat(returnedHanke3).isNotSameAs(returnedHanke)
         assertThat(returnedHanke3).isNotSameAs(returnedHanke2)
-        assertThat(returnedHanke3!!.id).isNotNull
 
         // Check that the returned hanke has the same 2 Yhteystietos:
-        assertThat(returnedHanke3.rakennuttajat).hasSize(0)
+        assertThat(returnedHanke3!!.rakennuttajat).hasSize(0)
         assertThat(returnedHanke3.omistajat).hasSize(1)
         assertThat(returnedHanke3.omistajat[0].id).isEqualTo(ytid1)
         assertThat(returnedHanke3.omistajat[0].nimi).isEqualTo(NAME_1)
@@ -652,11 +616,8 @@ class HankeServiceITests : DatabaseTest() {
         // Setup Hanke with one Yhteystieto:
         val request = HankeFactory.createRequest().withGeneratedOmistaja(1).build()
 
-        // Call create, get the return object, and make some general checks:
         val returnedHanke = hankeService.createHanke(request)
-        assertThat(returnedHanke).isNotNull
-        assertThat(returnedHanke).isNotSameAs(request)
-        assertThat(returnedHanke.id).isNotNull
+
         // Check and record the Yhteystieto's id
         assertThat(returnedHanke.omistajat).hasSize(1)
         assertThat(returnedHanke.omistajat[0].id).isNotNull
@@ -669,10 +630,7 @@ class HankeServiceITests : DatabaseTest() {
         val returnedHanke2 = hankeService.updateHanke(returnedHanke)
 
         // General checks (because using another API action)
-        assertThat(returnedHanke2).isNotNull
         assertThat(returnedHanke2).isNotSameAs(returnedHanke)
-        assertThat(returnedHanke2.id).isNotNull
-        assertThat(returnedHanke2.hankeTunnus).isNotNull
         // Check that the returned hanke only has one entry, with a new id
         assertThat(returnedHanke2.omistajat).hasSize(1)
         assertThat(returnedHanke2.omistajat[0].id).isNotNull
@@ -685,10 +643,9 @@ class HankeServiceITests : DatabaseTest() {
         assertThat(returnedHanke3).isNotNull
         assertThat(returnedHanke3).isNotSameAs(returnedHanke)
         assertThat(returnedHanke3).isNotSameAs(returnedHanke2)
-        assertThat(returnedHanke3!!.id).isNotNull
 
         // Check that the returned hanke only has one entry, with that new id
-        assertThat(returnedHanke3.omistajat).hasSize(1)
+        assertThat(returnedHanke3!!.omistajat).hasSize(1)
         assertThat(returnedHanke3.omistajat[0].id).isNotNull
         assertThat(returnedHanke3.omistajat[0].id).isEqualTo(ytid2)
     }
@@ -700,10 +657,8 @@ class HankeServiceITests : DatabaseTest() {
         // Setup Hanke with two Yhteystietos in the same group:
         val request = HankeFactory.createRequest().withGeneratedOmistajat(1, 2).build()
 
-        // Call create, get the return object, and make some general checks:
         val createdHanke = hankeService.createHanke(request)
-        assertThat(createdHanke).isNotNull
-        assertThat(createdHanke.id).isNotNull
+
         // Check and record the Yhteystieto ids, and to-be-changed field's value
         assertThat(createdHanke.omistajat).hasSize(2)
         assertThat(createdHanke.omistajat[0].id).isNotNull
@@ -831,7 +786,7 @@ class HankeServiceITests : DatabaseTest() {
         // (must be done via entities):
         // Fetching the yhteystieto is a bit clumsy since we don't have separate a
         // YhteystietoRepository.
-        var hankeEntity = hankeRepository.findById(hanke.id!!).get()
+        var hankeEntity = hankeRepository.findById(hanke.id).get()
         var yhteystietos = hankeEntity.listOfHankeYhteystieto
         var rakennuttajaEntity =
             yhteystietos.filter { it.contactType == ContactType.RAKENNUTTAJA }[0]
@@ -906,7 +861,7 @@ class HankeServiceITests : DatabaseTest() {
         assertThat(rakennuttajat[0].nimi).isEqualTo(NAME_2)
 
         // Unset the processing restriction flag:
-        hankeEntity = hankeRepository.findById(hanke.id!!).get()
+        hankeEntity = hankeRepository.findById(hanke.id).get()
         yhteystietos = hankeEntity.listOfHankeYhteystieto
         rakennuttajaEntity = yhteystietos.filter { it.contactType == ContactType.RAKENNUTTAJA }[0]
         rakennuttajaEntity.dataLocked = false
@@ -1153,7 +1108,7 @@ class HankeServiceITests : DatabaseTest() {
         assertEquals("testUser", event.actor.userId)
         assertEquals(UserRole.USER, event.actor.role)
         assertEquals(TestUtils.mockedIp, event.actor.ipAddress)
-        assertEquals(hanke.id?.toString(), event.target.id)
+        assertEquals(hanke.id.toString(), event.target.id)
         assertEquals(ObjectType.HANKE, event.target.type)
         assertNull(event.target.objectAfter)
         val expectedObject =
@@ -1301,7 +1256,7 @@ class HankeServiceITests : DatabaseTest() {
         assertEquals(USER_NAME, event.actor.userId)
         assertEquals(UserRole.USER, event.actor.role)
         assertEquals(TestUtils.mockedIp, event.actor.ipAddress)
-        assertEquals(hanke.id?.toString(), event.target.id)
+        assertEquals(hanke.id.toString(), event.target.id)
         assertEquals(ObjectType.HANKE, event.target.type)
         assertNull(event.target.objectBefore)
         val expectedObject =
@@ -1339,7 +1294,7 @@ class HankeServiceITests : DatabaseTest() {
         assertEquals(USER_NAME, event.actor.userId)
         assertEquals(UserRole.USER, event.actor.role)
         assertEquals(TestUtils.mockedIp, event.actor.ipAddress)
-        assertEquals(hanke.id?.toString(), event.target.id)
+        assertEquals(hanke.id.toString(), event.target.id)
         assertEquals(ObjectType.HANKE, event.target.type)
         assertNull(event.target.objectBefore)
         val expectedObject = expectedHankeLogObject(hanke, alkuPvm = null, loppuPvm = null)
@@ -1384,7 +1339,7 @@ class HankeServiceITests : DatabaseTest() {
         assertEquals("test7358", event.actor.userId)
         assertEquals(UserRole.USER, event.actor.role)
         assertEquals(TestUtils.mockedIp, event.actor.ipAddress)
-        assertEquals(hanke.id?.toString(), event.target.id)
+        assertEquals(hanke.id.toString(), event.target.id)
         assertEquals(ObjectType.HANKE, event.target.type)
         val expectedObjectBefore = expectedHankeLogObject(hanke, alkuPvm = null, loppuPvm = null)
         JSONAssert.assertEquals(
@@ -1431,7 +1386,7 @@ class HankeServiceITests : DatabaseTest() {
         assertEquals(1, hankeLogs.size)
         val event = hankeLogs[0].message.auditEvent
         assertEquals(Operation.UPDATE, event.operation)
-        assertEquals(hanke.id?.toString(), event.target.id)
+        assertEquals(hanke.id.toString(), event.target.id)
         assertEquals(ObjectType.HANKE, event.target.type)
         val expectedObjectBefore =
             expectedHankeLogObject(hanke, hanke.alueet[0], tormaystarkasteluTulos = true)
@@ -1442,7 +1397,7 @@ class HankeServiceITests : DatabaseTest() {
         )
         val templateData =
             TemplateData(
-                updatedHanke.id!!,
+                updatedHanke.id,
                 updatedHanke.hankeTunnus,
                 updatedHanke.alueet[0].id,
                 updatedHanke.alueet[0].geometriat?.id,
@@ -1581,7 +1536,7 @@ class HankeServiceITests : DatabaseTest() {
     ): String {
         val templateData =
             TemplateData(
-                hanke.id!!,
+                hanke.id,
                 hanke.hankeTunnus,
                 alue?.id,
                 alue?.geometriat?.id,

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationAuthorizerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationAuthorizerITest.kt
@@ -67,7 +67,7 @@ class ApplicationAuthorizerITest(
         fun `throws exception if user doesn't have the required permission`() {
             val hanke = hankeFactory.saveMinimal()
             val application = alluDataFactory.saveApplicationEntity(USERNAME, hanke)
-            permissionService.create(hanke.id!!, USERNAME, Kayttooikeustaso.HANKEMUOKKAUS)
+            permissionService.create(hanke.id, USERNAME, Kayttooikeustaso.HANKEMUOKKAUS)
 
             assertFailure {
                     authorizer.authorizeApplicationId(application.id!!, PermissionCode.DELETE.name)
@@ -82,7 +82,7 @@ class ApplicationAuthorizerITest(
         fun `returns true if user has the required permission`() {
             val hanke = hankeFactory.saveMinimal()
             val application = alluDataFactory.saveApplicationEntity(USERNAME, hanke)
-            permissionService.create(hanke.id!!, USERNAME, Kayttooikeustaso.HANKEMUOKKAUS)
+            permissionService.create(hanke.id, USERNAME, Kayttooikeustaso.HANKEMUOKKAUS)
 
             assertThat(
                     authorizer.authorizeApplicationId(application.id!!, PermissionCode.VIEW.name)
@@ -110,7 +110,7 @@ class ApplicationAuthorizerITest(
         fun `throws exception if user doesn't have EDIT_APPLICATIONS permission`() {
             val hanke = hankeFactory.saveMinimal(hankeTunnus = hankeTunnus)
             val application = AlluDataFactory.createApplication(hankeTunnus = hankeTunnus)
-            permissionService.create(hanke.id!!, USERNAME, Kayttooikeustaso.HANKEMUOKKAUS)
+            permissionService.create(hanke.id, USERNAME, Kayttooikeustaso.HANKEMUOKKAUS)
 
             assertFailure { authorizer.authorizeCreate(application) }
                 .all {
@@ -123,7 +123,7 @@ class ApplicationAuthorizerITest(
         fun `returns true if user has EDIT_APPLICATIONS permission`() {
             val hanke = hankeFactory.saveMinimal(hankeTunnus = hankeTunnus)
             val application = AlluDataFactory.createApplication(hankeTunnus = hankeTunnus)
-            permissionService.create(hanke.id!!, USERNAME, Kayttooikeustaso.HAKEMUSASIOINTI)
+            permissionService.create(hanke.id, USERNAME, Kayttooikeustaso.HAKEMUSASIOINTI)
 
             assertThat(authorizer.authorizeCreate(application)).isTrue()
         }

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceITest.kt
@@ -66,7 +66,6 @@ import fi.hel.haitaton.hanke.factory.AlluDataFactory.Companion.withCustomer
 import fi.hel.haitaton.hanke.factory.ApplicationHistoryFactory
 import fi.hel.haitaton.hanke.factory.AttachmentFactory
 import fi.hel.haitaton.hanke.factory.HankeFactory
-import fi.hel.haitaton.hanke.factory.HankeFactory.Companion.withHankealue
 import fi.hel.haitaton.hanke.findByType
 import fi.hel.haitaton.hanke.firstReceivedMessage
 import fi.hel.haitaton.hanke.getResourceAsBytes
@@ -917,7 +916,7 @@ class ApplicationServiceITest : DatabaseTest() {
         @Test
         fun `when application area outside hankealue should throw`() {
             val hanke = hankeFactory.createRequest().withHankealue().save()
-            val hankeEntity = hankeRepository.getReferenceById(hanke.id!!)
+            val hankeEntity = hankeRepository.getReferenceById(hanke.id)
             val application =
                 alluDataFactory.saveApplicationEntity(USERNAME, hanke = hankeEntity) {
                     it.alluid = 21
@@ -953,8 +952,8 @@ class ApplicationServiceITest : DatabaseTest() {
             val otherUser = "otherUser"
             val hanke = hankeFactory.saveMinimal(hankeTunnus = HANKE_TUNNUS)
             val hanke2 = hankeFactory.saveMinimal(hankeTunnus = "HAI-1236")
-            permissionService.create(hanke.id!!, USERNAME, HAKEMUSASIOINTI)
-            permissionService.create(hanke2.id!!, "otherUser", HAKEMUSASIOINTI)
+            permissionService.create(hanke.id, USERNAME, HAKEMUSASIOINTI)
+            permissionService.create(hanke2.id, "otherUser", HAKEMUSASIOINTI)
             alluDataFactory.saveApplicationEntities(3, USERNAME, hanke = hanke) { _, application ->
                 application.userId = USERNAME
                 application.applicationData =
@@ -980,8 +979,8 @@ class ApplicationServiceITest : DatabaseTest() {
             val hanke = hankeFactory.saveMinimal(hankeTunnus = HANKE_TUNNUS)
             val hanke2 = hankeFactory.saveMinimal(hankeTunnus = "HAI-1236")
             val hanke3 = hankeFactory.saveMinimal(hankeTunnus = "HAI-1237")
-            permissionService.create(hanke.id!!, USERNAME, HAKEMUSASIOINTI)
-            permissionService.create(hanke2.id!!, USERNAME, HAKEMUSASIOINTI)
+            permissionService.create(hanke.id, USERNAME, HAKEMUSASIOINTI)
+            permissionService.create(hanke2.id, USERNAME, HAKEMUSASIOINTI)
             val application1 =
                 alluDataFactory.saveApplicationEntity(username = USERNAME, hanke = hanke)
             val application2 =
@@ -1255,7 +1254,7 @@ class ApplicationServiceITest : DatabaseTest() {
         @Test
         fun `Throws an exception when application area is outside hankealue`() {
             val hanke = hankeFactory.createRequest().withHankealue().save()
-            val hankeEntity = hankeRepository.getReferenceById(hanke.id!!)
+            val hankeEntity = hankeRepository.getReferenceById(hanke.id)
             val application =
                 alluDataFactory.saveApplicationEntity(USERNAME, hanke = hankeEntity) {
                     it.applicationData =

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeAuthorizerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeAuthorizerITest.kt
@@ -57,7 +57,7 @@ class HankeAuthorizerITest(
         @Test
         fun `throws exception if user doesn't have the required permission for the hanke`() {
             val hanke = hankeFactory.saveMinimal(hankeTunnus = hankeTunnus)
-            permissionService.create(hanke.id!!, USERNAME, Kayttooikeustaso.KATSELUOIKEUS)
+            permissionService.create(hanke.id, USERNAME, Kayttooikeustaso.KATSELUOIKEUS)
 
             assertFailure { authorizer.authorizeHankeTunnus(hankeTunnus, PermissionCode.EDIT.name) }
                 .all {
@@ -69,7 +69,7 @@ class HankeAuthorizerITest(
         @Test
         fun `return true if user has the required permission for the hanke`() {
             val hanke = hankeFactory.saveMinimal(hankeTunnus = hankeTunnus)
-            permissionService.create(hanke.id!!, USERNAME, Kayttooikeustaso.KATSELUOIKEUS)
+            permissionService.create(hanke.id, USERNAME, Kayttooikeustaso.KATSELUOIKEUS)
 
             assertThat(authorizer.authorizeHankeTunnus(hankeTunnus, PermissionCode.VIEW.name))
                 .isTrue()

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaAuthorizerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaAuthorizerITest.kt
@@ -46,7 +46,7 @@ class HankeKayttajaAuthorizerITest(
 
         @Test
         fun `throws exception if user doesn't have any permission for the hanke`() {
-            val hankeId = hankeFactory.saveMinimal().id!!
+            val hankeId = hankeFactory.saveMinimal().id
             val kayttajaId = hankeKayttajaFactory.saveUser(hankeId).id
 
             assertFailure { authorizer.authorizeKayttajaId(kayttajaId, PermissionCode.VIEW.name) }
@@ -58,7 +58,7 @@ class HankeKayttajaAuthorizerITest(
 
         @Test
         fun `throws exception if user doesn't have the required permission for the hanke`() {
-            val hankeId = hankeFactory.saveMinimal().id!!
+            val hankeId = hankeFactory.saveMinimal().id
             val kayttajaId = hankeKayttajaFactory.saveUserAndPermission(hankeId).id
             permissionService.create(hankeId, USERNAME, Kayttooikeustaso.KATSELUOIKEUS)
 
@@ -71,7 +71,7 @@ class HankeKayttajaAuthorizerITest(
 
         @Test
         fun `return true if user has the required permission for the hanke`() {
-            val hankeId = hankeFactory.saveMinimal().id!!
+            val hankeId = hankeFactory.saveMinimal().id
             val kayttajaId = hankeKayttajaFactory.saveUserAndPermission(hankeId).id
             permissionService.create(hankeId, USERNAME, Kayttooikeustaso.HANKEMUOKKAUS)
 

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaControllerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaControllerITest.kt
@@ -166,7 +166,7 @@ class HankeKayttajaControllerITest(@Autowired override val mockMvc: MockMvc) : C
             val testData = HankeKayttajaFactory.generateHankeKayttajat()
             every { authorizer.authorizeHankeTunnus(HANKE_TUNNUS, VIEW.name) } returns true
             every { hankeService.findIdentifier(HANKE_TUNNUS) } returns hanke.identifier()
-            every { hankeKayttajaService.getKayttajatByHankeId(hanke.id!!) } returns testData
+            every { hankeKayttajaService.getKayttajatByHankeId(hanke.id) } returns testData
 
             val response: HankeKayttajaResponse =
                 getHankeKayttajat().andExpect(status().isOk).andReturnBody()
@@ -181,7 +181,7 @@ class HankeKayttajaControllerITest(@Autowired override val mockMvc: MockMvc) : C
             assertThat(response.kayttajat).hasSameElementsAs(testData)
             verifyOrder {
                 authorizer.authorizeHankeTunnus(HANKE_TUNNUS, VIEW.name)
-                hankeKayttajaService.getKayttajatByHankeId(hanke.id!!)
+                hankeKayttajaService.getKayttajatByHankeId(hanke.id)
                 disclosureLogService.saveDisclosureLogsForHankeKayttajat(
                     response.kayttajat,
                     USERNAME

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaServiceITest.kt
@@ -126,7 +126,7 @@ class HankeKayttajaServiceITest : DatabaseTest() {
             hankeFactory.createRequest().withYhteystiedot().save()
 
             val result: List<HankeKayttajaDto> =
-                hankeKayttajaService.getKayttajatByHankeId(hankeToFind.id!!)
+                hankeKayttajaService.getKayttajatByHankeId(hankeToFind.id)
 
             assertThat(result).hasSize(4)
         }
@@ -136,7 +136,7 @@ class HankeKayttajaServiceITest : DatabaseTest() {
             val hanke = hankeFactory.createRequest().withGeneratedOmistaja(1).save()
 
             val result: List<HankeKayttajaDto> =
-                hankeKayttajaService.getKayttajatByHankeId(hanke.id!!)
+                hankeKayttajaService.getKayttajatByHankeId(hanke.id)
 
             val entity: HankeKayttajaEntity =
                 hankeKayttajaRepository.findAll().also { assertThat(it).hasSize(1) }.first()
@@ -159,7 +159,7 @@ class HankeKayttajaServiceITest : DatabaseTest() {
             val hanke = hankeFactory.saveGenerated(userId = USERNAME)
 
             val result: HankeKayttajaEntity? =
-                hankeKayttajaService.getKayttajaByUserId(hanke.id!!, USERNAME)
+                hankeKayttajaService.getKayttajaByUserId(hanke.id, USERNAME)
 
             assertThat(result).isNotNull()
             with(result!!) {
@@ -185,7 +185,7 @@ class HankeKayttajaServiceITest : DatabaseTest() {
             permissionRepository.deleteAll()
 
             val result: HankeKayttajaEntity? =
-                hankeKayttajaService.getKayttajaByUserId(hanke.id!!, USERNAME)
+                hankeKayttajaService.getKayttajaByUserId(hanke.id, USERNAME)
 
             assertThat(result).isNull()
         }
@@ -193,7 +193,7 @@ class HankeKayttajaServiceITest : DatabaseTest() {
         @Test
         fun `When no kayttaja should return null`() {
             val hanke = hankeFactory.saveGenerated(userId = USERNAME)
-            val hankeId = hanke.id!!
+            val hankeId = hanke.id
             val createdKayttaja = hankeKayttajaService.getKayttajaByUserId(hankeId, USERNAME)!!
             hankeKayttajaRepository.deleteById(createdKayttaja.id)
 
@@ -211,7 +211,7 @@ class HankeKayttajaServiceITest : DatabaseTest() {
         @Test
         fun `Saves kayttaja with correct permission and other data`() {
             val hankeEntity = hankeFactory.saveEntity()
-            val savedHankeId = hankeEntity.id!!
+            val savedHankeId = hankeEntity.id
             assertThat(hankeKayttajaRepository.findAll()).isEmpty()
 
             hankeKayttajaService.addHankeFounder(savedHankeId, perustaja, USERNAME)
@@ -235,7 +235,7 @@ class HankeKayttajaServiceITest : DatabaseTest() {
         @Test
         fun `Writes user and token to audit log`() {
             val hankeEntity = hankeFactory.saveEntity()
-            val savedHankeId = hankeEntity.id!!
+            val savedHankeId = hankeEntity.id
             auditLogRepository.deleteAll()
 
             hankeKayttajaService.addHankeFounder(savedHankeId, perustaja, USERNAME)
@@ -300,7 +300,7 @@ class HankeKayttajaServiceITest : DatabaseTest() {
 
             hankeKayttajaService.saveNewTokensFromApplication(
                 application,
-                hanke.id!!,
+                hanke.id,
                 hanke.hankeTunnus,
                 hanke.nimi,
                 USERNAME,
@@ -338,7 +338,7 @@ class HankeKayttajaServiceITest : DatabaseTest() {
 
             hankeKayttajaService.saveNewTokensFromApplication(
                 application,
-                hanke.id!!,
+                hanke.id,
                 hanke.hankeTunnus,
                 hanke.nimi,
                 USERNAME
@@ -376,7 +376,7 @@ class HankeKayttajaServiceITest : DatabaseTest() {
 
             hankeKayttajaService.saveNewTokensFromApplication(
                 application,
-                hanke.id!!,
+                hanke.id,
                 hanke.hankeTunnus,
                 hanke.nimi,
                 USERNAME,
@@ -411,7 +411,7 @@ class HankeKayttajaServiceITest : DatabaseTest() {
 
             hankeKayttajaService.saveNewTokensFromApplication(
                 applicationEntity,
-                hanke.id!!,
+                hanke.id,
                 hanke.hankeTunnus,
                 hanke.nimi,
                 USERNAME,
@@ -461,7 +461,7 @@ class HankeKayttajaServiceITest : DatabaseTest() {
 
             hankeKayttajaService.saveNewTokensFromApplication(
                 application,
-                hanke.id!!,
+                hanke.id,
                 hanke.hankeTunnus,
                 hanke.nimi,
                 USERNAME
@@ -480,8 +480,8 @@ class HankeKayttajaServiceITest : DatabaseTest() {
         @Test
         fun `With pre-existing tokens creates only new ones`() {
             val hanke = hankeFactory.saveEntity()
-            kayttajaFactory.saveUserAndToken(hanke.id!!, "Existing User", "email1")
-            kayttajaFactory.saveUserAndToken(hanke.id!!, "Other User", "email4")
+            kayttajaFactory.saveUserAndToken(hanke.id, "Existing User", "email1")
+            kayttajaFactory.saveUserAndToken(hanke.id, "Other User", "email4")
             val applicationData =
                 createCableReportApplicationData(
                     customerWithContacts =
@@ -507,7 +507,7 @@ class HankeKayttajaServiceITest : DatabaseTest() {
 
             hankeKayttajaService.saveNewTokensFromApplication(
                 application,
-                hanke.id!!,
+                hanke.id,
                 hanke.hankeTunnus,
                 hanke.nimi,
                 USERNAME
@@ -528,8 +528,8 @@ class HankeKayttajaServiceITest : DatabaseTest() {
         @Test
         fun `With pre-existing permissions creates only new ones`() {
             val hanke = hankeFactory.saveEntity()
-            kayttajaFactory.saveUserAndPermission(hanke.id!!, "Existing User", "email1")
-            kayttajaFactory.saveUserAndPermission(hanke.id!!, "Other User", "email4")
+            kayttajaFactory.saveUserAndPermission(hanke.id, "Existing User", "email1")
+            kayttajaFactory.saveUserAndPermission(hanke.id, "Other User", "email4")
             val applicationData =
                 createCableReportApplicationData(
                     customerWithContacts =
@@ -555,7 +555,7 @@ class HankeKayttajaServiceITest : DatabaseTest() {
 
             hankeKayttajaService.saveNewTokensFromApplication(
                 application,
-                hanke.id!!,
+                hanke.id,
                 hanke.hankeTunnus,
                 hanke.nimi,
                 USERNAME
@@ -595,7 +595,7 @@ class HankeKayttajaServiceITest : DatabaseTest() {
 
             hankeKayttajaService.saveNewTokensFromApplication(
                 application,
-                hanke.id!!,
+                hanke.id,
                 hanke.hankeTunnus,
                 hanke.nimi,
                 USERNAME
@@ -674,7 +674,7 @@ class HankeKayttajaServiceITest : DatabaseTest() {
             val hanke = hankeFactory.save()
             val yhteystieto = HankeYhteystietoFactory.create()
             val contact = yhteystieto.alikontaktit[0]
-            kayttajaFactory.saveUserAndPermission(hanke.id!!, contact.fullName(), contact.email)
+            kayttajaFactory.saveUserAndPermission(hanke.id, contact.fullName(), contact.email)
             auditLogRepository.deleteAll()
 
             hankeKayttajaService.saveNewTokensFromHanke(
@@ -822,7 +822,7 @@ class HankeKayttajaServiceITest : DatabaseTest() {
             val hanke = hankeFactory.save()
             val kayttaja =
                 kayttajaFactory.saveUserAndPermission(
-                    hanke.id!!,
+                    hanke.id,
                     "Kolmas Kehveli",
                     "kolmas@kehveli.test"
                 )
@@ -1117,7 +1117,7 @@ class HankeKayttajaServiceITest : DatabaseTest() {
             val hanke = hankeFactory.save()
             val kayttaja =
                 kayttajaFactory.saveUserAndPermission(
-                    hanke.id!!,
+                    hanke.id,
                     userId = newUserId,
                 )
             kayttajaFactory.addToken(kayttaja)
@@ -1134,11 +1134,11 @@ class HankeKayttajaServiceITest : DatabaseTest() {
         @Test
         fun `throws an exception if the user has a permission for the hanke from elsewhere`() {
             val hanke = hankeFactory.save()
-            val kayttaja = kayttajaFactory.saveUserAndToken(hanke.id!!, tunniste = tunniste)
+            val kayttaja = kayttajaFactory.saveUserAndToken(hanke.id, tunniste = tunniste)
             val permission =
                 permissionService.create(
                     userId = newUserId,
-                    hankeId = hanke.id!!,
+                    hankeId = hanke.id,
                     kayttooikeustaso = Kayttooikeustaso.KATSELUOIKEUS
                 )
 
@@ -1154,11 +1154,7 @@ class HankeKayttajaServiceITest : DatabaseTest() {
         @Test
         fun `throws an exception if another user already has a permission for the hanke kayttaja`() {
             val hanke = hankeFactory.save()
-            val kayttaja =
-                kayttajaFactory.saveUserAndPermission(
-                    hanke.id!!,
-                    userId = "Other user",
-                )
+            val kayttaja = kayttajaFactory.saveUserAndPermission(hanke.id, userId = "Other user")
             kayttajaFactory.addToken(kayttaja)
 
             assertFailure { hankeKayttajaService.createPermissionFromToken(newUserId, "existing") }
@@ -1174,11 +1170,11 @@ class HankeKayttajaServiceITest : DatabaseTest() {
         @Test
         fun `Creates a permission`() {
             val hanke = hankeFactory.save()
-            kayttajaFactory.saveUserAndToken(hanke.id!!, tunniste = tunniste)
+            kayttajaFactory.saveUserAndToken(hanke.id, tunniste = tunniste)
 
             hankeKayttajaService.createPermissionFromToken(newUserId, tunniste)
 
-            val permission = permissionRepository.findOneByHankeIdAndUserId(hanke.id!!, newUserId)
+            val permission = permissionRepository.findOneByHankeIdAndUserId(hanke.id, newUserId)
             assertThat(permission)
                 .isNotNull()
                 .transform { it.kayttooikeustaso }
@@ -1188,7 +1184,7 @@ class HankeKayttajaServiceITest : DatabaseTest() {
         @Test
         fun `Removes the user token`() {
             val hanke = hankeFactory.save()
-            kayttajaFactory.saveUserAndToken(hanke.id!!, tunniste = tunniste)
+            kayttajaFactory.saveUserAndToken(hanke.id, tunniste = tunniste)
 
             hankeKayttajaService.createPermissionFromToken(newUserId, tunniste)
 
@@ -1198,7 +1194,7 @@ class HankeKayttajaServiceITest : DatabaseTest() {
         @Test
         fun `Writes the token removal to audit logs`() {
             val hanke = hankeFactory.save()
-            kayttajaFactory.saveUserAndToken(hanke.id!!, tunniste = tunniste)
+            kayttajaFactory.saveUserAndToken(hanke.id, tunniste = tunniste)
             auditLogRepository.deleteAll()
 
             hankeKayttajaService.createPermissionFromToken(newUserId, tunniste)
@@ -1223,7 +1219,7 @@ class HankeKayttajaServiceITest : DatabaseTest() {
         @Test
         fun `Throws exception if current user doesn't have a kayttaja`() {
             val hanke = hankeFactory.saveMinimal()
-            val kayttaja = kayttajaFactory.saveUser(hanke.id!!)
+            val kayttaja = kayttajaFactory.saveUser(hanke.id)
 
             assertFailure { hankeKayttajaService.resendInvitation(kayttaja.id, USERNAME) }
                 .all {
@@ -1235,7 +1231,7 @@ class HankeKayttajaServiceITest : DatabaseTest() {
         @Test
         fun `Throws exception if kayttaja already has permission`() {
             val hanke = hankeFactory.saveMinimal()
-            val kayttaja = kayttajaFactory.saveUserAndPermission(hanke.id!!)
+            val kayttaja = kayttajaFactory.saveUserAndPermission(hanke.id)
 
             assertFailure { hankeKayttajaService.resendInvitation(kayttaja.id, USERNAME) }
                 .all {
@@ -1250,11 +1246,11 @@ class HankeKayttajaServiceITest : DatabaseTest() {
         fun `Creates a new tunniste if kayttaja doesn't have one`() {
             val hanke = hankeFactory.saveMinimal(nimi = "Hanke")
             kayttajaFactory.saveUserAndPermission(
-                hanke.id!!,
+                hanke.id,
                 userId = USERNAME,
                 sahkoposti = "current@user"
             )
-            val kayttaja = kayttajaFactory.saveUser(hanke.id!!)
+            val kayttaja = kayttajaFactory.saveUser(hanke.id)
             assertThat(kayttajaTunnisteRepository.findAll()).isEmpty()
             justRun { emailSenderService.sendHankeInvitationEmail(any()) }
 
@@ -1270,11 +1266,11 @@ class HankeKayttajaServiceITest : DatabaseTest() {
         fun `If kayttaja has a tunniste recreates it and deletes the old one `() {
             val hanke = hankeFactory.saveMinimal(nimi = "Hanke")
             kayttajaFactory.saveUserAndPermission(
-                hanke.id!!,
+                hanke.id,
                 userId = USERNAME,
                 sahkoposti = "current@user"
             )
-            val kayttaja = kayttajaFactory.saveUserAndToken(hanke.id!!)
+            val kayttaja = kayttajaFactory.saveUserAndToken(hanke.id)
             assertThat(kayttajaTunnisteRepository.findAll()).hasSize(1)
             val tunnisteId = kayttaja.kayttajaTunniste!!.id
             val tunniste = kayttaja.kayttajaTunniste!!.tunniste
@@ -1296,12 +1292,12 @@ class HankeKayttajaServiceITest : DatabaseTest() {
         fun `Sends the invitation email`() {
             val hanke = hankeFactory.saveMinimal(nimi = "Hanke")
             kayttajaFactory.saveUserAndPermission(
-                hanke.id!!,
+                hanke.id,
                 userId = USERNAME,
                 sahkoposti = "current@user",
                 nimi = "Current User"
             )
-            val kayttaja = kayttajaFactory.saveUser(hanke.id!!)
+            val kayttaja = kayttajaFactory.saveUser(hanke.id)
             val capturedEmails = mutableListOf<HankeInvitationData>()
             justRun { emailSenderService.sendHankeInvitationEmail(capture(capturedEmails)) }
 

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/PermissionServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/PermissionServiceITest.kt
@@ -61,7 +61,7 @@ class PermissionServiceITest : DatabaseTest() {
     fun `getAllowedHankeIds with permissions returns list of IDs`() {
         val hankkeet = hankeFactory.saveSeveralMinimal(3)
         hankkeet
-            .map { it.id!! }
+            .map { it.id }
             .forEach {
                 permissionService.create(
                     userId = username,
@@ -85,7 +85,7 @@ class PermissionServiceITest : DatabaseTest() {
         listOf(kaikkiOikeudet, hankemuokkaus, hakemusasiointi, katseluoikeus).zip(hankkeet) {
             kayttooikeustaso,
             hanke ->
-            permissionService.create(hanke.id!!, username, kayttooikeustaso)
+            permissionService.create(hanke.id, username, kayttooikeustaso)
         }
 
         val response = permissionService.getAllowedHankeIds(username, PermissionCode.EDIT)
@@ -100,7 +100,7 @@ class PermissionServiceITest : DatabaseTest() {
 
     @Test
     fun `hasPermission with correct permission`() {
-        val hankeId = hankeFactory.saveMinimal().id!!
+        val hankeId = hankeFactory.saveMinimal().id
         permissionService.create(hankeId, username, Kayttooikeustaso.KAIKKI_OIKEUDET)
 
         assertTrue(permissionService.hasPermission(hankeId, username, PermissionCode.EDIT))
@@ -108,7 +108,7 @@ class PermissionServiceITest : DatabaseTest() {
 
     @Test
     fun `hasPermission with insufficient permissions`() {
-        val hankeId = hankeFactory.saveMinimal().id!!
+        val hankeId = hankeFactory.saveMinimal().id
         permissionService.create(hankeId, username, Kayttooikeustaso.HAKEMUSASIOINTI)
 
         assertFalse(permissionService.hasPermission(hankeId, username, PermissionCode.EDIT))
@@ -119,7 +119,7 @@ class PermissionServiceITest : DatabaseTest() {
 
         @Test
         fun `Creates a new permission`() {
-            val hankeId = hankeFactory.saveMinimal().id!!
+            val hankeId = hankeFactory.saveMinimal().id
 
             val result = permissionService.create(hankeId, username, Kayttooikeustaso.KATSELUOIKEUS)
 
@@ -135,7 +135,7 @@ class PermissionServiceITest : DatabaseTest() {
 
         @Test
         fun `Writes to audit log`() {
-            val hankeId = hankeFactory.saveMinimal().id!!
+            val hankeId = hankeFactory.saveMinimal().id
             assertThat(auditLogRepository.findAll()).isEmpty()
 
             val permission =
@@ -168,7 +168,7 @@ class PermissionServiceITest : DatabaseTest() {
 
         @Test
         fun `updateKayttooikeustaso updates an existing permission`() {
-            val hankeId = hankeFactory.saveMinimal().id!!
+            val hankeId = hankeFactory.saveMinimal().id
             val permission =
                 permissionService.create(hankeId, username, Kayttooikeustaso.KATSELUOIKEUS)
 
@@ -190,7 +190,7 @@ class PermissionServiceITest : DatabaseTest() {
 
         @Test
         fun `updateKayttooikeustaso writes to audit log`() {
-            val hankeId = hankeFactory.saveMinimal().id!!
+            val hankeId = hankeFactory.saveMinimal().id
             val permission =
                 permissionService.create(hankeId, username, Kayttooikeustaso.KATSELUOIKEUS)
             auditLogRepository.deleteAll()

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeServiceImpl.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeServiceImpl.kt
@@ -235,7 +235,7 @@ open class HankeServiceImpl(
             hakemus.id?.let { id -> applicationService.delete(id, userId) }
         }
 
-        hankeRepository.deleteById(hanke.id!!)
+        hankeRepository.deleteById(hanke.id)
         hankeLoggingService.logDelete(hanke, userId)
     }
 
@@ -246,7 +246,7 @@ open class HankeServiceImpl(
         }
 
     private fun initAccessForCreatedHanke(hanke: Hanke, perustaja: Perustaja?, userId: String) {
-        val hankeId = hanke.id!!
+        val hankeId = hanke.id
         hankeKayttajaService.addHankeFounder(hankeId, perustaja, userId)
         hankeKayttajaService.saveNewTokensFromHanke(hanke, userId)
     }
@@ -707,7 +707,7 @@ open class HankeServiceImpl(
             //   been removed in the database)
             // - the incoming ids are for different hanke (i.e. incorrect data in the incoming
             //   request)
-            throw HankeYhteystietoNotFoundException(hankeEntity.id!!, incomingId)
+            throw HankeYhteystietoNotFoundException(hankeEntity.id, incomingId)
         }
 
         if (validYhteystieto) {

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Persistence.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Persistence.kt
@@ -140,7 +140,7 @@ class HankeEntity(
     // NOTE: using IDENTITY (i.e. db does auto-increments, Hibernate reads the result back)
     // can be a performance problem if there is a need to do bulk inserts.
     // Using SEQUENCE would allow getting multiple ids more efficiently.
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY) var id: Int? = null,
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY) var id: Int = 0,
 
     // related
     // orphanRemoval is needed for even explicit child-object removal. JPA weirdness...
@@ -226,7 +226,7 @@ class HankeEntity(
     override fun hashCode(): Int {
         var result = status.hashCode()
         result = 31 * result + hankeTunnus.hashCode()
-        result = 31 * result + (id ?: 0)
+        result = 31 * result + id
         return result
     }
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationService.kt
@@ -159,12 +159,11 @@ open class ApplicationService(
         }
 
         val hanke = application.hanke
-        val hankeId = hanke.id
         if (!hanke.generated) {
             newApplicationData.areas?.let { areas ->
-                checkApplicationAreasInsideHankealue(hankeId, areas) { applicationArea ->
+                checkApplicationAreasInsideHankealue(hanke.id, areas) { applicationArea ->
                     "Application geometry doesn't match any hankealue when updating application for user $userId, " +
-                        "hankeId = $hankeId, applicationId = ${application.id}, " +
+                        "hankeId = ${hanke.id}, applicationId = ${application.id}, " +
                         "application geometry = ${applicationArea.geometry.toJsonString()}"
                 }
             }
@@ -197,12 +196,11 @@ open class ApplicationService(
         val application = getById(id)
 
         val hanke = application.hanke
-        val hankeId = hanke.id
         if (!hanke.generated) {
             application.applicationData.areas?.let { areas ->
-                checkApplicationAreasInsideHankealue(hankeId, areas) { applicationArea ->
+                checkApplicationAreasInsideHankealue(hanke.id, areas) { applicationArea ->
                     "Application geometry doesn't match any hankealue when sending application for user $userId, " +
-                        "hankeId = $hankeId, applicationId = ${application.id}, " +
+                        "hankeId = ${hanke.id}, applicationId = ${application.id}, " +
                         "application geometry = ${applicationArea.geometry.toJsonString()}"
                 }
             }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationService.kt
@@ -96,7 +96,7 @@ open class ApplicationService(
 
         if (!hanke.generated) {
             application.applicationData.areas?.let { areas ->
-                checkApplicationAreasInsideHankealue(hanke.id!!, areas) { applicationArea ->
+                checkApplicationAreasInsideHankealue(hanke.id, areas) { applicationArea ->
                     "Application geometry doesn't match any hankealue when creating a new application for user $userId, " +
                         "hankeId = ${hanke.id}, application geometry = ${applicationArea.geometry.toJsonString()}"
                 }
@@ -159,7 +159,7 @@ open class ApplicationService(
         }
 
         val hanke = application.hanke
-        val hankeId = hanke.id!!
+        val hankeId = hanke.id
         if (!hanke.generated) {
             newApplicationData.areas?.let { areas ->
                 checkApplicationAreasInsideHankealue(hankeId, areas) { applicationArea ->
@@ -197,7 +197,7 @@ open class ApplicationService(
         val application = getById(id)
 
         val hanke = application.hanke
-        val hankeId = hanke.id!!
+        val hankeId = hanke.id
         if (!hanke.generated) {
             application.applicationData.areas?.let { areas ->
                 checkApplicationAreasInsideHankealue(hankeId, areas) { applicationArea ->
@@ -355,7 +355,7 @@ open class ApplicationService(
             return
         }
 
-        val kayttaja = hankeKayttajaService.getKayttajaByUserId(hanke.id!!, currentUserId)
+        val kayttaja = hankeKayttajaService.getKayttajaByUserId(hanke.id, currentUserId)
         val contacts = application.applicationData.typedContacts(omit = kayttaja?.sahkoposti)
 
         provideAccess(
@@ -379,7 +379,7 @@ open class ApplicationService(
             return
         }
 
-        val kayttaja = hankeKayttajaService.getKayttajaByUserId(hanke.id!!, currentUserId)
+        val kayttaja = hankeKayttajaService.getKayttajaByUserId(hanke.id, currentUserId)
 
         val previousContacts = previousData.typedContacts()
         val updatedContacts = application.applicationData.typedContacts(omit = kayttaja?.sahkoposti)
@@ -403,7 +403,7 @@ open class ApplicationService(
     ) {
         hankeKayttajaService.saveNewTokensFromApplication(
             application = application,
-            hankeId = hanke.id!!,
+            hankeId = hanke.id,
             hankeTunnus = hanke.hankeTunnus,
             hankeNimi = hanke.nimi,
             currentUserId = currentUserId,

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentService.kt
@@ -55,7 +55,7 @@ class HankeAttachmentService(
         val filename = AttachmentValidator.validFilename(attachment.originalFilename)
         val hanke =
             findHanke(hankeTunnus).also { hanke ->
-                ensureRoomForAttachment(hanke.id!!)
+                ensureRoomForAttachment(hanke.id)
                 scanAttachment(filename, attachment.bytes)
             }
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/Hanke.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/Hanke.kt
@@ -18,7 +18,7 @@ import java.time.ZonedDateTime
 data class Hanke(
     @JsonView(ChangeLogView::class)
     @field:Schema(description = "Id, set by the service")
-    override var id: Int?,
+    override val id: Int,
     //
     @JsonView(ChangeLogView::class)
     @field:Schema(

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/PublicHanke.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/PublicHanke.kt
@@ -87,7 +87,7 @@ fun hankeToPublic(hanke: Hanke): PublicHanke {
     val alueet = hanke.alueet.map { hankealueToPublic(it) }
 
     return PublicHanke(
-        hanke.id!!,
+        hanke.id,
         hanke.hankeTunnus,
         hanke.nimi,
         hanke.kuvaus!!,

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaService.kt
@@ -1,6 +1,5 @@
 package fi.hel.haitaton.hanke.permissions
 
-import fi.hel.haitaton.hanke.HankeArgumentException
 import fi.hel.haitaton.hanke.HankeIdentifier
 import fi.hel.haitaton.hanke.HankeRepository
 import fi.hel.haitaton.hanke.application.ApplicationEntity
@@ -93,18 +92,16 @@ class HankeKayttajaService(
             "Creating users and user tokens for hanke ${hanke.id}, hankeTunnus=${hanke.hankeTunnus}}"
         }
 
-        val hankeId = hanke.id ?: throw HankeArgumentException("Hanke without id")
-
         val contacts =
             hanke
                 .extractYhteystiedot()
                 .flatMap { it.alikontaktit }
                 .mapNotNull { HankeUserContact.from(it.fullName(), it.email) }
 
-        val inviter = getKayttajaByUserId(hankeId, userId)
-        filterNewContacts(hankeId, contacts).forEach { contact ->
+        val inviter = getKayttajaByUserId(hanke.id, userId)
+        filterNewContacts(hanke.id, contacts).forEach { contact ->
             createTunnisteAndKayttaja(
-                hankeId,
+                hanke.id,
                 hanke.hankeTunnus,
                 hanke.nimi,
                 inviter,

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/HankeControllerTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/HankeControllerTest.kt
@@ -199,7 +199,7 @@ class HankeControllerTest {
     fun `test that the updateHanke will throw if mismatch in hanke tunnus payload vs path`() {
         val hankeUpdate = HankeFactory.create()
         val existingHanke = HankeFactory.create(hankeTunnus = "wrong")
-        every { permissionService.hasPermission(existingHanke.id!!, username, PermissionCode.EDIT) }
+        every { permissionService.hasPermission(existingHanke.id, username, PermissionCode.EDIT) }
             .returns(true)
         every { hankeAuthorizer.authorizeHankeTunnus("wrong", PermissionCode.EDIT) } returns true
 

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceTest.kt
@@ -365,7 +365,7 @@ class ApplicationServiceTest {
                 hankeKayttajaService.getKayttajaByUserId(1, USERNAME)
                 hankeKayttajaService.saveNewTokensFromApplication(
                     applicationEntity,
-                    hankeEntity.id!!,
+                    hankeEntity.id,
                     hankeEntity.hankeTunnus,
                     hankeEntity.nimi,
                     USERNAME,
@@ -479,7 +479,7 @@ class ApplicationServiceTest {
                 hankeKayttajaService.getKayttajaByUserId(1, USERNAME)
                 hankeKayttajaService.saveNewTokensFromApplication(
                     any(),
-                    hankeEntity.id!!,
+                    hankeEntity.id,
                     hankeEntity.hankeTunnus,
                     hankeEntity.nimi,
                     USERNAME,

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeFactory.kt
@@ -69,7 +69,7 @@ class HankeFactory(
         suunnitteluVaihe: SuunnitteluVaihe? = null,
     ): HankeEntity {
         val hanke = save(nimi, vaihe, suunnitteluVaihe)
-        return hankeRepository.getReferenceById(hanke.id!!)
+        return hankeRepository.getReferenceById(hanke.id)
     }
 
     fun saveMinimal(
@@ -131,7 +131,7 @@ class HankeFactory(
          * ```
          */
         fun create(
-            id: Int? = defaultId,
+            id: Int = defaultId,
             hankeTunnus: String = defaultHankeTunnus,
             nimi: String = defaultNimi,
             vaihe: Vaihe? = Vaihe.OHJELMOINTI,
@@ -158,7 +158,7 @@ class HankeFactory(
             )
 
         fun createMinimalEntity(
-            id: Int? = defaultId,
+            id: Int = defaultId,
             hankeTunnus: String = defaultHankeTunnus,
             nimi: String = defaultNimi,
             generated: Boolean = false,

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeIdentifierFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeIdentifierFactory.kt
@@ -13,4 +13,4 @@ object HankeIdentifierFactory {
 data class TestHankeIdentifier(override val id: Int, override val hankeTunnus: String) :
     HankeIdentifier
 
-fun Hanke.identifier(): HankeIdentifier = TestHankeIdentifier(id!!, hankeTunnus)
+fun Hanke.identifier(): HankeIdentifier = TestHankeIdentifier(id, hankeTunnus)


### PR DESCRIPTION
# Description

Make id mandatory (non-nullable) in both Hanke and HankeEntity. We give the id a default value in the entity, but it's rewritten during the initial persist. But it still needs to be a var, and not a val.

Also, remove some asserts that can never fail from HankeServiceITest.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1893

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [X] Other