### PR TITLE
HAI-1930 Remove redundant validation from Hanke drafts

### DIFF
--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/CreateHankeRequest.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/CreateHankeRequest.kt
@@ -25,7 +25,8 @@ data class CreateHankeRequest(
     )
     override val vaihe: Vaihe? = null,
     @field:Schema(
-        description = "Current planning stage, must be defined if vaihe = SUUNNITTELU",
+        description =
+            "Current planning stage, required for publishing used if vaihe is SUUNNITTELU.",
     )
     override val suunnitteluVaihe: SuunnitteluVaihe? = null,
     @field:Schema(

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/Hanke.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/Hanke.kt
@@ -14,94 +14,111 @@ import fi.hel.haitaton.hanke.tormaystarkastelu.TormaystarkasteluTulos
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.ZonedDateTime
 
-@Schema(description = "The project within which applications are processed")
+@Schema(description = "The project within which applications are processed.")
 data class Hanke(
     @JsonView(ChangeLogView::class)
-    @field:Schema(description = "Id, set by the service")
+    @field:Schema(description = "Id, set by the service.")
     override val id: Int,
     //
     @JsonView(ChangeLogView::class)
     @field:Schema(
-        description = "Hanke identity for external purposes, set by the service",
+        description = "Hanke identity for external purposes, set by the service.",
         example = "HAI24-123"
     )
     val hankeTunnus: String,
     //
     @JsonView(ChangeLogView::class)
-    @field:Schema(description = "Yhteinen kunnallistekninen työmaa")
+    @field:Schema(
+        description = "Shared Public Utility Site (Yhteinen kunnallistekninen työmaa). Optional."
+    )
     var onYKTHanke: Boolean?,
     //
     @JsonView(ChangeLogView::class)
-    @field:Schema(description = "Name of the Hanke, must not be blank")
+    @field:Schema(description = "Name of the project, must not be blank.")
     override var nimi: String,
     //
     @JsonView(ChangeLogView::class)
-    @field:Schema(description = "Description of the Hanke contents ")
+    @field:Schema(
+        description =
+            "Description of the project and the work done during it. Required for the project to be published."
+    )
     var kuvaus: String?,
     //
     @JsonView(ChangeLogView::class)
-    @field:Schema(description = "Hanke current stage", required = true)
+    @field:Schema(
+        description = "Current stage of the project. Required for the hanke to be published."
+    )
     override var vaihe: Vaihe?,
     //
     @JsonView(ChangeLogView::class)
     @field:Schema(
-        description = "Hanke current planning stage, must be defined if vaihe = SUUNNITTELU"
+        description =
+            "Hanke current planning stage, required for publishing if vaihe is SUUNNITTELU."
     )
     override var suunnitteluVaihe: SuunnitteluVaihe?,
     //
     @JsonView(ChangeLogView::class)
-    @field:Schema(description = "Version, set by the service")
+    @field:Schema(description = "Version, set by the service.")
     var version: Int?,
     //
     @JsonView(NotInChangeLogView::class)
-    @field:Schema(description = "User id of the Hanke creator, set by the service")
+    @field:Schema(description = "User id of the Hanke creator, set by the service.")
     val createdBy: String?,
     //
     @JsonView(NotInChangeLogView::class)
-    @field:Schema(description = "Timestamp of creation, set by the service")
+    @field:Schema(description = "Timestamp of creation, set by the service.")
     val createdAt: ZonedDateTime?,
     //
     @JsonView(NotInChangeLogView::class)
-    @field:Schema(description = "User id of the last modifier, set by the service")
+    @field:Schema(description = "User id of the last modifier, set by the service.")
     var modifiedBy: String?,
     //
     @JsonView(NotInChangeLogView::class)
-    @field:Schema(description = "Timestamp of last modification, set by the service")
+    @field:Schema(description = "Timestamp of last modification, set by the service.")
     var modifiedAt: ZonedDateTime?,
     //
     @JsonView(ChangeLogView::class)
-    @field:Schema(description = "Hanke current status, set by the service")
+    @field:Schema(description = "Hanke current status, set by the service.")
     var status: HankeStatus? = HankeStatus.DRAFT,
     //
     @JsonView(ChangeLogView::class)
-    @field:Schema(description = "Indicates whether the Hanke data is generated, set by the service")
+    @field:Schema(description = "Indicates if Hanke data is generated, set by the service.")
     var generated: Boolean = false,
 ) : HasId<Int>, BaseHanke {
 
     // --------------- Yhteystiedot -----------------
     @JsonView(NotInChangeLogView::class)
-    @field:Schema(description = "Project owners, contact information")
+    @field:Schema(
+        description =
+            "Project owners, contact information. At least one is required for the hanke to be published."
+    )
     override var omistajat = mutableListOf<HankeYhteystieto>()
 
     @JsonView(NotInChangeLogView::class)
-    @field:Schema(description = "Property developers, contact information")
+    @field:Schema(
+        description =
+            "Property developers, contact information. Not required for the hanke to be published."
+    )
     override var rakennuttajat = mutableListOf<HankeYhteystieto>()
 
     @JsonView(NotInChangeLogView::class)
-    @field:Schema(description = "Executor of the work")
+    @field:Schema(description = "Executor of the work. Not required for the hanke to be published.")
     override var toteuttajat = mutableListOf<HankeYhteystieto>()
 
     @JsonView(NotInChangeLogView::class)
-    @field:Schema(description = "Other contacts")
+    @field:Schema(description = "Other contacts. Not required for the hanke to be published.")
     override var muut = mutableListOf<HankeYhteystieto>()
 
     // --------------- Hankkeen lisätiedot / Työmaan tiedot -------------------
     @JsonView(ChangeLogView::class)
-    @field:Schema(description = "Work site street address", maxLength = 2000)
+    @field:Schema(
+        description = "Work site street address. Required for the hanke to be published.",
+        maxLength = 2000
+    )
     override var tyomaaKatuosoite: String? = null
 
     @JsonView(ChangeLogView::class)
-    @field:Schema(description = "Work site types")
+    @field:Schema(description = "Work site types. Not required for the hanke to be published.")
     var tyomaaTyyppi = mutableSetOf<TyomaaTyyppi>()
 
     val alkuPvm: ZonedDateTime?
@@ -111,24 +128,27 @@ data class Hanke(
         @JsonView(ChangeLogView::class) get(): ZonedDateTime? = alueet.loppuPvm()
 
     @JsonView(ChangeLogView::class)
-    @field:Schema(description = "Hanke areas data")
+    @field:Schema(
+        description =
+            "Hanke areas data. At least one alue is required for the hanke to be published."
+    )
     override var alueet = mutableListOf<Hankealue>()
 
     @JsonView(NotInChangeLogView::class)
-    @field:Schema(description = "Permission codes to this Hanke project")
+    @field:Schema(description = "Permission codes of the project.")
     var permissions: List<PermissionCode>? = null
 
     /** Number of days between haittaAlkuPvm and haittaLoppuPvm (incl. both days) */
     val haittaAjanKestoDays: Int?
         @JsonIgnore get() = alueet.haittaAjanKestoDays()
 
+    @JsonView(ChangeLogView::class)
+    @field:Schema(description = "Collision review result, set by the service.")
+    var tormaystarkasteluTulos: TormaystarkasteluTulos? = null
+
     @JsonView(NotInChangeLogView::class)
     fun getLiikennehaittaindeksi(): LiikennehaittaIndeksiType? =
         tormaystarkasteluTulos?.liikennehaittaIndeksi
-
-    @JsonView(ChangeLogView::class)
-    @field:Schema(description = "")
-    var tormaystarkasteluTulos: TormaystarkasteluTulos? = null
 
     fun toLogString(): String {
         return toString()

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/Hankealue.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/Hankealue.kt
@@ -12,39 +12,36 @@ import java.time.temporal.ChronoUnit
 
 /** NOTE Remember to update PublicHankealue after changes */
 @JsonView(ChangeLogView::class)
-@Schema(description = "Area data of a Hanke")
+@Schema(description = "Area data of a Hanke.")
 data class Hankealue(
-    @field:Schema(description = "Area identity, set by the service") override var id: Int? = null,
+    @field:Schema(description = "Area identity, set by the service.") override var id: Int? = null,
     //
-    @field:Schema(description = "Hanke identity of this area") var hankeId: Int? = null,
+    @field:Schema(description = "Hanke identity of this area.") var hankeId: Int? = null,
     //
-    @field:Schema(
-        description = "Nuisance start date, must not be null",
-        maximum = "2099-12-31T23:59:59.99Z"
-    )
+    @field:Schema(description = "Nuisance start date.", maximum = "2099-12-31T23:59:59.99Z")
     var haittaAlkuPvm: ZonedDateTime? = null,
     //
     @field:Schema(
-        description = "Nuisance end date, must not be before haittaAlkuPvm",
+        description = "Nuisance end date, must not be before haittaAlkuPvm.",
         maximum = "2099-12-31T23:59:59.99Z"
     )
     var haittaLoppuPvm: ZonedDateTime? = null,
     //
-    @field:Schema(description = "Geometry data") var geometriat: Geometriat? = null,
+    @field:Schema(description = "Geometry data.") var geometriat: Geometriat? = null,
     //
-    @field:Schema(description = "Street lane nuisance value and explanation")
+    @field:Schema(description = "Street lane nuisance value and explanation.")
     var kaistaHaitta: TodennakoinenHaittaPaaAjoRatojenKaistajarjestelyihin? = null,
     //
-    @field:Schema(description = "Street lane nuisance length")
+    @field:Schema(description = "Street lane nuisance length.")
     var kaistaPituusHaitta: KaistajarjestelynPituus? = null,
     //
-    @field:Schema(description = "Noise nuisance") var meluHaitta: Haitta13? = null,
+    @field:Schema(description = "Noise nuisance.") var meluHaitta: Haitta13? = null,
     //
-    @field:Schema(description = "Dust nuisance") var polyHaitta: Haitta13? = null,
+    @field:Schema(description = "Dust nuisance.") var polyHaitta: Haitta13? = null,
     //
-    @field:Schema(description = "Vibration nuisance") var tarinaHaitta: Haitta13? = null,
+    @field:Schema(description = "Vibration nuisance.") var tarinaHaitta: Haitta13? = null,
     //
-    @field:Schema(description = "Area name") var nimi: String? = null,
+    @field:Schema(description = "Area name.") var nimi: String? = null,
 ) : HasId<Int>
 
 fun List<Hankealue>.alkuPvm(): ZonedDateTime? = mapNotNull { it.haittaAlkuPvm }.minOfOrNull { it }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/validation/HankeValidator.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/validation/HankeValidator.kt
@@ -5,7 +5,6 @@ import fi.hel.haitaton.hanke.MAXIMUM_DATE
 import fi.hel.haitaton.hanke.MAXIMUM_HANKE_ALUE_NIMI_LENGTH
 import fi.hel.haitaton.hanke.MAXIMUM_HANKE_NIMI_LENGTH
 import fi.hel.haitaton.hanke.MAXIMUM_TYOMAAKATUOSOITE_LENGTH
-import fi.hel.haitaton.hanke.Vaihe
 import fi.hel.haitaton.hanke.domain.BaseHanke
 import fi.hel.haitaton.hanke.domain.HankeYhteystieto
 import fi.hel.haitaton.hanke.domain.Hankealue
@@ -14,9 +13,8 @@ import fi.hel.haitaton.hanke.isValidBusinessId
 import fi.hel.haitaton.hanke.validation.ValidationResult.Companion.allIn
 import fi.hel.haitaton.hanke.validation.ValidationResult.Companion.whenNotNull
 import fi.hel.haitaton.hanke.validation.Validators.isBeforeOrEqual
+import fi.hel.haitaton.hanke.validation.Validators.notBlank
 import fi.hel.haitaton.hanke.validation.Validators.notLongerThan
-import fi.hel.haitaton.hanke.validation.Validators.notNull
-import fi.hel.haitaton.hanke.validation.Validators.notNullOrBlank
 import fi.hel.haitaton.hanke.validation.Validators.validate
 import fi.hel.haitaton.hanke.validation.Validators.validateTrue
 import jakarta.validation.ConstraintValidator
@@ -51,10 +49,8 @@ private fun ConstraintValidatorContext.addViolation(error: HankeError, node: Str
 
 /** Doesn't check hanke alue, because they use a different error code. */
 private fun BaseHanke.validate() =
-    validate { notNullOrBlank(nimi, "nimi") }
-        .whenNotNull(nimi) { it.notLongerThan(MAXIMUM_HANKE_NIMI_LENGTH, "nimi") }
-        .and { notNull(vaihe, "vaihe") }
-        .andWhen(vaihe == Vaihe.SUUNNITTELU) { notNull(suunnitteluVaihe, "suunnitteluVaihe") }
+    validate { notBlank(nimi, "nimi") }
+        .and { nimi.notLongerThan(MAXIMUM_HANKE_NIMI_LENGTH, "nimi") }
         .whenNotNull(tyomaaKatuosoite) {
             it.notLongerThan(MAXIMUM_TYOMAAKATUOSOITE_LENGTH, "tyomaaKatuosoite")
         }
@@ -67,9 +63,7 @@ private fun validateHankeAlue(hankealue: Hankealue, path: String) = hankealue.va
 
 private fun Hankealue.validate(path: String) =
     whenNotNull(nimi) { it.notLongerThan(MAXIMUM_HANKE_ALUE_NIMI_LENGTH, "$path.nimi") }
-        .and { notNull(haittaAlkuPvm, "$path.haittaAlkuPvm") }
         .whenNotNull(haittaAlkuPvm) { isBeforeOrEqual(it, MAXIMUM_DATE, "$path.haittaAlkuPvm") }
-        .and { notNull(haittaLoppuPvm, "$path.haittaLoppuPvm") }
         .whenNotNull(haittaLoppuPvm) { isBeforeOrEqual(it, MAXIMUM_DATE, "$path.haittaLoppuPvm") }
         .andWhen(haittaAlkuPvm != null && haittaLoppuPvm != null) {
             isBeforeOrEqual(haittaAlkuPvm!!, haittaLoppuPvm!!, "$path.haittaLoppuPvm")

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/HankeControllerTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/HankeControllerTest.kt
@@ -289,33 +289,4 @@ class HankeControllerTest {
         assertThat(response.omistajat[0].nimi).isEqualTo("Pekka Pekkanen")
         verify { disclosureLogService.saveDisclosureLogsForHanke(any(), eq(username)) }
     }
-
-    @Test
-    fun `test that the updateHanke will give validation errors from null enum values`() {
-        val partialHanke =
-            Hanke(
-                id = 0,
-                hankeTunnus = "id123",
-                nimi = "",
-                kuvaus = "",
-                onYKTHanke = false,
-                vaihe = null,
-                suunnitteluVaihe = null,
-                version = 1,
-                createdBy = "",
-                createdAt = null,
-                modifiedBy = null,
-                modifiedAt = null,
-                status = null,
-            )
-        // mock HankeService response
-        every { hankeService.updateHanke(partialHanke) }.returns(partialHanke)
-
-        // Actual call
-        assertThatExceptionOfType(ConstraintViolationException::class.java)
-            .isThrownBy { hankeController.updateHanke(partialHanke, "id123") }
-            .withMessageContaining("updateHanke.hanke.vaihe: " + HankeError.HAI1002.toString())
-
-        verify { disclosureLogService wasNot Called }
-    }
 }


### PR DESCRIPTION
# Description

The only required information is hanke name from now on. 

However, fields are validated if they contain information (just like before).

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1930

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [x] Other

# Instructions for testing
For some reason, front end does not currently save have if it does not contain area information. 

This change can be tested as follows:

POST http://localhost:3001/api/hankkeet

```
{
    "nimi": "Kokeilu"
}
```

Should create.


# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 

# Other relevant info
Please describe here if there is e.g. some requirements for this change or
 other info that the tester/user needs to know.