### PR TITLE
HAI-1893 Add a separate DTO for hanke yhteystieto creation

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeControllerITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeControllerITests.kt
@@ -379,9 +379,7 @@ class HankeControllerITests(@Autowired override val mockMvc: MockMvc) : Controll
                     // There's no separate DTO for Hankealue, so they might contain IDs and audit
                     // fields. These are ignored in the service, however.
                     .withHankealue(hanke.alueet[0])
-                    // There's no separate DTO for HankeYhteystieto, so they might contain IDs and
-                    // audit fields. These are ignored in the service, however.
-                    .withYhteystiedot { id = 49 }
+                    .withYhteystiedot()
                     .build()
             assertThat(serviceParameter.captured).isEqualTo(expectedParameter)
             verifySequence {

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeServiceImpl.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeServiceImpl.kt
@@ -12,6 +12,7 @@ import fi.hel.haitaton.hanke.domain.Hankealue
 import fi.hel.haitaton.hanke.domain.HasId
 import fi.hel.haitaton.hanke.domain.HasYhteystiedot
 import fi.hel.haitaton.hanke.domain.Perustaja
+import fi.hel.haitaton.hanke.domain.Yhteystieto
 import fi.hel.haitaton.hanke.geometria.Geometriat
 import fi.hel.haitaton.hanke.geometria.GeometriatService
 import fi.hel.haitaton.hanke.logging.AuditLogService
@@ -594,7 +595,7 @@ open class HankeServiceImpl(
     }
 
     private fun processIncomingHankeYhteystietosOfSpecificTypeToEntity(
-        listOfHankeYhteystiedot: List<HankeYhteystieto>,
+        listOfHankeYhteystiedot: List<Yhteystieto>,
         hankeEntity: HankeEntity,
         contactType: ContactType,
         userid: String,
@@ -649,7 +650,7 @@ open class HankeServiceImpl(
     }
 
     private fun processCreateYhteystieto(
-        hankeYht: HankeYhteystieto,
+        hankeYht: Yhteystieto,
         validYhteystieto: Boolean,
         contactType: ContactType,
         userid: String,
@@ -689,7 +690,7 @@ open class HankeServiceImpl(
     }
 
     private fun processUpdateYhteystieto(
-        hankeYht: HankeYhteystieto,
+        hankeYht: Yhteystieto,
         existingYTs: MutableMap<Int, HankeYhteystietoEntity>,
         someFieldsSet: Boolean,
         validYhteystieto: Boolean,
@@ -765,7 +766,7 @@ open class HankeServiceImpl(
     }
 
     private fun areEqualIncomingVsExistingYhteystietos(
-        incoming: HankeYhteystieto,
+        incoming: Yhteystieto,
         existing: HankeYhteystietoEntity
     ): Boolean {
         if (incoming.nimi != existing.nimi) return false

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/BaseHanke.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/BaseHanke.kt
@@ -1,8 +1,10 @@
 package fi.hel.haitaton.hanke.domain
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import fi.hel.haitaton.hanke.ContactType
 import fi.hel.haitaton.hanke.SuunnitteluVaihe
 import fi.hel.haitaton.hanke.Vaihe
+import fi.hel.haitaton.hanke.Yhteyshenkilo
 
 interface BaseHanke : HasYhteystiedot {
     val nimi: String
@@ -13,7 +15,54 @@ interface BaseHanke : HasYhteystiedot {
 }
 
 interface HasYhteystiedot {
-    fun extractYhteystiedot(): List<HankeYhteystieto>
+    val omistajat: List<Yhteystieto>?
+    val rakennuttajat: List<Yhteystieto>?
+    val toteuttajat: List<Yhteystieto>?
+    val muut: List<Yhteystieto>?
 
-    fun yhteystiedotByType(): Map<ContactType, List<HankeYhteystieto>>
+    fun extractYhteystiedot(): List<Yhteystieto> =
+        listOfNotNull(omistajat, rakennuttajat, toteuttajat, muut).flatten()
+
+    fun yhteystiedotByType(): Map<ContactType, List<Yhteystieto>> {
+        return mapOf(
+                ContactType.OMISTAJA to omistajat,
+                ContactType.RAKENNUTTAJA to rakennuttajat,
+                ContactType.TOTEUTTAJA to toteuttajat,
+                ContactType.MUU to muut,
+            )
+            .mapValues { (_, yhteystiedot) -> yhteystiedot ?: listOf() }
+    }
+}
+
+interface Yhteystieto : HasId<Int> {
+    override val id: Int?
+    val nimi: String
+    val email: String
+    val alikontaktit: List<Yhteyshenkilo>
+    val puhelinnumero: String?
+    val organisaatioNimi: String?
+    val osasto: String?
+    val rooli: String?
+    val tyyppi: YhteystietoTyyppi?
+    val ytunnus: String?
+
+    /**
+     * Returns true if at least one Yhteystieto-field is non-null, non-empty and
+     * non-whitespace-only.
+     */
+    @JsonIgnore
+    fun isAnyFieldSet(): Boolean {
+        return isAnyMandatoryFieldSet() ||
+            !organisaatioNimi.isNullOrBlank() ||
+            !osasto.isNullOrBlank()
+    }
+
+    /**
+     * Returns true if at least one mandatory Yhteystieto-field is non-null, non-empty and
+     * non-whitespace-only.
+     */
+    @JsonIgnore
+    fun isAnyMandatoryFieldSet(): Boolean {
+        return nimi.isNotBlank() || email.isNotBlank()
+    }
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/BaseHanke.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/BaseHanke.kt
@@ -23,15 +23,14 @@ interface HasYhteystiedot {
     fun extractYhteystiedot(): List<Yhteystieto> =
         listOfNotNull(omistajat, rakennuttajat, toteuttajat, muut).flatten()
 
-    fun yhteystiedotByType(): Map<ContactType, List<Yhteystieto>> {
-        return mapOf(
+    fun yhteystiedotByType(): Map<ContactType, List<Yhteystieto>> =
+        mapOf(
                 ContactType.OMISTAJA to omistajat,
                 ContactType.RAKENNUTTAJA to rakennuttajat,
                 ContactType.TOTEUTTAJA to toteuttajat,
                 ContactType.MUU to muut,
             )
             .mapValues { (_, yhteystiedot) -> yhteystiedot ?: listOf() }
-    }
 }
 
 interface Yhteystieto : HasId<Int> {

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/BaseHanke.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/BaseHanke.kt
@@ -48,10 +48,20 @@ interface Yhteystieto : HasId<Int> {
     /**
      * Returns true if at least one Yhteystieto-field is non-null, non-empty and
      * non-whitespace-only.
+     *
+     * Id and tyyppi are not considered concrete information by themselves, so they are ignored
+     * here.
+     *
+     * Contact people are handled separately, so they are not included.
      */
     @JsonIgnore
     fun isAnyFieldSet(): Boolean =
-        isAnyMandatoryFieldSet() || !organisaatioNimi.isNullOrBlank() || !osasto.isNullOrBlank()
+        isAnyMandatoryFieldSet() ||
+            !puhelinnumero.isNullOrBlank() ||
+            !organisaatioNimi.isNullOrBlank() ||
+            !osasto.isNullOrBlank() ||
+            !rooli.isNullOrBlank() ||
+            !ytunnus.isNullOrBlank()
 
     /**
      * Returns true if at least one mandatory Yhteystieto-field is non-null, non-empty and

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/BaseHanke.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/BaseHanke.kt
@@ -51,18 +51,12 @@ interface Yhteystieto : HasId<Int> {
      * non-whitespace-only.
      */
     @JsonIgnore
-    fun isAnyFieldSet(): Boolean {
-        return isAnyMandatoryFieldSet() ||
-            !organisaatioNimi.isNullOrBlank() ||
-            !osasto.isNullOrBlank()
-    }
+    fun isAnyFieldSet(): Boolean =
+        isAnyMandatoryFieldSet() || !organisaatioNimi.isNullOrBlank() || !osasto.isNullOrBlank()
 
     /**
      * Returns true if at least one mandatory Yhteystieto-field is non-null, non-empty and
      * non-whitespace-only.
      */
-    @JsonIgnore
-    fun isAnyMandatoryFieldSet(): Boolean {
-        return nimi.isNotBlank() || email.isNotBlank()
-    }
+    @JsonIgnore fun isAnyMandatoryFieldSet(): Boolean = nimi.isNotBlank() || email.isNotBlank()
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/BaseHanke.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/BaseHanke.kt
@@ -13,19 +13,7 @@ interface BaseHanke : HasYhteystiedot {
 }
 
 interface HasYhteystiedot {
-    val omistajat: List<HankeYhteystieto>?
-    val rakennuttajat: List<HankeYhteystieto>?
-    val toteuttajat: List<HankeYhteystieto>?
-    val muut: List<HankeYhteystieto>?
+    fun extractYhteystiedot(): List<HankeYhteystieto>
 
-    fun extractYhteystiedot(): List<HankeYhteystieto> =
-        listOfNotNull(omistajat, rakennuttajat, toteuttajat, muut).flatten()
-
-    fun yhteystiedotByType(): Map<ContactType, List<HankeYhteystieto>> =
-        mapOf(
-            ContactType.OMISTAJA to (omistajat ?: listOf()),
-            ContactType.RAKENNUTTAJA to (rakennuttajat ?: listOf()),
-            ContactType.TOTEUTTAJA to (toteuttajat ?: listOf()),
-            ContactType.MUU to (muut ?: listOf()),
-        )
+    fun yhteystiedotByType(): Map<ContactType, List<HankeYhteystieto>>
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/CreateHankeRequest.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/CreateHankeRequest.kt
@@ -1,6 +1,5 @@
 package fi.hel.haitaton.hanke.domain
 
-import fi.hel.haitaton.hanke.ContactType
 import fi.hel.haitaton.hanke.SuunnitteluVaihe
 import fi.hel.haitaton.hanke.TyomaaTyyppi
 import fi.hel.haitaton.hanke.Vaihe
@@ -34,20 +33,20 @@ data class CreateHankeRequest(
         description =
             "Project owners, contact information. At least one is required for the hanke to be published.",
     )
-    val omistajat: List<Yhteystieto>? = null,
+    override val omistajat: List<NewYhteystieto>? = null,
     @field:Schema(
         description =
             "Property developers, contact information. Not required for the hanke to be published.",
     )
-    val rakennuttajat: List<Yhteystieto>? = null,
+    override val rakennuttajat: List<NewYhteystieto>? = null,
     @field:Schema(
         description = "Executor of the work. Not required for the hanke to be published.",
     )
-    val toteuttajat: List<Yhteystieto>? = null,
+    override val toteuttajat: List<NewYhteystieto>? = null,
     @field:Schema(
         description = "Other contacts. Not required for the hanke to be published.",
     )
-    val muut: List<Yhteystieto>? = null,
+    override val muut: List<NewYhteystieto>? = null,
     @field:Schema(
         description = "Work site street address. Required for the hanke to be published.",
         maxLength = 2000,
@@ -62,74 +61,45 @@ data class CreateHankeRequest(
             "Hanke areas data. At least one alue is required for the hanke to be published.",
     )
     override val alueet: List<Hankealue>? = null,
-) : BaseHanke {
-    override fun extractYhteystiedot(): List<HankeYhteystieto> =
-        listOfNotNull(omistajat, rakennuttajat, toteuttajat, muut).flatten().map {
-            it.toHankeYhteystieto()
-        }
+) : BaseHanke
 
-    override fun yhteystiedotByType(): Map<ContactType, List<HankeYhteystieto>> {
-        return mapOf(
-                ContactType.OMISTAJA to omistajat,
-                ContactType.RAKENNUTTAJA to rakennuttajat,
-                ContactType.TOTEUTTAJA to toteuttajat,
-                ContactType.MUU to muut,
-            )
-            .mapValues { (_, yhteystiedot) ->
-                yhteystiedot?.map { it.toHankeYhteystieto() } ?: listOf()
-            }
-    }
-
-    data class Yhteystieto(
-        @field:Schema(
-            description = "Contact name. Full name if an actual person.",
-        )
-        val nimi: String,
-        @field:Schema(
-            description = "Contact email address",
-        )
-        val email: String,
-        @field:Schema(
-            description = "Sub-contacts, i.e. contacts of this contact",
-        )
-        val alikontaktit: List<Yhteyshenkilo> = emptyList(),
-        @field:Schema(
-            description = "Phone number",
-        )
-        val puhelinnumero: String?,
-        @field:Schema(
-            description = "Organisation name",
-        )
-        val organisaatioNimi: String?,
-        @field:Schema(
-            description = "Contact department",
-        )
-        val osasto: String?,
-        @field:Schema(
-            description = "Role of the contact",
-        )
-        val rooli: String?,
-        @field:Schema(
-            description = "Contact type",
-        )
-        val tyyppi: YhteystietoTyyppi? = null,
-        @field:Schema(
-            description = "Business id, for contacts with tyyppi other than YKSITYISHENKILO",
-        )
-        val ytunnus: String? = null,
-    ) {
-        fun toHankeYhteystieto(): HankeYhteystieto =
-            HankeYhteystieto(
-                null,
-                nimi,
-                email,
-                alikontaktit,
-                puhelinnumero,
-                organisaatioNimi,
-                osasto,
-                rooli,
-                tyyppi,
-                ytunnus
-            )
-    }
+data class NewYhteystieto(
+    @field:Schema(
+        description = "Contact name. Full name if an actual person.",
+    )
+    override val nimi: String,
+    @field:Schema(
+        description = "Contact email address",
+    )
+    override val email: String,
+    @field:Schema(
+        description = "Sub-contacts, i.e. contacts of this contact",
+    )
+    override val alikontaktit: List<Yhteyshenkilo> = emptyList(),
+    @field:Schema(
+        description = "Phone number",
+    )
+    override val puhelinnumero: String?,
+    @field:Schema(
+        description = "Organisation name",
+    )
+    override val organisaatioNimi: String?,
+    @field:Schema(
+        description = "Contact department",
+    )
+    override val osasto: String?,
+    @field:Schema(
+        description = "Role of the contact",
+    )
+    override val rooli: String?,
+    @field:Schema(
+        description = "Contact type",
+    )
+    override val tyyppi: YhteystietoTyyppi? = null,
+    @field:Schema(
+        description = "Business id, for contacts with tyyppi other than YKSITYISHENKILO",
+    )
+    override val ytunnus: String? = null,
+) : Yhteystieto {
+    override val id by lazy { null }
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/CreateHankeRequest.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/CreateHankeRequest.kt
@@ -1,8 +1,10 @@
 package fi.hel.haitaton.hanke.domain
 
+import fi.hel.haitaton.hanke.ContactType
 import fi.hel.haitaton.hanke.SuunnitteluVaihe
 import fi.hel.haitaton.hanke.TyomaaTyyppi
 import fi.hel.haitaton.hanke.Vaihe
+import fi.hel.haitaton.hanke.Yhteyshenkilo
 import io.swagger.v3.oas.annotations.media.Schema
 
 data class CreateHankeRequest(
@@ -32,20 +34,20 @@ data class CreateHankeRequest(
         description =
             "Project owners, contact information. At least one is required for the hanke to be published.",
     )
-    override val omistajat: List<HankeYhteystieto>? = null,
+    val omistajat: List<Yhteystieto>? = null,
     @field:Schema(
         description =
             "Property developers, contact information. Not required for the hanke to be published.",
     )
-    override val rakennuttajat: List<HankeYhteystieto>? = null,
+    val rakennuttajat: List<Yhteystieto>? = null,
     @field:Schema(
         description = "Executor of the work. Not required for the hanke to be published.",
     )
-    override val toteuttajat: List<HankeYhteystieto>? = null,
+    val toteuttajat: List<Yhteystieto>? = null,
     @field:Schema(
         description = "Other contacts. Not required for the hanke to be published.",
     )
-    override val muut: List<HankeYhteystieto>? = null,
+    val muut: List<Yhteystieto>? = null,
     @field:Schema(
         description = "Work site street address. Required for the hanke to be published.",
         maxLength = 2000,
@@ -60,4 +62,74 @@ data class CreateHankeRequest(
             "Hanke areas data. At least one alue is required for the hanke to be published.",
     )
     override val alueet: List<Hankealue>? = null,
-) : BaseHanke
+) : BaseHanke {
+    override fun extractYhteystiedot(): List<HankeYhteystieto> =
+        listOfNotNull(omistajat, rakennuttajat, toteuttajat, muut).flatten().map {
+            it.toHankeYhteystieto()
+        }
+
+    override fun yhteystiedotByType(): Map<ContactType, List<HankeYhteystieto>> {
+        return mapOf(
+                ContactType.OMISTAJA to omistajat,
+                ContactType.RAKENNUTTAJA to rakennuttajat,
+                ContactType.TOTEUTTAJA to toteuttajat,
+                ContactType.MUU to muut,
+            )
+            .mapValues { (_, yhteystiedot) ->
+                yhteystiedot?.map { it.toHankeYhteystieto() } ?: listOf()
+            }
+    }
+
+    data class Yhteystieto(
+        @field:Schema(
+            description = "Contact name. Full name if an actual person.",
+        )
+        val nimi: String,
+        @field:Schema(
+            description = "Contact email address",
+        )
+        val email: String,
+        @field:Schema(
+            description = "Sub-contacts, i.e. contacts of this contact",
+        )
+        val alikontaktit: List<Yhteyshenkilo> = emptyList(),
+        @field:Schema(
+            description = "Phone number",
+        )
+        val puhelinnumero: String?,
+        @field:Schema(
+            description = "Organisation name",
+        )
+        val organisaatioNimi: String?,
+        @field:Schema(
+            description = "Contact department",
+        )
+        val osasto: String?,
+        @field:Schema(
+            description = "Role of the contact",
+        )
+        val rooli: String?,
+        @field:Schema(
+            description = "Contact type",
+        )
+        val tyyppi: YhteystietoTyyppi? = null,
+        @field:Schema(
+            description = "Business id, for contacts with tyyppi other than YKSITYISHENKILO",
+        )
+        val ytunnus: String? = null,
+    ) {
+        fun toHankeYhteystieto(): HankeYhteystieto =
+            HankeYhteystieto(
+                null,
+                nimi,
+                email,
+                alikontaktit,
+                puhelinnumero,
+                organisaatioNimi,
+                osasto,
+                rooli,
+                tyyppi,
+                ytunnus
+            )
+    }
+}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/Hanke.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/Hanke.kt
@@ -3,7 +3,6 @@ package fi.hel.haitaton.hanke.domain
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonView
 import fi.hel.haitaton.hanke.ChangeLogView
-import fi.hel.haitaton.hanke.ContactType
 import fi.hel.haitaton.hanke.HankeStatus
 import fi.hel.haitaton.hanke.NotInChangeLogView
 import fi.hel.haitaton.hanke.SuunnitteluVaihe
@@ -137,12 +136,4 @@ data class Hanke(
 
     override fun extractYhteystiedot(): List<HankeYhteystieto> =
         listOfNotNull(omistajat, rakennuttajat, toteuttajat, muut).flatten()
-
-    override fun yhteystiedotByType(): Map<ContactType, List<HankeYhteystieto>> =
-        mapOf(
-            ContactType.OMISTAJA to omistajat,
-            ContactType.RAKENNUTTAJA to rakennuttajat,
-            ContactType.TOTEUTTAJA to toteuttajat,
-            ContactType.MUU to muut,
-        )
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/Hanke.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/Hanke.kt
@@ -3,6 +3,7 @@ package fi.hel.haitaton.hanke.domain
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonView
 import fi.hel.haitaton.hanke.ChangeLogView
+import fi.hel.haitaton.hanke.ContactType
 import fi.hel.haitaton.hanke.HankeStatus
 import fi.hel.haitaton.hanke.NotInChangeLogView
 import fi.hel.haitaton.hanke.SuunnitteluVaihe
@@ -76,24 +77,24 @@ data class Hanke(
     @JsonView(ChangeLogView::class)
     @field:Schema(description = "Indicates whether the Hanke data is generated, set by the service")
     var generated: Boolean = false,
-) : HasId<Int>, BaseHanke {
+) : HasId<Int>, BaseHanke, HasYhteystiedot {
 
     // --------------- Yhteystiedot -----------------
     @JsonView(NotInChangeLogView::class)
     @field:Schema(description = "Project owners, contact information")
-    override var omistajat = mutableListOf<HankeYhteystieto>()
+    var omistajat = mutableListOf<HankeYhteystieto>()
 
     @JsonView(NotInChangeLogView::class)
     @field:Schema(description = "Property developers, contact information")
-    override var rakennuttajat = mutableListOf<HankeYhteystieto>()
+    var rakennuttajat = mutableListOf<HankeYhteystieto>()
 
     @JsonView(NotInChangeLogView::class)
     @field:Schema(description = "Executor of the work")
-    override var toteuttajat = mutableListOf<HankeYhteystieto>()
+    var toteuttajat = mutableListOf<HankeYhteystieto>()
 
     @JsonView(NotInChangeLogView::class)
     @field:Schema(description = "Other contacts")
-    override var muut = mutableListOf<HankeYhteystieto>()
+    var muut = mutableListOf<HankeYhteystieto>()
 
     // --------------- Hankkeen lisätiedot / Työmaan tiedot -------------------
     @JsonView(ChangeLogView::class)
@@ -133,4 +134,15 @@ data class Hanke(
     fun toLogString(): String {
         return toString()
     }
+
+    override fun extractYhteystiedot(): List<HankeYhteystieto> =
+        listOfNotNull(omistajat, rakennuttajat, toteuttajat, muut).flatten()
+
+    override fun yhteystiedotByType(): Map<ContactType, List<HankeYhteystieto>> =
+        mapOf(
+            ContactType.OMISTAJA to omistajat,
+            ContactType.RAKENNUTTAJA to rakennuttajat,
+            ContactType.TOTEUTTAJA to toteuttajat,
+            ContactType.MUU to muut,
+        )
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/Hanke.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/Hanke.kt
@@ -82,19 +82,19 @@ data class Hanke(
     // --------------- Yhteystiedot -----------------
     @JsonView(NotInChangeLogView::class)
     @field:Schema(description = "Project owners, contact information")
-    var omistajat = mutableListOf<HankeYhteystieto>()
+    override var omistajat = mutableListOf<HankeYhteystieto>()
 
     @JsonView(NotInChangeLogView::class)
     @field:Schema(description = "Property developers, contact information")
-    var rakennuttajat = mutableListOf<HankeYhteystieto>()
+    override var rakennuttajat = mutableListOf<HankeYhteystieto>()
 
     @JsonView(NotInChangeLogView::class)
     @field:Schema(description = "Executor of the work")
-    var toteuttajat = mutableListOf<HankeYhteystieto>()
+    override var toteuttajat = mutableListOf<HankeYhteystieto>()
 
     @JsonView(NotInChangeLogView::class)
     @field:Schema(description = "Other contacts")
-    var muut = mutableListOf<HankeYhteystieto>()
+    override var muut = mutableListOf<HankeYhteystieto>()
 
     // --------------- Hankkeen lisätiedot / Työmaan tiedot -------------------
     @JsonView(ChangeLogView::class)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/HankeYhteystieto.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/HankeYhteystieto.kt
@@ -1,6 +1,5 @@
 package fi.hel.haitaton.hanke.domain
 
-import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonView
 import fi.hel.haitaton.hanke.ChangeLogView
 import fi.hel.haitaton.hanke.NotInChangeLogView
@@ -23,41 +22,41 @@ data class HankeYhteystieto(
     // Mandatory info (person or juridical person):
     @JsonView(ChangeLogView::class)
     @field:Schema(description = "Contact name. Full name if an actual person.")
-    var nimi: String,
+    override var nimi: String,
     //
     @JsonView(ChangeLogView::class)
     @field:Schema(description = "Contact email address")
-    var email: String,
+    override var email: String,
 
     // Optional subcontacts (person)
     @JsonView(ChangeLogView::class)
     @field:Schema(description = "Sub-contacts, i.e. contacts of this contact")
-    var alikontaktit: List<Yhteyshenkilo> = emptyList(),
+    override var alikontaktit: List<Yhteyshenkilo> = emptyList(),
 
     // Optional
     @JsonView(ChangeLogView::class)
     @field:Schema(description = "Phone number")
-    var puhelinnumero: String?,
+    override var puhelinnumero: String?,
     //
     @JsonView(ChangeLogView::class)
     @field:Schema(description = "Organisation name")
-    var organisaatioNimi: String?,
+    override var organisaatioNimi: String?,
     //
     @JsonView(ChangeLogView::class)
     @field:Schema(description = "Contact department")
-    var osasto: String?,
+    override var osasto: String?,
     //
     @JsonView(ChangeLogView::class)
     @field:Schema(description = "Role of the contact")
-    var rooli: String?,
+    override var rooli: String?,
     //
     @JsonView(ChangeLogView::class)
     @field:Schema(description = "Contact type")
-    var tyyppi: YhteystietoTyyppi? = null,
+    override var tyyppi: YhteystietoTyyppi? = null,
     //
     @JsonView(ChangeLogView::class)
     @field:Schema(description = "Business id, for contacts with tyyppi other than YKSITYISHENKILO")
-    val ytunnus: String? = null,
+    override val ytunnus: String? = null,
 
     // Metadata
     @JsonView(NotInChangeLogView::class)
@@ -75,25 +74,4 @@ data class HankeYhteystieto(
     @JsonView(NotInChangeLogView::class)
     @field:Schema(description = "Timestamp of last modification, set by the service")
     var modifiedAt: ZonedDateTime? = null
-) : HasId<Int> {
-
-    /**
-     * Returns true if at least one Yhteystieto-field is non-null, non-empty and
-     * non-whitespace-only.
-     */
-    @JsonIgnore
-    fun isAnyFieldSet(): Boolean {
-        return isAnyMandatoryFieldSet() ||
-            !organisaatioNimi.isNullOrBlank() ||
-            !osasto.isNullOrBlank()
-    }
-
-    /**
-     * Returns true if at least one mandatory Yhteystieto-field is non-null, non-empty and
-     * non-whitespace-only.
-     */
-    @JsonIgnore
-    fun isAnyMandatoryFieldSet(): Boolean {
-        return nimi.isNotBlank() || email.isNotBlank()
-    }
-}
+) : HasId<Int>, Yhteystieto

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/validation/HankeValidator.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/validation/HankeValidator.kt
@@ -1,5 +1,6 @@
 package fi.hel.haitaton.hanke.validation
 
+import fi.hel.haitaton.hanke.ContactType
 import fi.hel.haitaton.hanke.HankeError
 import fi.hel.haitaton.hanke.MAXIMUM_DATE
 import fi.hel.haitaton.hanke.MAXIMUM_HANKE_ALUE_NIMI_LENGTH
@@ -58,10 +59,7 @@ private fun BaseHanke.validate() =
         .whenNotNull(tyomaaKatuosoite) {
             it.notLongerThan(MAXIMUM_TYOMAAKATUOSOITE_LENGTH, "tyomaaKatuosoite")
         }
-        .whenNotNull(omistajat) { allIn(it, "omistajat", ::validateYhteystieto) }
-        .whenNotNull(toteuttajat) { allIn(it, "toteuttajat", ::validateYhteystieto) }
-        .whenNotNull(rakennuttajat) { allIn(it, "rakennuttajat", ::validateYhteystieto) }
-        .whenNotNull(muut) { allIn(it, "muut", ::validateYhteystieto) }
+        .and { validateYhteystiedot(yhteystiedotByType()) }
 
 private fun validateHankeAlue(hankealue: Hankealue, path: String) = hankealue.validate(path)
 
@@ -74,6 +72,20 @@ private fun Hankealue.validate(path: String) =
         .andWhen(haittaAlkuPvm != null && haittaLoppuPvm != null) {
             isBeforeOrEqual(haittaAlkuPvm!!, haittaLoppuPvm!!, "$path.haittaLoppuPvm")
         }
+
+private fun validateYhteystiedot(
+    yhteystiedot: Map<ContactType, List<HankeYhteystieto>>
+): ValidationResult =
+    whenNotNull(yhteystiedot[ContactType.OMISTAJA]) {
+            allIn(it, "omistajat", ::validateYhteystieto)
+        }
+        .whenNotNull(yhteystiedot[ContactType.TOTEUTTAJA]) {
+            allIn(it, "toteuttajat", ::validateYhteystieto)
+        }
+        .whenNotNull(yhteystiedot[ContactType.RAKENNUTTAJA]) {
+            allIn(it, "rakennuttajat", ::validateYhteystieto)
+        }
+        .whenNotNull(yhteystiedot[ContactType.MUU]) { allIn(it, "muut", ::validateYhteystieto) }
 
 private fun validateYhteystieto(yhteystieto: HankeYhteystieto, path: String): ValidationResult =
     yhteystieto.validate(path)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/validation/HankeValidator.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/validation/HankeValidator.kt
@@ -8,8 +8,8 @@ import fi.hel.haitaton.hanke.MAXIMUM_HANKE_NIMI_LENGTH
 import fi.hel.haitaton.hanke.MAXIMUM_TYOMAAKATUOSOITE_LENGTH
 import fi.hel.haitaton.hanke.Vaihe
 import fi.hel.haitaton.hanke.domain.BaseHanke
-import fi.hel.haitaton.hanke.domain.HankeYhteystieto
 import fi.hel.haitaton.hanke.domain.Hankealue
+import fi.hel.haitaton.hanke.domain.Yhteystieto
 import fi.hel.haitaton.hanke.domain.YhteystietoTyyppi.YKSITYISHENKILO
 import fi.hel.haitaton.hanke.isValidBusinessId
 import fi.hel.haitaton.hanke.validation.ValidationResult.Companion.allIn
@@ -74,7 +74,7 @@ private fun Hankealue.validate(path: String) =
         }
 
 private fun validateYhteystiedot(
-    yhteystiedot: Map<ContactType, List<HankeYhteystieto>>
+    yhteystiedot: Map<ContactType, List<Yhteystieto>>
 ): ValidationResult =
     whenNotNull(yhteystiedot[ContactType.OMISTAJA]) {
             allIn(it, "omistajat", ::validateYhteystieto)
@@ -87,9 +87,9 @@ private fun validateYhteystiedot(
         }
         .whenNotNull(yhteystiedot[ContactType.MUU]) { allIn(it, "muut", ::validateYhteystieto) }
 
-private fun validateYhteystieto(yhteystieto: HankeYhteystieto, path: String): ValidationResult =
+private fun validateYhteystieto(yhteystieto: Yhteystieto, path: String): ValidationResult =
     yhteystieto.validate(path)
 
-private fun HankeYhteystieto.validate(path: String): ValidationResult =
+private fun Yhteystieto.validate(path: String): ValidationResult =
     whenNotNull(ytunnus) { validateTrue(it.isValidBusinessId(), "$path.ytunnus") }
         .andWhen(tyyppi == YKSITYISHENKILO) { validateTrue(ytunnus == null, "$path.ytunnus") }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/HankeControllerTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/HankeControllerTest.kt
@@ -5,9 +5,11 @@ import fi.hel.haitaton.hanke.configuration.FeatureFlags
 import fi.hel.haitaton.hanke.configuration.FeatureService
 import fi.hel.haitaton.hanke.domain.CreateHankeRequest
 import fi.hel.haitaton.hanke.domain.Hanke
+import fi.hel.haitaton.hanke.domain.NewYhteystieto
 import fi.hel.haitaton.hanke.domain.YhteystietoTyyppi.YKSITYISHENKILO
 import fi.hel.haitaton.hanke.domain.geometriat
 import fi.hel.haitaton.hanke.factory.HankeFactory
+import fi.hel.haitaton.hanke.factory.toHankeYhteystieto
 import fi.hel.haitaton.hanke.logging.DisclosureLogService
 import fi.hel.haitaton.hanke.permissions.PermissionCode
 import fi.hel.haitaton.hanke.permissions.PermissionService
@@ -251,7 +253,7 @@ class HankeControllerTest {
                 suunnitteluVaihe = null,
                 omistajat =
                     arrayListOf(
-                        CreateHankeRequest.Yhteystieto(
+                        NewYhteystieto(
                             nimi = "Pekka Pekkanen",
                             email = "pekka@pekka.fi",
                             puhelinnumero = "3212312",

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/HankeControllerTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/HankeControllerTest.kt
@@ -5,7 +5,6 @@ import fi.hel.haitaton.hanke.configuration.FeatureFlags
 import fi.hel.haitaton.hanke.configuration.FeatureService
 import fi.hel.haitaton.hanke.domain.CreateHankeRequest
 import fi.hel.haitaton.hanke.domain.Hanke
-import fi.hel.haitaton.hanke.domain.HankeYhteystieto
 import fi.hel.haitaton.hanke.domain.YhteystietoTyyppi.YKSITYISHENKILO
 import fi.hel.haitaton.hanke.domain.geometriat
 import fi.hel.haitaton.hanke.factory.HankeFactory
@@ -252,8 +251,7 @@ class HankeControllerTest {
                 suunnitteluVaihe = null,
                 omistajat =
                     arrayListOf(
-                        HankeYhteystieto(
-                            id = null,
+                        CreateHankeRequest.Yhteystieto(
                             nimi = "Pekka Pekkanen",
                             email = "pekka@pekka.fi",
                             puhelinnumero = "3212312",
@@ -274,7 +272,8 @@ class HankeControllerTest {
                     )
             )
         val mockedHanke = HankeFactory.create(id = 12, hankeTunnus = "JOKU12", nimi = request.nimi)
-        mockedHanke.omistajat = mutableListOf(request.omistajat!![0].copy(id = 1))
+        mockedHanke.omistajat =
+            mutableListOf(request.omistajat!![0].toHankeYhteystieto().copy(id = 1))
         every { hankeService.createHanke(request) }.returns(mockedHanke)
 
         val response: Hanke = hankeController.createHanke(request)

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/CreateHankeRequestBuilder.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/CreateHankeRequestBuilder.kt
@@ -6,6 +6,7 @@ import fi.hel.haitaton.hanke.domain.CreateHankeRequest
 import fi.hel.haitaton.hanke.domain.Hanke
 import fi.hel.haitaton.hanke.domain.HankeYhteystieto
 import fi.hel.haitaton.hanke.domain.Hankealue
+import fi.hel.haitaton.hanke.domain.NewYhteystieto
 
 data class CreateHankeRequestBuilder(
     private val hankeService: HankeService?,
@@ -56,7 +57,21 @@ data class CreateHankeRequestBuilder(
 }
 
 fun HankeYhteystieto.toCreateRequest() =
-    CreateHankeRequest.Yhteystieto(
+    NewYhteystieto(
+        nimi,
+        email,
+        alikontaktit,
+        puhelinnumero,
+        organisaatioNimi,
+        osasto,
+        rooli,
+        tyyppi,
+        ytunnus
+    )
+
+fun NewYhteystieto.toHankeYhteystieto() =
+    HankeYhteystieto(
+        id,
         nimi,
         email,
         alikontaktit,

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/CreateHankeRequestBuilder.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/CreateHankeRequestBuilder.kt
@@ -17,14 +17,13 @@ data class CreateHankeRequestBuilder(
 
     fun withRequest(f: CreateHankeRequest.() -> CreateHankeRequest) = copy(request = request.f())
 
-    fun withYhteystiedot(
-        mutator: HankeYhteystieto.() -> Unit = { id = null }
-    ): CreateHankeRequestBuilder = withRequest {
+    fun withYhteystiedot(): CreateHankeRequestBuilder = withRequest {
         copy(
-            omistajat = listOf(HankeYhteystietoFactory.createDifferentiated(1).apply(mutator)),
-            rakennuttajat = listOf(HankeYhteystietoFactory.createDifferentiated(2).apply(mutator)),
-            toteuttajat = listOf(HankeYhteystietoFactory.createDifferentiated(3).apply(mutator)),
-            muut = listOf(HankeYhteystietoFactory.createDifferentiated(4).apply(mutator)),
+            omistajat = listOf(HankeYhteystietoFactory.createDifferentiated(1).toCreateRequest()),
+            rakennuttajat =
+                listOf(HankeYhteystietoFactory.createDifferentiated(2).toCreateRequest()),
+            toteuttajat = listOf(HankeYhteystietoFactory.createDifferentiated(3).toCreateRequest()),
+            muut = listOf(HankeYhteystietoFactory.createDifferentiated(4).toCreateRequest()),
         )
     }
 
@@ -33,12 +32,17 @@ data class CreateHankeRequestBuilder(
     fun withGeneratedOmistajat(vararg discriminators: Int) = withRequest {
         copy(
             omistajat =
-                HankeYhteystietoFactory.createDifferentiated(discriminators.toList()) { id = null }
+                HankeYhteystietoFactory.createDifferentiated(discriminators.toList()).map {
+                    it.toCreateRequest()
+                }
         )
     }
 
     fun withGeneratedRakennuttaja(i: Int = 1) = withRequest {
-        copy(rakennuttajat = listOf(HankeYhteystietoFactory.createDifferentiated(i, id = null)))
+        copy(
+            rakennuttajat =
+                listOf(HankeYhteystietoFactory.createDifferentiated(i, id = null).toCreateRequest())
+        )
     }
 
     fun withHankealue(alue: Hankealue = HankealueFactory.create(id = null, hankeId = null)) =
@@ -50,3 +54,16 @@ data class CreateHankeRequestBuilder(
             )
         }
 }
+
+fun HankeYhteystieto.toCreateRequest() =
+    CreateHankeRequest.Yhteystieto(
+        nimi,
+        email,
+        alikontaktit,
+        puhelinnumero,
+        organisaatioNimi,
+        osasto,
+        rooli,
+        tyyppi,
+        ytunnus
+    )


### PR DESCRIPTION
# Description

Add a separate DTO for hanke yhteystieto creation.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1893

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [X] Other

# Instructions for testing
Create a hanke with some yhteystiedot. Can't be done from the UI.

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 

# Other relevant info
There are two commits. The first one has a previous iteration with a different approach. I'd be interested to know if you think that's better, or has parts that would be better.