### PR TITLE
HAI-1893 Add DTO for geometria in new hanke

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeControllerITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeControllerITests.kt
@@ -222,12 +222,12 @@ class HankeControllerITests(@Autowired override val mockMvc: MockMvc) : Controll
             val alue1 =
                 SavedHankealue(
                     hankeId = hankeIds[0],
-                    geometriat = Geometriat(1, FeatureCollection())
+                    geometriat = Geometriat(1, FeatureCollection(), version = 1)
                 )
             val alue2 =
                 SavedHankealue(
                     hankeId = hankeIds[1],
-                    geometriat = Geometriat(2, FeatureCollection())
+                    geometriat = Geometriat(2, FeatureCollection(), version = 1)
                 )
             val hanke1 = HankeFactory.create(id = hankeIds[0], hankeTunnus = HANKE_TUNNUS)
             val hanke2 = HankeFactory.create(id = hankeIds[1], hankeTunnus = "hanketunnus2")

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
@@ -30,6 +30,7 @@ import fi.hel.haitaton.hanke.domain.YhteystietoTyyppi.YRITYS
 import fi.hel.haitaton.hanke.factory.AlluDataFactory
 import fi.hel.haitaton.hanke.factory.AlluDataFactory.Companion.withArea
 import fi.hel.haitaton.hanke.factory.DateFactory
+import fi.hel.haitaton.hanke.factory.GeometriaFactory
 import fi.hel.haitaton.hanke.factory.HankeFactory
 import fi.hel.haitaton.hanke.factory.HankeFactory.Companion.defaultKuvaus
 import fi.hel.haitaton.hanke.factory.HankeFactory.Companion.withGeneratedOmistaja
@@ -37,7 +38,6 @@ import fi.hel.haitaton.hanke.factory.HankeFactory.Companion.withGeneratedRakennu
 import fi.hel.haitaton.hanke.factory.HankeFactory.Companion.withYhteystiedot
 import fi.hel.haitaton.hanke.factory.HankeYhteystietoFactory.defaultYtunnus
 import fi.hel.haitaton.hanke.factory.HankealueFactory
-import fi.hel.haitaton.hanke.geometria.Geometriat
 import fi.hel.haitaton.hanke.logging.AuditLogEntryEntity
 import fi.hel.haitaton.hanke.logging.AuditLogRepository
 import fi.hel.haitaton.hanke.logging.ObjectType
@@ -1290,10 +1290,7 @@ class HankeServiceITests : DatabaseTest() {
                     tyomaaTyyppi = mutableSetOf(TyomaaTyyppi.VESI, TyomaaTyyppi.MUU),
                 )
                 .save()
-        val geometria: Geometriat =
-            "/fi/hel/haitaton/hanke/geometria/hankeGeometriat.json"
-                .asJsonResource<Geometriat>()
-                .apply { id = 67 }
+        val geometria = GeometriaFactory.create().apply { id = 67 }
         hanke.alueet.add(HankealueFactory.create(id = null, geometriat = geometria))
         auditLogRepository.deleteAll()
         assertEquals(0, auditLogRepository.count())

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/geometria/GeometriatDaoImplITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/geometria/GeometriatDaoImplITest.kt
@@ -10,6 +10,7 @@ import assertk.assertions.isNull
 import assertk.assertions.isTrue
 import fi.hel.haitaton.hanke.DatabaseTest
 import fi.hel.haitaton.hanke.asJsonResource
+import fi.hel.haitaton.hanke.factory.GeometriaFactory
 import java.time.ZonedDateTime
 import org.geojson.Point
 import org.geojson.Polygon
@@ -34,8 +35,7 @@ internal class GeometriatDaoImplITest : DatabaseTest() {
 
     @Test
     fun `CRUD testing`() {
-        val hankeGeometriat: Geometriat =
-            "/fi/hel/haitaton/hanke/geometria/hankeGeometriat.json".asJsonResource()
+        val hankeGeometriat = GeometriaFactory.create()
         hankeGeometriat.createdByUserId = "1111"
         hankeGeometriat.modifiedByUserId = "2222"
 

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/geometria/GeometriatServiceImplITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/geometria/GeometriatServiceImplITest.kt
@@ -15,8 +15,8 @@ import assertk.assertions.prop
 import fi.hel.haitaton.hanke.DATABASE_TIMESTAMP_FORMAT
 import fi.hel.haitaton.hanke.DatabaseTest
 import fi.hel.haitaton.hanke.HankeService
-import fi.hel.haitaton.hanke.asJsonResource
 import fi.hel.haitaton.hanke.domain.geometriat
+import fi.hel.haitaton.hanke.factory.GeometriaFactory
 import fi.hel.haitaton.hanke.factory.HankeFactory
 import fi.hel.haitaton.hanke.factory.HankealueFactory
 import fi.hel.haitaton.hanke.test.Asserts.isRecentZDT
@@ -48,8 +48,7 @@ internal class GeometriatServiceImplITest : DatabaseTest() {
 
     @Test
     fun `save and load and update`() {
-        val geometriat: Geometriat =
-            "/fi/hel/haitaton/hanke/geometria/hankeGeometriat.json".asJsonResource()
+        val geometriat: Geometriat = GeometriaFactory.create()
         val username = SecurityContextHolder.getContext().authentication.name
 
         // For FK constraints we need a Hanke in database
@@ -131,11 +130,7 @@ internal class GeometriatServiceImplITest : DatabaseTest() {
 
     @Test
     fun `save Geometria with missing properties`() {
-        val geometriat: Geometriat =
-            "/fi/hel/haitaton/hanke/geometria/hankeGeometriat.json".asJsonResource()
-        geometriat.version = null
-        geometriat.createdAt = null
-        geometriat.modifiedAt = null
+        val geometriat = GeometriaFactory.createNew()
         geometriat.featureCollection?.crs?.properties = null
 
         assertThrows<GeometriaValidationException> {
@@ -145,11 +140,7 @@ internal class GeometriatServiceImplITest : DatabaseTest() {
 
     @Test
     fun `save Geometria with invalid coordinate system`() {
-        val geometriat: Geometriat =
-            "/fi/hel/haitaton/hanke/geometria/hankeGeometriat.json".asJsonResource()
-        geometriat.version = null
-        geometriat.createdAt = null
-        geometriat.modifiedAt = null
+        val geometriat = GeometriaFactory.createNew()
         geometriat.featureCollection?.crs?.properties?.set("name", "urn:ogc:def:crs:EPSG::0000")
 
         assertThrows<UnsupportedCoordinateSystemException> {
@@ -161,16 +152,7 @@ internal class GeometriatServiceImplITest : DatabaseTest() {
     inner class CreateGeometria {
         @Test
         fun `sets metadata correctly`() {
-            val geometriat =
-                "/fi/hel/haitaton/hanke/geometria/hankeGeometriat.json"
-                    .asJsonResource(Geometriat::class.java)
-                    .apply {
-                        createdAt = null
-                        createdByUserId = null
-                        modifiedAt = null
-                        modifiedByUserId = null
-                        version = null
-                    }
+            val geometriat = GeometriaFactory.createNew()
 
             val result = geometriatService.createGeometriat(geometriat)
 
@@ -190,8 +172,7 @@ internal class GeometriatServiceImplITest : DatabaseTest() {
 
         @Test
         fun `saves geometries correctly`() {
-            val geometriat: Geometriat =
-                "/fi/hel/haitaton/hanke/geometria/hankeGeometriat.json".asJsonResource()
+            val geometriat: Geometriat = GeometriaFactory.create()
 
             val result = geometriatService.createGeometriat(geometriat)
 

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/geometria/GeometriatServiceImplITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/geometria/GeometriatServiceImplITest.kt
@@ -12,7 +12,6 @@ import fi.hel.haitaton.hanke.HankeService
 import fi.hel.haitaton.hanke.asJsonResource
 import fi.hel.haitaton.hanke.domain.geometriat
 import fi.hel.haitaton.hanke.factory.HankeFactory
-import fi.hel.haitaton.hanke.factory.HankeFactory.Companion.withHankealue
 import fi.hel.haitaton.hanke.factory.HankealueFactory
 import org.geojson.Point
 import org.junit.jupiter.api.Test
@@ -88,7 +87,7 @@ internal class GeometriatServiceImplITest : DatabaseTest() {
         loadedGeometriat.featureCollection!!
             .features
             .add(loadedGeometriat.featureCollection!!.features[0])
-        geometriatService.saveGeometriat(loadedGeometriat)
+        geometriatService.saveGeometriat(loadedGeometriat, loadedGeometriat.id)
 
         // load
         loadedGeometriat = geometriatService.getGeometriat(loadedGeometriat.id!!)
@@ -135,7 +134,9 @@ internal class GeometriatServiceImplITest : DatabaseTest() {
         geometriat.modifiedAt = null
         geometriat.featureCollection?.crs?.properties = null
 
-        assertThrows<GeometriaValidationException> { geometriatService.saveGeometriat(geometriat) }
+        assertThrows<GeometriaValidationException> {
+            geometriatService.saveGeometriat(geometriat, null)
+        }
     }
 
     @Test
@@ -150,7 +151,7 @@ internal class GeometriatServiceImplITest : DatabaseTest() {
         geometriat.featureCollection?.crs?.properties?.set("name", "urn:ogc:def:crs:EPSG::0000")
 
         assertThrows<UnsupportedCoordinateSystemException> {
-            geometriatService.saveGeometriat(geometriat)
+            geometriatService.saveGeometriat(geometriat, null)
         }
     }
 

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluTormaysServicePGITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluTormaysServicePGITest.kt
@@ -24,12 +24,12 @@ internal class TormaystarkasteluTormaysServicePGITest : DatabaseTest() {
 
     @Autowired private lateinit var tormaysService: TormaystarkasteluTormaysService
 
-    private fun createHankeGeometria(): Geometriat {
+    private fun createHankeGeometria(): Set<Int> {
         val geometriat =
             "/fi/hel/haitaton/hanke/tormaystarkastelu/hankeGeometriat.json".asJsonResource(
                 Geometriat::class.java
             )
-        return geometriatDao.createGeometriat(geometriat)
+        return setOf(geometriatDao.createGeometriat(geometriat).id!!)
     }
 
     /**
@@ -38,15 +38,15 @@ internal class TormaystarkasteluTormaysServicePGITest : DatabaseTest() {
      */
     @Test
     fun yleisetKatuosat() {
-        val geometriat = createHankeGeometria()
-        assertThat(tormaysService.anyIntersectsYleinenKatuosa(arrayListOf(geometriat))).isTrue()
+        val geometriaIds = createHankeGeometria()
+        assertThat(tormaysService.anyIntersectsYleinenKatuosa(geometriaIds)).isTrue()
     }
 
     /** Test manually what general street classes (ylre_classes) Hanke geometries are located on */
     @Test
     fun yleisetKatuluokat() {
-        val geometriat = createHankeGeometria()
-        assertThat(tormaysService.maxIntersectingYleinenkatualueKatuluokka(arrayListOf(geometriat)))
+        val geometriaIds = createHankeGeometria()
+        assertThat(tormaysService.maxIntersectingYleinenkatualueKatuluokka(geometriaIds))
             .isEqualTo(TormaystarkasteluKatuluokka.ALUEELLINEN_KOKOOJAKATU.value)
     }
 
@@ -54,7 +54,7 @@ internal class TormaystarkasteluTormaysServicePGITest : DatabaseTest() {
     @Test
     fun katuluokat() {
         val geometriat = createHankeGeometria()
-        assertThat(tormaysService.maxIntersectingLiikenteellinenKatuluokka(arrayListOf(geometriat)))
+        assertThat(tormaysService.maxIntersectingLiikenteellinenKatuluokka(geometriat))
             .isEqualTo(TormaystarkasteluKatuluokka.ALUEELLINEN_KOKOOJAKATU.value)
     }
 
@@ -64,8 +64,8 @@ internal class TormaystarkasteluTormaysServicePGITest : DatabaseTest() {
      */
     @Test
     fun kantakaupunki() {
-        val geometriat = createHankeGeometria()
-        assertThat(tormaysService.anyIntersectsWithKantakaupunki(arrayListOf(geometriat))).isTrue()
+        val geometriaIds = createHankeGeometria()
+        assertThat(tormaysService.anyIntersectsWithKantakaupunki(geometriaIds)).isTrue()
     }
 
     /**
@@ -73,10 +73,10 @@ internal class TormaystarkasteluTormaysServicePGITest : DatabaseTest() {
      */
     @Test
     fun liikennemaarat15() {
-        val geometriat = createHankeGeometria()
+        val geometriaIds = createHankeGeometria()
         assertThat(
                 tormaysService.maxLiikennemaara(
-                    arrayListOf(geometriat),
+                    geometriaIds,
                     TormaystarkasteluLiikennemaaranEtaisyys.RADIUS_15
                 )
             )
@@ -88,10 +88,10 @@ internal class TormaystarkasteluTormaysServicePGITest : DatabaseTest() {
      */
     @Test
     fun liikennemaarat30() {
-        val geometriat = createHankeGeometria()
+        val geometriaIds = createHankeGeometria()
         assertThat(
                 tormaysService.maxLiikennemaara(
-                    arrayListOf(geometriat),
+                    geometriaIds,
                     TormaystarkasteluLiikennemaaranEtaisyys.RADIUS_30
                 )
             )
@@ -101,15 +101,15 @@ internal class TormaystarkasteluTormaysServicePGITest : DatabaseTest() {
     /** Test manually what Hanke geometries are located on critical area for buses */
     @Test
     fun bussiliikenteenKannaltaKriittinenAlue() {
-        val geometriat = createHankeGeometria()
-        assertThat(tormaysService.anyIntersectsCriticalBusRoutes(arrayListOf(geometriat))).isFalse()
+        val geometriaIds = createHankeGeometria()
+        assertThat(tormaysService.anyIntersectsCriticalBusRoutes(geometriaIds)).isFalse()
     }
 
     /** Test manually what bus routes each Hanke geometry is located on */
     @Test
     fun bussit() {
-        val geometriat = createHankeGeometria()
-        val bussit = tormaysService.getIntersectingBusRoutes(arrayListOf(geometriat))
+        val geometriaIds = createHankeGeometria()
+        val bussit = tormaysService.getIntersectingBusRoutes(geometriaIds)
         assertThat(bussit.size).isEqualTo(3)
         assertThat(bussit.map { it.reittiId }).containsOnly("1016", "1023N")
     }
@@ -117,17 +117,16 @@ internal class TormaystarkasteluTormaysServicePGITest : DatabaseTest() {
     /** Test manually what tram lane types each Hanke geometry is located on */
     @Test
     fun raitiotiet() {
-        val geometriat = createHankeGeometria()
-        assertThat(tormaysService.maxIntersectingTramByLaneType(arrayListOf(geometriat)))
+        val geometriaIds = createHankeGeometria()
+        assertThat(tormaysService.maxIntersectingTramByLaneType(geometriaIds))
             .isEqualTo(TormaystarkasteluRaitiotiekaistatyyppi.JAETTU.value)
     }
 
     /** Test manually what kind of cycleways Hanke geometries are located on */
     @Test
     fun pyorailyreitit() {
-        val geometriat = createHankeGeometria()
-        assertThat(tormaysService.anyIntersectsWithCyclewaysPriority(arrayListOf(geometriat)))
-            .isTrue()
-        assertThat(tormaysService.anyIntersectsWithCyclewaysMain(arrayListOf(geometriat))).isTrue()
+        val geometriaIds = createHankeGeometria()
+        assertThat(tormaysService.anyIntersectsWithCyclewaysPriority(geometriaIds)).isTrue()
+        assertThat(tormaysService.anyIntersectsWithCyclewaysMain(geometriaIds)).isTrue()
     }
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeMapper.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeMapper.kt
@@ -7,6 +7,7 @@ import fi.hel.haitaton.hanke.ContactType.TOTEUTTAJA
 import fi.hel.haitaton.hanke.domain.Hanke
 import fi.hel.haitaton.hanke.domain.HankeYhteystieto
 import fi.hel.haitaton.hanke.domain.SavedHankealue
+import fi.hel.haitaton.hanke.domain.resetFeatureProperties
 import fi.hel.haitaton.hanke.geometria.Geometriat
 import fi.hel.haitaton.hanke.tormaystarkastelu.TormaystarkasteluTulos
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeMapper.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeMapper.kt
@@ -7,7 +7,6 @@ import fi.hel.haitaton.hanke.ContactType.TOTEUTTAJA
 import fi.hel.haitaton.hanke.domain.Hanke
 import fi.hel.haitaton.hanke.domain.HankeYhteystieto
 import fi.hel.haitaton.hanke.domain.SavedHankealue
-import fi.hel.haitaton.hanke.domain.resetFeatureProperties
 import fi.hel.haitaton.hanke.geometria.Geometriat
 import fi.hel.haitaton.hanke.tormaystarkastelu.TormaystarkasteluTulos
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeServiceImpl.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeServiceImpl.kt
@@ -11,8 +11,11 @@ import fi.hel.haitaton.hanke.domain.HankeYhteystieto
 import fi.hel.haitaton.hanke.domain.Hankealue
 import fi.hel.haitaton.hanke.domain.HasId
 import fi.hel.haitaton.hanke.domain.HasYhteystiedot
+import fi.hel.haitaton.hanke.domain.NewHankealue
 import fi.hel.haitaton.hanke.domain.Perustaja
 import fi.hel.haitaton.hanke.domain.Yhteystieto
+import fi.hel.haitaton.hanke.domain.geometriaIds
+import fi.hel.haitaton.hanke.domain.resetFeatureProperties
 import fi.hel.haitaton.hanke.geometria.Geometriat
 import fi.hel.haitaton.hanke.geometria.GeometriatService
 import fi.hel.haitaton.hanke.logging.AuditLogService
@@ -120,7 +123,11 @@ open class HankeServiceImpl(
         val loggingEntryHolder = prepareLogging(entity)
         copyYhteystietosToEntity(request, entity, userId, loggingEntryHolder, mutableMapOf())
 
-        calculateTormaystarkastelu(request.alueet ?: listOf(), entity)
+        calculateTormaystarkastelu(
+            request.alueet ?: listOf(),
+            entity.listOfHankeAlueet.mapNotNull { it.geometriat }.toSet(),
+            entity
+        )
         entity.status = decideNewHankeStatus(entity)
 
         val savedHankeEntity = hankeRepository.save(entity)
@@ -156,12 +163,39 @@ open class HankeServiceImpl(
 
         // Create hankealueet
         request.alueet?.forEach {
-            val alueEntity = copyNonNullHankealueFieldsToEntity(hanketunnus, it, null)
+            val alueEntity = createAlueFromCreateRequest(entity.hankeTunnus, it)
             alueEntity.hanke = entity
             entity.listOfHankeAlueet.add(alueEntity)
         }
 
         return entity
+    }
+
+    private fun createAlueFromCreateRequest(
+        hanketunnus: String,
+        source: NewHankealue
+    ): HankealueEntity {
+        val result = HankealueEntity()
+
+        // Assuming the incoming date, while being zoned date and time, is in UTC and time value can
+        // be simply dropped here.
+        // Note, .toLocalDate() does not do any time zone conversion.
+        result.haittaLoppuPvm = source.haittaLoppuPvm?.toLocalDate()
+        result.haittaAlkuPvm = source.haittaAlkuPvm?.toLocalDate()
+
+        result.kaistaHaitta = source.kaistaHaitta
+        result.kaistaPituusHaitta = source.kaistaPituusHaitta
+        result.meluHaitta = source.meluHaitta
+        result.polyHaitta = source.polyHaitta
+        result.tarinaHaitta = source.tarinaHaitta
+        source.geometriat?.let {
+            it.resetFeatureProperties(hanketunnus)
+            val saved = geometriatService.createGeometria(it)
+            result.geometriat = saved.id
+        }
+        source.nimi?.let { result.nimi = source.nimi }
+
+        return result
     }
 
     /**
@@ -204,7 +238,7 @@ open class HankeServiceImpl(
         entity.modifiedAt = getCurrentTimeUTCAsLocalTime()
         entity.generated = false
 
-        calculateTormaystarkastelu(hanke.alueet, entity)
+        calculateTormaystarkastelu(hanke.alueet, hanke.alueet.geometriaIds(), entity)
         entity.status = decideNewHankeStatus(entity)
 
         // Save changes:
@@ -251,15 +285,12 @@ open class HankeServiceImpl(
         hankeKayttajaService.saveNewTokensFromHanke(hanke, userId)
     }
 
-    // TODO: functions to remove and invalidate Hanke's tormaystarkastelu-data
-    //   At least invalidation can be done purely working on the particular
-    //   tormaystarkasteluTulosEntity and -Repository.
-    //   See TormaystarkasteluRepositoryITests for a way to remove.
-
-    // ======================================================================
-
-    private fun calculateTormaystarkastelu(source: List<Hankealue>, target: HankeEntity) {
-        tormaystarkasteluService.calculateTormaystarkastelu(source)?.let {
+    private fun calculateTormaystarkastelu(
+        alueet: List<Hankealue>,
+        geometriaIds: Set<Int>,
+        target: HankeEntity
+    ) {
+        tormaystarkasteluService.calculateTormaystarkastelu(alueet, geometriaIds)?.let {
             target.tormaystarkasteluTulokset.clear()
             target.tormaystarkasteluTulokset.add(
                 TormaystarkasteluTulosEntity(
@@ -498,9 +529,8 @@ open class HankeServiceImpl(
         source.polyHaitta?.let { result.polyHaitta = source.polyHaitta }
         source.tarinaHaitta?.let { result.tarinaHaitta = source.tarinaHaitta }
         source.geometriat?.let {
-            it.id = result.geometriat ?: it.id
             it.resetFeatureProperties(hankeTunnus)
-            val saved = geometriatService.saveGeometriat(it)
+            val saved = geometriatService.saveGeometriat(it, result.geometriat)
             result.geometriat = saved?.id
         }
         source.nimi?.let { result.nimi = source.nimi }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeServiceImpl.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeServiceImpl.kt
@@ -15,7 +15,6 @@ import fi.hel.haitaton.hanke.domain.NewHankealue
 import fi.hel.haitaton.hanke.domain.Perustaja
 import fi.hel.haitaton.hanke.domain.Yhteystieto
 import fi.hel.haitaton.hanke.domain.geometriaIds
-import fi.hel.haitaton.hanke.domain.resetFeatureProperties
 import fi.hel.haitaton.hanke.geometria.Geometriat
 import fi.hel.haitaton.hanke.geometria.GeometriatService
 import fi.hel.haitaton.hanke.logging.AuditLogService

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeServiceImpl.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeServiceImpl.kt
@@ -190,7 +190,7 @@ open class HankeServiceImpl(
         result.tarinaHaitta = source.tarinaHaitta
         source.geometriat?.let {
             it.resetFeatureProperties(hanketunnus)
-            val saved = geometriatService.createGeometria(it)
+            val saved = geometriatService.createGeometriat(it)
             result.geometriat = saved.id
         }
         source.nimi?.let { result.nimi = source.nimi }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/BaseHanke.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/BaseHanke.kt
@@ -89,16 +89,16 @@ fun List<Hankealue>.geometriat(): List<HasFeatures> = mapNotNull { it.geometriat
 
 interface HasFeatures {
     val featureCollection: FeatureCollection?
-}
 
-fun HasFeatures.resetFeatureProperties(hankeTunnus: String?) {
-    featureCollection?.let { collection ->
-        collection.features.forEach { feature ->
-            feature.properties = mutableMapOf<String, Any?>("hankeTunnus" to hankeTunnus)
+    fun resetFeatureProperties(hankeTunnus: String?) {
+        featureCollection?.let { collection ->
+            collection.features.forEach { feature ->
+                feature.properties = mutableMapOf<String, Any?>("hankeTunnus" to hankeTunnus)
+            }
         }
     }
-}
 
-fun HasFeatures.hasFeatures(): Boolean {
-    return !featureCollection?.features.isNullOrEmpty()
+    fun hasFeatures(): Boolean {
+        return !featureCollection?.features.isNullOrEmpty()
+    }
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/BaseHanke.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/BaseHanke.kt
@@ -7,8 +7,8 @@ import fi.hel.haitaton.hanke.KaistajarjestelynPituus
 import fi.hel.haitaton.hanke.TodennakoinenHaittaPaaAjoRatojenKaistajarjestelyihin
 import fi.hel.haitaton.hanke.Vaihe
 import fi.hel.haitaton.hanke.Yhteyshenkilo
-import fi.hel.haitaton.hanke.geometria.Geometriat
 import java.time.ZonedDateTime
+import org.geojson.FeatureCollection
 
 interface BaseHanke : HasYhteystiedot {
     val nimi: String
@@ -76,11 +76,29 @@ interface Yhteystieto : HasId<Int> {
 interface Hankealue {
     val haittaAlkuPvm: ZonedDateTime?
     val haittaLoppuPvm: ZonedDateTime?
-    val geometriat: Geometriat?
+    val geometriat: HasFeatures?
     val kaistaHaitta: TodennakoinenHaittaPaaAjoRatojenKaistajarjestelyihin?
     val kaistaPituusHaitta: KaistajarjestelynPituus?
     val meluHaitta: Haitta13?
     val polyHaitta: Haitta13?
     val tarinaHaitta: Haitta13?
     val nimi: String?
+}
+
+fun List<Hankealue>.geometriat(): List<HasFeatures> = mapNotNull { it.geometriat }
+
+interface HasFeatures {
+    val featureCollection: FeatureCollection?
+}
+
+fun HasFeatures.resetFeatureProperties(hankeTunnus: String?) {
+    featureCollection?.let { collection ->
+        collection.features.forEach { feature ->
+            feature.properties = mutableMapOf<String, Any?>("hankeTunnus" to hankeTunnus)
+        }
+    }
+}
+
+fun HasFeatures.hasFeatures(): Boolean {
+    return !featureCollection?.features.isNullOrEmpty()
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/CreateHankeRequest.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/CreateHankeRequest.kt
@@ -6,9 +6,9 @@ import fi.hel.haitaton.hanke.TodennakoinenHaittaPaaAjoRatojenKaistajarjestelyihi
 import fi.hel.haitaton.hanke.TyomaaTyyppi
 import fi.hel.haitaton.hanke.Vaihe
 import fi.hel.haitaton.hanke.Yhteyshenkilo
-import fi.hel.haitaton.hanke.geometria.Geometriat
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.ZonedDateTime
+import org.geojson.FeatureCollection
 
 data class CreateHankeRequest(
     @field:Schema(
@@ -118,7 +118,7 @@ data class NewHankealue(
     @field:Schema(
         description = "Geometry data",
     )
-    override val geometriat: Geometriat? = null,
+    override val geometriat: NewGeometriat? = null,
     @field:Schema(
         description = "Street lane hindrance value and explanation",
     )
@@ -144,3 +144,8 @@ data class NewHankealue(
     )
     override val nimi: String? = null,
 ) : Hankealue
+
+data class NewGeometriat(
+    @field:Schema(description = "The geometry data")
+    override val featureCollection: FeatureCollection? = null,
+) : HasFeatures

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/SavedHankealue.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/SavedHankealue.kt
@@ -74,7 +74,9 @@ fun List<Hankealue>.kaistaPituusHaitat(): Set<KaistajarjestelynPituus> {
     return mapNotNull { it.kaistaPituusHaitta }.toSet()
 }
 
-fun List<Hankealue>.geometriat(): List<Geometriat> = mapNotNull { it.geometriat }
+fun List<SavedHankealue>.geometriat(): List<Geometriat> = mapNotNull { it.geometriat }
+
+fun List<SavedHankealue>.geometriaIds(): Set<Int> = mapNotNull { it.geometriat?.id }.toSet()
 
 fun List<Hankealue>.haittaAjanKestoDays(): Int? =
     if (alkuPvm() != null && loppuPvm() != null) {

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/geometria/Geometriat.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/geometria/Geometriat.kt
@@ -21,7 +21,7 @@ data class Geometriat(
     //
     @field:Schema(description = "Version, set by the service")
     @JsonView(ChangeLogView::class)
-    var version: Int? = null,
+    var version: Int,
     //
     @field:Schema(description = "User id of the geometry data creator, set by the service")
     @JsonView(NotInChangeLogView::class)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/geometria/Geometriat.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/geometria/Geometriat.kt
@@ -3,6 +3,7 @@ package fi.hel.haitaton.hanke.geometria
 import com.fasterxml.jackson.annotation.JsonView
 import fi.hel.haitaton.hanke.ChangeLogView
 import fi.hel.haitaton.hanke.NotInChangeLogView
+import fi.hel.haitaton.hanke.domain.HasFeatures
 import fi.hel.haitaton.hanke.domain.HasId
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.ZonedDateTime
@@ -16,7 +17,7 @@ data class Geometriat(
     //
     @JsonView(ChangeLogView::class)
     @field:Schema(description = "The geometry data")
-    var featureCollection: FeatureCollection? = null,
+    override var featureCollection: FeatureCollection? = null,
     //
     @field:Schema(description = "Version, set by the service")
     @JsonView(ChangeLogView::class)
@@ -37,22 +38,9 @@ data class Geometriat(
     @field:Schema(description = "Timestamp of last modification, set by the service")
     @JsonView(NotInChangeLogView::class)
     var modifiedAt: ZonedDateTime? = null
-) : HasId<Int> {
+) : HasId<Int>, HasFeatures {
     fun withFeatureCollection(input: FeatureCollection): Geometriat {
         this.featureCollection = input
         return this
-    }
-
-    fun resetFeatureProperties(hankeTunnus: String?) {
-        featureCollection?.let { collection ->
-            collection.features.forEach { feature ->
-                feature.properties = mutableMapOf<String, Any?>("hankeTunnus" to hankeTunnus)
-            }
-        }
-    }
-
-    @JsonView(NotInChangeLogView::class)
-    fun hasFeatures(): Boolean {
-        return !featureCollection?.features.isNullOrEmpty()
     }
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/geometria/GeometriatService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/geometria/GeometriatService.kt
@@ -1,8 +1,12 @@
 package fi.hel.haitaton.hanke.geometria
 
+import fi.hel.haitaton.hanke.domain.HasFeatures
+
 interface GeometriatService {
     /** Insert/Update geometries. */
-    fun saveGeometriat(geometriat: Geometriat): Geometriat?
+    fun saveGeometriat(geometriat: HasFeatures, existingId: Int?): Geometriat?
+
+    fun createGeometria(geometriat: HasFeatures): Geometriat
 
     /** Loads single geometry object. */
     fun getGeometriat(geometriatId: Int): Geometriat?

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/geometria/GeometriatService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/geometria/GeometriatService.kt
@@ -6,7 +6,7 @@ interface GeometriatService {
     /** Insert/Update geometries. */
     fun saveGeometriat(geometriat: HasFeatures, existingId: Int?): Geometriat?
 
-    fun createGeometria(geometriat: HasFeatures): Geometriat
+    fun createGeometriat(geometriat: HasFeatures): Geometriat
 
     /** Loads single geometry object. */
     fun getGeometriat(geometriatId: Int): Geometriat?

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/geometria/GeometriatServiceImpl.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/geometria/GeometriatServiceImpl.kt
@@ -2,8 +2,11 @@ package fi.hel.haitaton.hanke.geometria
 
 import fi.hel.haitaton.hanke.TZ_UTC
 import fi.hel.haitaton.hanke.currentUserId
+import fi.hel.haitaton.hanke.domain.HasFeatures
+import fi.hel.haitaton.hanke.domain.hasFeatures
 import java.time.ZonedDateTime
 import mu.KotlinLogging
+import org.geojson.FeatureCollection
 import org.springframework.transaction.annotation.Transactional
 
 private val logger = KotlinLogging.logger {}
@@ -11,57 +14,58 @@ private val logger = KotlinLogging.logger {}
 open class GeometriatServiceImpl(private val hankeGeometriaDao: GeometriatDao) : GeometriatService {
 
     @Transactional
-    override fun saveGeometriat(geometriat: Geometriat): Geometriat {
+    override fun saveGeometriat(geometriat: HasFeatures, existingId: Int?): Geometriat? {
         GeometriatValidator.expectValid(geometriat)
 
-        val now = ZonedDateTime.now(TZ_UTC)
-        val oldGeometriat =
-            if (geometriat.id != null) hankeGeometriaDao.retrieveGeometriat(geometriat.id!!)
-            else null
+        val oldGeometriat = existingId?.let { hankeGeometriaDao.retrieveGeometriat(existingId) }
         val hasFeatures = geometriat.hasFeatures()
-        val username = currentUserId()
 
         return when {
             oldGeometriat == null && !hasFeatures ->
                 throw IllegalArgumentException("New Geometriat does not contain any Features")
-            !hasFeatures -> {
-                // DELETE
-                geometriat.id = oldGeometriat!!.id
-                geometriat.createdByUserId = oldGeometriat.createdByUserId
-                geometriat.createdAt = oldGeometriat.createdAt
-                geometriat.modifiedByUserId = username
-                geometriat.modifiedAt = now
-                geometriat.version = oldGeometriat.version!! + 1
-                hankeGeometriaDao.deleteGeometriat(geometriat)
-                logger.info { "Deleted geometries ${geometriat.id}" }
-                geometriat
-            }
-            oldGeometriat == null -> {
-                // CREATE
-                geometriat.createdByUserId = username
-                geometriat.createdAt = now
-                geometriat.modifiedByUserId = null
-                geometriat.modifiedAt = null
-                geometriat.version = 0
-                val created = hankeGeometriaDao.createGeometriat(geometriat)
-                logger.info { "Created new geometries ${created.id}" }
-                created
-            }
-            else -> {
-                // UPDATE
-                if (oldGeometriat.version == null) {
-                    error("There is an old Geometriat ${oldGeometriat.id} but it has no 'version'")
-                } else {
-                    oldGeometriat.version = oldGeometriat.version!! + 1
-                }
-                oldGeometriat.modifiedByUserId = username
-                oldGeometriat.modifiedAt = now
-                oldGeometriat.featureCollection = geometriat.featureCollection
-                hankeGeometriaDao.updateGeometriat(oldGeometriat)
-                logger.info { "Updated geometries ${oldGeometriat.id}" }
-                oldGeometriat
-            }
+            oldGeometriat != null && !hasFeatures -> deleteGeometria(oldGeometriat)
+            oldGeometriat == null -> createGeometria(geometriat)
+            else -> updateGeometria(oldGeometriat, geometriat.featureCollection!!)
         }
+    }
+
+    override fun createGeometria(geometriat: HasFeatures): Geometriat {
+        val created =
+            Geometriat(
+                    featureCollection = geometriat.featureCollection,
+                    createdByUserId = currentUserId(),
+                    createdAt = ZonedDateTime.now(TZ_UTC),
+                    modifiedByUserId = null,
+                    modifiedAt = null,
+                    version = 0,
+                )
+                .let(hankeGeometriaDao::createGeometriat)
+
+        logger.info { "Created new geometries ${created.id}" }
+        return created
+    }
+
+    private fun deleteGeometria(geometriat: Geometriat): Geometriat? {
+        hankeGeometriaDao.deleteGeometriat(geometriat)
+        logger.info { "Deleted geometries ${geometriat.id}" }
+        return null
+    }
+
+    private fun updateGeometria(
+        geometriat: Geometriat,
+        newFeatures: FeatureCollection
+    ): Geometriat {
+        if (geometriat.version == null) {
+            error("There is an old Geometriat ${geometriat.id} but it has no 'version'")
+        } else {
+            geometriat.version = geometriat.version!! + 1
+        }
+        geometriat.modifiedByUserId = currentUserId()
+        geometriat.modifiedAt = ZonedDateTime.now(TZ_UTC)
+        geometriat.featureCollection = newFeatures
+        hankeGeometriaDao.updateGeometriat(geometriat)
+        logger.info { "Updated geometries ${geometriat.id}" }
+        return geometriat
     }
 
     /** Get geometries by geometry object id. */

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/geometria/GeometriatServiceImpl.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/geometria/GeometriatServiceImpl.kt
@@ -3,7 +3,6 @@ package fi.hel.haitaton.hanke.geometria
 import fi.hel.haitaton.hanke.TZ_UTC
 import fi.hel.haitaton.hanke.currentUserId
 import fi.hel.haitaton.hanke.domain.HasFeatures
-import fi.hel.haitaton.hanke.domain.hasFeatures
 import java.time.ZonedDateTime
 import mu.KotlinLogging
 import org.geojson.FeatureCollection
@@ -18,12 +17,12 @@ open class GeometriatServiceImpl(private val hankeGeometriaDao: GeometriatDao) :
         GeometriatValidator.expectValid(geometriat)
 
         val oldGeometriat = existingId?.let { hankeGeometriaDao.retrieveGeometriat(existingId) }
-        val hasFeatures = geometriat.hasFeatures()
+        val updateHasFeatures = geometriat.hasFeatures()
 
         return when {
-            oldGeometriat == null && !hasFeatures ->
+            oldGeometriat == null && !updateHasFeatures ->
                 throw IllegalArgumentException("New Geometriat does not contain any Features")
-            oldGeometriat != null && !hasFeatures -> deleteGeometriat(oldGeometriat)
+            oldGeometriat != null && !updateHasFeatures -> deleteGeometriat(oldGeometriat)
             oldGeometriat == null -> createGeometriat(geometriat)
             else -> updateGeometriat(oldGeometriat, geometriat.featureCollection!!)
         }
@@ -55,11 +54,7 @@ open class GeometriatServiceImpl(private val hankeGeometriaDao: GeometriatDao) :
         geometriat: Geometriat,
         newFeatures: FeatureCollection
     ): Geometriat {
-        if (geometriat.version == null) {
-            error("There is an old Geometriat ${geometriat.id} but it has no 'version'")
-        } else {
-            geometriat.version = geometriat.version!! + 1
-        }
+        geometriat.version = geometriat.version + 1
         geometriat.modifiedByUserId = currentUserId()
         geometriat.modifiedAt = ZonedDateTime.now(TZ_UTC)
         geometriat.featureCollection = newFeatures

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/geometria/GeometriatServiceImpl.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/geometria/GeometriatServiceImpl.kt
@@ -23,13 +23,13 @@ open class GeometriatServiceImpl(private val hankeGeometriaDao: GeometriatDao) :
         return when {
             oldGeometriat == null && !hasFeatures ->
                 throw IllegalArgumentException("New Geometriat does not contain any Features")
-            oldGeometriat != null && !hasFeatures -> deleteGeometria(oldGeometriat)
-            oldGeometriat == null -> createGeometria(geometriat)
-            else -> updateGeometria(oldGeometriat, geometriat.featureCollection!!)
+            oldGeometriat != null && !hasFeatures -> deleteGeometriat(oldGeometriat)
+            oldGeometriat == null -> createGeometriat(geometriat)
+            else -> updateGeometriat(oldGeometriat, geometriat.featureCollection!!)
         }
     }
 
-    override fun createGeometria(geometriat: HasFeatures): Geometriat {
+    override fun createGeometriat(geometriat: HasFeatures): Geometriat {
         val created =
             Geometriat(
                     featureCollection = geometriat.featureCollection,
@@ -45,13 +45,13 @@ open class GeometriatServiceImpl(private val hankeGeometriaDao: GeometriatDao) :
         return created
     }
 
-    private fun deleteGeometria(geometriat: Geometriat): Geometriat? {
+    private fun deleteGeometriat(geometriat: Geometriat): Geometriat? {
         hankeGeometriaDao.deleteGeometriat(geometriat)
         logger.info { "Deleted geometries ${geometriat.id}" }
         return null
     }
 
-    private fun updateGeometria(
+    private fun updateGeometriat(
         geometriat: Geometriat,
         newFeatures: FeatureCollection
     ): Geometriat {

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/geometria/GeometriatValidator.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/geometria/GeometriatValidator.kt
@@ -1,10 +1,11 @@
 package fi.hel.haitaton.hanke.geometria
 
 import fi.hel.haitaton.hanke.COORDINATE_SYSTEM_URN
+import fi.hel.haitaton.hanke.domain.HasFeatures
 
 class GeometriatValidator {
     companion object {
-        fun expectValid(value: Geometriat?) {
+        fun expectValid(value: HasFeatures?) {
             val featureCollection =
                 value?.featureCollection ?: throw GeometriaValidationException("featureCollection")
             when {

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluLaskentaService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluLaskentaService.kt
@@ -7,7 +7,6 @@ import fi.hel.haitaton.hanke.domain.haittaAjanKestoDays
 import fi.hel.haitaton.hanke.domain.kaistaHaitat
 import fi.hel.haitaton.hanke.domain.kaistaPituusHaitat
 import fi.hel.haitaton.hanke.domain.loppuPvm
-import fi.hel.haitaton.hanke.geometria.Geometriat
 import fi.hel.haitaton.hanke.roundToOneDecimal
 import kotlin.math.max
 import org.springframework.beans.factory.annotation.Autowired
@@ -16,20 +15,23 @@ open class TormaystarkasteluLaskentaService(
     @Autowired private val tormaysService: TormaystarkasteluTormaysService
 ) {
 
-    fun calculateTormaystarkastelu(alueet: List<Hankealue>): TormaystarkasteluTulos? {
+    fun calculateTormaystarkastelu(
+        alueet: List<Hankealue>,
+        geometriaIds: Set<Int>
+    ): TormaystarkasteluTulos? {
         if (!hasAllRequiredInformation(alueet)) {
             return null
         }
 
-        val perusIndeksi = calculatePerusIndeksi(alueet)
+        val perusIndeksi = calculatePerusIndeksi(alueet, geometriaIds)
 
-        val pyorailyLuokittelu = pyorailyLuokittelu(alueet.geometriat())
+        val pyorailyLuokittelu = pyorailyLuokittelu(geometriaIds)
         val pyorailyIndeksi = if (pyorailyLuokittelu >= 4) 3.0f else 1.0f
 
-        val bussiLuokittelu = bussiLuokittelu(alueet.geometriat())
+        val bussiLuokittelu = bussiLuokittelu(geometriaIds)
         val bussiIndeksi = if (bussiLuokittelu >= 3) 4.0f else 1.0f
 
-        val raitiovaunuLuokittelu = raitiovaunuLuokittelu(alueet.geometriat())
+        val raitiovaunuLuokittelu = raitiovaunuLuokittelu(geometriaIds)
         val raitiovaunuIndeksi = if (raitiovaunuLuokittelu >= 3) 4.0f else 1.0f
 
         return TormaystarkasteluTulos(
@@ -48,7 +50,7 @@ open class TormaystarkasteluLaskentaService(
             alueet.geometriat().isNotEmpty())
     }
 
-    private fun calculatePerusIndeksi(alueet: List<Hankealue>): Float {
+    private fun calculatePerusIndeksi(alueet: List<Hankealue>, geometriaIds: Set<Int>): Float {
         val luokittelu = mutableMapOf<LuokitteluType, Int>()
 
         luokittelu[LuokitteluType.HAITTA_AJAN_KESTO] =
@@ -58,39 +60,36 @@ open class TormaystarkasteluLaskentaService(
         luokittelu[LuokitteluType.KAISTAJARJESTELYN_PITUUS] =
             alueet.kaistaPituusHaitat().maxOfOrNull { it.value }!!
 
-        val katuluokkaLuokittelu = katuluokkaLuokittelu(alueet.geometriat())
+        val katuluokkaLuokittelu = katuluokkaLuokittelu(geometriaIds)
         luokittelu[LuokitteluType.KATULUOKKA] = katuluokkaLuokittelu
         luokittelu[LuokitteluType.LIIKENNEMAARA] =
-            liikennemaaraLuokittelu(alueet.geometriat(), katuluokkaLuokittelu)
+            liikennemaaraLuokittelu(geometriaIds, katuluokkaLuokittelu)
 
         return calculatePerusIndeksiFromLuokittelu(luokittelu)
     }
 
-    internal fun katuluokkaLuokittelu(geometriat: List<Geometriat>): Int {
-        return if (tormaysService.anyIntersectsYleinenKatuosa(geometriat)) {
+    internal fun katuluokkaLuokittelu(geometriaIds: Set<Int>): Int {
+        return if (tormaysService.anyIntersectsYleinenKatuosa(geometriaIds)) {
             // ON ylre_parts => street_classes?
-            tormaysService.maxIntersectingLiikenteellinenKatuluokka(geometriat)
+            tormaysService.maxIntersectingLiikenteellinenKatuluokka(geometriaIds)
             // EI street_classes => ylre_classes?
-            ?: tormaysService.maxIntersectingYleinenkatualueKatuluokka(geometriat)
+            ?: tormaysService.maxIntersectingYleinenkatualueKatuluokka(geometriaIds)
                 // EI ylre_classes
                 ?: 0
         } else {
             // EI ylre_parts => ylre_classes?
             val max =
-                tormaysService.maxIntersectingYleinenkatualueKatuluokka(geometriat)
+                tormaysService.maxIntersectingYleinenkatualueKatuluokka(geometriaIds)
                 // EI ylre_classes
                 ?: return 0
             // ON ylre_classes => street_classes?
-            tormaysService.maxIntersectingLiikenteellinenKatuluokka(geometriat)
+            tormaysService.maxIntersectingLiikenteellinenKatuluokka(geometriaIds)
             // JOS EI LÖYDY => Valitse ylre_classes
             ?: max
         }
     }
 
-    internal fun liikennemaaraLuokittelu(
-        geometriat: List<Geometriat>,
-        katuluokkaLuokittelu: Int
-    ): Int {
+    internal fun liikennemaaraLuokittelu(geometriaIds: Set<Int>, katuluokkaLuokittelu: Int): Int {
         if (katuluokkaLuokittelu == 0) {
             return 0
         }
@@ -102,7 +101,7 @@ open class TormaystarkasteluLaskentaService(
             } else {
                 TormaystarkasteluLiikennemaaranEtaisyys.RADIUS_15
             }
-        val maxVolume = tormaysService.maxLiikennemaara(geometriat, radius) ?: 0
+        val maxVolume = tormaysService.maxLiikennemaara(geometriaIds, radius) ?: 0
         return RajaArvoLuokittelija.getLiikennemaaraLuokka(maxVolume)
     }
 
@@ -114,21 +113,21 @@ open class TormaystarkasteluLaskentaService(
             .sum()
             .roundToOneDecimal()
 
-    internal fun pyorailyLuokittelu(geometriat: List<Geometriat>): Int =
+    internal fun pyorailyLuokittelu(geometriaIds: Set<Int>): Int =
         when {
-            tormaysService.anyIntersectsWithCyclewaysPriority(geometriat) ->
+            tormaysService.anyIntersectsWithCyclewaysPriority(geometriaIds) ->
                 PyorailyTormaysLuokittelu.PRIORISOITU_REITTI
-            tormaysService.anyIntersectsWithCyclewaysMain(geometriat) ->
+            tormaysService.anyIntersectsWithCyclewaysMain(geometriaIds) ->
                 PyorailyTormaysLuokittelu.PAAREITTI
             else -> PyorailyTormaysLuokittelu.EI_PYORAILUREITTI
         }.value
 
-    internal fun bussiLuokittelu(geometriat: List<Geometriat>): Int {
-        if (tormaysService.anyIntersectsCriticalBusRoutes(geometriat)) {
+    internal fun bussiLuokittelu(geometriaIds: Set<Int>): Int {
+        if (tormaysService.anyIntersectsCriticalBusRoutes(geometriaIds)) {
             return BussiLiikenneLuokittelu.KAMPPI_RAUTATIENTORI.value
         }
 
-        val bussireitit = tormaysService.getIntersectingBusRoutes(geometriat)
+        val bussireitit = tormaysService.getIntersectingBusRoutes(geometriaIds)
 
         val valueByRunkolinja =
             bussireitit.maxOfOrNull { it.runkolinja.toBussiLiikenneLuokittelu().value }
@@ -142,6 +141,6 @@ open class TormaystarkasteluLaskentaService(
         return max(valueByRajaArvo, valueByRunkolinja)
     }
 
-    private fun raitiovaunuLuokittelu(geometriat: List<Geometriat>) =
-        tormaysService.maxIntersectingTramByLaneType(geometriat) ?: 0
+    private fun raitiovaunuLuokittelu(geometriaIds: Set<Int>) =
+        tormaysService.maxIntersectingTramByLaneType(geometriaIds) ?: 0
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluTormaysService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluTormaysService.kt
@@ -1,35 +1,33 @@
 package fi.hel.haitaton.hanke.tormaystarkastelu
 
-import fi.hel.haitaton.hanke.geometria.Geometriat
-
 interface TormaystarkasteluTormaysService {
 
     // yleinen katuosa, ylre_parts
-    fun anyIntersectsYleinenKatuosa(geometriat: List<Geometriat>): Boolean
+    fun anyIntersectsYleinenKatuosa(geometriaIds: Set<Int>): Boolean
 
     // yleinen katualue, ylre_classes
-    fun maxIntersectingYleinenkatualueKatuluokka(geometriat: List<Geometriat>): Int?
+    fun maxIntersectingYleinenkatualueKatuluokka(geometriaIds: Set<Int>): Int?
 
     // liikenteellinen katuluokka, street_classes
-    fun maxIntersectingLiikenteellinenKatuluokka(geometriat: List<Geometriat>): Int?
+    fun maxIntersectingLiikenteellinenKatuluokka(geometriaIds: Set<Int>): Int?
 
     // kantakaupunki, central_business_area
-    fun anyIntersectsWithKantakaupunki(geometriat: List<Geometriat>): Boolean
+    fun anyIntersectsWithKantakaupunki(geometriaIds: Set<Int>): Boolean
 
     fun maxLiikennemaara(
-        geometriat: List<Geometriat>,
+        geometriaIds: Set<Int>,
         etaisyys: TormaystarkasteluLiikennemaaranEtaisyys
     ): Int?
 
-    fun anyIntersectsCriticalBusRoutes(geometriat: List<Geometriat>): Boolean
+    fun anyIntersectsCriticalBusRoutes(geometriaIds: Set<Int>): Boolean
 
-    fun getIntersectingBusRoutes(geometriat: List<Geometriat>): Set<TormaystarkasteluBussireitti>
+    fun getIntersectingBusRoutes(geometriaIds: Set<Int>): Set<TormaystarkasteluBussireitti>
 
-    fun maxIntersectingTramByLaneType(geometriat: List<Geometriat>): Int?
+    fun maxIntersectingTramByLaneType(geometriaIds: Set<Int>): Int?
 
-    fun anyIntersectsWithCyclewaysPriority(geometriat: List<Geometriat>): Boolean
+    fun anyIntersectsWithCyclewaysPriority(geometriaIds: Set<Int>): Boolean
 
-    fun anyIntersectsWithCyclewaysMain(geometriat: List<Geometriat>): Boolean
+    fun anyIntersectsWithCyclewaysMain(geometriaIds: Set<Int>): Boolean
 }
 
 /** There are two(2) separate traffic counts - one for radius of 15m and other for 30m */

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/HankeMapperTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/HankeMapperTest.kt
@@ -11,15 +11,14 @@ import fi.hel.haitaton.hanke.ContactType.RAKENNUTTAJA
 import fi.hel.haitaton.hanke.ContactType.TOTEUTTAJA
 import fi.hel.haitaton.hanke.domain.Hanke
 import fi.hel.haitaton.hanke.domain.YhteystietoTyyppi.YRITYS
-import fi.hel.haitaton.hanke.domain.resetFeatureProperties
 import fi.hel.haitaton.hanke.factory.AlluDataFactory.Companion.teppoEmail
 import fi.hel.haitaton.hanke.factory.DateFactory
+import fi.hel.haitaton.hanke.factory.GeometriaFactory
 import fi.hel.haitaton.hanke.factory.HankeFactory
 import fi.hel.haitaton.hanke.factory.HankeYhteystietoFactory
 import fi.hel.haitaton.hanke.factory.HankeYhteystietoFactory.defaultYtunnus
 import fi.hel.haitaton.hanke.factory.HankealueFactory
 import fi.hel.haitaton.hanke.factory.TEPPO_TESTI
-import fi.hel.haitaton.hanke.geometria.Geometriat
 import java.time.ZonedDateTime
 import org.junit.jupiter.api.Test
 
@@ -27,14 +26,11 @@ private const val MOCK_ID = 1
 
 class HankeMapperTest {
 
-    val geometry: Geometriat =
-        "/fi/hel/haitaton/hanke/geometria/hankeGeometriat.json".asJsonResource()
-
     @Test
     fun `when entity contains all fields should map domain object correspondingly`() {
         val entity = HankeFactory.createEntity()
 
-        val result = HankeMapper.domainFrom(entity, mapOf(MOCK_ID to geometry))
+        val result = HankeMapper.domainFrom(entity, mapOf(MOCK_ID to GeometriaFactory.create()))
 
         assertThat(result).all {
             prop(Hanke::id).isEqualTo(entity.id)
@@ -92,7 +88,8 @@ class HankeMapperTest {
                 hankeId = hankeId,
                 haittaAlkuPvm = DateFactory.getStartDatetime().toLocalDate().atStartOfDay(TZ_UTC),
                 haittaLoppuPvm = DateFactory.getEndDatetime().toLocalDate().atStartOfDay(TZ_UTC),
-                geometriat = geometry.apply { resetFeatureProperties(hankeTunnus) },
+                geometriat =
+                    GeometriaFactory.create().apply { resetFeatureProperties(hankeTunnus) },
             )
         )
 }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/HankeMapperTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/HankeMapperTest.kt
@@ -11,6 +11,7 @@ import fi.hel.haitaton.hanke.ContactType.RAKENNUTTAJA
 import fi.hel.haitaton.hanke.ContactType.TOTEUTTAJA
 import fi.hel.haitaton.hanke.domain.Hanke
 import fi.hel.haitaton.hanke.domain.YhteystietoTyyppi.YRITYS
+import fi.hel.haitaton.hanke.domain.resetFeatureProperties
 import fi.hel.haitaton.hanke.factory.AlluDataFactory.Companion.teppoEmail
 import fi.hel.haitaton.hanke.factory.DateFactory
 import fi.hel.haitaton.hanke.factory.HankeFactory

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/CreateHankeRequestBuilder.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/CreateHankeRequestBuilder.kt
@@ -6,6 +6,7 @@ import fi.hel.haitaton.hanke.domain.CreateHankeRequest
 import fi.hel.haitaton.hanke.domain.Hanke
 import fi.hel.haitaton.hanke.domain.HankeYhteystieto
 import fi.hel.haitaton.hanke.domain.Hankealue
+import fi.hel.haitaton.hanke.domain.NewGeometriat
 import fi.hel.haitaton.hanke.domain.NewHankealue
 import fi.hel.haitaton.hanke.domain.NewYhteystieto
 
@@ -60,7 +61,7 @@ fun Hankealue.toCreateRequest() =
     NewHankealue(
         haittaAlkuPvm,
         haittaLoppuPvm,
-        geometriat,
+        geometriat?.let { NewGeometriat(it.featureCollection) },
         kaistaHaitta,
         kaistaPituusHaitta,
         meluHaitta,

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/GeometriaFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/GeometriaFactory.kt
@@ -1,0 +1,13 @@
+package fi.hel.haitaton.hanke.factory
+
+import fi.hel.haitaton.hanke.asJsonResource
+import fi.hel.haitaton.hanke.domain.NewGeometriat
+import fi.hel.haitaton.hanke.geometria.Geometriat
+
+object GeometriaFactory {
+
+    fun create(): Geometriat =
+        "/fi/hel/haitaton/hanke/geometria/hankeGeometriat.json".asJsonResource()
+
+    fun createNew(): NewGeometriat = NewGeometriat(create().featureCollection)
+}

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankealueFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankealueFactory.kt
@@ -5,7 +5,6 @@ import fi.hel.haitaton.hanke.HankeEntity
 import fi.hel.haitaton.hanke.HankealueEntity
 import fi.hel.haitaton.hanke.KaistajarjestelynPituus
 import fi.hel.haitaton.hanke.TodennakoinenHaittaPaaAjoRatojenKaistajarjestelyihin
-import fi.hel.haitaton.hanke.asJsonResource
 import fi.hel.haitaton.hanke.domain.SavedHankealue
 import fi.hel.haitaton.hanke.geometria.Geometriat
 import java.time.ZonedDateTime
@@ -17,8 +16,7 @@ object HankealueFactory {
         hankeId: Int? = 2,
         haittaAlkuPvm: ZonedDateTime? = DateFactory.getStartDatetime(),
         haittaLoppuPvm: ZonedDateTime? = DateFactory.getEndDatetime(),
-        geometriat: Geometriat? =
-            "/fi/hel/haitaton/hanke/geometria/hankeGeometriat.json".asJsonResource(),
+        geometriat: Geometriat? = GeometriaFactory.create(),
         kaistaHaitta: TodennakoinenHaittaPaaAjoRatojenKaistajarjestelyihin? =
             TodennakoinenHaittaPaaAjoRatojenKaistajarjestelyihin.KAKSI,
         kaistaPituusHaitta: KaistajarjestelynPituus? = KaistajarjestelynPituus.NELJA,

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/geometria/GeometriatServiceImplTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/geometria/GeometriatServiceImplTest.kt
@@ -9,36 +9,28 @@ import assertk.assertions.isNotSameAs
 import assertk.assertions.isNull
 import assertk.assertions.prop
 import fi.hel.haitaton.hanke.asJsonResource
+import fi.hel.haitaton.hanke.test.Asserts.isRecentZDT
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.verify
 import io.mockk.verifySequence
-import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.springframework.security.core.Authentication
-import org.springframework.security.core.context.SecurityContext
-import org.springframework.security.core.context.SecurityContextHolder
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.test.context.junit.jupiter.SpringExtension
 
+private const val USERNAME = "tester"
+
+@ExtendWith(SpringExtension::class)
+@WithMockUser(USERNAME)
 internal class GeometriatServiceImplTest {
 
     private val geometriatDao: GeometriatDao = mockk()
 
     private val service = GeometriatServiceImpl(geometriatDao)
-
-    companion object {
-
-        @BeforeAll
-        @JvmStatic
-        fun setUp() {
-            val securityContext: SecurityContext = mockk()
-            val authentication: Authentication = mockk()
-            every { securityContext.authentication } returns authentication
-            every { authentication.name } returns "tester"
-            SecurityContextHolder.setContext(securityContext)
-        }
-    }
 
     private fun loadGeometriat(): Geometriat {
         return "/fi/hel/haitaton/hanke/geometria/hankeGeometriat.json".asJsonResource()
@@ -69,6 +61,7 @@ internal class GeometriatServiceImplTest {
             prop(Geometriat::version).isEqualTo(1)
             prop(Geometriat::createdAt).isNotNull()
             prop(Geometriat::modifiedAt).isNotNull()
+            prop(Geometriat::modifiedByUserId).isEqualTo(USERNAME)
             prop(Geometriat::featureCollection).isNotNull()
             isNotSameAs(geometriat)
         }
@@ -92,8 +85,9 @@ internal class GeometriatServiceImplTest {
         assertThat(savedHankeGeometria).isNotNull().all {
             prop(Geometriat::id).isEqualTo(42)
             prop(Geometriat::version).isEqualTo(0)
-            prop(Geometriat::createdAt).isNotNull()
+            prop(Geometriat::createdAt).isRecentZDT()
             prop(Geometriat::modifiedAt).isNull()
+            prop(Geometriat::modifiedByUserId).isNull()
             prop(Geometriat::featureCollection).isNotNull()
             isNotSameAs(geometriat)
         }
@@ -128,10 +122,12 @@ internal class GeometriatServiceImplTest {
         geometriat.id = geometriatId
         geometriat.version = null
         geometriat.createdAt = null
+        geometriat.createdByUserId = null
         geometriat.modifiedAt = null
         val oldGeometriat = loadGeometriat()
         oldGeometriat.id = geometriatId
         oldGeometriat.version = 1
+        oldGeometriat.createdByUserId = "Another user"
         oldGeometriat.featureCollection!!.features.clear()
 
         every { geometriatDao.retrieveGeometriat(geometriatId) } returns oldGeometriat
@@ -145,12 +141,53 @@ internal class GeometriatServiceImplTest {
         verify(exactly = 0) { geometriatDao.createGeometriat(any()) }
         assertThat(savedHankeGeometria).isNotNull().all {
             prop(Geometriat::version).isEqualTo(2)
-            prop(Geometriat::createdAt).isNotNull()
-            prop(Geometriat::modifiedAt).isNotNull()
+            prop(Geometriat::createdAt).isEqualTo(oldGeometriat.createdAt)
+            prop(Geometriat::createdByUserId).isEqualTo("Another user")
+            prop(Geometriat::modifiedAt).isRecentZDT()
+            prop(Geometriat::modifiedByUserId).isEqualTo(USERNAME)
             prop(Geometriat::featureCollection).isNotNull().all {
                 transform("features") { it.features }.isNotEmpty()
             }
             isNotSameAs(geometriat)
+        }
+    }
+
+    @Nested
+    inner class CreateGeometria {
+        @Test
+        fun `sets metadata correctly`() {
+            val geometriat = loadGeometriat()
+            every { geometriatDao.createGeometriat(any()) } answers
+                {
+                    firstArg<Geometriat>().apply { id = 42 }
+                }
+
+            val savedHankeGeometria = service.createGeometriat(geometriat)
+
+            assertThat(savedHankeGeometria).isNotNull().all {
+                prop(Geometriat::version).isEqualTo(0)
+                prop(Geometriat::createdAt).isRecentZDT()
+                prop(Geometriat::createdByUserId).isEqualTo(USERNAME)
+                prop(Geometriat::modifiedAt).isNull()
+                prop(Geometriat::modifiedByUserId).isNull()
+                isNotSameAs(geometriat)
+            }
+        }
+
+        @Test
+        fun `adds features from parameters`() {
+            val geometriat = loadGeometriat()
+            every { geometriatDao.createGeometriat(any()) } answers
+                {
+                    firstArg<Geometriat>().apply { id = 42 }
+                }
+
+            val savedHankeGeometria = service.createGeometriat(geometriat)
+
+            assertThat(savedHankeGeometria).isNotNull().all {
+                isNotSameAs(geometriat)
+                prop(Geometriat::featureCollection).isEqualTo(geometriat.featureCollection)
+            }
         }
     }
 }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/geometria/GeometriatServiceImplTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/geometria/GeometriatServiceImplTest.kt
@@ -9,6 +9,7 @@ import assertk.assertions.isNotSameAs
 import assertk.assertions.isNull
 import assertk.assertions.prop
 import fi.hel.haitaton.hanke.asJsonResource
+import fi.hel.haitaton.hanke.factory.GeometriaFactory
 import fi.hel.haitaton.hanke.test.Asserts.isRecentZDT
 import io.mockk.every
 import io.mockk.just
@@ -32,19 +33,11 @@ internal class GeometriatServiceImplTest {
 
     private val service = GeometriatServiceImpl(geometriatDao)
 
-    private fun loadGeometriat(): Geometriat {
-        return "/fi/hel/haitaton/hanke/geometria/hankeGeometriat.json".asJsonResource()
-    }
-
     @Test
     fun `save Geometriat OK - with old version`() {
         val geometriaId = 42
-        val geometriat = loadGeometriat()
-        geometriat.id = null
-        geometriat.version = null
-        geometriat.createdAt = null
-        geometriat.modifiedAt = null
-        val oldGeometriat = loadGeometriat()
+        val geometriat = GeometriaFactory.createNew()
+        val oldGeometriat = GeometriaFactory.create()
         oldGeometriat.id = geometriaId
         oldGeometriat.version = 0
 
@@ -69,11 +62,7 @@ internal class GeometriatServiceImplTest {
 
     @Test
     fun `save Geometriat OK - without old version`() {
-        val geometriat = loadGeometriat()
-        geometriat.id = 666
-        geometriat.version = null
-        geometriat.createdAt = null
-        geometriat.modifiedAt = null
+        val geometriat = GeometriaFactory.createNew()
         every { geometriatDao.createGeometriat(any()) } answers
             {
                 firstArg<Geometriat>().apply { id = 42 }
@@ -99,7 +88,7 @@ internal class GeometriatServiceImplTest {
         val geometriat: Geometriat =
             "/fi/hel/haitaton/hanke/geometria/hankeGeometriat-delete.json".asJsonResource()
         geometriat.id = geometriatId
-        val oldGeometriat = loadGeometriat()
+        val oldGeometriat = GeometriaFactory.create()
         oldGeometriat.version = 0
         oldGeometriat.id = geometriatId
 
@@ -118,13 +107,8 @@ internal class GeometriatServiceImplTest {
     @Test
     fun `save Geometriat OK - with an empty old version (after delete)`() {
         val geometriatId = 1
-        val geometriat = loadGeometriat()
-        geometriat.id = geometriatId
-        geometriat.version = null
-        geometriat.createdAt = null
-        geometriat.createdByUserId = null
-        geometriat.modifiedAt = null
-        val oldGeometriat = loadGeometriat()
+        val geometriat = GeometriaFactory.createNew()
+        val oldGeometriat = GeometriaFactory.create()
         oldGeometriat.id = geometriatId
         oldGeometriat.version = 1
         oldGeometriat.createdByUserId = "Another user"
@@ -156,7 +140,7 @@ internal class GeometriatServiceImplTest {
     inner class CreateGeometria {
         @Test
         fun `sets metadata correctly`() {
-            val geometriat = loadGeometriat()
+            val geometriat = GeometriaFactory.create()
             every { geometriatDao.createGeometriat(any()) } answers
                 {
                     firstArg<Geometriat>().apply { id = 42 }
@@ -176,7 +160,7 @@ internal class GeometriatServiceImplTest {
 
         @Test
         fun `adds features from parameters`() {
-            val geometriat = loadGeometriat()
+            val geometriat = GeometriaFactory.create()
             every { geometriatDao.createGeometriat(any()) } answers
                 {
                     firstArg<Geometriat>().apply { id = 42 }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluLaskentaServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluLaskentaServiceTest.kt
@@ -6,11 +6,9 @@ import assertk.assertions.isNotNull
 import fi.hel.haitaton.hanke.KaistajarjestelynPituus
 import fi.hel.haitaton.hanke.TZ_UTC
 import fi.hel.haitaton.hanke.TodennakoinenHaittaPaaAjoRatojenKaistajarjestelyihin
-import fi.hel.haitaton.hanke.asJsonResource
 import fi.hel.haitaton.hanke.domain.SavedHankealue
 import fi.hel.haitaton.hanke.domain.geometriaIds
-import fi.hel.haitaton.hanke.domain.geometriat
-import fi.hel.haitaton.hanke.geometria.Geometriat
+import fi.hel.haitaton.hanke.factory.GeometriaFactory
 import fi.hel.haitaton.hanke.tormaystarkastelu.TormaystarkasteluLiikennemaaranEtaisyys.RADIUS_15
 import fi.hel.haitaton.hanke.tormaystarkastelu.TormaystarkasteluLiikennemaaranEtaisyys.RADIUS_30
 import io.mockk.checkUnnecessaryStub
@@ -441,16 +439,12 @@ internal class TormaystarkasteluLaskentaServiceTest {
     }
 
     private fun setupHappyCase(): List<SavedHankealue> {
-        val geometriat =
-            "/fi/hel/haitaton/hanke/geometria/hankeGeometriat.json".asJsonResource(
-                Geometriat::class.java
-            )
 
         val alkuPvm = ZonedDateTime.of(2021, 3, 4, 0, 0, 0, 0, TZ_UTC)
         val alueet =
             listOf(
                 SavedHankealue(
-                    geometriat = geometriat,
+                    geometriat = GeometriaFactory.create(),
                     haittaAlkuPvm = alkuPvm,
                     haittaLoppuPvm = alkuPvm.plusDays(7),
                     kaistaHaitta = TodennakoinenHaittaPaaAjoRatojenKaistajarjestelyihin.YKSI,

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluLaskentaServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluLaskentaServiceTest.kt
@@ -8,6 +8,7 @@ import fi.hel.haitaton.hanke.TZ_UTC
 import fi.hel.haitaton.hanke.TodennakoinenHaittaPaaAjoRatojenKaistajarjestelyihin
 import fi.hel.haitaton.hanke.asJsonResource
 import fi.hel.haitaton.hanke.domain.SavedHankealue
+import fi.hel.haitaton.hanke.domain.geometriaIds
 import fi.hel.haitaton.hanke.domain.geometriat
 import fi.hel.haitaton.hanke.geometria.Geometriat
 import fi.hel.haitaton.hanke.tormaystarkastelu.TormaystarkasteluLiikennemaaranEtaisyys.RADIUS_15
@@ -73,7 +74,7 @@ internal class TormaystarkasteluLaskentaServiceTest {
     @Nested
     inner class KatuluokkaLuokittelu {
         // The parameter is only used to call mocks
-        val geometriat = listOf<Geometriat>()
+        val geometriat = setOf<Int>()
 
         @Nested
         inner class WithYlreParts {
@@ -216,7 +217,7 @@ internal class TormaystarkasteluLaskentaServiceTest {
     @Nested
     inner class LiikennemaaraLuokittelu {
         // The parameter is only used to call mocks
-        val geometriat = listOf<Geometriat>()
+        val geometriat = setOf<Int>()
 
         @Test
         fun `returns 0 when street class is 0`() {
@@ -286,7 +287,7 @@ internal class TormaystarkasteluLaskentaServiceTest {
     @Nested
     inner class PyorailyLuokittelu {
         // The parameter is only used to call mocks
-        val geometriat = listOf<Geometriat>()
+        val geometriat = setOf<Int>()
 
         @Test
         fun `returns 5 when intersect with priority route`() {
@@ -330,7 +331,7 @@ internal class TormaystarkasteluLaskentaServiceTest {
     @Nested
     inner class BussiLuokittelu {
         // The parameter is only used to call mocks
-        val geometriat = listOf<Geometriat>()
+        val geometriat = setOf<Int>()
 
         @Test
         fun `returns 5 when intersects with critical bus routes`() {
@@ -419,8 +420,9 @@ internal class TormaystarkasteluLaskentaServiceTest {
     @Test
     fun `calculateTormaystarkastelu happy case`() {
         val alueet = setupHappyCase()
+        val geometriaIds = alueet.geometriaIds()
 
-        val tulos = laskentaService.calculateTormaystarkastelu(alueet)
+        val tulos = laskentaService.calculateTormaystarkastelu(alueet, geometriaIds)
 
         assertThat(tulos).isNotNull()
         assertThat(tulos!!.liikennehaittaIndeksi).isNotNull()
@@ -428,13 +430,13 @@ internal class TormaystarkasteluLaskentaServiceTest {
         assertThat(tulos.liikennehaittaIndeksi.indeksi).isEqualTo(4.0f)
 
         verifyAll {
-            tormaysService.anyIntersectsYleinenKatuosa(alueet.geometriat())
-            tormaysService.maxIntersectingLiikenteellinenKatuluokka(alueet.geometriat())
-            tormaysService.maxLiikennemaara(alueet.geometriat(), RADIUS_30)
-            tormaysService.anyIntersectsWithCyclewaysPriority(alueet.geometriat())
-            tormaysService.anyIntersectsWithCyclewaysMain(alueet.geometriat())
-            tormaysService.anyIntersectsCriticalBusRoutes(alueet.geometriat())
-            tormaysService.maxIntersectingTramByLaneType(alueet.geometriat())
+            tormaysService.anyIntersectsYleinenKatuosa(geometriaIds)
+            tormaysService.maxIntersectingLiikenteellinenKatuluokka(geometriaIds)
+            tormaysService.maxLiikennemaara(geometriaIds, RADIUS_30)
+            tormaysService.anyIntersectsWithCyclewaysPriority(geometriaIds)
+            tormaysService.anyIntersectsWithCyclewaysMain(geometriaIds)
+            tormaysService.anyIntersectsCriticalBusRoutes(geometriaIds)
+            tormaysService.maxIntersectingTramByLaneType(geometriaIds)
         }
     }
 
@@ -455,18 +457,17 @@ internal class TormaystarkasteluLaskentaServiceTest {
                     kaistaPituusHaitta = KaistajarjestelynPituus.YKSI
                 )
             )
+        val geometriaIds = alueet.geometriaIds()
 
-        every { tormaysService.anyIntersectsYleinenKatuosa(alueet.geometriat()) } returns true
-        every {
-            tormaysService.maxIntersectingLiikenteellinenKatuluokka(alueet.geometriat())
-        } returns TormaystarkasteluKatuluokka.ALUEELLINEN_KOKOOJAKATU.value
-        every { tormaysService.maxLiikennemaara(alueet.geometriat(), RADIUS_30) } returns 1000
-        every { tormaysService.anyIntersectsWithCyclewaysPriority(alueet.geometriat()) } returns
-            false
-        every { tormaysService.anyIntersectsWithCyclewaysMain(alueet.geometriat()) } returns true
-        every { tormaysService.maxIntersectingTramByLaneType(alueet.geometriat()) } returns
+        every { tormaysService.anyIntersectsYleinenKatuosa(geometriaIds) } returns true
+        every { tormaysService.maxIntersectingLiikenteellinenKatuluokka(geometriaIds) } returns
+            TormaystarkasteluKatuluokka.ALUEELLINEN_KOKOOJAKATU.value
+        every { tormaysService.maxLiikennemaara(geometriaIds, RADIUS_30) } returns 1000
+        every { tormaysService.anyIntersectsWithCyclewaysPriority(geometriaIds) } returns false
+        every { tormaysService.anyIntersectsWithCyclewaysMain(geometriaIds) } returns true
+        every { tormaysService.maxIntersectingTramByLaneType(geometriaIds) } returns
             TormaystarkasteluRaitiotiekaistatyyppi.JAETTU.value
-        every { tormaysService.anyIntersectsCriticalBusRoutes(alueet.geometriat()) } returns true
+        every { tormaysService.anyIntersectsCriticalBusRoutes(geometriaIds) } returns true
 
         return alueet
     }


### PR DESCRIPTION
# Description

Add a separate geometria-DTO for use in hanke creation

Also:
- refactor Tormaystarkastelu to use a set of geometria IDs, since it was all it needed from the geometries.
- Refactor GeometriaServiceImpl to maybe be a bit more understandable.
- Stop using the geometry ID given by the user when updating hanke

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1893

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [X] Other

# Instructions for testing
Create a hanke with an alue. Can't be tested with the UI.

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 