### PR TITLE
HAI-2038 Add a hankealue for every application area in generated hanke

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
@@ -939,14 +939,14 @@ class HankeServiceITests : DatabaseTest() {
         @Test
         fun `creates hankealueet from the application areas`() {
             val inputApplication = AlluDataFactory.cableReportWithoutHanke()
-            assertThat(inputApplication.applicationData.areas).isNotNull.isNotEmpty
+            assertThat(inputApplication.applicationData.areas).isNotEmpty
 
             val application = hankeService.generateHankeWithApplication(inputApplication, USER_NAME)
 
             val hanke = hankeService.loadHanke(application.hankeTunnus)!!
             hanke.alueet.forEach { hankealue ->
                 val features = hankealue.geometriat?.featureCollection?.features
-                assertThat(features).isNotNull.hasSize(1)
+                assertThat(features).hasSize(1)
                 val polygon = features!![0].geometry as Polygon
                 assertThat(polygon.coordinates)
                     .isEqualTo(inputApplication.applicationData.areas!![0].geometry.coordinates)

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/geometria/GeometriatDaoImplITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/geometria/GeometriatDaoImplITest.kt
@@ -62,7 +62,7 @@ internal class GeometriatDaoImplITest : DatabaseTest() {
         geometriat.featureCollection!!
             .features
             .add(geometriat.featureCollection!!.features[0]) // add one more geometry
-        geometriat.version = geometriat.version!! + 1
+        geometriat.version += 1
         geometriat.modifiedAt = ZonedDateTime.now()
         geometriatDao.updateGeometriat(geometriat)
         loadedGeometriat = geometriatDao.retrieveGeometriat(geometriaId)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeServiceImpl.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeServiceImpl.kt
@@ -862,6 +862,7 @@ open class HankeServiceImpl(
      * - Generated flag true.
      * - Hanke name is same as application name (limited to first 100 characters).
      * - Perustaja generated from application data orderer.
+     * - Hankealueet are created from the application areas.
      */
     private fun generateHankeFrom(cableReport: CableReportWithoutHanke): Hanke {
         val hankealueet =

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeServiceImpl.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeServiceImpl.kt
@@ -866,8 +866,7 @@ open class HankeServiceImpl(
     private fun generateHankeFrom(cableReport: CableReportWithoutHanke): Hanke {
         val hankealueet =
             cableReport.applicationData.areas
-                ?.map { it.geometry }
-                ?.map { Feature().apply { geometry = it } }
+                ?.map { Feature().apply { geometry = it.geometry } }
                 ?.map { FeatureCollection().add(it) }
                 ?.map { NewGeometriat(it) }
                 ?.map {

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeServiceImpl.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeServiceImpl.kt
@@ -11,6 +11,7 @@ import fi.hel.haitaton.hanke.domain.HankeYhteystieto
 import fi.hel.haitaton.hanke.domain.Hankealue
 import fi.hel.haitaton.hanke.domain.HasId
 import fi.hel.haitaton.hanke.domain.HasYhteystiedot
+import fi.hel.haitaton.hanke.domain.NewGeometriat
 import fi.hel.haitaton.hanke.domain.NewHankealue
 import fi.hel.haitaton.hanke.domain.Perustaja
 import fi.hel.haitaton.hanke.domain.Yhteystieto
@@ -26,6 +27,8 @@ import fi.hel.haitaton.hanke.tormaystarkastelu.TormaystarkasteluLaskentaService
 import fi.hel.haitaton.hanke.tormaystarkastelu.TormaystarkasteluTulosEntity
 import fi.hel.haitaton.hanke.validation.HankePublicValidator
 import mu.KotlinLogging
+import org.geojson.Feature
+import org.geojson.FeatureCollection
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.transaction.annotation.Transactional
 
@@ -860,12 +863,30 @@ open class HankeServiceImpl(
      * - Hanke name is same as application name (limited to first 100 characters).
      * - Perustaja generated from application data orderer.
      */
-    private fun generateHankeFrom(cableReport: CableReportWithoutHanke): Hanke =
-        createHankeInternal(
-            CreateHankeRequest(nimi = limitHankeName(cableReport.applicationData.name)),
+    private fun generateHankeFrom(cableReport: CableReportWithoutHanke): Hanke {
+        val hankealueet =
+            cableReport.applicationData.areas
+                ?.map { it.geometry }
+                ?.map { Feature().apply { geometry = it } }
+                ?.map { FeatureCollection().add(it) }
+                ?.map { NewGeometriat(it) }
+                ?.map {
+                    NewHankealue(
+                        geometriat = it,
+                        haittaAlkuPvm = cableReport.applicationData.startTime,
+                        haittaLoppuPvm = cableReport.applicationData.endTime,
+                    )
+                }
+
+        return createHankeInternal(
+            CreateHankeRequest(
+                nimi = limitHankeName(cableReport.applicationData.name),
+                alueet = hankealueet,
+            ),
             perustaja = perustajaFrom(cableReport.applicationData),
             generated = true,
         )
+    }
 
     private fun limitHankeName(name: String): String =
         if (name.length > MAXIMUM_HANKE_NIMI_LENGTH) {

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/PublicHanke.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/PublicHanke.kt
@@ -27,7 +27,7 @@ data class PublicGeometriat(
 fun geometriatToPublic(geometriat: Geometriat) =
     PublicGeometriat(
         geometriat.id!!,
-        geometriat.version!!,
+        geometriat.version,
         geometriat.createdAt!!,
         geometriat.modifiedAt,
         geometriat.featureCollection

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/geometria/GeometriatDaoImpl.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/geometria/GeometriatDaoImpl.kt
@@ -73,7 +73,7 @@ class GeometriatDaoImpl(private val jdbcOperations: JdbcOperations) : Geometriat
                     id = ?
             """.trimIndent()
             ) { ps ->
-                ps.setInt(1, geometriat.version!!)
+                ps.setInt(1, geometriat.version)
                 if (geometriat.modifiedByUserId != null) {
                     ps.setString(2, geometriat.modifiedByUserId!!)
                 } else {
@@ -128,7 +128,7 @@ class GeometriatDaoImpl(private val jdbcOperations: JdbcOperations) : Geometriat
                     RETURNING id
                     """.trimIndent(),
                     { rs, _ -> rs.getInt(1) },
-                    geometriat.version ?: 0,
+                    geometriat.version,
                     geometriat.createdByUserId,
                     if (geometriat.createdAt != null) {
                         Timestamp(geometriat.createdAt!!.toInstant().toEpochMilli())


### PR DESCRIPTION
# Description

Create a new hankealue for each application area in the cable report application. The geometry of the hankealueet is the same as the application area. The start and end times of every hankealue are the same as the application dates.

Also, fix some compiler warnings left over from PR #473.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2038

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
I tested this by:
- I authenticated to the Swagger UI
- In the UI, I opened a cable report application I had made earlier.
- I copied the response to the application GET request from the network tab.
- I pasted the application JSON to http://localhost:3001/api/swagger-ui/index.html#/application-controller/createWithGeneratedHanke.
- I opened the newly created hanke to see that it had hankealue, and also that the hanke had start and end dates.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 

# Other relevant info
This doesn't work from the UI yet, since the UI adds the areas on a separate page to where the application is created. Support for that is coming in HAI-2039.