### PR TITLE
HAI-2041 Change my-permissions endpoint path

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaControllerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaControllerITest.kt
@@ -161,7 +161,7 @@ class HankeKayttajaControllerITest(@Autowired override val mockMvc: MockMvc) : C
 
     @Nested
     inner class WhoAmIByHanke {
-        private val url = "/hankkeet/my-permissions"
+        private val url = "/my-permissions"
 
         private val tunnus1 = "HAI23-1"
         private val kayttaja1 = UUID.fromString("93473a95-1520-428c-b203-5d770fef78aa")

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaController.kt
@@ -35,6 +35,27 @@ class HankeKayttajaController(
     private val permissionService: PermissionService,
     private val disclosureLogService: DisclosureLogService,
 ) {
+    @GetMapping("/my-permissions")
+    @Operation(
+        summary = "Get your permissions for your own projects",
+        description = "Returns a map of current users Hanke identifiers and respective permissions."
+    )
+    @ApiResponses(
+        value =
+            [
+                ApiResponse(
+                    description = "Permissions grouped by hankeTunnus.",
+                    responseCode = "200",
+                )
+            ]
+    )
+    fun whoAmIByHanke(): Map<String, WhoamiResponse> {
+        val permissions: List<HankePermission> =
+            permissionService.permissionsByHanke(userId = currentUserId())
+
+        return permissions.associate { it.hankeTunnus to it.toWhoamiResponse() }
+    }
+
     @GetMapping("/hankkeet/{hankeTunnus}/whoami")
     @Operation(summary = "Get your own permission for a hanke")
     @ApiResponses(
@@ -61,27 +82,6 @@ class HankeKayttajaController(
 
         val hankeKayttaja = hankeKayttajaService.getKayttajaByUserId(hankeIdentifier.id, userId)
         return WhoamiResponse(hankeKayttaja?.id, permission.kayttooikeustasoEntity)
-    }
-
-    @GetMapping("hankkeet/my-permissions")
-    @Operation(
-        summary = "Get your permissions for your own projects",
-        description = "Returns a map of current users Hanke identifiers and respective permissions."
-    )
-    @ApiResponses(
-        value =
-            [
-                ApiResponse(
-                    description = "Permissions grouped by hankeTunnus.",
-                    responseCode = "200",
-                )
-            ]
-    )
-    fun whoAmIByHanke(): Map<String, WhoamiResponse> {
-        val permissions: List<HankePermission> =
-            permissionService.permissionsByHanke(userId = currentUserId())
-
-        return permissions.associate { it.hankeTunnus to it.toWhoamiResponse() }
     }
 
     @GetMapping("/hankkeet/{hankeTunnus}/kayttajat")


### PR DESCRIPTION
# Description

Change /hankkeet/my-permissions to just /my-permissions as we have /hankkeet/{hankeTunnus}.

This is done to have these separated more clearly.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2041

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [x] Other

# Instructions for testing
Front end is not implemented, so:

- Create johtoselvitys (it autogenerates a hanke)
- Create hanke via "luo uusi hanke"
- GET http://localhost:3001/api/my-permissions
- Verify response, autogenerated hanke should have an existing hankekayttaja. For normally created hanke, it should be null. Both privileges should be at level KAIKKI_OIKEUDET.

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 

# Other relevant info
Please describe here if there is e.g. some requirements for this change or
 other info that the tester/user needs to know.