### PR TITLE
HAI-1966 Add column for hanke attachment blob location

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentRepositoryITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentRepositoryITests.kt
@@ -1,0 +1,65 @@
+package fi.hel.haitaton.hanke.attachment.hanke
+
+import assertk.all
+import assertk.assertThat
+import assertk.assertions.hasSize
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotNull
+import assertk.assertions.prop
+import fi.hel.haitaton.hanke.DatabaseTest
+import fi.hel.haitaton.hanke.HankeEntity
+import fi.hel.haitaton.hanke.attachment.USERNAME
+import fi.hel.haitaton.hanke.attachment.common.HankeAttachmentEntity
+import fi.hel.haitaton.hanke.attachment.common.HankeAttachmentRepository
+import fi.hel.haitaton.hanke.factory.AttachmentFactory
+import fi.hel.haitaton.hanke.factory.HankeFactory
+import fi.hel.haitaton.hanke.test.Asserts.isRecent
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.NullSource
+import org.junit.jupiter.params.provider.ValueSource
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.MediaType.APPLICATION_PDF_VALUE
+import org.springframework.test.context.ActiveProfiles
+import org.testcontainers.junit.jupiter.Testcontainers
+
+/** Consists of [HankeEntity.id] and a UUID. */
+private const val BLOB_LOCATION = "1/bcae2ff2-74e9-48d2-a8ed-e33a40652304"
+
+@Testcontainers
+@ActiveProfiles("test")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class HankeAttachmentRepositoryITests : DatabaseTest() {
+
+    @Autowired private lateinit var hankeFactory: HankeFactory
+    @Autowired private lateinit var hankeAttachmentRepository: HankeAttachmentRepository
+
+    @NullSource
+    @ValueSource(strings = [BLOB_LOCATION])
+    @ParameterizedTest
+    fun `Should save and find hanke attachment with nullable blob location`(blobLocation: String?) {
+        val hanke = hankeFactory.saveMinimal()
+        val saved = hankeAttachmentRepository.save(newAttachment(hanke, blobLocation))
+
+        val attachments = hankeAttachmentRepository.findAll()
+
+        assertThat(attachments).hasSize(1)
+        assertThat(attachments.first()).all {
+            prop(HankeAttachmentEntity::id).isNotNull().isEqualTo(saved.id)
+            prop(HankeAttachmentEntity::fileName).isEqualTo(AttachmentFactory.FILE_NAME)
+            prop(HankeAttachmentEntity::contentType).isEqualTo(APPLICATION_PDF_VALUE)
+            prop(HankeAttachmentEntity::createdByUserId).isEqualTo(USERNAME)
+            prop(HankeAttachmentEntity::createdAt).isRecent()
+            prop(HankeAttachmentEntity::hanke).isEqualTo(hanke)
+            prop(HankeAttachmentEntity::blobLocation).isEqualTo(blobLocation)
+        }
+    }
+
+    fun newAttachment(hanke: HankeEntity, blobLocation: String?) =
+        AttachmentFactory.hankeAttachmentEntity(
+            id = null,
+            hanke = hanke,
+            createdByUser = USERNAME,
+            blobLocation = blobLocation,
+        )
+}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/common/AttachmentEntity.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/common/AttachmentEntity.kt
@@ -58,8 +58,7 @@ class HankeAttachmentEntity(
     contentType: String,
     createdByUserId: String,
     createdAt: OffsetDateTime,
-
-    /** Hanke in which this attachment belongs to. */
+    @Column(name = "blob_location") var blobLocation: String?,
     @ManyToOne(fetch = FetchType.LAZY) @JoinColumn(name = "hanke_id") var hanke: HankeEntity,
 ) : AttachmentEntity(id, fileName, contentType, createdByUserId, createdAt) {
     fun toMetadata(): HankeAttachmentMetadata {

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentService.kt
@@ -66,6 +66,7 @@ class HankeAttachmentService(
                 contentType = attachment.contentType!!,
                 createdAt = now(),
                 createdByUserId = currentUserId(),
+                blobLocation = null, // null until blobs are implemented
                 hanke = hanke,
             )
         val savedAttachment = attachmentRepository.save(entity)

--- a/services/hanke-service/src/main/resources/db/changelog/changesets/054-add-hanke-attachment-blob-location.yml
+++ b/services/hanke-service/src/main/resources/db/changelog/changesets/054-add-hanke-attachment-blob-location.yml
@@ -1,0 +1,14 @@
+databaseChangeLog:
+  - changeSet:
+      id: 054-add-hanke-attachment-file-location
+      author: Niko Pitkonen
+      changes:
+        - addColumn:
+            tableName: hanke_attachment
+            columns:
+              - column:
+                  name: blob_location
+                  type: text
+                  constraints:
+                    nullable: true
+                    unique: true

--- a/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -135,3 +135,5 @@ databaseChangeLog:
       file: db/changelog/changesets/052-remove-suunnitteluvaihe-from-hanke.yml
   - include:
       file: db/changelog/changesets/053-add-indices-for-hanke-permission-query.yml
+  - include:
+      file: db/changelog/changesets/054-add-hanke-attachment-blob-location.yml

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/AttachmentFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/AttachmentFactory.kt
@@ -15,8 +15,6 @@ import java.util.UUID
 import org.springframework.http.MediaType.APPLICATION_PDF_VALUE
 import org.springframework.stereotype.Component
 
-private const val FILE_NAME = "file.pdf"
-
 private val dummyData = "ABC".toByteArray()
 private val defaultAttachmentId = UUID.fromString("5cba3a76-28ad-42aa-b7e6-b5c1775be81a")
 
@@ -35,6 +33,7 @@ class AttachmentFactory(
     }
 
     companion object {
+        const val FILE_NAME = "file.pdf"
 
         fun applicationAttachmentEntity(
             id: UUID = defaultAttachmentId,
@@ -56,10 +55,11 @@ class AttachmentFactory(
             )
 
         fun hankeAttachmentEntity(
-            id: UUID = defaultAttachmentId,
+            id: UUID? = defaultAttachmentId,
             fileName: String = FILE_NAME,
+            blobLocation: String? = null,
             contentType: String = APPLICATION_PDF_VALUE,
-            createdByUser: String = currentUserId(),
+            createdByUser: String = "currentUserId",
             createdAt: OffsetDateTime = OffsetDateTime.now(),
             hanke: HankeEntity,
         ): HankeAttachmentEntity =
@@ -70,6 +70,7 @@ class AttachmentFactory(
                 createdByUserId = createdByUser,
                 createdAt = createdAt,
                 hanke = hanke,
+                blobLocation = blobLocation,
             )
 
         fun hankeAttachmentMetadata(


### PR DESCRIPTION
# Description

HAI-1966 Add column for hanke attachment blob location

For now, blob location is nullable to support files that are still in the db.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1966

## Type of change

- [ ] Bug fix 
- [x] New feature 
- [ ] Other

# Instructions for testing
Unit test is the only way to verify for now. However this change should create any regressions on adding hanke attachments.

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 

# Other relevant info
Please describe here if there is e.g. some requirements for this change or
 other info that the tester/user needs to know.