### PR TITLE
HAI-2039 Recreate hankealue in generated hanke on update

### DIFF
--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankealueService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankealueService.kt
@@ -13,6 +13,8 @@ import org.geojson.Feature
 import org.geojson.FeatureCollection
 import org.springframework.stereotype.Service
 
+const val HANKEALUE_DEFAULT_NAME = "Hankealue"
+
 @Service
 class HankealueService(
     private val geometriatService: GeometriatService,
@@ -116,9 +118,10 @@ class HankealueService(
                 .map { Feature().apply { geometry = it.geometry } }
                 .map { FeatureCollection().add(it) }
                 .map { NewGeometriat(it) }
-                .map {
+                .mapIndexed { i, geometria ->
                     NewHankealue(
-                        geometriat = it,
+                        nimi = "$HANKEALUE_DEFAULT_NAME ${i + 1}",
+                        geometriat = geometria,
                         haittaAlkuPvm = cableReportData.startTime,
                         haittaLoppuPvm = cableReportData.endTime,
                     )

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankealueService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankealueService.kt
@@ -13,8 +13,6 @@ import org.geojson.Feature
 import org.geojson.FeatureCollection
 import org.springframework.stereotype.Service
 
-const val HANKEALUE_DEFAULT_NAME = "Hankealue"
-
 @Service
 class HankealueService(
     private val geometriatService: GeometriatService,
@@ -111,6 +109,8 @@ class HankealueService(
         }
 
     companion object {
+        private const val HANKEALUE_DEFAULT_NAME = "Hankealue"
+
         fun createHankealueetFromCableReport(
             cableReportData: CableReportApplicationData
         ): List<NewHankealue> =

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/configuration/Configuration.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/configuration/Configuration.kt
@@ -91,6 +91,7 @@ class Configuration {
         hankeRepository: HankeRepository,
         hankeLoggingService: HankeLoggingService,
         featureFlags: FeatureFlags,
+        hankealueService: HankealueService,
     ): ApplicationService =
         ApplicationService(
             applicationRepository,
@@ -106,6 +107,7 @@ class Configuration {
             hankeRepository,
             hankeLoggingService,
             featureFlags,
+            hankealueService,
         )
 
     @Bean

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceTest.kt
@@ -11,6 +11,7 @@ import assertk.assertions.isNotEmpty
 import assertk.assertions.isNotNull
 import fi.hel.haitaton.hanke.HankeEntity
 import fi.hel.haitaton.hanke.HankeRepository
+import fi.hel.haitaton.hanke.HankealueService
 import fi.hel.haitaton.hanke.allu.AlluException
 import fi.hel.haitaton.hanke.allu.AlluLoginException
 import fi.hel.haitaton.hanke.allu.AlluStatus
@@ -75,6 +76,7 @@ class ApplicationServiceTest {
     private val permissionService: PermissionService = mockk()
     private val emailSenderService: EmailSenderService = mockk()
     private val attachmentService: ApplicationAttachmentService = mockk()
+    private val hankealueService: HankealueService = mockk()
 
     private val disclosureLogService: DisclosureLogService = mockk(relaxUnitFun = true)
     private val loggingService: ApplicationLoggingService = mockk(relaxUnitFun = true)
@@ -97,7 +99,8 @@ class ApplicationServiceTest {
             permissionService,
             hankeRepository,
             hankeLoggingService,
-            featureFlags
+            featureFlags,
+            hankealueService,
         )
 
     companion object {
@@ -233,8 +236,8 @@ class ApplicationServiceTest {
             verifySequence {
                 applicationRepository.findOneById(3)
                 geometriatDao.validateGeometriat(any())
-                geometriatDao.isInsideHankeAlueet(1, any())
                 cableReportService.getApplicationInformation(42)
+                geometriatDao.isInsideHankeAlueet(1, any())
                 applicationRepository.save(applicationEntity)
                 geometriatDao.calculateCombinedArea(
                     listOf(applicationData.areas?.first()?.geometry!!)
@@ -270,6 +273,7 @@ class ApplicationServiceTest {
             every { geometriatDao.calculateArea(any()) } returns 100f
             justRun { cableReportService.update(42, any()) }
             justRun { cableReportService.addAttachment(42, any()) }
+            every { hankealueService.createAlueetFromCreateRequest(any(), any()) } returns listOf()
             every { featureFlags.isDisabled(Feature.USER_MANAGEMENT) } returns true
 
             applicationService.updateApplicationData(
@@ -282,6 +286,7 @@ class ApplicationServiceTest {
                 applicationRepository.findOneById(3)
                 geometriatDao.validateGeometriat(any())
                 cableReportService.getApplicationInformation(42)
+                hankealueService.createAlueetFromCreateRequest(any(), any())
                 applicationRepository.save(any())
                 geometriatDao.calculateCombinedArea(any())
                 geometriatDao.calculateArea(any())

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/GeometriaFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/GeometriaFactory.kt
@@ -3,8 +3,15 @@ package fi.hel.haitaton.hanke.factory
 import fi.hel.haitaton.hanke.asJsonResource
 import fi.hel.haitaton.hanke.domain.NewGeometriat
 import fi.hel.haitaton.hanke.geometria.Geometriat
+import org.geojson.Polygon
 
 object GeometriaFactory {
+
+    val polygon: Polygon = "/fi/hel/haitaton/hanke/geometria/polygon.json".asJsonResource()
+    val secondPolygon: Polygon =
+        "/fi/hel/haitaton/hanke/geometria/toinen_polygoni.json".asJsonResource()
+    val thirdPolygon: Polygon =
+        "/fi/hel/haitaton/hanke/geometria/kolmas_polygoni.json".asJsonResource()
 
     fun create(): Geometriat =
         "/fi/hel/haitaton/hanke/geometria/hankeGeometriat.json".asJsonResource()

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/test/Asserts.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/test/Asserts.kt
@@ -1,11 +1,23 @@
 package fi.hel.haitaton.hanke.test
 
 import assertk.Assert
+import assertk.all
+import assertk.assertions.first
+import assertk.assertions.hasSize
 import assertk.assertions.isBetween
+import assertk.assertions.isEqualTo
+import assertk.assertions.isInstanceOf
+import assertk.assertions.isNotNull
+import assertk.assertions.prop
+import fi.hel.haitaton.hanke.domain.Hankealue
+import fi.hel.haitaton.hanke.domain.HasFeatures
 import java.time.Duration
 import java.time.OffsetDateTime
 import java.time.ZonedDateTime
 import java.time.temporal.TemporalAmount
+import org.geojson.Feature
+import org.geojson.FeatureCollection
+import org.geojson.Geometry
 
 object Asserts {
 
@@ -22,4 +34,22 @@ object Asserts {
             val now = ZonedDateTime.now()
             assertThat(actual).isBetween(now.minus(offset), now)
         }
+
+    fun <T> Assert<Feature>.hasSameCoordinatesAs(other: Geometry<T>) {
+        prop(Feature::getGeometry)
+            .isInstanceOf(Geometry::class)
+            .prop("coordinates") { it.coordinates }
+            .isEqualTo(other.coordinates)
+    }
+
+    fun <T> Assert<Hankealue>.hasSingleGeometryWithCoordinates(other: Geometry<T>) {
+        prop(Hankealue::geometriat)
+            .isNotNull()
+            .prop(HasFeatures::featureCollection)
+            .isNotNull()
+            .all {
+                prop(FeatureCollection::getFeatures).hasSize(1)
+                prop(FeatureCollection::getFeatures).first().hasSameCoordinatesAs(other)
+            }
+    }
 }


### PR DESCRIPTION
# Description

When a cable report application is updated, recreate the hankealueet of the associated hanke, if it's generated.

Also, give every generated hankealue a name. The names follow the same pattern as UI: "Hankealue 1", "Hankealue 2" and so forth. Because the hankealueet are recreated at every update, the indexing always starts at one.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2039

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
- Start to create a cable report application through the UI.
- After filling in areas on the area page save and suspend. 
- Go to the hanke that was generated for the application
- Check that the hanke has the same areas you gave the application.
- Edit the application areas. Save and suspend again.
- Check that the generated hanke has the same changes in its areas.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 