### PR TITLE
HAI-1944 Fix Docker builds

### DIFF
--- a/services/hanke-service/build.gradle.kts
+++ b/services/hanke-service/build.gradle.kts
@@ -195,3 +195,5 @@ mjml {
         """{"collapseWhitespace": false, "minifyCSS": true, "removeEmptyAttributes": true }"""
     )
 }
+
+node { download.set(true) }


### PR DESCRIPTION
# Description

Docker builds are failing because of missing nmp. Turns out, the MJML plugin depends on the gradle node plugin, but that doesn't download node out-of-the-box. We need to instruct it to download node.

Add configuration so that the Gradle node plugin downloads node during build.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1944

## Type of change

- [X] Bug fix 
- [ ] New feature 
- [ ] Other

# Instructions for testing
1. Build the hanke-service docker service.
2. Do a local operation like `./gradlew test`.

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 