### PR TITLE
HAI-1967 Add a client for Azure Blob

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -100,6 +100,7 @@ services:
       HAITATON_PASSWORD: haitaton
       HAITATON_OAUTH2_CLIENT_ID: https://api.hel.fi/auth/haitatonapidev
       HAITATON_OAUTH2_USER_INFO_URI: https://tunnistamo.test.hel.ninja/openid/userinfo
+      HAITATON_BLOB_CONNECTION_STRING: BlobEndpoint=http://azurite:10000/devstoreaccount1;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;
       #      HAITATON_CORS_ALLOWED_ORIGINS: http://localhost:8000
       HAITATON_GDPR_DISABLED: ${HAITATON_GDPR_DISABLED:-true}
       ALLU_BASEURL: ${ALLU_BASEURL}

--- a/services/hanke-service/build.gradle.kts
+++ b/services/hanke-service/build.gradle.kts
@@ -37,6 +37,7 @@ springBoot { buildInfo() }
 tasks.getByName<BootRun>("bootRun") {
     environment("HAITATON_SWAGGER_PATH_PREFIX", "/v3")
     environment("HAITATON_EMAIL_ENABLED", "true")
+    environment("HAITATON_BLOB_CONNECTION_STRING", "UseDevelopmentStorage=true;")
 }
 
 spotless {
@@ -112,6 +113,10 @@ dependencies {
     // Sentry
     implementation("io.sentry:sentry-spring-boot-starter-jakarta:$sentryVersion")
     implementation("io.sentry:sentry-logback:$sentryVersion")
+
+    // Azure
+    implementation(platform("com.azure:azure-sdk-bom:1.2.18"))
+    implementation("com.azure:azure-storage-blob")
 
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
 }

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/azure/BlobFileClientITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/azure/BlobFileClientITest.kt
@@ -1,0 +1,87 @@
+package fi.hel.haitaton.hanke.attachment.azure
+
+import com.azure.core.util.BinaryData
+import com.azure.storage.blob.BlobContainerClient
+import com.azure.storage.blob.BlobServiceClient
+import fi.hel.haitaton.hanke.attachment.common.FileClientTest
+import fi.hel.haitaton.hanke.attachment.common.TestFile
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.TestInstance
+import org.springframework.http.MediaType
+import org.springframework.test.context.ActiveProfiles
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.junit.jupiter.Testcontainers
+import org.testcontainers.utility.DockerImageName
+
+@Testcontainers
+@ActiveProfiles("test")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class BlobFileClientITest : FileClientTest() {
+
+    private lateinit var azuriteContainer: GenericContainer<*>
+    private lateinit var serviceClient: BlobServiceClient
+    private lateinit var hankeAttachmentClient: BlobContainerClient
+
+    override lateinit var fileClient: BlobFileClient
+
+    private val containers: Containers =
+        Containers(
+            decisions = "paatokset-test",
+            hakemusAttachments = "hakemusliitteet-test",
+            hankeAttachments = "hankeliitteet-test"
+        )
+
+    @BeforeAll
+    fun setup() {
+        azuriteContainer =
+            GenericContainer(DockerImageName.parse("mcr.microsoft.com/azure-storage/azurite"))
+                .withExposedPorts(10000)
+        azuriteContainer.start()
+        val connectionString =
+            "BlobEndpoint=http://${azuriteContainer.host}:${azuriteContainer.firstMappedPort}/devstoreaccount1;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;"
+        serviceClient = AzureContainerServiceClient(connectionString).blobServiceClient()
+        hankeAttachmentClient = serviceClient.getBlobContainerClient(containers.hankeAttachments)
+
+        fileClient = BlobFileClient(serviceClient, containers)
+
+        for (container in containers) {
+            serviceClient.getBlobContainerClient(container).createIfNotExists()
+        }
+    }
+
+    @BeforeEach
+    fun clearContainers() {
+        for (container in containers) {
+            val containerClient = serviceClient.getBlobContainerClient(container)
+
+            containerClient.listBlobs().forEach { containerClient.getBlobClient(it.name).delete() }
+        }
+    }
+
+    @AfterAll
+    fun teardown() {
+        azuriteContainer.stop()
+    }
+
+    override fun listBlobs(container: Container): List<TestFile> =
+        when (container) {
+                Container.HAKEMUS_LIITTEET ->
+                    serviceClient.getBlobContainerClient(containers.hakemusAttachments)
+                Container.HANKE_LIITTEET ->
+                    serviceClient.getBlobContainerClient(containers.hankeAttachments)
+                Container.PAATOKSET -> serviceClient.getBlobContainerClient(containers.decisions)
+            }
+            .listBlobs()
+            .map {
+                TestFile(
+                    it.name,
+                    MediaType.parseMediaType(it.properties.contentType),
+                    it.properties.contentLength.toInt(),
+                    it.properties.contentDisposition,
+                    BinaryData.fromString("")
+                )
+            }
+            .toList()
+}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/azure/AzureContainerServiceClient.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/azure/AzureContainerServiceClient.kt
@@ -1,0 +1,36 @@
+package fi.hel.haitaton.hanke.attachment.azure
+
+import com.azure.storage.blob.BlobServiceClient
+import com.azure.storage.blob.BlobServiceClientBuilder
+import kotlin.reflect.full.memberProperties
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Profile
+
+@Configuration
+@Profile("!test")
+class AzureContainerServiceClient(
+    @Value("\${haitaton.azure.blob.connection-string}") private val connectionString: String,
+) {
+    @Bean
+    fun blobServiceClient(): BlobServiceClient =
+        BlobServiceClientBuilder().connectionString(connectionString).buildClient()
+}
+
+@ConfigurationProperties(prefix = "haitaton.azure.blob")
+data class Containers(
+    val decisions: String,
+    val hakemusAttachments: String,
+    val hankeAttachments: String,
+) : Iterable<String> {
+    override fun iterator(): Iterator<String> =
+        Containers::class.memberProperties.map { it.get(this) as String }.iterator()
+}
+
+enum class Container {
+    HAKEMUS_LIITTEET,
+    HANKE_LIITTEET,
+    PAATOKSET,
+}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/azure/BlobFileClient.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/azure/BlobFileClient.kt
@@ -1,0 +1,76 @@
+package fi.hel.haitaton.hanke.attachment.azure
+
+import com.azure.core.http.HttpHeaderName
+import com.azure.core.util.BinaryData
+import com.azure.storage.blob.BlobServiceClient
+import com.azure.storage.blob.models.BlobErrorCode
+import com.azure.storage.blob.models.BlobHttpHeaders
+import com.azure.storage.blob.models.BlobStorageException
+import com.azure.storage.blob.options.BlobParallelUploadOptions
+import fi.hel.haitaton.hanke.attachment.common.DownloadNotFoundException
+import fi.hel.haitaton.hanke.attachment.common.DownloadResponse
+import fi.hel.haitaton.hanke.attachment.common.FileClient
+import org.springframework.context.annotation.Profile
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Component
+
+@Component
+@Profile("!test")
+class BlobFileClient(blobServiceClient: BlobServiceClient, containers: Containers) : FileClient {
+
+    private val decisionClient = blobServiceClient.getBlobContainerClient(containers.decisions)
+
+    private val hakemusAttachmentClient =
+        blobServiceClient.getBlobContainerClient(containers.hakemusAttachments)
+
+    private val hankeAttachmentClient =
+        blobServiceClient.getBlobContainerClient(containers.hankeAttachments)
+
+    override fun upload(
+        container: Container,
+        path: String,
+        originalFilename: String,
+        contentType: MediaType,
+        content: ByteArray,
+    ) {
+        val options = BlobParallelUploadOptions(BinaryData.fromBytes(content))
+        options.headers = BlobHttpHeaders()
+        options.headers.setContentType(contentType.toString())
+        options.headers.setContentDisposition("attachment; filename=$originalFilename")
+        getContainerClient(container).getBlobClient(path).uploadWithResponse(options, null, null)
+    }
+
+    override fun download(container: Container, path: String): DownloadResponse {
+        try {
+            val response =
+                getContainerClient(container)
+                    .getBlobClient(path)
+                    .downloadContentWithResponse(null, null, null, null)
+
+            val contentType = response.headers[HttpHeaderName.CONTENT_TYPE].value
+            val contentLength = response.headers[HttpHeaderName.CONTENT_LENGTH].value
+
+            return DownloadResponse(
+                MediaType.parseMediaType(contentType),
+                contentLength.toInt(),
+                response.value
+            )
+        } catch (e: BlobStorageException) {
+            if (e.errorCode == BlobErrorCode.BLOB_NOT_FOUND) {
+                throw DownloadNotFoundException(path, container)
+            } else {
+                throw e
+            }
+        }
+    }
+
+    override fun delete(container: Container, path: String): Boolean =
+        getContainerClient(container).getBlobClient(path).deleteIfExists()
+
+    private fun getContainerClient(container: Container) =
+        when (container) {
+            Container.HAKEMUS_LIITTEET -> hakemusAttachmentClient
+            Container.HANKE_LIITTEET -> hankeAttachmentClient
+            Container.PAATOKSET -> decisionClient
+        }
+}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/common/FileClient.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/common/FileClient.kt
@@ -1,0 +1,30 @@
+package fi.hel.haitaton.hanke.attachment.common
+
+import com.azure.core.util.BinaryData
+import fi.hel.haitaton.hanke.attachment.azure.Container
+import org.springframework.http.MediaType
+
+interface FileClient {
+
+    fun upload(
+        container: Container,
+        path: String,
+        originalFilename: String,
+        contentType: MediaType,
+        content: ByteArray,
+    )
+
+    @Throws(DownloadNotFoundException::class)
+    fun download(container: Container, path: String): DownloadResponse
+
+    fun delete(container: Container, path: String): Boolean
+}
+
+data class DownloadResponse(
+    val contentType: MediaType,
+    val contentLength: Int,
+    val content: BinaryData,
+)
+
+data class DownloadNotFoundException(val path: String, val container: Container) :
+    RuntimeException("Downloaded file was not found, path=$path, container=$container")

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/configuration/Configuration.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/configuration/Configuration.kt
@@ -14,6 +14,7 @@ import fi.hel.haitaton.hanke.allu.CableReportServiceAllu
 import fi.hel.haitaton.hanke.application.ApplicationRepository
 import fi.hel.haitaton.hanke.application.ApplicationService
 import fi.hel.haitaton.hanke.attachment.application.ApplicationAttachmentService
+import fi.hel.haitaton.hanke.attachment.azure.Containers
 import fi.hel.haitaton.hanke.email.EmailProperties
 import fi.hel.haitaton.hanke.email.EmailSenderService
 import fi.hel.haitaton.hanke.gdpr.GdprProperties
@@ -50,6 +51,7 @@ import reactor.netty.http.client.HttpClient
     FeatureFlags::class,
     AlluProperties::class,
     EmailProperties::class,
+    Containers::class,
 )
 class Configuration {
     @Value("\${haitaton.allu.insecure}") var alluTrustInsecure: Boolean = false

--- a/services/hanke-service/src/main/resources/application.properties
+++ b/services/hanke-service/src/main/resources/application.properties
@@ -106,3 +106,9 @@ haitaton.email.filter.use=${HAITATON_EMAIL_FILTER_USE:true}
 haitaton.email.filter.allow-list=${HAITATON_EMAIL_FILTER_ALLOW_LIST:haitaton@test.com}
 haitaton.email.from=${HAITATON_EMAIL_FROM:Haitaton <noreply.haitaton@hel.fi>}
 haitaton.email.baseUrl=${HAITATON_EMAIL_BASEURL:http://localhost:3001}
+
+haitaton.azure.blob.decisions=${HAITATON_BLOB_CONTAINER_DECISIONS:haitaton-paatokset-local}
+haitaton.azure.blob.hanke-attachments=${HAITATON_BLOB_CONTAINER_HANKE_LIITTEET:haitaton-hankeliitteet-local}
+haitaton.azure.blob.hakemus-attachments=${HAITATON_BLOB_CONTAINER_HAKEMUS_LIITTEET:haitaton-hakemusliitteet-local}
+haitaton.azure.blob.default-connection-string=AuthType=azure;ClientId=${AZURE_CLIENT_ID:};ClientSecret=${AZURE_CLIENT_SECRET:};TenantId=${AZURE_TENANT_ID:};BlobEndpoint=https://${AZURE_STORAGE_ACCOUNT:}.blob.core.windows.net/;
+haitaton.azure.blob.connection-string=${HAITATON_BLOB_CONNECTION_STRING:${haitaton.azure.blob.default-connection-string}}

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/attachment/common/FileClientTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/attachment/common/FileClientTest.kt
@@ -1,0 +1,222 @@
+package fi.hel.haitaton.hanke.attachment.common
+
+import assertk.all
+import assertk.assertFailure
+import assertk.assertThat
+import assertk.assertions.containsExactlyInAnyOrder
+import assertk.assertions.extracting
+import assertk.assertions.first
+import assertk.assertions.hasClass
+import assertk.assertions.hasSize
+import assertk.assertions.isEmpty
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isTrue
+import assertk.assertions.messageContains
+import assertk.assertions.prop
+import fi.hel.haitaton.hanke.attachment.azure.Container
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+import org.junit.jupiter.params.provider.ValueSource
+import org.springframework.http.MediaType
+
+/**
+ * This is shared test class for [fi.hel.haitaton.hanke.attachment.azure.BlobFileClientITest] and
+ * [MockFileClientTest] to make sure they have the same behaviour.
+ */
+abstract class FileClientTest {
+    private val testContent = "This was created in an integration test".toByteArray()
+    private val container = Container.HANKE_LIITTEET
+    abstract val fileClient: FileClient
+
+    @Nested
+    inner class Upload {
+
+        @ParameterizedTest
+        @ValueSource(strings = ["test/test.txt", "stuff/other.txt", "43/file.pdf"])
+        fun `uploads the file to the correct path`(path: String) {
+            fileClient.upload(container, path, "test.txt", MediaType.TEXT_PLAIN, testContent)
+
+            val attachments = listBlobs()
+            assertThat(attachments).hasSize(1)
+            assertThat(attachments).first().prop(TestFile::path).isEqualTo(path)
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = ["test.txt", "other.txt", "file.pdf"])
+        fun `uploads a file with the correct content disposition`(originalFileName: String) {
+            fileClient.upload(
+                container,
+                "test/$originalFileName",
+                originalFileName,
+                MediaType.TEXT_PLAIN,
+                testContent
+            )
+
+            val blobs = listBlobs()
+            assertThat(blobs).hasSize(1)
+            assertThat(blobs)
+                .first()
+                .prop(TestFile::contentDisposition)
+                .isEqualTo("attachment; filename=$originalFileName")
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = ["text/plain", "application/pdf", "image/png", "image/x-dwg"])
+        fun `uploads a file with the correct content type`(mediaTypeString: String) {
+            val mediaType = MediaType.parseMediaType(mediaTypeString)
+
+            fileClient.upload(container, "test/test.txt", "test.txt", mediaType, testContent)
+
+            val blobs = listBlobs()
+            assertThat(blobs).hasSize(1)
+            assertThat(blobs).first().prop(TestFile::contentType).isEqualTo(mediaType)
+        }
+
+        @Test
+        fun `uploads several files to different paths`() {
+            val paths = listOf("test/test.txt", "test/test.png", "test/test.pdf")
+
+            paths.forEach {
+                fileClient.upload(container, it, "test.txt", MediaType.TEXT_PLAIN, testContent)
+            }
+
+            val blobs = listBlobs()
+            assertThat(blobs).hasSize(3)
+            assertThat(blobs)
+                .extracting { it.path }
+                .containsExactlyInAnyOrder("test/test.txt", "test/test.png", "test/test.pdf")
+        }
+
+        @Test
+        fun `overwrites file when uploading a file with an existing path`() {
+            val path = "test/test.txt"
+            fileClient.upload(container, path, "test.txt", MediaType.TEXT_PLAIN, testContent)
+            val newContent = "This is not the original content".toByteArray()
+            val newFilename = "other.txt"
+            val newMediaType = MediaType.TEXT_MARKDOWN
+
+            fileClient.upload(container, path, newFilename, newMediaType, newContent)
+
+            val blobs = listBlobs()
+            assertThat(blobs).hasSize(1)
+            assertThat(blobs).first().all {
+                prop(TestFile::path).isEqualTo(path)
+                prop(TestFile::contentDisposition).isEqualTo("attachment; filename=$newFilename")
+                prop(TestFile::contentType).isEqualTo(newMediaType)
+            }
+            val content = fileClient.download(container, path).content.toBytes()
+            assertThat(content).isEqualTo(newContent)
+        }
+
+        @ParameterizedTest
+        @EnumSource(Container::class)
+        fun `uploads to the given container`(container: Container) {
+            val path = "test/test.txt"
+            fileClient.upload(container, path, "test.txt", MediaType.TEXT_PLAIN, testContent)
+
+            val attachments = listBlobs(container)
+            assertThat(attachments).hasSize(1)
+            assertThat(attachments).first().prop(TestFile::path).isEqualTo(path)
+            assertThat(listBlobsFromOtherContainers(container)).isEmpty()
+        }
+    }
+
+    @Nested
+    inner class Download {
+        private val path = "test/test.dwg"
+
+        @Test
+        fun `throw exception when blob not found`() {
+            assertFailure { fileClient.download(container, path) }
+                .all {
+                    hasClass(DownloadNotFoundException::class)
+                    messageContains("path=$path")
+                    messageContains("container=$container")
+                }
+        }
+
+        @Test
+        fun `downloads the file along with content type and length`() {
+            val contentType = MediaType.parseMediaType("image/x-dwg")
+            fileClient.upload(container, path, "test.dwg", contentType, testContent)
+
+            val result = fileClient.download(container, path)
+
+            assertThat(result.content.toBytes()).isEqualTo(testContent)
+            assertThat(result.contentType).isEqualTo(contentType)
+            assertThat(result.contentLength).isEqualTo(testContent.size)
+        }
+
+        @ParameterizedTest
+        @EnumSource(Container::class)
+        fun `download from the given container`(container: Container) {
+            val contentType = MediaType.parseMediaType("image/x-dwg")
+            fileClient.upload(container, path, "test.dwg", contentType, testContent)
+
+            val result = fileClient.download(container, path)
+
+            assertThat(result.content.toBytes()).isEqualTo(testContent)
+        }
+    }
+
+    @Nested
+    inner class Delete {
+        private val originalFileName = "test.txt"
+        private val mediaType = MediaType.TEXT_PLAIN
+        private val path = "test/test.txt"
+
+        @Test
+        fun `returns false when blob not found`() {
+            assertThat(fileClient.delete(container, path)).isFalse()
+        }
+
+        @Test
+        fun `deletes the uploaded file`() {
+            fileClient.upload(container, path, originalFileName, mediaType, testContent)
+
+            val response = fileClient.delete(container, path)
+
+            assertThat(response).isTrue()
+            assertThat(listBlobs()).isEmpty()
+        }
+
+        @Test
+        fun `deletes the correct file from several uploaded files`() {
+            val targetPath = "test/test.txt"
+            val otherPath = "test/test2.txt"
+            val thirdPath = "test/test3.txt"
+            fileClient.upload(container, otherPath, originalFileName, mediaType, testContent)
+            fileClient.upload(container, targetPath, originalFileName, mediaType, testContent)
+            fileClient.upload(container, thirdPath, originalFileName, mediaType, testContent)
+
+            val response = fileClient.delete(container, targetPath)
+
+            assertThat(response).isTrue()
+            val blobs = listBlobs()
+            assertThat(blobs).hasSize(2)
+            assertThat(blobs).extracting { it.path }.containsExactlyInAnyOrder(otherPath, thirdPath)
+        }
+
+        @ParameterizedTest
+        @EnumSource(Container::class)
+        fun `deletes from the given container`(container: Container) {
+            fileClient.upload(container, path, originalFileName, mediaType, testContent)
+            assertThat(listBlobs(container)).hasSize(1)
+
+            val response = fileClient.delete(container, path)
+
+            assertThat(response).isTrue()
+            assertThat(listBlobs(container)).isEmpty()
+        }
+    }
+
+    abstract fun listBlobs(container: Container): List<TestFile>
+
+    fun listBlobs(): List<TestFile> = listBlobs(container)
+
+    fun listBlobsFromOtherContainers(container: Container): List<TestFile> =
+        Container.entries.minus(container).flatMap { listBlobs(it) }
+}

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/attachment/common/MockFileClient.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/attachment/common/MockFileClient.kt
@@ -1,0 +1,63 @@
+package fi.hel.haitaton.hanke.attachment.common
+
+import com.azure.core.util.BinaryData
+import fi.hel.haitaton.hanke.attachment.azure.Container
+import java.util.EnumMap
+import org.junit.jupiter.api.extension.BeforeAllCallback
+import org.junit.jupiter.api.extension.BeforeEachCallback
+import org.junit.jupiter.api.extension.ExtensionContext
+import org.springframework.context.annotation.Profile
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Component
+
+@Component
+@Profile("test")
+class MockFileClient : FileClient, BeforeAllCallback, BeforeEachCallback {
+    private val fileMap: EnumMap<Container, MutableMap<String, TestFile>> =
+        EnumMap(Container::class.java)
+
+    override fun beforeAll(context: ExtensionContext?) {
+        Container.entries.forEach { fileMap[it] = mutableMapOf() }
+    }
+
+    override fun beforeEach(context: ExtensionContext?) {
+        Container.entries.forEach { fileMap[it]!!.clear() }
+    }
+
+    override fun upload(
+        container: Container,
+        path: String,
+        originalFilename: String,
+        contentType: MediaType,
+        content: ByteArray,
+    ) {
+        fileMap[container]!![path] =
+            TestFile(
+                path,
+                contentType,
+                content.size,
+                "attachment; filename=$originalFilename",
+                BinaryData.fromBytes(content)
+            )
+    }
+
+    override fun download(container: Container, path: String): DownloadResponse =
+        fileMap[container]!![path]?.toDownloadResponse()
+            ?: throw DownloadNotFoundException(path, container)
+
+    override fun delete(container: Container, path: String): Boolean =
+        fileMap[container]!!.remove(path) != null
+
+    internal fun listBlobs(container: Container): List<TestFile> =
+        fileMap[container]!!.values.toList()
+}
+
+data class TestFile(
+    val path: String,
+    val contentType: MediaType,
+    val contentLength: Int,
+    val contentDisposition: String,
+    val content: BinaryData,
+) {
+    fun toDownloadResponse() = DownloadResponse(contentType, contentLength, content)
+}

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/attachment/common/MockFileClientTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/attachment/common/MockFileClientTest.kt
@@ -1,0 +1,16 @@
+package fi.hel.haitaton.hanke.attachment.common
+
+import fi.hel.haitaton.hanke.attachment.azure.Container
+import org.junit.jupiter.api.extension.RegisterExtension
+
+open class MockFileClientTest : FileClientTest() {
+
+    override val fileClient: MockFileClient = Companion.fileClient
+
+    override fun listBlobs(container: Container): List<TestFile> =
+        Companion.fileClient.listBlobs(container)
+
+    companion object {
+        @JvmField @RegisterExtension val fileClient = MockFileClient()
+    }
+}

--- a/services/hanke-service/src/test/resources/application-test.properties
+++ b/services/hanke-service/src/test/resources/application-test.properties
@@ -1,3 +1,6 @@
+haitaton.azure.blob.decisions=paatokset-test
+haitaton.azure.blob.hakemus-attachments=hakemusliitteet-test
+haitaton.azure.blob.hanke-attachments=hankeliitteet-test
 haitaton.clamav.baseUrl=http://localhost:6789
 haitaton.email.filter.use=false
 haitaton.email.from=no-reply@hel.fi


### PR DESCRIPTION
# Description

Add a client for Azure Blob. The client can upload, download and delete files.

In upload, Content-Type and Content-Disposition headers are set for the files. These might come useful later when we want to download directly from Blob storage.

Download returns a Azure's BinaryData object for the content, because the bytes can be streamed from that object. This might be useful, if we can stream the data directly to the HTTP response. It would reduce the memory footprint of downloads significantly. Content length is also returned separately to facilitate the streaming. If the streaming is not feasible, the data can be easily accessed as a ByteArray.

Ways to connect in different scenarios:
- In the cloud, AZURE_CLIENT_ID etc. environment variables are read in application.properties to form a connection string.
- When run in Docker Compose, a HAITATON_BLOB_CONNECTION_STRING variable is set in docker-compose.yml. HAITATON_BLOB_CONNECTION_STRING overrides the default connection string in application.properties.
- If started with `./gradlew bootRun`, HAITATON_BLOB_CONNECTION_STRING is set in build.gradle.kts.
- In BlobFileClientITest, an Azurite container is started with Testcontainers. The connection string is handcrafted in the same file, along with the client.
- Other integration tests don't exist yet, but the hope is that they could use MockFileClient to reduce the number of different Spring configurations.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1967

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
I added this temp piece of code in BlobFileClient to test the client with Docker Compose and `./gradlew bootRun`.
```
    @EventListener(ApplicationReadyEvent::class)
    fun atStart() {
        val i = 4
        val testPath = "fake/test$i.txt"
        val originalFilename = "test$i.txt"
        val contentType = MediaType.TEXT_PLAIN
        val content = "This is test file #$i".toByteArray()

        println("<AtStart> Trying to delete a file.")
        val deleteResult = delete(Container.HANKE_LIITTEET, testPath)
        println("<AtStart> deleteResult $deleteResult")

        println("<AtStart> Uploading a file.")
        val options = BlobParallelUploadOptions(BinaryData.fromBytes(content))
        options.headers = BlobHttpHeaders()
        options.headers.setContentType(contentType.toString())
        options.headers.setContentDisposition("attachment; filename=$originalFilename")
        upload(Container.HANKE_LIITTEET, testPath, originalFilename, contentType, content)

        hankeAttachmentClient.listBlobs().forEach {
            println("<AtStart> ${it.name} ${it.properties.contentLength} ${it.properties.contentType} ${it.properties.contentDisposition}")
        }

        println("<AtStart> Downloading a file.")
        val downloaded = download(Container.HANKE_LIITTEET, testPath)
        println("<AtStart> ${downloaded.content.toStream().readAllBytes().toString(Charsets.UTF_8)}")
        println("<AtStart> Downloaded: $downloaded")
    }
```

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 