### PR TITLE
HAI-1969 Download hanke attachments from Blob Storage

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentControllerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentControllerITest.kt
@@ -14,6 +14,7 @@ import fi.hel.haitaton.hanke.application.ApplicationAuthorizer
 import fi.hel.haitaton.hanke.application.ApplicationNotFoundException
 import fi.hel.haitaton.hanke.application.ApplicationService
 import fi.hel.haitaton.hanke.attachment.APPLICATION_ID
+import fi.hel.haitaton.hanke.attachment.DUMMY_DATA
 import fi.hel.haitaton.hanke.attachment.FILE_NAME_PDF
 import fi.hel.haitaton.hanke.attachment.USERNAME
 import fi.hel.haitaton.hanke.attachment.andExpectError
@@ -21,7 +22,6 @@ import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentMetadata
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType.MUU
 import fi.hel.haitaton.hanke.attachment.common.AttachmentContent
-import fi.hel.haitaton.hanke.attachment.dummyData
 import fi.hel.haitaton.hanke.attachment.testFile
 import fi.hel.haitaton.hanke.factory.AttachmentFactory
 import fi.hel.haitaton.hanke.permissions.PermissionCode.EDIT_APPLICATIONS
@@ -109,12 +109,12 @@ class ApplicationAttachmentControllerITest(@Autowired override val mockMvc: Mock
 
         every { authorizer.authorizeApplicationId(APPLICATION_ID, VIEW.name) } returns true
         every { applicationAttachmentService.getContent(APPLICATION_ID, attachmentId) } returns
-            AttachmentContent(FILE_NAME_PDF, APPLICATION_PDF_VALUE, dummyData)
+            AttachmentContent(FILE_NAME_PDF, APPLICATION_PDF_VALUE, DUMMY_DATA)
 
         getAttachmentContent(attachmentId = attachmentId)
             .andExpect(status().isOk)
             .andExpect(header().string(CONTENT_DISPOSITION, "attachment; filename=$FILE_NAME_PDF"))
-            .andExpect(content().bytes(dummyData))
+            .andExpect(content().bytes(DUMMY_DATA))
 
         verifyOrder {
             authorizer.authorizeApplicationId(APPLICATION_ID, VIEW.name)

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentServiceITest.kt
@@ -1,7 +1,6 @@
 package fi.hel.haitaton.hanke.attachment.application
 
 import assertk.assertThat
-import assertk.assertions.containsExactly
 import assertk.assertions.each
 import assertk.assertions.endsWith
 import assertk.assertions.hasSize
@@ -20,6 +19,7 @@ import fi.hel.haitaton.hanke.allu.CableReportService
 import fi.hel.haitaton.hanke.application.ApplicationAlreadyProcessingException
 import fi.hel.haitaton.hanke.application.ApplicationEntity
 import fi.hel.haitaton.hanke.application.ApplicationNotFoundException
+import fi.hel.haitaton.hanke.attachment.DEFAULT_DATA
 import fi.hel.haitaton.hanke.attachment.FILE_NAME_PDF
 import fi.hel.haitaton.hanke.attachment.USERNAME
 import fi.hel.haitaton.hanke.attachment.body
@@ -32,7 +32,6 @@ import fi.hel.haitaton.hanke.attachment.common.AttachmentContentService
 import fi.hel.haitaton.hanke.attachment.common.AttachmentInvalidException
 import fi.hel.haitaton.hanke.attachment.common.AttachmentLimitReachedException
 import fi.hel.haitaton.hanke.attachment.common.AttachmentNotFoundException
-import fi.hel.haitaton.hanke.attachment.defaultData
 import fi.hel.haitaton.hanke.attachment.failResult
 import fi.hel.haitaton.hanke.attachment.response
 import fi.hel.haitaton.hanke.attachment.successResult
@@ -202,7 +201,7 @@ class ApplicationAttachmentServiceITest : DatabaseTest() {
         assertThat(attachmentInDb.attachmentType).isEqualTo(typeInput)
 
         val content = attachmentContentService.findApplicationContent(result.id)
-        assertThat(content).containsExactly(*defaultData)
+        assertThat(content).isEqualTo(DEFAULT_DATA)
 
         verify { cableReportService wasNot Called }
     }

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/azure/BlobFileClientITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/azure/BlobFileClientITest.kt
@@ -12,10 +12,8 @@ import org.junit.jupiter.api.TestInstance
 import org.springframework.http.MediaType
 import org.springframework.test.context.ActiveProfiles
 import org.testcontainers.containers.GenericContainer
-import org.testcontainers.junit.jupiter.Testcontainers
 import org.testcontainers.utility.DockerImageName
 
-@Testcontainers
 @ActiveProfiles("test")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class BlobFileClientITest : FileClientTest() {

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/common/AttachmentContentServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/common/AttachmentContentServiceITest.kt
@@ -1,0 +1,113 @@
+package fi.hel.haitaton.hanke.attachment.common
+
+import assertk.all
+import assertk.assertFailure
+import assertk.assertThat
+import assertk.assertions.hasClass
+import assertk.assertions.hasMessage
+import assertk.assertions.isEqualTo
+import fi.hel.haitaton.hanke.DatabaseTest
+import fi.hel.haitaton.hanke.attachment.USERNAME
+import fi.hel.haitaton.hanke.factory.HankeAttachmentFactory
+import fi.hel.haitaton.hanke.factory.HankeFactory
+import java.util.UUID
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.test.context.ActiveProfiles
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+@WithMockUser(USERNAME)
+class AttachmentContentServiceITest : DatabaseTest(), HankeAttachmentFactory {
+
+    @Autowired private lateinit var attachmentContentService: AttachmentContentService
+    @Autowired override lateinit var fileClient: MockFileClient
+    @Autowired override lateinit var hankeAttachmentRepository: HankeAttachmentRepository
+    @Autowired
+    override lateinit var hankeAttachmentContentRepository: HankeAttachmentContentRepository
+    @Autowired override lateinit var hankeFactory: HankeFactory
+
+    @BeforeEach
+    fun beforeEach() {
+        fileClient.recreateContainers()
+    }
+
+    private val hankeId = 1
+    private val attachmentId = UUID.fromString("b820121e-ad54-4ab8-926a-c4a8193010b5")
+    private val path = "$hankeId/$attachmentId"
+    private val bytes = "Test content. Sisältää myös skandeja.".toByteArray()
+
+    @Nested
+    inner class FindHankeContent {
+        @Test
+        fun `returns the content when blobLocation is specified`() {
+            saveContentToCloud(path, bytes = bytes)
+            val attachmentEntity =
+                HankeAttachmentFactory.createEntity(attachmentId, blobLocation = path)
+
+            val result = attachmentContentService.findHankeContent(attachmentEntity)
+
+            assertThat(result).isEqualTo(bytes)
+        }
+
+        @Test
+        fun `returns the content when blobLocation is not specified`() {
+            val attachmentEntity = saveAttachment(blobLocation = null)
+            saveContentToDb(attachmentEntity.id!!, bytes)
+
+            val result = attachmentContentService.findHankeContent(attachmentEntity)
+
+            assertThat(result).isEqualTo(bytes)
+        }
+    }
+
+    @Nested
+    inner class ReadHankeAttachmentFromFile {
+
+        @Test
+        fun `returns the right content`() {
+            saveContentToCloud(path, bytes = bytes)
+
+            val result = attachmentContentService.readHankeAttachmentFromFile(path, attachmentId)
+
+            assertThat(result).isEqualTo(bytes)
+        }
+
+        @Test
+        fun `throws AttachmentNotFoundException if attachment not found`() {
+            assertFailure {
+                    attachmentContentService.readHankeAttachmentFromFile(path, attachmentId)
+                }
+                .all {
+                    hasClass(AttachmentNotFoundException::class)
+                    hasMessage("Attachment not found, id=$attachmentId")
+                }
+        }
+    }
+
+    @Nested
+    inner class ReadHankeAttachmentFromDatabase {
+        @Test
+        fun `returns the right content`() {
+            val attachmentId = saveAttachment().id!!
+            saveContentToDb(attachmentId, bytes)
+
+            val result = attachmentContentService.readHankeAttachmentFromDatabase(attachmentId)
+
+            assertThat(result).isEqualTo(bytes)
+        }
+
+        @Test
+        fun `throws AttachmentNotFoundException if attachment not found`() {
+            assertFailure { attachmentContentService.readHankeAttachmentFromDatabase(attachmentId) }
+                .all {
+                    hasClass(AttachmentNotFoundException::class)
+                    hasMessage("Attachment not found, id=$attachmentId")
+                }
+        }
+    }
+}

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentControllerITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentControllerITests.kt
@@ -6,12 +6,12 @@ import fi.hel.haitaton.hanke.HankeError
 import fi.hel.haitaton.hanke.HankeError.HAI0001
 import fi.hel.haitaton.hanke.HankeNotFoundException
 import fi.hel.haitaton.hanke.IntegrationTestConfiguration
+import fi.hel.haitaton.hanke.attachment.DUMMY_DATA
 import fi.hel.haitaton.hanke.attachment.FILE_NAME_PDF
 import fi.hel.haitaton.hanke.attachment.HANKE_TUNNUS
 import fi.hel.haitaton.hanke.attachment.USERNAME
 import fi.hel.haitaton.hanke.attachment.andExpectError
 import fi.hel.haitaton.hanke.attachment.common.AttachmentContent
-import fi.hel.haitaton.hanke.attachment.dummyData
 import fi.hel.haitaton.hanke.attachment.testFile
 import fi.hel.haitaton.hanke.factory.AttachmentFactory
 import fi.hel.haitaton.hanke.hankeError
@@ -89,12 +89,12 @@ class HankeAttachmentControllerITests(@Autowired override val mockMvc: MockMvc) 
         val liiteId = UUID.fromString("19d6a9f7-afb0-469f-b570-cba0d10b03fc")
         every { authorizer.authorizeHankeTunnus(HANKE_TUNNUS, VIEW.name) } returns true
         every { hankeAttachmentService.getContent(HANKE_TUNNUS, liiteId) } returns
-            AttachmentContent(FILE_NAME_PDF, APPLICATION_PDF_VALUE, dummyData)
+            AttachmentContent(FILE_NAME_PDF, APPLICATION_PDF_VALUE, DUMMY_DATA)
 
         getAttachmentContent(attachmentId = liiteId)
             .andExpect(status().isOk)
             .andExpect(header().string(CONTENT_DISPOSITION, "attachment; filename=$FILE_NAME_PDF"))
-            .andExpect(content().bytes(dummyData))
+            .andExpect(content().bytes(DUMMY_DATA))
 
         verifyOrder {
             authorizer.authorizeHankeTunnus(HANKE_TUNNUS, VIEW.name)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/common/AttachmentContentService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/common/AttachmentContentService.kt
@@ -1,7 +1,9 @@
 package fi.hel.haitaton.hanke.attachment.common
 
+import fi.hel.haitaton.hanke.attachment.azure.Container
 import java.util.UUID
 import mu.KotlinLogging
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 
 private val logger = KotlinLogging.logger {}
@@ -9,7 +11,8 @@ private val logger = KotlinLogging.logger {}
 @Service
 class AttachmentContentService(
     private val applicationAttachmentContentRepository: ApplicationAttachmentContentRepository,
-    private val hankeAttachmentContentRepository: HankeAttachmentContentRepository
+    private val hankeAttachmentContentRepository: HankeAttachmentContentRepository,
+    private val fileClient: FileClient,
 ) {
 
     fun saveApplicationContent(attachmentId: UUID, content: ByteArray) {
@@ -31,12 +34,21 @@ class AttachmentContentService(
         hankeAttachmentContentRepository.save(HankeAttachmentContentEntity(attachmentId, content))
     }
 
-    fun findHankeContent(attachmentId: UUID): ByteArray =
-        hankeAttachmentContentRepository
-            .findById(attachmentId)
-            .map { it.content }
-            .orElseThrow {
+    fun findHankeContent(attachment: HankeAttachmentEntity): ByteArray =
+        attachment.blobLocation?.let { readHankeAttachmentFromFile(it, attachment.id!!) }
+            ?: readHankeAttachmentFromDatabase(attachment.id!!)
+
+    fun readHankeAttachmentFromFile(location: String, attachmentId: UUID): ByteArray =
+        try {
+            fileClient.download(Container.HANKE_LIITTEET, location).content.toBytes()
+        } catch (e: DownloadNotFoundException) {
+            throw AttachmentNotFoundException(attachmentId)
+        }
+
+    fun readHankeAttachmentFromDatabase(attachmentId: UUID): ByteArray =
+        hankeAttachmentContentRepository.findByIdOrNull(attachmentId)?.content
+            ?: run {
                 logger.error { "Content not found for hanke attachment $attachmentId" }
-                AttachmentNotFoundException(attachmentId)
+                throw AttachmentNotFoundException(attachmentId)
             }
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentController.kt
@@ -74,11 +74,7 @@ class HankeAttachmentController(private val hankeAttachmentService: HankeAttachm
     @ApiResponses(
         value =
             [
-                ApiResponse(
-                    description = "Success",
-                    responseCode = "200",
-                    content = [Content(schema = Schema(implementation = HankeError::class))]
-                ),
+                ApiResponse(description = "Success", responseCode = "200"),
                 ApiResponse(
                     description = "Hanke not found",
                     responseCode = "404",
@@ -97,7 +93,7 @@ class HankeAttachmentController(private val hankeAttachmentService: HankeAttachm
     )
     fun postAttachment(
         @PathVariable hankeTunnus: String,
-        @RequestParam("liite") attachment: MultipartFile
+        @RequestParam("liite") attachment: MultipartFile,
     ): HankeAttachmentMetadata {
         return hankeAttachmentService.addAttachment(hankeTunnus, attachment)
     }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentService.kt
@@ -39,10 +39,8 @@ class HankeAttachmentService(
     @Transactional(readOnly = true)
     fun getContent(hankeTunnus: String, attachmentId: UUID): AttachmentContent {
         val attachment = findHanke(hankeTunnus).liitteet.findBy(attachmentId)
-        val content = attachmentContentService.findHankeContent(attachmentId)
-        with(attachment) {
-            return AttachmentContent(fileName, contentType, content)
-        }
+        val content = attachmentContentService.findHankeContent(attachment)
+        return AttachmentContent(attachment.fileName, attachment.contentType, content)
     }
 
     @Transactional

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/attachment/AttachmentTestUtil.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/attachment/AttachmentTestUtil.kt
@@ -19,18 +19,17 @@ const val USERNAME = "username"
 const val FILE_NAME_PDF = "file.pdf"
 const val FILE_PARAM = "liite"
 const val HANKE_TUNNUS = "HAI-1234"
-const val HANKE_ID = 123
 const val APPLICATION_ID = 1L
-const val CONTENT_TYPE = "Content-Type"
+const val CONTENT_TYPE_HEADER = "Content-Type"
 
-val dummyData = "ABC".toByteArray()
-val defaultData = "/fi/hel/haitaton/hanke/decision/fake-decision.pdf".getResourceAsBytes()
+val DUMMY_DATA = "ABC".toByteArray()
+val DEFAULT_DATA = "/fi/hel/haitaton/hanke/decision/fake-decision.pdf".getResourceAsBytes()
 
 fun testFile(
     fileParam: String = FILE_PARAM,
     fileName: String = FILE_NAME_PDF,
     contentType: String? = APPLICATION_PDF_VALUE,
-    data: ByteArray = defaultData,
+    data: ByteArray = DEFAULT_DATA,
 ) = MockMultipartFile(fileParam, fileName, contentType, data)
 
 fun ResultActions.andExpectError(error: HankeError): ResultActions =
@@ -39,7 +38,7 @@ fun ResultActions.andExpectError(error: HankeError): ResultActions =
 fun response(data: String): MockResponse =
     MockResponse()
         .setBody(data)
-        .addHeader(CONTENT_TYPE, APPLICATION_JSON_VALUE)
+        .addHeader(CONTENT_TYPE_HEADER, APPLICATION_JSON_VALUE)
         .setResponseCode(200)
 
 fun body(success: Boolean = true, results: List<FileResult>): String =

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/attachment/common/MockFileClient.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/attachment/common/MockFileClient.kt
@@ -3,24 +3,21 @@ package fi.hel.haitaton.hanke.attachment.common
 import com.azure.core.util.BinaryData
 import fi.hel.haitaton.hanke.attachment.azure.Container
 import java.util.EnumMap
-import org.junit.jupiter.api.extension.BeforeAllCallback
-import org.junit.jupiter.api.extension.BeforeEachCallback
-import org.junit.jupiter.api.extension.ExtensionContext
 import org.springframework.context.annotation.Profile
 import org.springframework.http.MediaType
 import org.springframework.stereotype.Component
 
 @Component
 @Profile("test")
-class MockFileClient : FileClient, BeforeAllCallback, BeforeEachCallback {
+class MockFileClient : FileClient {
     private val fileMap: EnumMap<Container, MutableMap<String, TestFile>> =
         EnumMap(Container::class.java)
 
-    override fun beforeAll(context: ExtensionContext?) {
+    fun recreateContainers() {
         Container.entries.forEach { fileMap[it] = mutableMapOf() }
     }
 
-    override fun beforeEach(context: ExtensionContext?) {
+    fun clearContainers() {
         Container.entries.forEach { fileMap[it]!!.clear() }
     }
 

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/attachment/common/MockFileClientTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/attachment/common/MockFileClientTest.kt
@@ -1,16 +1,28 @@
 package fi.hel.haitaton.hanke.attachment.common
 
 import fi.hel.haitaton.hanke.attachment.azure.Container
-import org.junit.jupiter.api.extension.RegisterExtension
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
 
 open class MockFileClientTest : FileClientTest() {
 
     override val fileClient: MockFileClient = Companion.fileClient
 
+    @BeforeEach
+    fun cleanUp() {
+        fileClient.clearContainers()
+    }
+
     override fun listBlobs(container: Container): List<TestFile> =
         Companion.fileClient.listBlobs(container)
 
     companion object {
-        @JvmField @RegisterExtension val fileClient = MockFileClient()
+        private val fileClient = MockFileClient()
+
+        @JvmStatic
+        @BeforeAll
+        fun setup() {
+            fileClient.recreateContainers()
+        }
     }
 }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeAttachmentFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeAttachmentFactory.kt
@@ -1,0 +1,95 @@
+package fi.hel.haitaton.hanke.factory
+
+import fi.hel.haitaton.hanke.HankeEntity
+import fi.hel.haitaton.hanke.attachment.DEFAULT_DATA
+import fi.hel.haitaton.hanke.attachment.FILE_NAME_PDF
+import fi.hel.haitaton.hanke.attachment.USERNAME
+import fi.hel.haitaton.hanke.attachment.azure.Container.HANKE_LIITTEET
+import fi.hel.haitaton.hanke.attachment.common.FileClient
+import fi.hel.haitaton.hanke.attachment.common.HankeAttachmentContentEntity
+import fi.hel.haitaton.hanke.attachment.common.HankeAttachmentContentRepository
+import fi.hel.haitaton.hanke.attachment.common.HankeAttachmentEntity
+import fi.hel.haitaton.hanke.attachment.common.HankeAttachmentRepository
+import java.time.OffsetDateTime
+import java.util.UUID
+import org.springframework.http.MediaType
+
+interface HankeAttachmentFactory {
+    val hankeAttachmentRepository: HankeAttachmentRepository
+    val hankeAttachmentContentRepository: HankeAttachmentContentRepository
+    val hankeFactory: HankeFactory
+    val fileClient: FileClient
+
+    fun saveAttachment(
+        blobLocation: String? = null,
+        filename: String = FILE_NAME_PDF,
+        contentType: String = CONTENT_TYPE,
+        hanke: HankeEntity = hankeFactory.saveEntity(),
+    ): HankeAttachmentEntity {
+        val attachment =
+            createEntity(
+                blobLocation = blobLocation,
+                fileName = filename,
+                contentType = contentType,
+                hanke = hanke
+            )
+        return hankeAttachmentRepository.save(attachment)
+    }
+
+    fun saveContentToDb(attachmentId: UUID, bytes: ByteArray): HankeAttachmentContentEntity {
+        val entity = HankeAttachmentContentEntity(attachmentId, bytes)
+        return hankeAttachmentContentRepository.save(entity)
+    }
+
+    fun saveContentToCloud(
+        path: String,
+        filename: String = FILE_NAME_PDF,
+        mediaType: MediaType = MEDIA_TYPE,
+        bytes: ByteArray = DEFAULT_DATA
+    ) {
+        fileClient.upload(HANKE_LIITTEET, path, filename, mediaType, bytes)
+    }
+
+    fun HankeAttachmentEntity.withDbContent(
+        bytes: ByteArray = DEFAULT_DATA
+    ): HankeAttachmentEntity {
+        saveContentToDb(id!!, bytes)
+        return this
+    }
+
+    fun HankeAttachmentEntity.withCloudContent(
+        path: String = "${hanke.id}/${id}",
+        filename: String = FILE_NAME_PDF,
+        mediaType: MediaType = Companion.MEDIA_TYPE,
+        bytes: ByteArray = DEFAULT_DATA
+    ): HankeAttachmentEntity {
+        blobLocation = path
+        hankeAttachmentRepository.save(this)
+        saveContentToCloud(path, filename, mediaType, bytes)
+        return this
+    }
+
+    companion object {
+
+        val MEDIA_TYPE = MediaType.APPLICATION_PDF
+        val CONTENT_TYPE = MEDIA_TYPE.toString()
+        val CREATED_AT: OffsetDateTime = OffsetDateTime.parse("2023-11-09T10:03:55+02:00")
+
+        fun createEntity(
+            id: UUID? = null,
+            fileName: String = FILE_NAME_PDF,
+            contentType: String = CONTENT_TYPE,
+            blobLocation: String? = null,
+            hanke: HankeEntity = HankeFactory.createMinimalEntity()
+        ) =
+            HankeAttachmentEntity(
+                id = id,
+                fileName = fileName,
+                contentType = contentType,
+                createdByUserId = USERNAME,
+                createdAt = CREATED_AT,
+                blobLocation = blobLocation,
+                hanke = hanke,
+            )
+    }
+}


### PR DESCRIPTION
# Description

When blob_location is present in the attachment, download the attachment content from Blob Storage instead of the database.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1969

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
1. Add a file to the haitaton-hankeliitteet-local container in Azurite with Azure Storage Explorer or the CLI. Take a note of the path.
2. Add an attachment to a hanke. You can use the https://github.com/City-of-Helsinki/haitaton-ui/pull/409 branch for this if it's not merged yet.
3. In the DB, update the bloc_location column of the attachment to contain the path of the file you added to Azurite earlier.
4. In the DB, delete the matching hanke_attachment_content row.
5. You should be able to download the attachment through the UI.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 