### PR TITLE
HAI-1969 Separate authorization and business logic in hanke attachments

### DIFF
--- a/azure-pipelines-hanke-service-pr.yml
+++ b/azure-pipelines-hanke-service-pr.yml
@@ -17,6 +17,7 @@ pr:
     - main
     - dev
     - releases/*
+    - HAI*
 
 # By default, use self-hosted agents
 pool: Default

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/IntegrationTestConfiguration.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/IntegrationTestConfiguration.kt
@@ -3,6 +3,7 @@ package fi.hel.haitaton.hanke
 import fi.hel.haitaton.hanke.application.ApplicationAuthorizer
 import fi.hel.haitaton.hanke.application.ApplicationService
 import fi.hel.haitaton.hanke.attachment.application.ApplicationAttachmentService
+import fi.hel.haitaton.hanke.attachment.hanke.HankeAttachmentAuthorizer
 import fi.hel.haitaton.hanke.attachment.hanke.HankeAttachmentService
 import fi.hel.haitaton.hanke.configuration.FeatureFlags
 import fi.hel.haitaton.hanke.configuration.FeatureService
@@ -79,8 +80,12 @@ class IntegrationTestConfiguration {
     @Bean fun hankeKayttajaService(): HankeKayttajaService = mockk()
 
     @Bean fun hankeKayttajaAuthorizer(): HankeKayttajaAuthorizer = mockk(relaxUnitFun = true)
+
     @Bean fun hankeAuthorizer(): HankeAuthorizer = mockk(relaxUnitFun = true)
+
     @Bean fun applicationAuthorizer(): ApplicationAuthorizer = mockk(relaxUnitFun = true)
+
+    @Bean fun hankeAttachmentAuthorizer(): HankeAttachmentAuthorizer = mockk(relaxUnitFun = true)
 
     @Bean fun featureService(featureFlags: FeatureFlags) = FeatureService(featureFlags)
 

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentAuthorizerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentAuthorizerITest.kt
@@ -1,0 +1,126 @@
+package fi.hel.haitaton.hanke.attachment.hanke
+
+import assertk.all
+import assertk.assertFailure
+import assertk.assertThat
+import assertk.assertions.hasClass
+import assertk.assertions.isTrue
+import assertk.assertions.messageContains
+import fi.hel.haitaton.hanke.DatabaseTest
+import fi.hel.haitaton.hanke.HankeNotFoundException
+import fi.hel.haitaton.hanke.attachment.USERNAME
+import fi.hel.haitaton.hanke.attachment.common.AttachmentNotFoundException
+import fi.hel.haitaton.hanke.attachment.common.FileClient
+import fi.hel.haitaton.hanke.attachment.common.HankeAttachmentContentRepository
+import fi.hel.haitaton.hanke.attachment.common.HankeAttachmentRepository
+import fi.hel.haitaton.hanke.factory.HankeAttachmentFactory
+import fi.hel.haitaton.hanke.factory.HankeFactory
+import fi.hel.haitaton.hanke.permissions.Kayttooikeustaso
+import fi.hel.haitaton.hanke.permissions.PermissionCode.EDIT
+import fi.hel.haitaton.hanke.permissions.PermissionCode.VIEW
+import fi.hel.haitaton.hanke.permissions.PermissionService
+import java.util.UUID
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.test.context.ActiveProfiles
+
+@SpringBootTest
+@ActiveProfiles("test")
+@WithMockUser(USERNAME)
+class HankeAttachmentAuthorizerITest(
+    @Autowired private val authorizer: HankeAttachmentAuthorizer,
+    @Autowired private val permissionService: PermissionService,
+    @Autowired override val hankeFactory: HankeFactory,
+    @Autowired override val hankeAttachmentRepository: HankeAttachmentRepository,
+    @Autowired override val hankeAttachmentContentRepository: HankeAttachmentContentRepository,
+    @Autowired override val fileClient: FileClient,
+) : DatabaseTest(), HankeAttachmentFactory {
+    private val hankeTunnus = "HAI24-14"
+    private val attachmentId = UUID.fromString("3b0e3149-37a2-4393-af03-6a34b946fef1")
+
+    @Nested
+    inner class AuthorizeAttachment {
+        @Test
+        fun `throws exception if hankeTunnus is not found`() {
+            assertFailure { authorizer.authorizeAttachment(hankeTunnus, attachmentId, VIEW.name) }
+                .all {
+                    hasClass(HankeNotFoundException::class)
+                    messageContains(hankeTunnus)
+                }
+        }
+
+        @Test
+        fun `throws exception if user doesn't have any permission for the hanke`() {
+            hankeFactory.saveMinimal(hankeTunnus = hankeTunnus)
+
+            assertFailure { authorizer.authorizeAttachment(hankeTunnus, attachmentId, VIEW.name) }
+                .all {
+                    hasClass(HankeNotFoundException::class)
+                    messageContains(hankeTunnus)
+                }
+        }
+
+        @Test
+        fun `throws exception if user doesn't have the required permission for the hanke`() {
+            val hanke = hankeFactory.saveMinimal(hankeTunnus = hankeTunnus)
+            permissionService.create(hanke.id, USERNAME, Kayttooikeustaso.KATSELUOIKEUS)
+
+            assertFailure { authorizer.authorizeAttachment(hankeTunnus, attachmentId, EDIT.name) }
+                .all {
+                    hasClass(HankeNotFoundException::class)
+                    messageContains(hankeTunnus)
+                }
+        }
+
+        @Test
+        fun `throws exception if the attachment is not found`() {
+            val hanke = hankeFactory.saveMinimal(hankeTunnus = hankeTunnus)
+            permissionService.create(hanke.id, USERNAME, Kayttooikeustaso.KATSELUOIKEUS)
+
+            assertFailure { authorizer.authorizeAttachment(hankeTunnus, attachmentId, VIEW.name) }
+                .all {
+                    hasClass(AttachmentNotFoundException::class)
+                    messageContains(attachmentId.toString())
+                }
+        }
+
+        @Test
+        fun `throws exception if the attachment belongs to another hanke`() {
+            val hanke = hankeFactory.saveMinimal(hankeTunnus = hankeTunnus)
+            val attachment = saveAttachment()
+            permissionService.create(hanke.id, USERNAME, Kayttooikeustaso.KATSELUOIKEUS)
+
+            assertFailure {
+                    authorizer.authorizeAttachment(hankeTunnus, attachment.id!!, VIEW.name)
+                }
+                .all {
+                    hasClass(AttachmentNotFoundException::class)
+                    messageContains(attachment.id.toString())
+                }
+        }
+
+        @Test
+        fun `returns true if the attachment is found, it belongs to the hanke and the user has the correct permission`() {
+            val hanke = hankeFactory.saveMinimal(hankeTunnus = hankeTunnus)
+            val attachment = saveAttachment(hanke = hanke)
+            permissionService.create(hanke.id, USERNAME, Kayttooikeustaso.KATSELUOIKEUS)
+
+            assertThat(authorizer.authorizeAttachment(hankeTunnus, attachment.id!!, VIEW.name))
+                .isTrue()
+        }
+
+        @Test
+        fun `throws error if enum value not found`() {
+            assertFailure { authorizer.authorizeAttachment(hankeTunnus, attachmentId, "Not real") }
+                .all {
+                    hasClass(IllegalArgumentException::class)
+                    messageContains(
+                        "No enum constant fi.hel.haitaton.hanke.permissions.PermissionCode.Not real"
+                    )
+                }
+        }
+    }
+}

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentControllerITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentControllerITests.kt
@@ -1,7 +1,6 @@
 package fi.hel.haitaton.hanke.attachment.hanke
 
 import fi.hel.haitaton.hanke.ControllerTest
-import fi.hel.haitaton.hanke.HankeAuthorizer
 import fi.hel.haitaton.hanke.HankeError
 import fi.hel.haitaton.hanke.HankeError.HAI0001
 import fi.hel.haitaton.hanke.HankeNotFoundException
@@ -56,7 +55,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 class HankeAttachmentControllerITests(@Autowired override val mockMvc: MockMvc) : ControllerTest {
 
     @Autowired private lateinit var hankeAttachmentService: HankeAttachmentService
-    @Autowired private lateinit var authorizer: HankeAuthorizer
+    @Autowired private lateinit var authorizer: HankeAttachmentAuthorizer
 
     @BeforeEach
     fun clearMocks() {
@@ -87,8 +86,8 @@ class HankeAttachmentControllerITests(@Autowired override val mockMvc: MockMvc) 
     @Test
     fun `getAttachmentContent when valid request should return attachment file`() {
         val liiteId = UUID.fromString("19d6a9f7-afb0-469f-b570-cba0d10b03fc")
-        every { authorizer.authorizeHankeTunnus(HANKE_TUNNUS, VIEW.name) } returns true
-        every { hankeAttachmentService.getContent(HANKE_TUNNUS, liiteId) } returns
+        every { authorizer.authorizeAttachment(HANKE_TUNNUS, liiteId, VIEW.name) } returns true
+        every { hankeAttachmentService.getContent(liiteId) } returns
             AttachmentContent(FILE_NAME_PDF, APPLICATION_PDF_VALUE, DUMMY_DATA)
 
         getAttachmentContent(attachmentId = liiteId)
@@ -97,8 +96,8 @@ class HankeAttachmentControllerITests(@Autowired override val mockMvc: MockMvc) 
             .andExpect(content().bytes(DUMMY_DATA))
 
         verifyOrder {
-            authorizer.authorizeHankeTunnus(HANKE_TUNNUS, VIEW.name)
-            hankeAttachmentService.getContent(HANKE_TUNNUS, liiteId)
+            authorizer.authorizeAttachment(HANKE_TUNNUS, liiteId, VIEW.name)
+            hankeAttachmentService.getContent(liiteId)
         }
     }
 
@@ -130,14 +129,14 @@ class HankeAttachmentControllerITests(@Autowired override val mockMvc: MockMvc) 
     @Test
     fun `deleteAttachment when valid request should succeed`() {
         val liiteId = UUID.fromString("357bb2e4-9464-4aff-9e66-f4b2764ffbf4")
-        every { authorizer.authorizeHankeTunnus(HANKE_TUNNUS, EDIT.name) } returns true
-        justRun { hankeAttachmentService.deleteAttachment(HANKE_TUNNUS, liiteId) }
+        every { authorizer.authorizeAttachment(HANKE_TUNNUS, liiteId, EDIT.name) } returns true
+        justRun { hankeAttachmentService.deleteAttachment(liiteId) }
 
         deleteAttachment(attachmentId = liiteId).andExpect(status().isOk)
 
         verifyOrder {
-            authorizer.authorizeHankeTunnus(HANKE_TUNNUS, EDIT.name)
-            hankeAttachmentService.deleteAttachment(HANKE_TUNNUS, liiteId)
+            authorizer.authorizeAttachment(HANKE_TUNNUS, liiteId, EDIT.name)
+            hankeAttachmentService.deleteAttachment(liiteId)
         }
     }
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentAuthorizer.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentAuthorizer.kt
@@ -1,0 +1,35 @@
+package fi.hel.haitaton.hanke.attachment.hanke
+
+import fi.hel.haitaton.hanke.HankeRepository
+import fi.hel.haitaton.hanke.attachment.common.AttachmentNotFoundException
+import fi.hel.haitaton.hanke.attachment.common.HankeAttachmentRepository
+import fi.hel.haitaton.hanke.permissions.Authorizer
+import fi.hel.haitaton.hanke.permissions.PermissionCode
+import fi.hel.haitaton.hanke.permissions.PermissionService
+import java.util.UUID
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+class HankeAttachmentAuthorizer(
+    permissionService: PermissionService,
+    hankeRepository: HankeRepository,
+    private val attachmentRepository: HankeAttachmentRepository,
+) : Authorizer(permissionService, hankeRepository) {
+    @Transactional(readOnly = true)
+    fun authorizeAttachment(
+        hankeTunnus: String,
+        attachmentId: UUID,
+        permissionCode: String
+    ): Boolean {
+        val permission = PermissionCode.valueOf(permissionCode)
+
+        authorizeHankeTunnus(hankeTunnus, permission)
+        if (findHanketunnusForAttachment(attachmentId) == hankeTunnus) return true
+        throw AttachmentNotFoundException(attachmentId)
+    }
+
+    private fun findHanketunnusForAttachment(attachmentId: UUID): String? =
+        attachmentRepository.findByIdOrNull(attachmentId)?.hanke?.hankeTunnus
+}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentController.kt
@@ -39,7 +39,7 @@ class HankeAttachmentController(private val hankeAttachmentService: HankeAttachm
                 ),
             ]
     )
-    @PreAuthorize("@hankeAuthorizer.authorizeHankeTunnus(#hankeTunnus,'VIEW')")
+    @PreAuthorize("@hankeAttachmentAuthorizer.authorizeHankeTunnus(#hankeTunnus,'VIEW')")
     fun getMetadataList(@PathVariable hankeTunnus: String): List<HankeAttachmentMetadata> {
         return hankeAttachmentService.getMetadataList(hankeTunnus)
     }
@@ -57,12 +57,14 @@ class HankeAttachmentController(private val hankeAttachmentService: HankeAttachm
                 ),
             ]
     )
-    @PreAuthorize("@hankeAuthorizer.authorizeHankeTunnus(#hankeTunnus,'VIEW')")
+    @PreAuthorize(
+        "@hankeAttachmentAuthorizer.authorizeAttachment(#hankeTunnus,#attachmentId,'VIEW')"
+    )
     fun getAttachmentContent(
         @PathVariable hankeTunnus: String,
         @PathVariable attachmentId: UUID,
     ): ResponseEntity<ByteArray> {
-        val content = hankeAttachmentService.getContent(hankeTunnus, attachmentId)
+        val content = hankeAttachmentService.getContent(attachmentId)
 
         return ResponseEntity.ok()
             .headers(buildHeaders(content.fileName, content.contentType))
@@ -89,7 +91,7 @@ class HankeAttachmentController(private val hankeAttachmentService: HankeAttachm
     )
     @PreAuthorize(
         "@featureService.isEnabled('HANKE_EDITING') && " +
-            "@hankeAuthorizer.authorizeHankeTunnus(#hankeTunnus,'EDIT')"
+            "@hankeAttachmentAuthorizer.authorizeHankeTunnus(#hankeTunnus,'EDIT')"
     )
     fun postAttachment(
         @PathVariable hankeTunnus: String,
@@ -113,9 +115,9 @@ class HankeAttachmentController(private val hankeAttachmentService: HankeAttachm
     )
     @PreAuthorize(
         "@featureService.isEnabled('HANKE_EDITING') && " +
-            "@hankeAuthorizer.authorizeHankeTunnus(#hankeTunnus,'EDIT')"
+            "@hankeAttachmentAuthorizer.authorizeAttachment(#hankeTunnus,#attachmentId,'EDIT')"
     )
     fun deleteAttachment(@PathVariable hankeTunnus: String, @PathVariable attachmentId: UUID) {
-        return hankeAttachmentService.deleteAttachment(hankeTunnus, attachmentId)
+        return hankeAttachmentService.deleteAttachment(attachmentId)
     }
 }


### PR DESCRIPTION
# Description

Authorization and business logic have been intertwined in hanke attachments. Authorization has checked that the user has the correct permission for the hanketunnus in the URL, but checking that the application belongs to that hanke has been done in HankeAttachmentService.

Separate authorization and business logic by adding a new authorizer for hanke attachments. The authorizer checks that the user has the correct permission for the hanke and that the attachment belongs to that hanke. So we don't need to pass the hanketunnus to the service anymore.

Also, enable PR builds also for branches that target any branch starting
with HAI.

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [X] Other

# Instructions for testing
Downloading and deleting attachments works like before.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 