### PR TITLE
HAI-1994 Split AttachmentContentService in two

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentServiceITest.kt
@@ -28,7 +28,6 @@ import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType.LIIKENNEJARJESTELY
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType.MUU
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType.VALTAKIRJA
-import fi.hel.haitaton.hanke.attachment.common.AttachmentContentService
 import fi.hel.haitaton.hanke.attachment.common.AttachmentInvalidException
 import fi.hel.haitaton.hanke.attachment.common.AttachmentLimitReachedException
 import fi.hel.haitaton.hanke.attachment.common.AttachmentNotFoundException
@@ -70,7 +69,7 @@ private const val ALLU_ID = 42
 class ApplicationAttachmentServiceITest : DatabaseTest() {
     @MockkBean private lateinit var cableReportService: CableReportService
     @Autowired private lateinit var applicationAttachmentService: ApplicationAttachmentService
-    @Autowired private lateinit var attachmentContentService: AttachmentContentService
+    @Autowired private lateinit var attachmentContentService: ApplicationAttachmentContentService
     @Autowired private lateinit var applicationAttachmentRepository: ApplicationAttachmentRepository
     @Autowired private lateinit var alluDataFactory: AlluDataFactory
     @Autowired private lateinit var attachmentFactory: AttachmentFactory

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentContentServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentContentServiceITest.kt
@@ -1,4 +1,4 @@
-package fi.hel.haitaton.hanke.attachment.common
+package fi.hel.haitaton.hanke.attachment.hanke
 
 import assertk.all
 import assertk.assertFailure
@@ -8,6 +8,10 @@ import assertk.assertions.hasMessage
 import assertk.assertions.isEqualTo
 import fi.hel.haitaton.hanke.DatabaseTest
 import fi.hel.haitaton.hanke.attachment.USERNAME
+import fi.hel.haitaton.hanke.attachment.common.AttachmentNotFoundException
+import fi.hel.haitaton.hanke.attachment.common.HankeAttachmentContentRepository
+import fi.hel.haitaton.hanke.attachment.common.HankeAttachmentRepository
+import fi.hel.haitaton.hanke.attachment.common.MockFileClient
 import fi.hel.haitaton.hanke.factory.HankeAttachmentFactory
 import fi.hel.haitaton.hanke.factory.HankeFactory
 import java.util.UUID
@@ -22,9 +26,9 @@ import org.springframework.test.context.ActiveProfiles
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("test")
 @WithMockUser(USERNAME)
-class AttachmentContentServiceITest : DatabaseTest(), HankeAttachmentFactory {
+class HankeAttachmentContentServiceITest : DatabaseTest(), HankeAttachmentFactory {
 
-    @Autowired private lateinit var attachmentContentService: AttachmentContentService
+    @Autowired private lateinit var attachmentContentService: HankeAttachmentContentService
     @Autowired override lateinit var fileClient: MockFileClient
     @Autowired override lateinit var hankeAttachmentRepository: HankeAttachmentRepository
     @Autowired

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentContentService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentContentService.kt
@@ -1,0 +1,30 @@
+package fi.hel.haitaton.hanke.attachment.application
+
+import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentContentEntity
+import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentContentRepository
+import fi.hel.haitaton.hanke.attachment.common.AttachmentNotFoundException
+import java.util.UUID
+import mu.KotlinLogging
+import org.springframework.stereotype.Service
+
+private val logger = KotlinLogging.logger {}
+
+@Service
+class ApplicationAttachmentContentService(
+    private val applicationAttachmentContentRepository: ApplicationAttachmentContentRepository
+) {
+    fun saveApplicationContent(attachmentId: UUID, content: ByteArray) {
+        applicationAttachmentContentRepository.save(
+            ApplicationAttachmentContentEntity(attachmentId, content)
+        )
+    }
+
+    fun findApplicationContent(attachmentId: UUID): ByteArray =
+        applicationAttachmentContentRepository
+            .findById(attachmentId)
+            .map { it.content }
+            .orElseThrow {
+                logger.error { "Content not found for application attachment $attachmentId" }
+                AttachmentNotFoundException(attachmentId)
+            }
+}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentService.kt
@@ -14,7 +14,6 @@ import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentMetadata
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentRepository
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType
 import fi.hel.haitaton.hanke.attachment.common.AttachmentContent
-import fi.hel.haitaton.hanke.attachment.common.AttachmentContentService
 import fi.hel.haitaton.hanke.attachment.common.AttachmentInvalidException
 import fi.hel.haitaton.hanke.attachment.common.AttachmentLimitReachedException
 import fi.hel.haitaton.hanke.attachment.common.AttachmentNotFoundException
@@ -37,7 +36,7 @@ class ApplicationAttachmentService(
     private val cableReportService: CableReportService,
     private val applicationRepository: ApplicationRepository,
     private val attachmentRepository: ApplicationAttachmentRepository,
-    private val attachmentContentService: AttachmentContentService,
+    private val attachmentContentService: ApplicationAttachmentContentService,
     private val scanClient: FileScanClient,
 ) {
     @Transactional(readOnly = true)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentContentService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentContentService.kt
@@ -1,6 +1,12 @@
-package fi.hel.haitaton.hanke.attachment.common
+package fi.hel.haitaton.hanke.attachment.hanke
 
 import fi.hel.haitaton.hanke.attachment.azure.Container
+import fi.hel.haitaton.hanke.attachment.common.AttachmentNotFoundException
+import fi.hel.haitaton.hanke.attachment.common.DownloadNotFoundException
+import fi.hel.haitaton.hanke.attachment.common.FileClient
+import fi.hel.haitaton.hanke.attachment.common.HankeAttachmentContentEntity
+import fi.hel.haitaton.hanke.attachment.common.HankeAttachmentContentRepository
+import fi.hel.haitaton.hanke.attachment.common.HankeAttachmentEntity
 import java.util.UUID
 import mu.KotlinLogging
 import org.springframework.data.repository.findByIdOrNull
@@ -9,27 +15,10 @@ import org.springframework.stereotype.Service
 private val logger = KotlinLogging.logger {}
 
 @Service
-class AttachmentContentService(
-    private val applicationAttachmentContentRepository: ApplicationAttachmentContentRepository,
+class HankeAttachmentContentService(
     private val hankeAttachmentContentRepository: HankeAttachmentContentRepository,
     private val fileClient: FileClient,
 ) {
-
-    fun saveApplicationContent(attachmentId: UUID, content: ByteArray) {
-        applicationAttachmentContentRepository.save(
-            ApplicationAttachmentContentEntity(attachmentId, content)
-        )
-    }
-
-    fun findApplicationContent(attachmentId: UUID): ByteArray =
-        applicationAttachmentContentRepository
-            .findById(attachmentId)
-            .map { it.content }
-            .orElseThrow {
-                logger.error { "Content not found for application attachment $attachmentId" }
-                AttachmentNotFoundException(attachmentId)
-            }
-
     fun saveHankeContent(attachmentId: UUID, content: ByteArray) {
         hankeAttachmentContentRepository.save(HankeAttachmentContentEntity(attachmentId, content))
     }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentService.kt
@@ -4,7 +4,6 @@ import fi.hel.haitaton.hanke.ALLOWED_ATTACHMENT_COUNT
 import fi.hel.haitaton.hanke.HankeNotFoundException
 import fi.hel.haitaton.hanke.HankeRepository
 import fi.hel.haitaton.hanke.attachment.common.AttachmentContent
-import fi.hel.haitaton.hanke.attachment.common.AttachmentContentService
 import fi.hel.haitaton.hanke.attachment.common.AttachmentInvalidException
 import fi.hel.haitaton.hanke.attachment.common.AttachmentNotFoundException
 import fi.hel.haitaton.hanke.attachment.common.AttachmentValidator
@@ -29,7 +28,7 @@ private val logger = KotlinLogging.logger {}
 class HankeAttachmentService(
     val hankeRepository: HankeRepository,
     val attachmentRepository: HankeAttachmentRepository,
-    val attachmentContentService: AttachmentContentService,
+    val attachmentContentService: HankeAttachmentContentService,
     val scanClient: FileScanClient,
 ) {
 

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/AttachmentFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/AttachmentFactory.kt
@@ -1,12 +1,12 @@
 package fi.hel.haitaton.hanke.factory
 
 import fi.hel.haitaton.hanke.HankeEntity
+import fi.hel.haitaton.hanke.attachment.application.ApplicationAttachmentContentService
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentEntity
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentMetadata
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentRepository
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType.MUU
-import fi.hel.haitaton.hanke.attachment.common.AttachmentContentService
 import fi.hel.haitaton.hanke.attachment.common.HankeAttachmentEntity
 import fi.hel.haitaton.hanke.attachment.common.HankeAttachmentMetadata
 import fi.hel.haitaton.hanke.currentUserId
@@ -21,7 +21,7 @@ private val defaultAttachmentId = UUID.fromString("5cba3a76-28ad-42aa-b7e6-b5c17
 @Component
 class AttachmentFactory(
     private val applicationAttachmentRepository: ApplicationAttachmentRepository,
-    private val attachmentContentService: AttachmentContentService,
+    private val attachmentContentService: ApplicationAttachmentContentService,
 ) {
     fun saveAttachment(applicationId: Long): ApplicationAttachmentEntity {
         val attachment =


### PR DESCRIPTION
# Description

AttachmentContentService can be split cleanly in two, leaving one class to handle application-related content and the other to handle hanke-related content.

The motivation is that the content service is getting larger with the addition of the Blob Storage support. Some of it is temporary while we support both Blob Storage and database storage, but some are permanent since we have to be more explicit with Blob Storage than with the database.

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [X] Other