### PR TITLE
HAI-1994 Delete attachments from Blob Storage

### DIFF
--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/azure/BlobFileClient.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/azure/BlobFileClient.kt
@@ -43,11 +43,13 @@ class BlobFileClient(blobServiceClient: BlobServiceClient, containers: Container
         contentType: MediaType,
         content: ByteArray,
     ) {
+        logger.info { "Uploading Blob to container $container with path $path..." }
         val options = BlobParallelUploadOptions(BinaryData.fromBytes(content))
         options.headers = BlobHttpHeaders()
         options.headers.setContentType(contentType.toString())
         options.headers.setContentDisposition("attachment; filename=$originalFilename")
         getContainerClient(container).getBlobClient(path).uploadWithResponse(options, null, null)
+        logger.info { "Uploaded Blob to container $container with path $path" }
     }
 
     override fun download(container: Container, path: String): DownloadResponse {
@@ -75,8 +77,12 @@ class BlobFileClient(blobServiceClient: BlobServiceClient, containers: Container
         }
     }
 
-    override fun delete(container: Container, path: String): Boolean =
-        getContainerClient(container).getBlobClient(path).deleteIfExists()
+    override fun delete(container: Container, path: String): Boolean {
+        logger.info { "Deleting Blob from container $container with path $path..." }
+        val response = getContainerClient(container).getBlobClient(path).deleteIfExists()
+        logger.info { "Deleted Blob from container $container with path $path" }
+        return response
+    }
 
     private fun getContainerClient(container: Container) =
         when (container) {

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentContentService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentContentService.kt
@@ -23,6 +23,11 @@ class HankeAttachmentContentService(
         hankeAttachmentContentRepository.save(HankeAttachmentContentEntity(attachmentId, content))
     }
 
+    fun delete(attachment: HankeAttachmentEntity) {
+        logger.info { "Deleting attachment content from attachment ${attachment.id}..." }
+        attachment.blobLocation?.let { fileClient.delete(Container.HANKE_LIITTEET, it) }
+    }
+
     fun find(attachment: HankeAttachmentEntity): ByteArray =
         attachment.blobLocation?.let { readFromFile(it, attachment.id!!) }
             ?: readFromDatabase(attachment.id!!)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentController.kt
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import java.util.UUID
+import mu.KotlinLogging
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.DeleteMapping
@@ -20,6 +21,8 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.multipart.MultipartFile
+
+private val logger = KotlinLogging.logger {}
 
 @RestController
 @RequestMapping("/hankkeet/{hankeTunnus}/liitteet")
@@ -118,6 +121,7 @@ class HankeAttachmentController(private val hankeAttachmentService: HankeAttachm
             "@hankeAttachmentAuthorizer.authorizeAttachment(#hankeTunnus,#attachmentId,'EDIT')"
     )
     fun deleteAttachment(@PathVariable hankeTunnus: String, @PathVariable attachmentId: UUID) {
-        return hankeAttachmentService.deleteAttachment(attachmentId)
+        hankeAttachmentService.deleteAttachment(attachmentId)
+        logger.info { "Deleted hanke attachment $attachmentId" }
     }
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentService.kt
@@ -78,9 +78,10 @@ class HankeAttachmentService(
 
     @Transactional
     fun deleteAttachment(attachmentId: UUID) {
+        logger.info { "Deleting attachment $attachmentId..." }
         val attachmentToDelete = findAttachment(attachmentId)
+        attachmentContentService.delete(attachmentToDelete)
         attachmentToDelete.hanke.liitteet.remove(attachmentToDelete)
-        logger.info { "Deleted hanke attachment ${attachmentToDelete.id}" }
     }
 
     private fun findAttachment(attachmentId: UUID) =

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/attachment/common/MockFileClient.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/attachment/common/MockFileClient.kt
@@ -45,8 +45,7 @@ class MockFileClient : FileClient {
     override fun delete(container: Container, path: String): Boolean =
         fileMap[container]!!.remove(path) != null
 
-    internal fun listBlobs(container: Container): List<TestFile> =
-        fileMap[container]!!.values.toList()
+    fun listBlobs(container: Container): List<TestFile> = fileMap[container]!!.values.toList()
 }
 
 data class TestFile(


### PR DESCRIPTION
# Description

Delete attachment content from Blob Storage when a single attachment is removed.

Deleting the content when a hanke is removed will be done in a separate task (HAI-2013).

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1994

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
Use the branch from #505 to test this.
1. Add an attachment to a hanke in the UI.
2. Call the temporary endpoint to move the content to Azurite.
3. Check that the file is visible in Azurite with Azure Storage Explorer or CLI.
4. Delete the attachment from the Haitaton UI.
5. Check that the file is longer in Azurite with Azure Storage Explorer or CLI.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 