### PR TITLE
HAI-1967 Use default credential builder for cloud environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,15 @@ $ az storage container list --connection-string "DefaultEndpointsProtocol=http;A
 Azurite is configured to produce debug logging in `azurite-debug.log`.
 Azurite uses Docker top-level volume for data (see https://docs.docker.com/compose/compose-file/07-volumes/).
 
+Connecting to Azurite for hanke-service is handled with connection strings. For `./gradlew bootRun`,
+the connection string is set in build.gradle.kts. The special development storage string can be used
+there. For the Docker Compose environment, the connection string is set in docker-compose.yml. It's
+slightly more involved, since it needs a customized endpoint to connect inside the Docker network.
+
+Connection strings are not set in the cloud environments. In cloud environments, the connection is
+authenticated by the default authenticator, which reads environment variables AZURE_CLIENT_ID,
+AZURE_CLIENT_SECRET and AZURE_TENANT_ID to build an authenticator.
+
 ### Swagger UI
 
 Swagger UI (see https://springdoc.org/) and OpenAPI v3 description (JSON). You

--- a/scripts/docker-azurite/setup.sh
+++ b/scripts/docker-azurite/setup.sh
@@ -3,7 +3,14 @@
 # Wait for Azurite to be ready
 /tmp/wait-for.sh azurite:10000 -t 30 -- echo "Azurite is up"
 
+connection_string="\
+DefaultEndpointsProtocol=http;\
+AccountName=devstoreaccount1;\
+AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;\
+BlobEndpoint=http://azurite:10000/devstoreaccount1;\
+"
+
 # Create Blob Containers
-az storage container create --name haitaton-hakemusliitteet-local --connection-string "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://azurite:10000/devstoreaccount1;"
-az storage container create --name haitaton-hankeliitteet-local --connection-string "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://azurite:10000/devstoreaccount1;"
-az storage container create --name haitaton-paatokset-local --connection-string "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://azurite:10000/devstoreaccount1;"
+az storage container create --name haitaton-hakemusliitteet-local --connection-string ${connection_string}
+az storage container create --name haitaton-hankeliitteet-local --connection-string ${connection_string}
+az storage container create --name haitaton-paatokset-local --connection-string ${connection_string}

--- a/services/hanke-service/build.gradle.kts
+++ b/services/hanke-service/build.gradle.kts
@@ -117,6 +117,7 @@ dependencies {
     // Azure
     implementation(platform("com.azure:azure-sdk-bom:1.2.18"))
     implementation("com.azure:azure-storage-blob")
+    implementation("com.azure:azure-identity")
 
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
 }

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/azure/BlobFileClientITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/azure/BlobFileClientITest.kt
@@ -41,7 +41,7 @@ class BlobFileClientITest : FileClientTest() {
         azuriteContainer.start()
         val connectionString =
             "BlobEndpoint=http://${azuriteContainer.host}:${azuriteContainer.firstMappedPort}/devstoreaccount1;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;"
-        serviceClient = AzureContainerServiceClient(connectionString).blobServiceClient()
+        serviceClient = AzureContainerServiceClient(connectionString, "").blobServiceClient()
         hankeAttachmentClient = serviceClient.getBlobContainerClient(containers.hankeAttachments)
 
         fileClient = BlobFileClient(serviceClient, containers)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/azure/AzureContainerServiceClient.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/azure/AzureContainerServiceClient.kt
@@ -1,22 +1,40 @@
 package fi.hel.haitaton.hanke.attachment.azure
 
+import com.azure.identity.DefaultAzureCredentialBuilder
 import com.azure.storage.blob.BlobServiceClient
 import com.azure.storage.blob.BlobServiceClientBuilder
 import kotlin.reflect.full.memberProperties
+import mu.KotlinLogging
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Profile
 
+private val logger = KotlinLogging.logger {}
+
 @Configuration
 @Profile("!test")
 class AzureContainerServiceClient(
-    @Value("\${haitaton.azure.blob.connection-string}") private val connectionString: String,
+    @Value("\${haitaton.azure.blob.connection-string}") private val connectionString: String?,
+    @Value("\${haitaton.azure.blob.endpoint}") private val endpoint: String,
 ) {
     @Bean
-    fun blobServiceClient(): BlobServiceClient =
-        BlobServiceClientBuilder().connectionString(connectionString).buildClient()
+    fun blobServiceClient(): BlobServiceClient {
+        logger.info { "Creating BlobServiceClient" }
+        return if (connectionString != null) {
+            logger.info { "Connecting using a connection string (local development)" }
+            logger.info { "Connection string is $connectionString" }
+            BlobServiceClientBuilder().connectionString(connectionString).buildClient()
+        } else {
+            logger.info { "Connecting using a default credential provider (cloud environments)" }
+            logger.info { "Endpoint is $endpoint" }
+            BlobServiceClientBuilder()
+                .endpoint(endpoint)
+                .credential(DefaultAzureCredentialBuilder().build())
+                .buildClient()
+        }
+    }
 }
 
 @ConfigurationProperties(prefix = "haitaton.azure.blob")

--- a/services/hanke-service/src/main/resources/application.properties
+++ b/services/hanke-service/src/main/resources/application.properties
@@ -110,5 +110,5 @@ haitaton.email.baseUrl=${HAITATON_EMAIL_BASEURL:http://localhost:3001}
 haitaton.azure.blob.decisions=${HAITATON_BLOB_CONTAINER_DECISIONS:haitaton-paatokset-local}
 haitaton.azure.blob.hanke-attachments=${HAITATON_BLOB_CONTAINER_HANKE_LIITTEET:haitaton-hankeliitteet-local}
 haitaton.azure.blob.hakemus-attachments=${HAITATON_BLOB_CONTAINER_HAKEMUS_LIITTEET:haitaton-hakemusliitteet-local}
-haitaton.azure.blob.default-connection-string=AuthType=azure;ClientId=${AZURE_CLIENT_ID:};ClientSecret=${AZURE_CLIENT_SECRET:};TenantId=${AZURE_TENANT_ID:};BlobEndpoint=https://${AZURE_STORAGE_ACCOUNT:}.blob.core.windows.net/;
-haitaton.azure.blob.connection-string=${HAITATON_BLOB_CONNECTION_STRING:${haitaton.azure.blob.default-connection-string}}
+haitaton.azure.blob.endpoint=https://${AZURE_STORAGE_ACCOUNT:}.blob.core.windows.net/
+haitaton.azure.blob.connection-string=${HAITATON_BLOB_CONNECTION_STRING:#{null}}


### PR DESCRIPTION
# Description

Blob Storage can't use a connection string to connect to Azure AD (https://stackoverflow.com/questions/67715786/blob-storage-java-sdk-authorize-by-azure-ad).

Use the default credential builder when the connection string is not explicitly defined, i.e. in cloud environments. Also, add some diagnostic logging to startup.

## Type of change

- [X] Bug fix 
- [ ] New feature 
- [ ] Other