### PR TITLE
HAI-1994 Temp endpoint for moving attachment content to Blob

### DIFF
--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentService.kt
@@ -76,9 +76,17 @@ class HankeAttachmentService(
         }
     }
 
+    /** Move the attachment content to cloud. In test-data use for now, can be used for HAI-1964. */
+    @Transactional
+    fun moveToCloud(attachmentId: UUID): String {
+        logger.info { "Moving attachment content to cloud for hanke attachment $attachmentId" }
+        val attachment = findAttachment(attachmentId)
+        return attachmentContentService.moveToCloud(attachment)
+    }
+
     @Transactional
     fun deleteAttachment(attachmentId: UUID) {
-        logger.info { "Deleting attachment $attachmentId..." }
+        logger.info { "Deleting hanke attachment $attachmentId..." }
         val attachmentToDelete = findAttachment(attachmentId)
         attachmentContentService.delete(attachmentToDelete)
         attachmentToDelete.hanke.liitteet.remove(attachmentToDelete)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/testdata/TestDataController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/testdata/TestDataController.kt
@@ -1,10 +1,14 @@
 package fi.hel.haitaton.hanke.testdata
 
+import fi.hel.haitaton.hanke.attachment.hanke.HankeAttachmentService
 import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
+import java.util.UUID
 import mu.KotlinLogging
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.context.event.ApplicationReadyEvent
 import org.springframework.context.event.EventListener
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
@@ -16,6 +20,7 @@ private val logger = KotlinLogging.logger {}
 @ConditionalOnProperty(name = ["haitaton.testdata.enabled"], havingValue = "true")
 class TestDataController(
     private val testDataService: TestDataService,
+    private val hankeAttachmentService: HankeAttachmentService,
 ) {
 
     @EventListener(ApplicationReadyEvent::class)
@@ -38,4 +43,18 @@ class TestDataController(
         testDataService.unlinkApplicationsFromAllu()
         logger.warn { "Unlinked all applications from Allu." }
     }
+
+    /**
+     * Temporary for moving hanke attachment content to cloud to make testing easier. Can be removed
+     * in HAI-1964.
+     */
+    @PostMapping("/move-hanke-attachment-to-cloud/{attachmentId}")
+    @SecurityRequirement(name = "bearerAuth")
+    fun moveHankeAttachmentToCloud(@PathVariable attachmentId: UUID): AttachmentCloudPath {
+        val path = hankeAttachmentService.moveToCloud(attachmentId)
+        logger.info { "Moving attachment content to cloud for hanke attachment $attachmentId" }
+        return AttachmentCloudPath(path)
+    }
+
+    data class AttachmentCloudPath(val path: String)
 }


### PR DESCRIPTION
# Description

Add a temporary endpoint for moving attachment content to Blob Storage. The endpoint will take an attachment ID as its parameter and move the content of that attachment to the cloud.

The motivation is to make testing Blob functionality easier. Adding a single attachment to the cloud required 4 steps earlier, now it needs 2 and the steps are easier.

At least some of the service implementation can be used later for the background migration process (HAI-1964).

After using the UI to upload an attachment, look up its ID from the network tab, and use the Swagger UI to call http://localhost:3001/api/swagger-ui/index.html#/test-data-controller/replaceContent. Authorization is needed as usual. The attachment will be uploaded to Blob Storage and the content will be removed from the database.

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [X] Other