### PR TITLE
HAI Remove explicit Spring Security version

### DIFF
--- a/services/hanke-service/build.gradle.kts
+++ b/services/hanke-service/build.gradle.kts
@@ -9,8 +9,6 @@ version = "0.0.1-SNAPSHOT"
 
 val sentryVersion = "6.33.1"
 
-ext["spring-security.version"] = "6.0.4"
-
 repositories { mavenCentral() }
 
 sourceSets {


### PR DESCRIPTION
# Description

The Spring Security version was specified explicitly while preparing for the Spring 3.0 upgrade. A special transitional version of Spring Security made the upgrade easier. When the upgrade to 3.1 was completed, this specification should've been deleted, but the version was updated instead.

Removing the version will make Spring Security follow Spring Boot's recommended version. So it will update as we update Spring Boot.

## Type of change

- [X] Bug fix 
- [ ] New feature 
- [ ] Other