### PR TITLE
HAI-2013 Delete Blobs when hanke is deleted

### DIFF
--- a/services/hanke-service/build.gradle.kts
+++ b/services/hanke-service/build.gradle.kts
@@ -115,6 +115,7 @@ dependencies {
     // Azure
     implementation(platform("com.azure:azure-sdk-bom:1.2.18"))
     implementation("com.azure:azure-storage-blob")
+    implementation("com.azure:azure-storage-blob-batch")
     implementation("com.azure:azure-identity")
 
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentContentServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentContentServiceITest.kt
@@ -16,14 +16,13 @@ import fi.hel.haitaton.hanke.attachment.azure.Container
 import fi.hel.haitaton.hanke.attachment.common.AttachmentNotFoundException
 import fi.hel.haitaton.hanke.attachment.common.HankeAttachmentContentEntity
 import fi.hel.haitaton.hanke.attachment.common.HankeAttachmentContentRepository
-import fi.hel.haitaton.hanke.attachment.common.HankeAttachmentRepository
 import fi.hel.haitaton.hanke.attachment.common.MockFileClient
+import fi.hel.haitaton.hanke.attachment.common.MockFileClientExtension
 import fi.hel.haitaton.hanke.factory.HankeAttachmentFactory
-import fi.hel.haitaton.hanke.factory.HankeFactory
 import java.util.UUID
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.security.test.context.support.WithMockUser
@@ -32,19 +31,13 @@ import org.springframework.test.context.ActiveProfiles
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("test")
 @WithMockUser(USERNAME)
-class HankeAttachmentContentServiceITest : DatabaseTest(), HankeAttachmentFactory {
-
-    @Autowired private lateinit var attachmentContentService: HankeAttachmentContentService
-    @Autowired override lateinit var fileClient: MockFileClient
-    @Autowired override lateinit var hankeAttachmentRepository: HankeAttachmentRepository
-    @Autowired
-    override lateinit var hankeAttachmentContentRepository: HankeAttachmentContentRepository
-    @Autowired override lateinit var hankeFactory: HankeFactory
-
-    @BeforeEach
-    fun beforeEach() {
-        fileClient.recreateContainers()
-    }
+@ExtendWith(MockFileClientExtension::class)
+class HankeAttachmentContentServiceITest(
+    @Autowired private val attachmentContentService: HankeAttachmentContentService,
+    @Autowired private val fileClient: MockFileClient,
+    @Autowired private val hankeAttachmentContentRepository: HankeAttachmentContentRepository,
+    @Autowired private val hankeAttachmentFactory: HankeAttachmentFactory,
+) : DatabaseTest() {
 
     private val hankeId = 1
     private val attachmentId = UUID.fromString("b820121e-ad54-4ab8-926a-c4a8193010b5")
@@ -55,7 +48,7 @@ class HankeAttachmentContentServiceITest : DatabaseTest(), HankeAttachmentFactor
     inner class Delete {
         @Test
         fun `deletes the content when blobLocation is specified`() {
-            saveContentToCloud(path, bytes = bytes)
+            hankeAttachmentFactory.saveContentToCloud(path, bytes = bytes)
             val attachmentEntity =
                 HankeAttachmentFactory.createEntity(attachmentId, blobLocation = path)
 
@@ -76,7 +69,8 @@ class HankeAttachmentContentServiceITest : DatabaseTest(), HankeAttachmentFactor
 
         @Test
         fun `doesn't do anything if blobLocation is not specified`() {
-            val attachmentEntity = saveAttachment(blobLocation = null).withDbContent(bytes)
+            val attachmentEntity =
+                hankeAttachmentFactory.save(blobLocation = null).withDbContent(bytes).value
 
             attachmentContentService.delete(attachmentEntity)
 
@@ -93,7 +87,7 @@ class HankeAttachmentContentServiceITest : DatabaseTest(), HankeAttachmentFactor
     inner class Find {
         @Test
         fun `returns the content when blobLocation is specified`() {
-            saveContentToCloud(path, bytes = bytes)
+            hankeAttachmentFactory.saveContentToCloud(path, bytes = bytes)
             val attachmentEntity =
                 HankeAttachmentFactory.createEntity(attachmentId, blobLocation = path)
 
@@ -104,8 +98,8 @@ class HankeAttachmentContentServiceITest : DatabaseTest(), HankeAttachmentFactor
 
         @Test
         fun `returns the content when blobLocation is not specified`() {
-            val attachmentEntity = saveAttachment(blobLocation = null)
-            saveContentToDb(attachmentEntity.id!!, bytes)
+            val attachmentEntity =
+                hankeAttachmentFactory.save(blobLocation = null).withDbContent(bytes).value
 
             val result = attachmentContentService.find(attachmentEntity)
 
@@ -118,7 +112,7 @@ class HankeAttachmentContentServiceITest : DatabaseTest(), HankeAttachmentFactor
 
         @Test
         fun `returns the right content`() {
-            saveContentToCloud(path, bytes = bytes)
+            hankeAttachmentFactory.saveContentToCloud(path, bytes = bytes)
 
             val result = attachmentContentService.readFromFile(path, attachmentId)
 
@@ -139,8 +133,8 @@ class HankeAttachmentContentServiceITest : DatabaseTest(), HankeAttachmentFactor
     inner class ReadFromDatabase {
         @Test
         fun `returns the right content`() {
-            val attachmentId = saveAttachment().id!!
-            saveContentToDb(attachmentId, bytes)
+            val attachmentId = hankeAttachmentFactory.save().value.id!!
+            hankeAttachmentFactory.saveContentToDb(attachmentId, bytes)
 
             val result = attachmentContentService.readFromDatabase(attachmentId)
 

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentRepositoryITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentRepositoryITests.kt
@@ -12,8 +12,9 @@ import fi.hel.haitaton.hanke.attachment.USERNAME
 import fi.hel.haitaton.hanke.attachment.common.HankeAttachmentEntity
 import fi.hel.haitaton.hanke.attachment.common.HankeAttachmentRepository
 import fi.hel.haitaton.hanke.factory.AttachmentFactory
+import fi.hel.haitaton.hanke.factory.HankeAttachmentFactory
 import fi.hel.haitaton.hanke.factory.HankeFactory
-import fi.hel.haitaton.hanke.test.Asserts.isRecent
+import fi.hel.haitaton.hanke.test.Asserts.isSameInstantAs
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.NullSource
 import org.junit.jupiter.params.provider.ValueSource
@@ -47,14 +48,15 @@ class HankeAttachmentRepositoryITests : DatabaseTest() {
             prop(HankeAttachmentEntity::fileName).isEqualTo(AttachmentFactory.FILE_NAME)
             prop(HankeAttachmentEntity::contentType).isEqualTo(APPLICATION_PDF_VALUE)
             prop(HankeAttachmentEntity::createdByUserId).isEqualTo(USERNAME)
-            prop(HankeAttachmentEntity::createdAt).isRecent()
+            prop(HankeAttachmentEntity::createdAt)
+                .isSameInstantAs(HankeAttachmentFactory.CREATED_AT)
             prop(HankeAttachmentEntity::hanke).isEqualTo(hanke)
             prop(HankeAttachmentEntity::blobLocation).isEqualTo(blobLocation)
         }
     }
 
     fun newAttachment(hanke: HankeEntity, blobLocation: String?) =
-        AttachmentFactory.hankeAttachmentEntity(
+        HankeAttachmentFactory.createEntity(
             id = null,
             hanke = hanke,
             createdByUser = USERNAME,

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Persistence.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Persistence.kt
@@ -114,7 +114,7 @@ enum class Haitta13 {
 @Table(name = "hanke")
 class HankeEntity(
     @Enumerated(EnumType.STRING) var status: HankeStatus = HankeStatus.DRAFT,
-    val hankeTunnus: String,
+    override val hankeTunnus: String,
     var nimi: String,
     var kuvaus: String? = null,
     @Enumerated(EnumType.STRING) var vaihe: Vaihe? = null,
@@ -156,7 +156,7 @@ class HankeEntity(
         orphanRemoval = true
     )
     var liitteet: MutableList<HankeAttachmentEntity> = mutableListOf(),
-) : HasId<Int> {
+) : HankeIdentifier {
     // --------------- Hankkeen lisätiedot / Työmaan tiedot -------------------
     var tyomaaKatuosoite: String? = null
 
@@ -232,8 +232,8 @@ interface HankeRepository : JpaRepository<HankeEntity, Int> {
     fun findAllByStatus(status: HankeStatus): List<HankeEntity>
 }
 
-interface HankeIdentifier {
-    val id: Int
+interface HankeIdentifier : HasId<Int> {
+    override val id: Int
     val hankeTunnus: String
 
     fun logString() = "Hanke: (id=${id}, tunnus=${hankeTunnus})"

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/common/FileClient.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/common/FileClient.kt
@@ -18,6 +18,8 @@ interface FileClient {
     fun download(container: Container, path: String): DownloadResponse
 
     fun delete(container: Container, path: String): Boolean
+
+    fun deleteAllByPrefix(container: Container, prefix: String)
 }
 
 data class DownloadResponse(

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentService.kt
@@ -1,6 +1,7 @@
 package fi.hel.haitaton.hanke.attachment.hanke
 
 import fi.hel.haitaton.hanke.ALLOWED_ATTACHMENT_COUNT
+import fi.hel.haitaton.hanke.HankeIdentifier
 import fi.hel.haitaton.hanke.HankeNotFoundException
 import fi.hel.haitaton.hanke.HankeRepository
 import fi.hel.haitaton.hanke.attachment.common.AttachmentContent
@@ -90,6 +91,14 @@ class HankeAttachmentService(
         val attachmentToDelete = findAttachment(attachmentId)
         attachmentContentService.delete(attachmentToDelete)
         attachmentToDelete.hanke.liitteet.remove(attachmentToDelete)
+    }
+
+    @Transactional
+    fun deleteAllAttachments(hanke: HankeIdentifier) {
+        logger.info { "Deleting all attachments from hanke ${hanke.logString()}" }
+        attachmentContentService.deleteAllForHanke(hanke.id)
+        val hankeEntity = hankeRepository.findByIdOrNull(hanke.id)
+        hankeEntity?.liitteet?.clear()
     }
 
     private fun findAttachment(attachmentId: UUID) =

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/Hanke.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/Hanke.kt
@@ -3,6 +3,7 @@ package fi.hel.haitaton.hanke.domain
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonView
 import fi.hel.haitaton.hanke.ChangeLogView
+import fi.hel.haitaton.hanke.HankeIdentifier
 import fi.hel.haitaton.hanke.HankeStatus
 import fi.hel.haitaton.hanke.NotInChangeLogView
 import fi.hel.haitaton.hanke.TyomaaTyyppi
@@ -24,7 +25,7 @@ data class Hanke(
         description = "Hanke identity for external purposes, set by the service.",
         example = "HAI24-123"
     )
-    val hankeTunnus: String,
+    override val hankeTunnus: String,
     //
     @JsonView(ChangeLogView::class)
     @field:Schema(
@@ -76,7 +77,7 @@ data class Hanke(
     @JsonView(ChangeLogView::class)
     @field:Schema(description = "Indicates if Hanke data is generated, set by the service.")
     var generated: Boolean = false,
-) : HasId<Int>, BaseHanke, HasYhteystiedot {
+) : BaseHanke, HasYhteystiedot, HankeIdentifier {
 
     // --------------- Yhteystiedot -----------------
     @JsonView(NotInChangeLogView::class)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/HankeLoggingService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/HankeLoggingService.kt
@@ -55,4 +55,7 @@ class HankeLoggingService(private val auditLogService: AuditLogService) {
             auditLogService.create(it)
         }
     }
+
+    fun createAll(auditLogEntries: MutableList<AuditLogEntry>) =
+        auditLogService.createAll(auditLogEntries)
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/YhteystietoLoggingEntryHolder.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/YhteystietoLoggingEntryHolder.kt
@@ -62,7 +62,7 @@ class YhteystietoLoggingEntryHolder {
      * @param failureDescription description for the failure, if one is available
      * @param oldEntity for logging the previous field values; can be null (when creating new)
      * @param newEntity for logging the new state of field values; can be null (when deleting or
-     * reading)
+     *   reading)
      * @param userId ID of the user making the API call
      */
     fun addLogEntriesForEvent(
@@ -114,7 +114,7 @@ class YhteystietoLoggingEntryHolder {
             }
     }
 
-    fun saveLogEntries(auditLogService: AuditLogService) {
+    fun saveLogEntries(auditLogService: HankeLoggingService) {
         auditLogService.createAll(auditLogEntries)
     }
 }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/application/AlluUpdateServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/application/AlluUpdateServiceTest.kt
@@ -21,12 +21,9 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.integration.jdbc.lock.JdbcLockRegistry
-import org.springframework.test.context.junit.jupiter.SpringExtension
 import org.springframework.web.reactive.function.client.WebClientResponseException
 
-@ExtendWith(SpringExtension::class)
 class AlluUpdateServiceTest {
     private val applicationRepository: ApplicationRepository = mockk()
     private val alluStatusRepository: AlluStatusRepository = mockk()

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/attachment/common/MockFileClient.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/attachment/common/MockFileClient.kt
@@ -20,6 +20,10 @@ class MockFileClient : FileClient {
         Container.entries.forEach { fileMap[it] = mutableMapOf() }
     }
 
+    fun removeContainers() {
+        Container.entries.forEach { fileMap[it] = mutableMapOf() }
+    }
+
     fun clearContainers() {
         Container.entries.forEach { fileMap[it]!!.clear() }
     }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/attachment/common/MockFileClientExtension.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/attachment/common/MockFileClientExtension.kt
@@ -1,0 +1,28 @@
+package fi.hel.haitaton.hanke.attachment.common
+
+import org.junit.jupiter.api.extension.BeforeAllCallback
+import org.junit.jupiter.api.extension.BeforeEachCallback
+import org.junit.jupiter.api.extension.ExtensionContext
+import org.springframework.test.context.junit.jupiter.SpringExtension
+
+class MockFileClientExtension : BeforeEachCallback, BeforeAllCallback {
+    lateinit var client: MockFileClient
+
+    override fun beforeEach(context: ExtensionContext?) {
+        client.clearContainers()
+    }
+
+    override fun beforeAll(context: ExtensionContext) {
+        if (!this::client.isInitialized) {
+            client =
+                SpringExtension.getApplicationContext(context).getBean(MockFileClient::class.java)
+        }
+
+        client.recreateContainers()
+    }
+
+    companion object {
+        fun create(): MockFileClientExtension =
+            MockFileClientExtension().apply { client = MockFileClient() }
+    }
+}

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/attachment/common/MockFileClientExtension.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/attachment/common/MockFileClientExtension.kt
@@ -1,11 +1,41 @@
 package fi.hel.haitaton.hanke.attachment.common
 
+import org.junit.jupiter.api.extension.AfterAllCallback
 import org.junit.jupiter.api.extension.BeforeAllCallback
 import org.junit.jupiter.api.extension.BeforeEachCallback
 import org.junit.jupiter.api.extension.ExtensionContext
 import org.springframework.test.context.junit.jupiter.SpringExtension
 
-class MockFileClientExtension : BeforeEachCallback, BeforeAllCallback {
+/**
+ * A test extension that sets and cleans up the mock file client.
+ *
+ * In integration tests where the Spring context contains a MockFileClient, the extension can be
+ * used by adding an annotation to the class:
+ * ```
+ * @ExtendWith(MockFileClientExtension::class)
+ * ```
+ *
+ * The file client is retrieved from the Spring context, so the same client can be accessed by
+ * autowiring the file client as a dependency as normal:
+ * ```
+ * @Autowired private val fileClient: MockFileClient
+ * ```
+ *
+ * For unit tests without a Spring context, the extension can be used by creating and registering
+ * the extension in the test's companion object:
+ * ```
+ * companion object {
+ *     @JvmField @RegisterExtension val mockFileClientExtension = MockFileClientExtension.create()
+ * }
+ * ```
+ *
+ * In this case, the file client is created for the extension and can be accessed from the
+ * extension:
+ * ```
+ * val fileClient: MockFileClient = mockFileClientExtension.client
+ * ```
+ */
+class MockFileClientExtension : BeforeEachCallback, BeforeAllCallback, AfterAllCallback {
     lateinit var client: MockFileClient
 
     override fun beforeEach(context: ExtensionContext?) {
@@ -19,6 +49,10 @@ class MockFileClientExtension : BeforeEachCallback, BeforeAllCallback {
         }
 
         client.recreateContainers()
+    }
+
+    override fun afterAll(context: ExtensionContext?) {
+        client.removeContainers()
     }
 
     companion object {

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/attachment/common/MockFileClientTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/attachment/common/MockFileClientTest.kt
@@ -1,28 +1,15 @@
 package fi.hel.haitaton.hanke.attachment.common
 
 import fi.hel.haitaton.hanke.attachment.azure.Container
-import org.junit.jupiter.api.BeforeAll
-import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.extension.RegisterExtension
 
 open class MockFileClientTest : FileClientTest() {
 
-    override val fileClient: MockFileClient = Companion.fileClient
+    override val fileClient: MockFileClient = mockFileClientExtension.client
 
-    @BeforeEach
-    fun cleanUp() {
-        fileClient.clearContainers()
-    }
-
-    override fun listBlobs(container: Container): List<TestFile> =
-        Companion.fileClient.listBlobs(container)
+    override fun listBlobs(container: Container): List<TestFile> = fileClient.listBlobs(container)
 
     companion object {
-        private val fileClient = MockFileClient()
-
-        @JvmStatic
-        @BeforeAll
-        fun setup() {
-            fileClient.recreateContainers()
-        }
+        @JvmField @RegisterExtension val mockFileClientExtension = MockFileClientExtension.create()
     }
 }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/AttachmentFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/AttachmentFactory.kt
@@ -1,13 +1,11 @@
 package fi.hel.haitaton.hanke.factory
 
-import fi.hel.haitaton.hanke.HankeEntity
 import fi.hel.haitaton.hanke.attachment.application.ApplicationAttachmentContentService
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentEntity
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentMetadata
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentRepository
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType.MUU
-import fi.hel.haitaton.hanke.attachment.common.HankeAttachmentEntity
 import fi.hel.haitaton.hanke.attachment.common.HankeAttachmentMetadata
 import fi.hel.haitaton.hanke.currentUserId
 import java.time.OffsetDateTime
@@ -52,25 +50,6 @@ class AttachmentFactory(
                 createdAt = createdAt,
                 attachmentType = attachmentType,
                 applicationId = applicationId,
-            )
-
-        fun hankeAttachmentEntity(
-            id: UUID? = defaultAttachmentId,
-            fileName: String = FILE_NAME,
-            blobLocation: String? = null,
-            contentType: String = APPLICATION_PDF_VALUE,
-            createdByUser: String = "currentUserId",
-            createdAt: OffsetDateTime = OffsetDateTime.now(),
-            hanke: HankeEntity,
-        ): HankeAttachmentEntity =
-            HankeAttachmentEntity(
-                id = id,
-                fileName = fileName,
-                contentType = contentType,
-                createdByUserId = createdByUser,
-                createdAt = createdAt,
-                hanke = hanke,
-                blobLocation = blobLocation,
             )
 
         fun hankeAttachmentMetadata(

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeAttachmentBuilder.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeAttachmentBuilder.kt
@@ -1,0 +1,31 @@
+package fi.hel.haitaton.hanke.factory
+
+import fi.hel.haitaton.hanke.attachment.DEFAULT_DATA
+import fi.hel.haitaton.hanke.attachment.FILE_NAME_PDF
+import fi.hel.haitaton.hanke.attachment.common.HankeAttachmentEntity
+import fi.hel.haitaton.hanke.attachment.common.HankeAttachmentRepository
+import fi.hel.haitaton.hanke.attachment.hanke.HankeAttachmentContentService.Companion.cloudPath
+import org.springframework.http.MediaType
+
+data class HankeAttachmentBuilder(
+    val value: HankeAttachmentEntity,
+    val attachmentRepository: HankeAttachmentRepository,
+    val hankeAttachmentFactory: HankeAttachmentFactory
+) {
+    fun withDbContent(bytes: ByteArray = DEFAULT_DATA): HankeAttachmentBuilder {
+        hankeAttachmentFactory.saveContentToDb(value.id!!, bytes)
+        return this
+    }
+
+    fun withCloudContent(
+        path: String = value.cloudPath(),
+        filename: String = FILE_NAME_PDF,
+        mediaType: MediaType = HankeAttachmentFactory.MEDIA_TYPE,
+        bytes: ByteArray = DEFAULT_DATA
+    ): HankeAttachmentBuilder {
+        this.value.blobLocation = path
+        attachmentRepository.save(value)
+        hankeAttachmentFactory.saveContentToCloud(path, filename, mediaType, bytes)
+        return this
+    }
+}

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeFactory.kt
@@ -19,7 +19,6 @@ import fi.hel.haitaton.hanke.domain.CreateHankeRequest
 import fi.hel.haitaton.hanke.domain.Hanke
 import fi.hel.haitaton.hanke.domain.HankeFounder
 import fi.hel.haitaton.hanke.domain.HankeYhteystieto
-import fi.hel.haitaton.hanke.factory.AttachmentFactory.Companion.hankeAttachmentEntity
 import fi.hel.haitaton.hanke.factory.HankeYhteystietoFactory.createEntity
 import fi.hel.haitaton.hanke.factory.HankealueFactory.createHankeAlueEntity
 import fi.hel.haitaton.hanke.tormaystarkastelu.TormaystarkasteluTulos
@@ -184,7 +183,10 @@ class HankeFactory(
                         mutableListOf(createHankeAlueEntity(mockId = mockId, hankeEntity = this))
                     liitteet =
                         mutableListOf(
-                            hankeAttachmentEntity(hanke = this, createdByUser = defaultUser)
+                            HankeAttachmentFactory.createEntity(
+                                hanke = this,
+                                createdByUser = defaultUser
+                            )
                         )
                     tormaystarkasteluTulokset = mutableListOf(tormaysTarkastelu(hankeEntity = this))
                 }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/test/Asserts.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/test/Asserts.kt
@@ -35,6 +35,10 @@ object Asserts {
             assertThat(actual).isBetween(now.minus(offset), now)
         }
 
+    fun Assert<OffsetDateTime>.isSameInstantAs(expected: OffsetDateTime) {
+        this.prop(OffsetDateTime::toInstant).isEqualTo(expected.toInstant())
+    }
+
     fun <T> Assert<Feature>.hasSameCoordinatesAs(other: Geometry<T>) {
         prop(Feature::getGeometry)
             .isInstanceOf(Geometry::class)


### PR DESCRIPTION
# Description

Use a batch operation to delete all the attachment Blobs of a hanke when the hanke is removed. The operation removes all Blobs matching the directory the hanke attachments are in, so it also removes any that might have been orphaned earlier. It can't handle subdirectories, though, since we don't have a use case for them. Implementing deleting objects from subdirectories seemed to require a recursive search for them.

Refactor HankeAttachmentFactory. It was confusing to have it as an interface with default functions. To enable the use of a fluid interface for creating content for the attachments, use a builder that stores the required dependencies and the saved entity. Remove functionality related to hanke attachments from AttachmentFactory and use HankeAttachmentFactory instead.

Mark Hanke and HankeEntity as implementations of HankeIdentifier, i.e. they have id and hanketunnus fields. This enables using HankeIdentifier as a convenient parameter type when we need just the two pieces of information from a hanke. Also, it enables the use of `logString()` from HankeIdentifier for both Hanke or HankeEntity, which is convenient since logging both the ID and hanketunnus of a hanke is very common and recommended.

Add a `createAll()` method to HankeLoggingService as a delegate for `AuditLogService.createAll()`. With this change, HankeService no longer needs a separate dependency on AuditLogService.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2013

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
1. Add attachments to a hanke. Create a new hanke if necessary.
2. Use http://localhost:3001/api/swagger-ui/index.html#/test-data-controller/moveHankeAttachmentToCloud on some of them to move their content to Blob Storage (Azurite locally).
3. Check that there are files in Blob Storage using Azure Storage Explorer.
4. Remove the hanke.
5. Check that the files are gone from Azure Storage Explorer.

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 