### PR TITLE
HAI Improve Dockerfile-local

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -120,7 +120,6 @@ services:
       - db
       - clamav-api
       - azurite-setup
-    command: [ "./wait-for-it.sh", "-t", "30", "--strict", "db:5432", "--", "java", "-jar", "haitaton.jar" ]
     networks:
       backbone:
         aliases:

--- a/services/hanke-service/Dockerfile-local
+++ b/services/hanke-service/Dockerfile-local
@@ -4,7 +4,8 @@ WORKDIR /workspace/app
 COPY gradlew settings.gradle.kts ./
 COPY gradle/ ./gradle/
 COPY services/hanke-service/build.gradle.kts ./services/hanke-service/
-COPY services/hanke-service/src ./services/hanke-service/src
+COPY services/hanke-service/src/main ./services/hanke-service/src/main
+COPY scripts/wait-for-it.sh ./
 
 RUN --mount=type=cache,target=/root/.gradle ./gradlew --no-daemon :services:hanke-service:assemble
 RUN mkdir -p services/hanke-service/build/dependency && \
@@ -17,5 +18,6 @@ ARG DEPENDENCY=/workspace/app/services/hanke-service/build/dependency
 COPY --from=build ${DEPENDENCY}/BOOT-INF/lib /app/lib
 COPY --from=build ${DEPENDENCY}/META-INF /app/META-INF
 COPY --from=build ${DEPENDENCY}/BOOT-INF/classes /app
+COPY --from=build /workspace/app/wait-for-it.sh ./
 
-ENTRYPOINT exec java -cp app:app/lib/* fi.hel.haitaton.hanke.ApplicationKt
+ENTRYPOINT ["./wait-for-it.sh", "db:5432", "--timeout=50", "--strict", "--", "java", "-cp", "app:app/lib/*", "fi.hel.haitaton.hanke.ApplicationKt"]

--- a/services/hanke-service/Dockerfile-local
+++ b/services/hanke-service/Dockerfile-local
@@ -5,7 +5,6 @@ COPY gradlew settings.gradle.kts ./
 COPY gradle/ ./gradle/
 COPY services/hanke-service/build.gradle.kts ./services/hanke-service/
 COPY services/hanke-service/src/main ./services/hanke-service/src/main
-COPY scripts/wait-for-it.sh ./
 
 RUN --mount=type=cache,target=/root/.gradle ./gradlew --no-daemon :services:hanke-service:assemble
 RUN mkdir -p services/hanke-service/build/dependency && \
@@ -18,6 +17,7 @@ ARG DEPENDENCY=/workspace/app/services/hanke-service/build/dependency
 COPY --from=build ${DEPENDENCY}/BOOT-INF/lib /app/lib
 COPY --from=build ${DEPENDENCY}/META-INF /app/META-INF
 COPY --from=build ${DEPENDENCY}/BOOT-INF/classes /app
-COPY --from=build /workspace/app/wait-for-it.sh ./
+COPY scripts/wait-for-it.sh ./
+
 
 ENTRYPOINT ["./wait-for-it.sh", "db:5432", "--timeout=50", "--strict", "--", "java", "-cp", "app:app/lib/*", "fi.hel.haitaton.hanke.ApplicationKt"]

--- a/services/hanke-service/Dockerfile-local
+++ b/services/hanke-service/Dockerfile-local
@@ -1,21 +1,21 @@
-FROM eclipse-temurin:17 as builder
-USER root
+FROM eclipse-temurin:17 as build
+WORKDIR /workspace/app
 
-# Copy gradle to avoid redownloading it
-COPY *.gradle gradle.* gradlew /builder/
-COPY gradle /builder/gradle
-WORKDIR /builder
-RUN ./gradlew --version
-RUN java -version
+COPY gradlew settings.gradle.kts ./
+COPY gradle/ ./gradle/
+COPY services/hanke-service/build.gradle.kts ./services/hanke-service/
+COPY services/hanke-service/src ./services/hanke-service/src
 
-ADD . /builder
-WORKDIR /builder
-# Add GRADLE_OPTS to prevent JVM forking while building
-RUN GRADLE_OPTS="-XX:MaxMetaspaceSize=256m -XX:+HeapDumpOnOutOfMemoryError -Xms256m -Xmx512m" ./gradlew assemble --no-daemon
+RUN --mount=type=cache,target=/root/.gradle ./gradlew --no-daemon :services:hanke-service:assemble
+RUN mkdir -p services/hanke-service/build/dependency && \
+    (cd services/hanke-service/build/dependency; jar -xf ../libs/*SNAPSHOT.jar)
 
 FROM eclipse-temurin:17
-WORKDIR /app
-EXPOSE 8080 8081
-COPY --from=builder /builder/services/hanke-service/build/libs/hanke-service-*.jar /app/haitaton.jar
-COPY --from=builder /builder/scripts/wait-for-it.sh /app/wait-for-it.sh
-CMD ["java", "-jar", "haitaton.jar" ]
+VOLUME /tmp
+
+ARG DEPENDENCY=/workspace/app/services/hanke-service/build/dependency
+COPY --from=build ${DEPENDENCY}/BOOT-INF/lib /app/lib
+COPY --from=build ${DEPENDENCY}/META-INF /app/META-INF
+COPY --from=build ${DEPENDENCY}/BOOT-INF/classes /app
+
+ENTRYPOINT exec java -cp app:app/lib/* fi.hel.haitaton.hanke.ApplicationKt


### PR DESCRIPTION
# Description

Implement layered multistage build adhering to best practices: https://spring.io/guides/topicals/spring-boot-docker/

Should speed up consecutive build times. I did some testing:

- Scenario: You have haitaton stack running in docker compose, you edit the source code.
- Command:  docker compose up -d --force-recreate --build haitaton-hanke 
- Results: 
  - old way: 84 seconds 
  - new way: 23 seconds

On the very first build, the caching mechanism cannot (of course) be used, so there is not much of a difference there.

### Jira Issue: -

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [x] Other

# Instructions for testing
Please describe tests how this change or new feature can be tested.

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 

# Other relevant info
Please describe here if there is e.g. some requirements for this change or
 other info that the tester/user needs to know.