### PR TITLE
HAI Upgrade Spring Boot to 3.2.8

### DIFF
--- a/services/hanke-service/build.gradle.kts
+++ b/services/hanke-service/build.gradle.kts
@@ -49,7 +49,7 @@ spotless {
 
 plugins {
     val kotlinVersion = "2.0.0"
-    id("org.springframework.boot") version "3.1.12"
+    id("org.springframework.boot") version "3.2.8"
     id("io.spring.dependency-management") version "1.1.6"
     id("com.diffplug.spotless") version "6.25.0"
     kotlin("jvm") version kotlinVersion

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/ControllerExceptionHandler.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/ControllerExceptionHandler.kt
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestControllerAdvice
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException
+import org.springframework.web.servlet.resource.NoResourceFoundException
 
 private val logger = KotlinLogging.logger {}
 
@@ -189,6 +190,15 @@ class ControllerExceptionHandler {
         logger.warn { ex.message }
         Sentry.captureException(ex)
         return HankeError.HAI0003
+    }
+
+    @ExceptionHandler(NoResourceFoundException::class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    @Hidden
+    fun noResourceFoundException(ex: NoResourceFoundException): HankeError {
+        logger.warn { ex.message }
+        Sentry.captureException(ex)
+        return HankeError.HAI0004
     }
 
     @ExceptionHandler(Throwable::class)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/configuration/LockService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/configuration/LockService.kt
@@ -4,6 +4,7 @@ import javax.sql.DataSource
 import mu.KotlinLogging
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Profile
 import org.springframework.integration.jdbc.lock.DefaultLockRepository
 import org.springframework.integration.jdbc.lock.JdbcLockRegistry
 import org.springframework.integration.jdbc.lock.LockRepository
@@ -12,6 +13,7 @@ import org.springframework.stereotype.Service
 private val logger = KotlinLogging.logger {}
 
 @Configuration
+@Profile("!test")
 class LockRepositories {
     /** The time to hold on to dead locks. */
     private val timeToLive = 15 * 60 * 1000 // 15 minutes in milliseconds
@@ -30,6 +32,7 @@ class LockRepositories {
 }
 
 @Service
+@Profile("!test")
 class LockService(private val jdbcLockRegistry: JdbcLockRegistry) {
 
     /** Run the given function if a lock is obtained. If the lock is not obtained, do nothing. */

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/AlluUpdateService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/AlluUpdateService.kt
@@ -5,12 +5,14 @@ import fi.hel.haitaton.hanke.allu.AlluStatusRepository
 import fi.hel.haitaton.hanke.configuration.LockService
 import java.time.OffsetDateTime
 import mu.KotlinLogging
+import org.springframework.context.annotation.Profile
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
 
 private val logger = KotlinLogging.logger {}
 
 @Service
+@Profile("!test")
 class AlluUpdateService(
     private val hakemusRepository: HakemusRepository,
     private val alluStatusRepository: AlluStatusRepository,

--- a/services/hanke-service/src/test/resources/application-test.yml
+++ b/services/hanke-service/src/test/resources/application-test.yml
@@ -24,6 +24,9 @@ haitaton:
 sentry.dsn:
 
 spring:
+  datasource:
+    hikari:
+      connection-timeout: 500
   jpa:
     show-sql: false
   mail:


### PR DESCRIPTION
# Description

Some fixes were needed to get the upgrade to work:

- Add an exception handler for NoResourceFoundException. After the
  update, TestDataController endpoints started to return 500 Internal
  error when they were called with the controller disabled by environment
  variables. Before the update, they returned 404 Not Found. The added
  exception handler returns the expected behaviour.
- Disable AlluUpdateService and LockService in tests. They're not
  used, but they cause problems when the test context is shutting down.
  There's a problem with TestContainer and Spring lifetimes, where the
  test container is shutdown before the application context, causing the
  database connections to time out. The thing trying to call the
  database at shutdown is the JdbcLockRegistry.
- Use reusable containers. This is an alternative solution to the
  previous problem.

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [X] Other