### PR TITLE
HAI-2116 Added central business area tormays material

### DIFF
--- a/scripts/gis-material-update/README.md
+++ b/scripts/gis-material-update/README.md
@@ -121,6 +121,7 @@ Where `<source>` is currently one of:
 - `ylre_katuosat` - Helsinki YLRE parts, polygons.
 - `maka_autoliikennemaarat` - Traffic volumes (car traffic)
 - `cycle_infra` - Cycle infra (local file)
+- `central_business_area` - Helsinki city "kantakaupunki"
 
 Data files are downloaded to `./haitaton-downloads` -directory.
 
@@ -300,6 +301,27 @@ Output files (names configured in `config.yaml`)
 
 - cycle_infra.gpkg
 - tormays_cycle_infra_polys.gpkg
+
+### `central_business_area`
+
+Prerequisite: fetched `central_business_area` -material.
+
+Docker example run (ensure that image build and file copying is
+already performed as instructed above):
+
+```sh
+docker-compose up -d gis-db
+docker-compose run --rm gis-fetch central_business_area
+docker-compose run --rm gis-process central_business_area
+docker-compose stop gis-db
+```
+
+Processed GIS material is available in:
+haitaton-gis-output
+
+Output files (names configured in `config.yaml`)
+
+- tormays_central_business_areas.gpkg
 
 # Run tests
 

--- a/scripts/gis-material-update/config.yaml
+++ b/scripts/gis-material-update/config.yaml
@@ -66,7 +66,7 @@ central_business_area:
   addr: "WFS:https://kartta.hel.fi/ws/geoserver/avoindata/wfs"
   layer: "avoindata:Piirijako_pienalue"
   local_file: "central_business_areas.gpkg"
-  target_file: "tormays_central_business_areas.gpkg"
+  target_file: "tormays_central_business_area_polys.gpkg"
 
 common:
   download_path: "/downloads"

--- a/scripts/gis-material-update/config.yaml
+++ b/scripts/gis-material-update/config.yaml
@@ -62,6 +62,11 @@ cycle_infra:
   target_buffer_file: "tormays_cycle_infra_polys.gpkg"
   buffer:
     - 20
+central_business_area:
+  addr: "WFS:https://kartta.hel.fi/ws/geoserver/avoindata/wfs"
+  layer: "avoindata:Piirijako_pienalue"
+  local_file: "central_business_areas.gpkg"
+  target_file: "tormays_central_business_areas.gpkg"
 
 common:
   download_path: "/downloads"

--- a/scripts/gis-material-update/fetch/fetch_data.sh
+++ b/scripts/gis-material-update/fetch/fetch_data.sh
@@ -69,7 +69,7 @@ cycle_infra)
     cp "$addr" "$local_file"
     ;;
 # plain WFS fetch
-hki|ylre_katualueet|ylre_katuosat|maka_autoliikennemaarat|osm|helsinki_osm_lines)
+hki|ylre_katualueet|ylre_katuosat|maka_autoliikennemaarat|osm|helsinki_osm_lines|central_business_area)
     ogr2ogr -progress -f GPKG "$local_file" ${extra_args:+$extra_args} ${extra_quoted_args:+"$extra_quoted_args"} "$addr" "$layer"
     ;;
 *)

--- a/scripts/gis-material-update/process/modules/central_business_area.py
+++ b/scripts/gis-material-update/process/modules/central_business_area.py
@@ -1,0 +1,113 @@
+import pandas as pd
+import geopandas as gpd
+from sqlalchemy import create_engine
+
+
+from modules.config import Config
+
+
+class CentralBusinessAreas:
+    """Process Central Business Areas"""
+
+    def __init__(self, cfg: Config):
+        self._cfg = cfg
+        self._process_result_polygons = None
+        self._process_result_merged_polygon = None
+        self._module = "central_business_area"
+
+        filename = cfg.local_file(self._module)
+        layer = cfg.layer(self._module)
+        df = gpd.read_file(filename, layer=layer)
+        self._orig = df
+
+        self._kantakaupunki_peruspiiri_nimi = [
+            "VIRONNIEMI",
+            "REIJOLA",
+            "KALLIO",
+            "KAMPINMALMI",
+            "ULLANLINNA",
+            "PASILA",
+            "TAKA-TÖÖLÖ",
+            "VANHAKAUPUNKI",
+            "VALLILA",
+            "ALPPIHARJU",
+        ]
+        self._kantakaupunki_not_osaalue_nimi = [
+            "SUOMENLINNA",
+            "LÄNSISAARET",
+        ]
+        # only listed peruspiiri areas are included except two listed osaalue areas:
+        self._df = df[
+            (
+                df["peruspiiri_nimi_fi"]
+                .str.upper()
+                .isin(self._kantakaupunki_peruspiiri_nimi)
+            )
+            & (
+                ~df["osaalue_nimi_fi"]
+                .str.upper()
+                .isin(self._kantakaupunki_not_osaalue_nimi)
+            )
+        ].loc[
+            :,
+            [
+                "tunnus",
+                "osaalue_tunnus",
+                "osaalue_nimi_fi",
+                "osaalue_nimi_se",
+                "peruspiiri_nimi_fi",
+                "peruspiiri_nimi_se",
+                "suurpiiri_nimi_fi",
+                "suurpiiri_nimi_se",
+                "geometry",
+            ],
+        ]
+        self._df["central_business_area"] = 1
+        self._df["fid"] = self._df.reset_index().index
+        self._df = self._df[
+            [
+                "fid",
+                "central_business_area",
+                "tunnus",
+                "osaalue_tunnus",
+                "osaalue_nimi_fi",
+                "osaalue_nimi_se",
+                "peruspiiri_nimi_fi",
+                "peruspiiri_nimi_se",
+                "suurpiiri_nimi_fi",
+                "suurpiiri_nimi_se",
+                "geometry",
+            ]
+        ]
+        self._df = self._df.set_index("fid")
+
+    def process(self):
+        # no buffering or further processing needed
+        self._process_result = self._df.copy()
+        self._process_result_polygons = self._process_result
+
+    def persist_to_database(self):
+        connection = create_engine(self._cfg.pg_conn_uri())
+
+        self._orig.to_postgis(
+            "central_business_area_orig_polys",
+            connection,
+            "public",
+            if_exists="replace",
+            index=True,
+            index_label="fid",
+        )
+
+        self._process_result.to_postgis(
+            "central_business_area_polys",
+            connection,
+            "public",
+            if_exists="replace",
+            index=True,
+            index_label="fid",
+        )
+
+    def save_to_file(self):
+        file_name = self._cfg.target_file(self._module)
+        self._df.to_file(file_name, driver="GPKG")
+        

--- a/scripts/gis-material-update/process/process_data.py
+++ b/scripts/gis-material-update/process/process_data.py
@@ -13,6 +13,7 @@ from modules.ylre_katuosat import YlreKatuosat
 from modules.tram_infra import TramInfra
 from modules.tram_lines import TramLines
 from modules.cycling_infra import CycleInfra
+from modules.central_business_area import CentralBusinessAreas
 
 DEFAULT_DEPLOYMENT_PROFILE = "local_development"
 
@@ -42,6 +43,8 @@ def instantiate_processor(item: str, cfg: Config) -> GisProcessor:
         return TramLines(cfg)
     elif item == "cycle_infra":
         return CycleInfra(cfg)
+    elif item == "central_business_area":
+        return CentralBusinessAreas(cfg)
     else:
         try:
             raise RuntimeError("Configuration not recognized: {}".format(item))

--- a/scripts/gis-material-update/process/test/test_central_business_area.py
+++ b/scripts/gis-material-update/process/test/test_central_business_area.py
@@ -1,0 +1,46 @@
+import unittest
+
+from test.compare_utils import TormaysCheckerMixin
+from modules.config import Config
+from modules.central_business_area import CentralBusinessAreas
+
+
+class TestCentralBusinessAreas(TormaysCheckerMixin, unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.cfg = Config()
+        tormays_data = CentralBusinessAreas(cls.cfg)
+        tormays_data.process()
+
+        cls._target_dataframe = tormays_data._process_result_polygons
+
+    def test_tormays_geometry_is_polygon_or_multipolygon(self):
+        accepted_geometries = ["multipolygon", "polygon"]
+        self.check_geometry_type_is_in_list(self._target_dataframe, accepted_geometries)
+
+    def test_tormays_geometry_has_configured_crs(self):
+        self.check_geometry_has_configured_crs(self._target_dataframe, self.cfg.crs())
+
+    def test_tormays_attributes(self):
+        self.check_geom_data_attributes(
+            self._target_dataframe,
+            [
+                "tunnus",
+                "osaalue_tunnus",
+                "osaalue_nimi_fi",
+                "osaalue_nimi_se",
+                "peruspiiri_nimi_fi",
+                "peruspiiri_nimi_se",
+                "suurpiiri_nimi_fi",
+                "suurpiiri_nimi_se",
+                "geometry",
+                "central_business_area",
+            ],
+        )
+
+    def test_tormays_min_area(self):
+        self.check_geom_data_min_area(self._target_dataframe)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Description

* Compute central business area tormays materials base on named attributes

* Implemeted test mixin method for multiple geometries

* Document updated for central business areas processing

* Update scripts/gis-material-update/data/README.md

### Jira Issue: 
https://helsinkisolutionoffice.atlassian.net/browse/HAI-2116

## Type of change

- [ ] Bug fix 
- [x] New feature 
- [ ] Other

# Instructions for testing
Check instructions from scripts/gis-material-update/readme to process central_business_area data. 
Then check data (=tormays_central_business_areas.gpkg) with QGIS:
* current feature count: 123 (this amount might be changed over time)
* geometries are looking ok (=areas)
* objects are having following attributes: 
                "fid",
                "central_business_area",
                "tunnus",
                "osaalue_tunnus",
                "osaalue_nimi_fi",
                "osaalue_nimi_se",
                "peruspiiri_nimi_fi",
                "peruspiiri_nimi_se",
                "suurpiiri_nimi_fi",
                "suurpiiri_nimi_se"


# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [x] I have made necessary changes to the documentation, link to confluence
 or other location: 
https://helsinkisolutionoffice.atlassian.net/wiki/spaces/HAI/pages/8292401164/Paikkatietoaineiston+k+sittely#Kantakaupunki

# Other relevant info
Please describe here if there is e.g. some requirements for this change or
 other info that the tester/user needs to know.