### PR TITLE
HAI-1984 Add blobLocation to application attachment

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/allu/CableReportServiceITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/allu/CableReportServiceITests.kt
@@ -13,8 +13,8 @@ import fi.hel.haitaton.hanke.OBJECT_MAPPER
 import fi.hel.haitaton.hanke.application.ApplicationDecisionNotFoundException
 import fi.hel.haitaton.hanke.configuration.Configuration.Companion.webClientWithLargeBuffer
 import fi.hel.haitaton.hanke.factory.AlluDataFactory
+import fi.hel.haitaton.hanke.factory.ApplicationAttachmentFactory
 import fi.hel.haitaton.hanke.factory.ApplicationHistoryFactory
-import fi.hel.haitaton.hanke.factory.AttachmentFactory
 import fi.hel.haitaton.hanke.getResourceAsBytes
 import java.time.ZonedDateTime
 import okhttp3.MultipartReader
@@ -107,7 +107,7 @@ class CableReportServiceITests {
         addStubbedLoginResponse()
         val alluId = 123
         val file = "test file content".toByteArray()
-        val attachment = AttachmentFactory.applicationAttachmentEntity(applicationId = 123456)
+        val attachment = ApplicationAttachmentFactory.createEntity(applicationId = 123456)
         val mockResponse = MockResponse().setResponseCode(200)
         (1..3).forEach { _ -> mockWebServer.enqueue(mockResponse) }
         val attachments = listOf(attachment, attachment, attachment)

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceITest.kt
@@ -62,8 +62,8 @@ import fi.hel.haitaton.hanke.factory.AlluDataFactory.Companion.suorittajaCustome
 import fi.hel.haitaton.hanke.factory.AlluDataFactory.Companion.teppoEmail
 import fi.hel.haitaton.hanke.factory.AlluDataFactory.Companion.withArea
 import fi.hel.haitaton.hanke.factory.AlluDataFactory.Companion.withCustomer
+import fi.hel.haitaton.hanke.factory.ApplicationAttachmentFactory
 import fi.hel.haitaton.hanke.factory.ApplicationHistoryFactory
-import fi.hel.haitaton.hanke.factory.AttachmentFactory
 import fi.hel.haitaton.hanke.factory.GeometriaFactory
 import fi.hel.haitaton.hanke.factory.HankeFactory
 import fi.hel.haitaton.hanke.factory.UserContactFactory.hakijaContact
@@ -146,7 +146,7 @@ class ApplicationServiceITest : DatabaseTest() {
     @Autowired private lateinit var geometriatDao: GeometriatDao
 
     @Autowired private lateinit var alluDataFactory: AlluDataFactory
-    @Autowired private lateinit var attachmentFactory: AttachmentFactory
+    @Autowired private lateinit var attachmentFactory: ApplicationAttachmentFactory
     @Autowired private lateinit var hankeFactory: HankeFactory
 
     companion object {

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentControllerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentControllerITest.kt
@@ -23,7 +23,7 @@ import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType.MUU
 import fi.hel.haitaton.hanke.attachment.common.AttachmentContent
 import fi.hel.haitaton.hanke.attachment.testFile
-import fi.hel.haitaton.hanke.factory.AttachmentFactory
+import fi.hel.haitaton.hanke.factory.ApplicationAttachmentFactory
 import fi.hel.haitaton.hanke.permissions.PermissionCode.EDIT_APPLICATIONS
 import fi.hel.haitaton.hanke.permissions.PermissionCode.VIEW
 import io.mockk.checkUnnecessaryStub
@@ -81,9 +81,7 @@ class ApplicationAttachmentControllerITest(@Autowired override val mockMvc: Mock
     @Test
     fun `getApplicationAttachments when valid request should return metadata list`() {
         val data =
-            (1..3).map {
-                AttachmentFactory.applicationAttachmentMetadata(fileName = "${it}file.pdf")
-            }
+            (1..3).map { ApplicationAttachmentFactory.createMetadata(fileName = "${it}file.pdf") }
         every { authorizer.authorizeApplicationId(APPLICATION_ID, VIEW.name) } returns true
         every { applicationAttachmentService.getMetadataList(APPLICATION_ID) } returns data
         val result: List<ApplicationAttachmentMetadata> =
@@ -128,7 +126,7 @@ class ApplicationAttachmentControllerITest(@Autowired override val mockMvc: Mock
         every { authorizer.authorizeApplicationId(APPLICATION_ID, EDIT_APPLICATIONS.name) } returns
             true
         every { applicationAttachmentService.addAttachment(APPLICATION_ID, MUU, file) } returns
-            AttachmentFactory.applicationAttachmentMetadata()
+            ApplicationAttachmentFactory.createMetadata()
 
         val result: ApplicationAttachmentMetadata =
             postAttachment(file = file).andExpect(status().isOk).andReturnBody()

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentRepositoryITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentRepositoryITests.kt
@@ -1,0 +1,65 @@
+package fi.hel.haitaton.hanke.attachment.application
+
+import assertk.all
+import assertk.assertThat
+import assertk.assertions.hasSize
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotNull
+import assertk.assertions.prop
+import fi.hel.haitaton.hanke.DatabaseTest
+import fi.hel.haitaton.hanke.attachment.USERNAME
+import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentEntity
+import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentRepository
+import fi.hel.haitaton.hanke.factory.AlluDataFactory
+import fi.hel.haitaton.hanke.factory.ApplicationAttachmentFactory
+import fi.hel.haitaton.hanke.factory.HankeFactory
+import fi.hel.haitaton.hanke.test.Asserts.isSameInstantAs
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.NullSource
+import org.junit.jupiter.params.provider.ValueSource
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.MediaType
+import org.springframework.test.context.ActiveProfiles
+
+private const val BLOB_LOCATION = "1/bcae2ff2-74e9-48d2-a8ed-e33a40652304"
+
+@ActiveProfiles("test")
+@SpringBootTest
+class ApplicationAttachmentRepositoryITests : DatabaseTest() {
+
+    @Autowired private lateinit var alluDataFactory: AlluDataFactory
+    @Autowired private lateinit var hankeFactory: HankeFactory
+    @Autowired private lateinit var applicationAttachmentRepository: ApplicationAttachmentRepository
+
+    @NullSource
+    @ValueSource(strings = [BLOB_LOCATION])
+    @ParameterizedTest
+    fun `Should save and find hanke attachment with nullable blob location`(blobLocation: String?) {
+        val hanke = hankeFactory.saveMinimal()
+        val application = alluDataFactory.saveApplicationEntity("User", hanke)
+        val saved =
+            applicationAttachmentRepository.save(
+                ApplicationAttachmentFactory.createEntity(
+                    applicationId = application.id!!,
+                    blobLocation = blobLocation,
+                )
+            )
+
+        val attachments = applicationAttachmentRepository.findAll()
+
+        assertThat(attachments).hasSize(1)
+        assertThat(attachments.first()).all {
+            prop(ApplicationAttachmentEntity::id).isNotNull().isEqualTo(saved.id)
+            prop(ApplicationAttachmentEntity::fileName)
+                .isEqualTo(ApplicationAttachmentFactory.FILE_NAME)
+            prop(ApplicationAttachmentEntity::contentType)
+                .isEqualTo(MediaType.APPLICATION_PDF_VALUE)
+            prop(ApplicationAttachmentEntity::createdByUserId).isEqualTo(USERNAME)
+            prop(ApplicationAttachmentEntity::createdAt)
+                .isSameInstantAs(ApplicationAttachmentFactory.CREATED_AT)
+            prop(ApplicationAttachmentEntity::applicationId).isEqualTo(application.id)
+            prop(ApplicationAttachmentEntity::blobLocation).isEqualTo(blobLocation)
+        }
+    }
+}

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentServiceITest.kt
@@ -36,7 +36,7 @@ import fi.hel.haitaton.hanke.attachment.successResult
 import fi.hel.haitaton.hanke.attachment.testFile
 import fi.hel.haitaton.hanke.factory.AlluDataFactory
 import fi.hel.haitaton.hanke.factory.AlluDataFactory.Companion.createAlluApplicationResponse
-import fi.hel.haitaton.hanke.factory.AttachmentFactory
+import fi.hel.haitaton.hanke.factory.ApplicationAttachmentFactory
 import fi.hel.haitaton.hanke.factory.HankeFactory
 import fi.hel.haitaton.hanke.test.Asserts.isRecent
 import io.mockk.Called
@@ -71,7 +71,7 @@ class ApplicationAttachmentServiceITest : DatabaseTest() {
     @Autowired private lateinit var attachmentContentService: ApplicationAttachmentContentService
     @Autowired private lateinit var applicationAttachmentRepository: ApplicationAttachmentRepository
     @Autowired private lateinit var alluDataFactory: AlluDataFactory
-    @Autowired private lateinit var attachmentFactory: AttachmentFactory
+    @Autowired private lateinit var attachmentFactory: ApplicationAttachmentFactory
     @Autowired private lateinit var hankeFactory: HankeFactory
 
     private lateinit var mockWebServer: MockWebServer
@@ -226,7 +226,7 @@ class ApplicationAttachmentServiceITest : DatabaseTest() {
         val application = initApplication()
         val attachments =
             (1..ALLOWED_ATTACHMENT_COUNT).map {
-                AttachmentFactory.applicationAttachmentEntity(applicationId = application.id!!)
+                ApplicationAttachmentFactory.createEntity(applicationId = application.id!!)
             }
         applicationAttachmentRepository.saveAll(attachments)
 

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentControllerITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentControllerITests.kt
@@ -14,7 +14,7 @@ import fi.hel.haitaton.hanke.attachment.common.AttachmentContent
 import fi.hel.haitaton.hanke.attachment.common.AttachmentInvalidException
 import fi.hel.haitaton.hanke.attachment.common.AttachmentUploadService
 import fi.hel.haitaton.hanke.attachment.testFile
-import fi.hel.haitaton.hanke.factory.AttachmentFactory
+import fi.hel.haitaton.hanke.factory.HankeAttachmentFactory
 import fi.hel.haitaton.hanke.factory.TestHankeIdentifier
 import fi.hel.haitaton.hanke.hankeError
 import fi.hel.haitaton.hanke.permissions.PermissionCode.EDIT
@@ -74,7 +74,7 @@ class HankeAttachmentControllerITests(@Autowired override val mockMvc: MockMvc) 
 
     @Test
     fun `getMetadataList when valid request should return metadata list`() {
-        val data = (1..3).map { AttachmentFactory.hankeAttachment(fileName = "${it}file.pdf") }
+        val data = (1..3).map { HankeAttachmentFactory.create(fileName = "${it}file.pdf") }
         every { authorizer.authorizeHankeTunnus(HANKE_TUNNUS, VIEW.name) } returns true
         every { hankeAttachmentService.getMetadataList(HANKE_TUNNUS) } returns data
 
@@ -110,7 +110,7 @@ class HankeAttachmentControllerITests(@Autowired override val mockMvc: MockMvc) 
         val hanke = TestHankeIdentifier(1, HANKE_TUNNUS)
         every { authorizer.authorizeHankeTunnus(HANKE_TUNNUS, EDIT.name) } returns true
         every { attachmentUploadService.uploadHankeAttachment(hanke.hankeTunnus, file) } returns
-            AttachmentFactory.hankeAttachment()
+            HankeAttachmentFactory.create()
 
         postAttachment(file = file).andExpect(status().isOk)
 

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentMigratorITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentMigratorITest.kt
@@ -19,7 +19,6 @@ import fi.hel.haitaton.hanke.attachment.common.HankeAttachmentEntity
 import fi.hel.haitaton.hanke.attachment.common.HankeAttachmentWithContent
 import fi.hel.haitaton.hanke.attachment.common.MockFileClient
 import fi.hel.haitaton.hanke.attachment.common.MockFileClientExtension
-import fi.hel.haitaton.hanke.factory.AttachmentFactory
 import fi.hel.haitaton.hanke.factory.HankeAttachmentFactory
 import fi.hel.haitaton.hanke.test.Asserts.isValidBlobLocation
 import java.util.UUID
@@ -128,7 +127,7 @@ class HankeAttachmentMigratorITest(
         HankeAttachmentWithContent(
             id = id,
             hankeId = hankeId,
-            content = AttachmentFactory.attachmentContent(bytes = bytes)
+            content = HankeAttachmentFactory.createContent(bytes = bytes)
         )
 
     private fun blobPath(id: Int) = HankeAttachmentContentService.generateBlobPath(id)

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentRepositoryITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentRepositoryITests.kt
@@ -11,7 +11,7 @@ import fi.hel.haitaton.hanke.HankeEntity
 import fi.hel.haitaton.hanke.attachment.USERNAME
 import fi.hel.haitaton.hanke.attachment.common.HankeAttachmentEntity
 import fi.hel.haitaton.hanke.attachment.common.HankeAttachmentRepository
-import fi.hel.haitaton.hanke.factory.AttachmentFactory
+import fi.hel.haitaton.hanke.factory.ApplicationAttachmentFactory
 import fi.hel.haitaton.hanke.factory.HankeAttachmentFactory
 import fi.hel.haitaton.hanke.factory.HankeFactory
 import fi.hel.haitaton.hanke.test.Asserts.isSameInstantAs
@@ -45,7 +45,7 @@ class HankeAttachmentRepositoryITests : DatabaseTest() {
         assertThat(attachments).hasSize(1)
         assertThat(attachments.first()).all {
             prop(HankeAttachmentEntity::id).isNotNull().isEqualTo(saved.id)
-            prop(HankeAttachmentEntity::fileName).isEqualTo(AttachmentFactory.FILE_NAME)
+            prop(HankeAttachmentEntity::fileName).isEqualTo(ApplicationAttachmentFactory.FILE_NAME)
             prop(HankeAttachmentEntity::contentType).isEqualTo(APPLICATION_PDF_VALUE)
             prop(HankeAttachmentEntity::createdByUserId).isEqualTo(USERNAME)
             prop(HankeAttachmentEntity::createdAt)

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentServiceITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentServiceITests.kt
@@ -28,7 +28,6 @@ import fi.hel.haitaton.hanke.attachment.common.HankeAttachmentEntity
 import fi.hel.haitaton.hanke.attachment.common.HankeAttachmentRepository
 import fi.hel.haitaton.hanke.attachment.common.MockFileClient
 import fi.hel.haitaton.hanke.attachment.common.MockFileClientExtension
-import fi.hel.haitaton.hanke.factory.AttachmentFactory
 import fi.hel.haitaton.hanke.factory.HankeAttachmentFactory
 import fi.hel.haitaton.hanke.factory.HankeFactory
 import fi.hel.haitaton.hanke.factory.HankeIdentifierFactory
@@ -167,7 +166,7 @@ class HankeAttachmentServiceITests(
         fun `Should throw if attachment amount is exceeded`() {
             val hanke = hankeFactory.saveEntity()
             (1..ALLOWED_ATTACHMENT_COUNT)
-                .map { AttachmentFactory.hankeAttachmentEntity(hanke = hanke) }
+                .map { HankeAttachmentFactory.createEntity(hanke = hanke) }
                 .let { hankeAttachmentRepository.saveAll(it) }
 
             assertFailure {
@@ -219,7 +218,7 @@ class HankeAttachmentServiceITests(
             val hanke = hankeFactory.saveEntity()
             val attachments =
                 (1..ALLOWED_ATTACHMENT_COUNT).map {
-                    AttachmentFactory.hankeAttachmentEntity(hanke = hanke)
+                    HankeAttachmentFactory.createEntity(hanke = hanke)
                 }
             hankeAttachmentRepository.saveAll(attachments)
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentService.kt
@@ -81,6 +81,7 @@ class ApplicationAttachmentService(
                 id = null,
                 fileName = filename,
                 contentType = attachment.contentType!!,
+                blobLocation = null,
                 createdByUserId = currentUserId(),
                 createdAt = now(),
                 attachmentType = attachmentType,

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/common/AttachmentEntity.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/common/AttachmentEntity.kt
@@ -35,6 +35,9 @@ abstract class AttachmentEntity(
 
     /** Creation timestamp. */
     @Column(name = "created_at", updatable = false, nullable = false) var createdAt: OffsetDateTime,
+
+    /** Location of the file in Azure Blob. */
+    @Column(name = "blob_location") var blobLocation: String?,
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -58,9 +61,9 @@ class HankeAttachmentEntity(
     contentType: String,
     createdByUserId: String,
     createdAt: OffsetDateTime,
-    @Column(name = "blob_location") var blobLocation: String?,
+    blobLocation: String?,
     @ManyToOne(fetch = FetchType.LAZY) @JoinColumn(name = "hanke_id") var hanke: HankeEntity,
-) : AttachmentEntity(id, fileName, contentType, createdByUserId, createdAt) {
+) : AttachmentEntity(id, fileName, contentType, createdByUserId, createdAt, blobLocation) {
     fun toDomain(): HankeAttachment {
         return HankeAttachment(
             id = id!!,
@@ -96,11 +99,12 @@ class ApplicationAttachmentEntity(
     contentType: String,
     createdByUserId: String,
     createdAt: OffsetDateTime,
+    blobLocation: String?,
     @Column(name = "application_id") var applicationId: Long,
     @Enumerated(EnumType.STRING)
     @Column(name = "attachment_type")
     var attachmentType: ApplicationAttachmentType,
-) : AttachmentEntity(id, fileName, contentType, createdByUserId, createdAt) {
+) : AttachmentEntity(id, fileName, contentType, createdByUserId, createdAt, blobLocation) {
     fun toDto(): ApplicationAttachmentMetadata {
         return ApplicationAttachmentMetadata(
             id = id!!,

--- a/services/hanke-service/src/main/resources/db/changelog/changesets/058-add-blob-location-to-application-attachment.yml
+++ b/services/hanke-service/src/main/resources/db/changelog/changesets/058-add-blob-location-to-application-attachment.yml
@@ -1,0 +1,14 @@
+databaseChangeLog:
+  - changeSet:
+      id: 058-add-blob-location-to-application-attachment
+      author: Topias Heinonen
+      changes:
+        - addColumn:
+            tableName: application_attachment
+            columns:
+              - column:
+                  name: blob_location
+                  type: text
+                  constraints:
+                    nullable: true
+                    unique: true

--- a/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -141,3 +141,5 @@ databaseChangeLog:
       file: db/changelog/changesets/055-make-nimi-mandatory-in-hankealue.yml
   - include:
       file: db/changelog/changesets/056-remove-perustaja-from-hanke.yml
+  - include:
+      file: db/changelog/changesets/058-add-blob-location-to-application-attachment.yml

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/attachment/AttachmentTestUtil.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/attachment/AttachmentTestUtil.kt
@@ -23,7 +23,9 @@ const val APPLICATION_ID = 1L
 const val CONTENT_TYPE_HEADER = "Content-Type"
 
 val DUMMY_DATA = "ABC".toByteArray()
-val DEFAULT_DATA = "/fi/hel/haitaton/hanke/decision/fake-decision.pdf".getResourceAsBytes()
+val DEFAULT_DATA by lazy {
+    "/fi/hel/haitaton/hanke/decision/fake-decision.pdf".getResourceAsBytes()
+}
 
 fun testFile(
     fileParam: String = FILE_PARAM,

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentMigrationSchedulerTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentMigrationSchedulerTest.kt
@@ -4,7 +4,8 @@ import fi.hel.haitaton.hanke.attachment.common.AttachmentContent
 import fi.hel.haitaton.hanke.attachment.common.HankeAttachmentWithContent
 import fi.hel.haitaton.hanke.attachment.hanke.HankeAttachmentMigrationScheduler.Companion.MIGRATE_HANKE_ATTACHMENT
 import fi.hel.haitaton.hanke.configuration.LockService
-import fi.hel.haitaton.hanke.factory.AttachmentFactory
+import fi.hel.haitaton.hanke.factory.ApplicationAttachmentFactory
+import fi.hel.haitaton.hanke.factory.HankeAttachmentFactory
 import fi.hel.haitaton.hanke.factory.HankeFactory
 import io.mockk.Called
 import io.mockk.checkUnnecessaryStub
@@ -95,8 +96,12 @@ class HankeAttachmentMigrationSchedulerTest {
 
     private fun unMigratedAttachment(): HankeAttachmentWithContent {
         val hanke = HankeFactory.createEntity()
-        val attachment = AttachmentFactory.hankeAttachmentEntity(hanke = hanke)
-        val content = AttachmentFactory.hankeAttachmentContentEntity(attachmentId = attachment.id!!)
+        val attachment =
+            HankeAttachmentFactory.createEntity(
+                id = ApplicationAttachmentFactory.defaultAttachmentId,
+                hanke = hanke,
+            )
+        val content = HankeAttachmentFactory.createContentEntity(attachmentId = attachment.id!!)
 
         return HankeAttachmentWithContent(
             id = content.attachmentId,

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/ApplicationAttachmentFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/ApplicationAttachmentFactory.kt
@@ -1,6 +1,7 @@
 package fi.hel.haitaton.hanke.factory
 
-import fi.hel.haitaton.hanke.HankeEntity
+import fi.hel.haitaton.hanke.attachment.DUMMY_DATA
+import fi.hel.haitaton.hanke.attachment.USERNAME
 import fi.hel.haitaton.hanke.attachment.application.ApplicationAttachmentContentService
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentEntity
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentMetadata
@@ -8,41 +9,37 @@ import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentRepository
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType.MUU
 import fi.hel.haitaton.hanke.attachment.common.AttachmentContent
-import fi.hel.haitaton.hanke.attachment.common.HankeAttachment
-import fi.hel.haitaton.hanke.attachment.common.HankeAttachmentContentEntity
-import fi.hel.haitaton.hanke.attachment.common.HankeAttachmentEntity
 import fi.hel.haitaton.hanke.currentUserId
 import java.time.OffsetDateTime
 import java.util.UUID
 import org.springframework.http.MediaType.APPLICATION_PDF_VALUE
 import org.springframework.stereotype.Component
 
-private val dummyData = "ABC".toByteArray()
-private val defaultAttachmentId = UUID.fromString("5cba3a76-28ad-42aa-b7e6-b5c1775be81a")
-
 @Component
-class AttachmentFactory(
+class ApplicationAttachmentFactory(
     private val applicationAttachmentRepository: ApplicationAttachmentRepository,
     private val attachmentContentService: ApplicationAttachmentContentService,
 ) {
     fun saveAttachment(applicationId: Long): ApplicationAttachmentEntity {
         val attachment =
-            applicationAttachmentRepository.save(
-                applicationAttachmentEntity(applicationId = applicationId)
-            )
-        attachmentContentService.save(attachment.id!!, dummyData)
+            applicationAttachmentRepository.save(createEntity(applicationId = applicationId))
+        attachmentContentService.save(attachment.id!!, DUMMY_DATA)
         return attachment
     }
 
     companion object {
+        val defaultAttachmentId: UUID = UUID.fromString("5cba3a76-28ad-42aa-b7e6-b5c1775be81a")
+        val CREATED_AT: OffsetDateTime = OffsetDateTime.parse("2023-11-09T10:03:55+02:00")
+
         const val FILE_NAME = "file.pdf"
 
-        fun applicationAttachmentEntity(
+        fun createEntity(
             id: UUID = defaultAttachmentId,
             fileName: String = FILE_NAME,
             contentType: String = APPLICATION_PDF_VALUE,
-            createdByUserId: String = "currentUserId",
-            createdAt: OffsetDateTime = OffsetDateTime.now(),
+            blobLocation: String? = null,
+            createdByUserId: String = USERNAME,
+            createdAt: OffsetDateTime = CREATED_AT,
             attachmentType: ApplicationAttachmentType = MUU,
             applicationId: Long,
         ): ApplicationAttachmentEntity =
@@ -50,50 +47,14 @@ class AttachmentFactory(
                 id = id,
                 fileName = fileName,
                 contentType = contentType,
+                blobLocation = blobLocation,
                 createdByUserId = createdByUserId,
                 createdAt = createdAt,
                 attachmentType = attachmentType,
                 applicationId = applicationId,
             )
 
-        fun hankeAttachmentEntity(
-            id: UUID? = defaultAttachmentId,
-            fileName: String = FILE_NAME,
-            blobLocation: String? = null,
-            contentType: String = APPLICATION_PDF_VALUE,
-            createdByUser: String = "currentUserId",
-            createdAt: OffsetDateTime = OffsetDateTime.now(),
-            hanke: HankeEntity,
-        ): HankeAttachmentEntity =
-            HankeAttachmentEntity(
-                id = id,
-                fileName = fileName,
-                contentType = contentType,
-                createdByUserId = createdByUser,
-                createdAt = createdAt,
-                hanke = hanke,
-                blobLocation = blobLocation,
-            )
-
-        fun hankeAttachmentContentEntity(attachmentId: UUID, content: ByteArray = dummyData) =
-            HankeAttachmentContentEntity(attachmentId, content)
-
-        fun hankeAttachment(
-            attachmentId: UUID = defaultAttachmentId,
-            fileName: String = FILE_NAME,
-            createdByUser: String = currentUserId(),
-            createdAt: OffsetDateTime = OffsetDateTime.now(),
-            hankeTunnus: String = "HAI-1234",
-        ): HankeAttachment =
-            HankeAttachment(
-                id = attachmentId,
-                fileName = fileName,
-                createdByUserId = createdByUser,
-                createdAt = createdAt,
-                hankeTunnus = hankeTunnus,
-            )
-
-        fun applicationAttachmentMetadata(
+        fun createMetadata(
             attachmentId: UUID = defaultAttachmentId,
             fileName: String = FILE_NAME,
             createdBy: String = currentUserId(),
@@ -110,10 +71,10 @@ class AttachmentFactory(
                 attachmentType = attachmentType
             )
 
-        fun attachmentContent(
+        fun createContent(
             fileName: String = FILE_NAME,
             contentType: String = APPLICATION_PDF_VALUE,
-            bytes: ByteArray = dummyData,
+            bytes: ByteArray = DUMMY_DATA,
         ) = AttachmentContent(fileName = fileName, contentType = contentType, bytes = bytes)
     }
 }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeAttachmentFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeAttachmentFactory.kt
@@ -2,14 +2,17 @@ package fi.hel.haitaton.hanke.factory
 
 import fi.hel.haitaton.hanke.HankeEntity
 import fi.hel.haitaton.hanke.attachment.DEFAULT_DATA
+import fi.hel.haitaton.hanke.attachment.DUMMY_DATA
 import fi.hel.haitaton.hanke.attachment.FILE_NAME_PDF
 import fi.hel.haitaton.hanke.attachment.USERNAME
 import fi.hel.haitaton.hanke.attachment.azure.Container.HANKE_LIITTEET
 import fi.hel.haitaton.hanke.attachment.common.FileClient
+import fi.hel.haitaton.hanke.attachment.common.HankeAttachment
 import fi.hel.haitaton.hanke.attachment.common.HankeAttachmentContentEntity
 import fi.hel.haitaton.hanke.attachment.common.HankeAttachmentContentRepository
 import fi.hel.haitaton.hanke.attachment.common.HankeAttachmentEntity
 import fi.hel.haitaton.hanke.attachment.common.HankeAttachmentRepository
+import fi.hel.haitaton.hanke.currentUserId
 import java.time.OffsetDateTime
 import java.util.UUID
 import org.springframework.http.MediaType
@@ -66,6 +69,21 @@ class HankeAttachmentFactory(
         val CONTENT_TYPE = MEDIA_TYPE.toString()
         val CREATED_AT: OffsetDateTime = OffsetDateTime.parse("2023-11-09T10:03:55+02:00")
 
+        fun create(
+            attachmentId: UUID = ApplicationAttachmentFactory.defaultAttachmentId,
+            fileName: String = ApplicationAttachmentFactory.FILE_NAME,
+            createdByUser: String = currentUserId(),
+            createdAt: OffsetDateTime = OffsetDateTime.now(),
+            hankeTunnus: String = "HAI-1234",
+        ): HankeAttachment =
+            HankeAttachment(
+                id = attachmentId,
+                fileName = fileName,
+                createdByUserId = createdByUser,
+                createdAt = createdAt,
+                hankeTunnus = hankeTunnus,
+            )
+
         fun createEntity(
             id: UUID? = null,
             fileName: String = FILE_NAME_PDF,
@@ -84,5 +102,14 @@ class HankeAttachmentFactory(
                 blobLocation = blobLocation,
                 hanke = hanke,
             )
+
+        fun createContentEntity(attachmentId: UUID, content: ByteArray = DUMMY_DATA) =
+            HankeAttachmentContentEntity(attachmentId, content)
+
+        fun createContent(
+            fileName: String = ApplicationAttachmentFactory.FILE_NAME,
+            contentType: String = MediaType.APPLICATION_PDF_VALUE,
+            bytes: ByteArray = DUMMY_DATA,
+        ) = ApplicationAttachmentFactory.createContent(fileName, contentType, bytes)
     }
 }


### PR DESCRIPTION
# Description

Add a column to the application attachment table to store the file's location in Azure Blob.

Also, move the remaining HankeAttachment-related functions from AttachmentFactory to HankeAttachmentFactory. Rename AttachmentFactory to ApplicationAttachmentFactory.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1984

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
1. Start hanke-service
2. Check that the database has a new column.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 