### PR TITLE
HAI-1987 Download application attachments from blob

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentContentServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentContentServiceITest.kt
@@ -8,9 +8,7 @@ import assertk.assertions.hasMessage
 import assertk.assertions.isEqualTo
 import fi.hel.haitaton.hanke.DatabaseTest
 import fi.hel.haitaton.hanke.attachment.USERNAME
-import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentContentRepository
 import fi.hel.haitaton.hanke.attachment.common.AttachmentNotFoundException
-import fi.hel.haitaton.hanke.attachment.common.MockFileClient
 import fi.hel.haitaton.hanke.attachment.common.MockFileClientExtension
 import fi.hel.haitaton.hanke.factory.ApplicationAttachmentFactory
 import java.util.UUID
@@ -28,9 +26,6 @@ import org.springframework.test.context.ActiveProfiles
 @ExtendWith(MockFileClientExtension::class)
 class ApplicationAttachmentContentServiceITest(
     @Autowired private val attachmentContentService: ApplicationAttachmentContentService,
-    @Autowired private val fileClient: MockFileClient,
-    @Autowired
-    private val applicationAttachmentContentRepository: ApplicationAttachmentContentRepository,
     @Autowired private val applicationAttachmentFactory: ApplicationAttachmentFactory,
 ) : DatabaseTest() {
 

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentContentServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentContentServiceITest.kt
@@ -1,0 +1,109 @@
+package fi.hel.haitaton.hanke.attachment.application
+
+import assertk.all
+import assertk.assertFailure
+import assertk.assertThat
+import assertk.assertions.hasClass
+import assertk.assertions.hasMessage
+import assertk.assertions.isEqualTo
+import fi.hel.haitaton.hanke.DatabaseTest
+import fi.hel.haitaton.hanke.attachment.USERNAME
+import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentContentRepository
+import fi.hel.haitaton.hanke.attachment.common.AttachmentNotFoundException
+import fi.hel.haitaton.hanke.attachment.common.MockFileClient
+import fi.hel.haitaton.hanke.attachment.common.MockFileClientExtension
+import fi.hel.haitaton.hanke.factory.ApplicationAttachmentFactory
+import java.util.UUID
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.test.context.ActiveProfiles
+
+@SpringBootTest
+@ActiveProfiles("test")
+@WithMockUser(USERNAME)
+@ExtendWith(MockFileClientExtension::class)
+class ApplicationAttachmentContentServiceITest(
+    @Autowired private val attachmentContentService: ApplicationAttachmentContentService,
+    @Autowired private val fileClient: MockFileClient,
+    @Autowired
+    private val applicationAttachmentContentRepository: ApplicationAttachmentContentRepository,
+    @Autowired private val applicationAttachmentFactory: ApplicationAttachmentFactory,
+) : DatabaseTest() {
+
+    private val applicationId = 1L
+    private val attachmentId = UUID.fromString("b820121e-ad54-4ab8-926a-c4a8193010b5")
+    private val path = "$applicationId/$attachmentId"
+    private val bytes = "Test content. Sisältää myös skandeja.".toByteArray()
+
+    @Nested
+    inner class Find {
+        @Test
+        fun `returns the content when blobLocation is specified`() {
+            applicationAttachmentFactory.saveContentToCloud(path, bytes = bytes)
+            val attachmentEntity =
+                ApplicationAttachmentFactory.createEntity(attachmentId, blobLocation = path)
+
+            val result = attachmentContentService.find(attachmentEntity)
+
+            assertThat(result).isEqualTo(bytes)
+        }
+
+        @Test
+        fun `returns the content when blobLocation is not specified`() {
+            val attachmentEntity =
+                applicationAttachmentFactory.save(blobLocation = null).withDbContent(bytes).value
+
+            val result = attachmentContentService.find(attachmentEntity)
+
+            assertThat(result).isEqualTo(bytes)
+        }
+    }
+
+    @Nested
+    inner class ReadFromFile {
+
+        @Test
+        fun `returns the right content`() {
+            applicationAttachmentFactory.saveContentToCloud(path, bytes = bytes)
+
+            val result = attachmentContentService.readFromFile(path, attachmentId)
+
+            assertThat(result).isEqualTo(bytes)
+        }
+
+        @Test
+        fun `throws AttachmentNotFoundException if attachment not found`() {
+            assertFailure { attachmentContentService.readFromFile(path, attachmentId) }
+                .all {
+                    hasClass(AttachmentNotFoundException::class)
+                    hasMessage("Attachment not found, id=$attachmentId")
+                }
+        }
+    }
+
+    @Nested
+    inner class ReadFromDatabase {
+        @Test
+        fun `returns the right content`() {
+            val attachmentId = applicationAttachmentFactory.save().value.id!!
+            applicationAttachmentFactory.saveContentToDb(attachmentId, bytes)
+
+            val result = attachmentContentService.readFromDatabase(attachmentId)
+
+            assertThat(result).isEqualTo(bytes)
+        }
+
+        @Test
+        fun `throws AttachmentNotFoundException if attachment not found`() {
+            assertFailure { attachmentContentService.readFromDatabase(attachmentId) }
+                .all {
+                    hasClass(AttachmentNotFoundException::class)
+                    hasMessage("Attachment not found, id=$attachmentId")
+                }
+        }
+    }
+}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentContentService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentContentService.kt
@@ -1,30 +1,59 @@
 package fi.hel.haitaton.hanke.attachment.application
 
+import fi.hel.haitaton.hanke.attachment.azure.Container
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentContentEntity
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentContentRepository
+import fi.hel.haitaton.hanke.attachment.common.AttachmentEntity
 import fi.hel.haitaton.hanke.attachment.common.AttachmentNotFoundException
+import fi.hel.haitaton.hanke.attachment.common.DownloadNotFoundException
+import fi.hel.haitaton.hanke.attachment.common.FileClient
 import java.util.UUID
 import mu.KotlinLogging
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 
 private val logger = KotlinLogging.logger {}
 
 @Service
 class ApplicationAttachmentContentService(
-    private val applicationAttachmentContentRepository: ApplicationAttachmentContentRepository
+    val contentRepository: ApplicationAttachmentContentRepository,
+    val fileClient: FileClient,
 ) {
     fun save(attachmentId: UUID, content: ByteArray) {
-        applicationAttachmentContentRepository.save(
-            ApplicationAttachmentContentEntity(attachmentId, content)
-        )
+        contentRepository.save(ApplicationAttachmentContentEntity(attachmentId, content))
     }
 
-    fun find(attachmentId: UUID): ByteArray =
-        applicationAttachmentContentRepository
-            .findById(attachmentId)
-            .map { it.content }
-            .orElseThrow {
-                logger.error { "Content not found for application attachment $attachmentId" }
-                AttachmentNotFoundException(attachmentId)
+    fun find(attachment: AttachmentEntity): ByteArray =
+        attachment.blobLocation?.let { readFromFile(it, attachment.id!!) }
+            ?: readFromDatabase(attachment.id!!)
+
+    fun readFromFile(location: String, attachmentId: UUID): ByteArray {
+        return try {
+            fileClient.download(Container.HAKEMUS_LIITTEET, location).content.toBytes()
+        } catch (e: DownloadNotFoundException) {
+            throw AttachmentNotFoundException(attachmentId)
+        }
+    }
+
+    fun readFromDatabase(attachmentId: UUID): ByteArray =
+        contentRepository.findByIdOrNull(attachmentId)?.content
+            ?: run {
+                logger.error { "Content not found for hakemus attachment $attachmentId" }
+                throw AttachmentNotFoundException(attachmentId)
             }
+
+    companion object {
+        fun generateBlobPath(applicationId: Long) =
+            "${applicationPrefix(applicationId)}${UUID.randomUUID()}"
+                .also { logger.info { "Generated blob path: $it" } }
+
+        /**
+         * Prefix derived from application each attachment of that application should have in the
+         * cloud storage.
+         *
+         * Used to distinguish the attachments of different applications from each other in the
+         * cloud storage and to enable deleting all of them at once.
+         */
+        private fun applicationPrefix(applicationId: Long): String = "$applicationId/"
+    }
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentService.kt
@@ -47,7 +47,7 @@ class ApplicationAttachmentService(
     @Transactional(readOnly = true)
     fun getContent(attachmentId: UUID): AttachmentContent {
         val attachment = findAttachment(attachmentId)
-        val content = attachmentContentService.find(attachmentId)
+        val content = attachmentContentService.find(attachment)
 
         return AttachmentContent(attachment.fileName, attachment.contentType, content)
     }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/AlluDataFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/AlluDataFactory.kt
@@ -33,6 +33,7 @@ const val TEPPO_TESTI = "Teppo Testihenkilö"
 @Component
 class AlluDataFactory(
     private val applicationRepository: ApplicationRepository,
+    private val hankeFactory: HankeFactory,
 ) {
     companion object {
         const val defaultApplicationId: Long = 1
@@ -401,7 +402,7 @@ class AlluDataFactory(
      */
     fun saveApplicationEntity(
         username: String,
-        hanke: HankeEntity,
+        hanke: HankeEntity = hankeFactory.saveMinimal(),
         mapper: (ApplicationEntity) -> ApplicationEntity = { it },
         application: Application = createApplication(),
         mutator: (ApplicationEntity) -> Unit = {},

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/ApplicationAttachmentBuilder.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/ApplicationAttachmentBuilder.kt
@@ -1,0 +1,31 @@
+package fi.hel.haitaton.hanke.factory
+
+import fi.hel.haitaton.hanke.attachment.DEFAULT_DATA
+import fi.hel.haitaton.hanke.attachment.FILE_NAME_PDF
+import fi.hel.haitaton.hanke.attachment.application.ApplicationAttachmentContentService.Companion.generateBlobPath
+import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentEntity
+import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentRepository
+import org.springframework.http.MediaType
+
+data class ApplicationAttachmentBuilder(
+    val value: ApplicationAttachmentEntity,
+    val attachmentRepository: ApplicationAttachmentRepository,
+    val applicationAttachmentFactory: ApplicationAttachmentFactory
+) {
+    fun withDbContent(bytes: ByteArray = DEFAULT_DATA): ApplicationAttachmentBuilder {
+        applicationAttachmentFactory.saveContentToDb(value.id!!, bytes)
+        return this
+    }
+
+    fun withCloudContent(
+        path: String = generateBlobPath(value.applicationId),
+        filename: String = FILE_NAME_PDF,
+        mediaType: MediaType = ApplicationAttachmentFactory.MEDIA_TYPE,
+        bytes: ByteArray = DEFAULT_DATA
+    ): ApplicationAttachmentBuilder {
+        this.value.blobLocation = path
+        attachmentRepository.save(value)
+        applicationAttachmentFactory.saveContentToCloud(path, filename, mediaType, bytes)
+        return this
+    }
+}

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/ApplicationAttachmentFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/ApplicationAttachmentFactory.kt
@@ -1,47 +1,99 @@
 package fi.hel.haitaton.hanke.factory
 
+import fi.hel.haitaton.hanke.application.ApplicationEntity
+import fi.hel.haitaton.hanke.attachment.DEFAULT_DATA
 import fi.hel.haitaton.hanke.attachment.DUMMY_DATA
+import fi.hel.haitaton.hanke.attachment.FILE_NAME_PDF
 import fi.hel.haitaton.hanke.attachment.USERNAME
 import fi.hel.haitaton.hanke.attachment.application.ApplicationAttachmentContentService
+import fi.hel.haitaton.hanke.attachment.azure.Container.HAKEMUS_LIITTEET
+import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentContentEntity
+import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentContentRepository
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentEntity
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentMetadata
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentRepository
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType.MUU
 import fi.hel.haitaton.hanke.attachment.common.AttachmentContent
+import fi.hel.haitaton.hanke.attachment.common.FileClient
 import fi.hel.haitaton.hanke.currentUserId
 import java.time.OffsetDateTime
 import java.util.UUID
+import org.springframework.http.MediaType
 import org.springframework.http.MediaType.APPLICATION_PDF_VALUE
 import org.springframework.stereotype.Component
 
 @Component
 class ApplicationAttachmentFactory(
-    private val applicationAttachmentRepository: ApplicationAttachmentRepository,
-    private val attachmentContentService: ApplicationAttachmentContentService,
+    private val attachmentRepository: ApplicationAttachmentRepository,
+    private val contentService: ApplicationAttachmentContentService,
+    private val contentRepository: ApplicationAttachmentContentRepository,
+    private val alluDataFactory: AlluDataFactory,
+    private val fileClient: FileClient,
 ) {
+    fun save(
+        id: UUID? = null,
+        fileName: String = FILE_NAME_PDF,
+        contentType: String = CONTENT_TYPE,
+        createdByUser: String = USERNAME,
+        createdAt: OffsetDateTime = CREATED_AT,
+        blobLocation: String? = null,
+        attachmentType: ApplicationAttachmentType = MUU,
+        application: ApplicationEntity = alluDataFactory.saveApplicationEntity(USERNAME),
+    ): ApplicationAttachmentBuilder {
+        val entity =
+            attachmentRepository.save(
+                createEntity(
+                    id,
+                    fileName,
+                    contentType,
+                    blobLocation,
+                    createdByUser,
+                    createdAt,
+                    attachmentType,
+                    application.id!!,
+                )
+            )
+        return ApplicationAttachmentBuilder(entity, attachmentRepository, this)
+    }
+
     fun saveAttachment(applicationId: Long): ApplicationAttachmentEntity {
-        val attachment =
-            applicationAttachmentRepository.save(createEntity(applicationId = applicationId))
-        attachmentContentService.save(attachment.id!!, DUMMY_DATA)
+        val attachment = attachmentRepository.save(createEntity(applicationId = applicationId))
+        contentService.save(attachment.id!!, DUMMY_DATA)
         return attachment
+    }
+
+    fun saveContentToDb(attachmentId: UUID, bytes: ByteArray): ApplicationAttachmentContentEntity {
+        val entity = ApplicationAttachmentContentEntity(attachmentId, bytes)
+        return contentRepository.save(entity)
+    }
+
+    fun saveContentToCloud(
+        path: String,
+        filename: String = FILE_NAME_PDF,
+        mediaType: MediaType = MEDIA_TYPE,
+        bytes: ByteArray = DEFAULT_DATA
+    ) {
+        fileClient.upload(HAKEMUS_LIITTEET, path, filename, mediaType, bytes)
     }
 
     companion object {
         val defaultAttachmentId: UUID = UUID.fromString("5cba3a76-28ad-42aa-b7e6-b5c1775be81a")
+        val MEDIA_TYPE = MediaType.APPLICATION_PDF
+        val CONTENT_TYPE = MEDIA_TYPE.toString()
         val CREATED_AT: OffsetDateTime = OffsetDateTime.parse("2023-11-09T10:03:55+02:00")
 
         const val FILE_NAME = "file.pdf"
 
         fun createEntity(
-            id: UUID = defaultAttachmentId,
+            id: UUID? = defaultAttachmentId,
             fileName: String = FILE_NAME,
             contentType: String = APPLICATION_PDF_VALUE,
             blobLocation: String? = null,
             createdByUserId: String = USERNAME,
             createdAt: OffsetDateTime = CREATED_AT,
             attachmentType: ApplicationAttachmentType = MUU,
-            applicationId: Long,
+            applicationId: Long = AlluDataFactory.defaultApplicationId,
         ): ApplicationAttachmentEntity =
             ApplicationAttachmentEntity(
                 id = id,


### PR DESCRIPTION
# Description

When blob_location is present in the attachment, download the attachment content from Blob Storage instead of the database.

The download is done inside a DB transaction for now. This will be changed in another PR for this same story.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1987

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
1. Upload a file to Azurite with Azure Storage Explorer.
2. In DB, change an application attachment's `blob_location` to match the uploaded file name.
3. Download the attachment through UI.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 