### PR TITLE
HAI-1987 Remove temp method for moving hanke attachments to cloud

### DIFF
--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentService.kt
@@ -63,14 +63,6 @@ class HankeAttachmentService(
             .toDomain()
     }
 
-    /** Move the attachment content to cloud. In test-data use for now, can be used for HAI-1964. */
-    @Transactional
-    fun moveToCloud(attachmentId: UUID): String {
-        logger.info { "Moving attachment content to cloud for hanke attachment $attachmentId" }
-        val attachment = findAttachment(attachmentId)
-        return attachmentContentService.moveToCloud(attachment)
-    }
-
     @Transactional
     fun deleteAttachment(attachmentId: UUID) {
         logger.info { "Deleting hanke attachment $attachmentId..." }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/testdata/TestDataController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/testdata/TestDataController.kt
@@ -1,14 +1,10 @@
 package fi.hel.haitaton.hanke.testdata
 
-import fi.hel.haitaton.hanke.attachment.hanke.HankeAttachmentService
 import io.swagger.v3.oas.annotations.Operation
-import io.swagger.v3.oas.annotations.security.SecurityRequirement
-import java.util.UUID
 import mu.KotlinLogging
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.context.event.ApplicationReadyEvent
 import org.springframework.context.event.EventListener
-import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
@@ -18,10 +14,7 @@ private val logger = KotlinLogging.logger {}
 @RestController
 @RequestMapping("/testdata")
 @ConditionalOnProperty(name = ["haitaton.testdata.enabled"], havingValue = "true")
-class TestDataController(
-    private val testDataService: TestDataService,
-    private val hankeAttachmentService: HankeAttachmentService,
-) {
+class TestDataController(private val testDataService: TestDataService) {
 
     @EventListener(ApplicationReadyEvent::class)
     fun logWarning() {
@@ -43,18 +36,4 @@ class TestDataController(
         testDataService.unlinkApplicationsFromAllu()
         logger.warn { "Unlinked all applications from Allu." }
     }
-
-    /**
-     * Temporary for moving hanke attachment content to cloud to make testing easier. Can be removed
-     * in HAI-1964.
-     */
-    @PostMapping("/move-hanke-attachment-to-cloud/{attachmentId}")
-    @SecurityRequirement(name = "bearerAuth")
-    fun moveHankeAttachmentToCloud(@PathVariable attachmentId: UUID): AttachmentCloudPath {
-        val path = hankeAttachmentService.moveToCloud(attachmentId)
-        logger.info { "Moving attachment content to cloud for hanke attachment $attachmentId" }
-        return AttachmentCloudPath(path)
-    }
-
-    data class AttachmentCloudPath(val path: String)
 }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeAttachmentBuilder.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeAttachmentBuilder.kt
@@ -4,7 +4,7 @@ import fi.hel.haitaton.hanke.attachment.DEFAULT_DATA
 import fi.hel.haitaton.hanke.attachment.FILE_NAME_PDF
 import fi.hel.haitaton.hanke.attachment.common.HankeAttachmentEntity
 import fi.hel.haitaton.hanke.attachment.common.HankeAttachmentRepository
-import fi.hel.haitaton.hanke.attachment.hanke.HankeAttachmentContentService.Companion.cloudPath
+import fi.hel.haitaton.hanke.attachment.hanke.HankeAttachmentContentService.Companion.generateBlobPath
 import org.springframework.http.MediaType
 
 data class HankeAttachmentBuilder(
@@ -18,7 +18,7 @@ data class HankeAttachmentBuilder(
     }
 
     fun withCloudContent(
-        path: String = value.cloudPath(),
+        path: String = generateBlobPath(value.hanke.id),
         filename: String = FILE_NAME_PDF,
         mediaType: MediaType = HankeAttachmentFactory.MEDIA_TYPE,
         bytes: ByteArray = DEFAULT_DATA


### PR DESCRIPTION
# Description

Hanke attachments are uploaded to the cloud now, so we no longer need this test data controller method.

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [X] Other