### PR TITLE
HAI-1987 Refactor application attachment services

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/IntegrationTestConfiguration.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/IntegrationTestConfiguration.kt
@@ -2,6 +2,7 @@ package fi.hel.haitaton.hanke
 
 import fi.hel.haitaton.hanke.application.ApplicationAuthorizer
 import fi.hel.haitaton.hanke.application.ApplicationService
+import fi.hel.haitaton.hanke.attachment.application.ApplicationAttachmentMetadataService
 import fi.hel.haitaton.hanke.attachment.application.ApplicationAttachmentService
 import fi.hel.haitaton.hanke.attachment.common.AttachmentUploadService
 import fi.hel.haitaton.hanke.attachment.hanke.HankeAttachmentAuthorizer
@@ -75,6 +76,8 @@ class IntegrationTestConfiguration {
     @Bean fun hankeAttachmentService(): HankeAttachmentService = mockk()
 
     @Bean fun attachmentUploadService(): AttachmentUploadService = mockk()
+
+    @Bean fun applicationAttachmentMetadataService(): ApplicationAttachmentMetadataService = mockk()
 
     @Bean fun applicationAttachmentService(): ApplicationAttachmentService = mockk()
 

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/allu/CableReportServiceITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/allu/CableReportServiceITests.kt
@@ -107,7 +107,7 @@ class CableReportServiceITests {
         addStubbedLoginResponse()
         val alluId = 123
         val file = "test file content".toByteArray()
-        val attachment = ApplicationAttachmentFactory.createEntity(applicationId = 123456)
+        val attachment = ApplicationAttachmentFactory.create(applicationId = 123456)
         val mockResponse = MockResponse().setResponseCode(200)
         (1..3).forEach { _ -> mockWebServer.enqueue(mockResponse) }
         val attachments = listOf(attachment, attachment, attachment)

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentContentServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentContentServiceITest.kt
@@ -42,7 +42,7 @@ class ApplicationAttachmentContentServiceITest(
             val attachmentEntity =
                 ApplicationAttachmentFactory.createEntity(attachmentId, blobLocation = path)
 
-            val result = attachmentContentService.find(attachmentEntity)
+            val result = attachmentContentService.find(attachmentEntity.toDomain())
 
             assertThat(result).isEqualTo(bytes)
         }
@@ -52,7 +52,7 @@ class ApplicationAttachmentContentServiceITest(
             val attachmentEntity =
                 applicationAttachmentFactory.save(blobLocation = null).withDbContent(bytes).value
 
-            val result = attachmentContentService.find(attachmentEntity)
+            val result = attachmentContentService.find(attachmentEntity.toDomain())
 
             assertThat(result).isEqualTo(bytes)
         }

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentControllerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentControllerITest.kt
@@ -18,7 +18,7 @@ import fi.hel.haitaton.hanke.attachment.DUMMY_DATA
 import fi.hel.haitaton.hanke.attachment.FILE_NAME_PDF
 import fi.hel.haitaton.hanke.attachment.USERNAME
 import fi.hel.haitaton.hanke.attachment.andExpectError
-import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentMetadata
+import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentMetadataDto
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType.MUU
 import fi.hel.haitaton.hanke.attachment.common.AttachmentContent
@@ -84,7 +84,7 @@ class ApplicationAttachmentControllerITest(@Autowired override val mockMvc: Mock
             (1..3).map { ApplicationAttachmentFactory.createMetadata(fileName = "${it}file.pdf") }
         every { authorizer.authorizeApplicationId(APPLICATION_ID, VIEW.name) } returns true
         every { applicationAttachmentService.getMetadataList(APPLICATION_ID) } returns data
-        val result: List<ApplicationAttachmentMetadata> =
+        val result: List<ApplicationAttachmentMetadataDto> =
             getMetadataList().andExpect(status().isOk).andReturnBody()
 
         assertThat(result).each { d ->
@@ -128,7 +128,7 @@ class ApplicationAttachmentControllerITest(@Autowired override val mockMvc: Mock
         every { applicationAttachmentService.addAttachment(APPLICATION_ID, MUU, file) } returns
             ApplicationAttachmentFactory.createMetadata()
 
-        val result: ApplicationAttachmentMetadata =
+        val result: ApplicationAttachmentMetadataDto =
             postAttachment(file = file).andExpect(status().isOk).andReturnBody()
 
         with(result) {

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/common/AttachmentUploadServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/common/AttachmentUploadServiceITest.kt
@@ -67,10 +67,10 @@ class AttachmentUploadServiceITest(
                 )
 
             assertThat(result).all {
-                prop(HankeAttachment::hankeTunnus).isEqualTo(hanke.hankeTunnus)
-                prop(HankeAttachment::createdAt).isRecent()
-                prop(HankeAttachment::createdByUserId).isEqualTo(USERNAME)
-                prop(HankeAttachment::fileName).isEqualTo(file.originalFilename)
+                prop(HankeAttachmentMetadataDto::hankeTunnus).isEqualTo(hanke.hankeTunnus)
+                prop(HankeAttachmentMetadataDto::createdAt).isRecent()
+                prop(HankeAttachmentMetadataDto::createdByUserId).isEqualTo(USERNAME)
+                prop(HankeAttachmentMetadataDto::fileName).isEqualTo(file.originalFilename)
             }
             val attachment = attachmentRepository.findById(result.id).orElseThrow()
             val blob = fileClient.download(Container.HANKE_LIITTEET, attachment.blobLocation!!)

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentControllerITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentControllerITests.kt
@@ -74,7 +74,7 @@ class HankeAttachmentControllerITests(@Autowired override val mockMvc: MockMvc) 
 
     @Test
     fun `getMetadataList when valid request should return metadata list`() {
-        val data = (1..3).map { HankeAttachmentFactory.create(fileName = "${it}file.pdf") }
+        val data = (1..3).map { HankeAttachmentFactory.createMetadata(fileName = "${it}file.pdf") }
         every { authorizer.authorizeHankeTunnus(HANKE_TUNNUS, VIEW.name) } returns true
         every { hankeAttachmentService.getMetadataList(HANKE_TUNNUS) } returns data
 
@@ -110,7 +110,7 @@ class HankeAttachmentControllerITests(@Autowired override val mockMvc: MockMvc) 
         val hanke = TestHankeIdentifier(1, HANKE_TUNNUS)
         every { authorizer.authorizeHankeTunnus(HANKE_TUNNUS, EDIT.name) } returns true
         every { attachmentUploadService.uploadHankeAttachment(hanke.hankeTunnus, file) } returns
-            HankeAttachmentFactory.create()
+            HankeAttachmentFactory.createMetadata()
 
         postAttachment(file = file).andExpect(status().isOk)
 

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentControllerITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentControllerITests.kt
@@ -74,7 +74,7 @@ class HankeAttachmentControllerITests(@Autowired override val mockMvc: MockMvc) 
 
     @Test
     fun `getMetadataList when valid request should return metadata list`() {
-        val data = (1..3).map { HankeAttachmentFactory.createMetadata(fileName = "${it}file.pdf") }
+        val data = (1..3).map { HankeAttachmentFactory.createDto(fileName = "${it}file.pdf") }
         every { authorizer.authorizeHankeTunnus(HANKE_TUNNUS, VIEW.name) } returns true
         every { hankeAttachmentService.getMetadataList(HANKE_TUNNUS) } returns data
 
@@ -110,7 +110,7 @@ class HankeAttachmentControllerITests(@Autowired override val mockMvc: MockMvc) 
         val hanke = TestHankeIdentifier(1, HANKE_TUNNUS)
         every { authorizer.authorizeHankeTunnus(HANKE_TUNNUS, EDIT.name) } returns true
         every { attachmentUploadService.uploadHankeAttachment(hanke.hankeTunnus, file) } returns
-            HankeAttachmentFactory.createMetadata()
+            HankeAttachmentFactory.createDto()
 
         postAttachment(file = file).andExpect(status().isOk)
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/CableReportService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/CableReportService.kt
@@ -1,7 +1,7 @@
 package fi.hel.haitaton.hanke.allu
 
 import fi.hel.haitaton.hanke.application.ApplicationDecisionNotFoundException
-import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachment
+import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentMetadata
 import java.time.Duration.ofSeconds
 import java.time.ZonedDateTime
 import kotlinx.coroutines.CoroutineDispatcher
@@ -179,8 +179,8 @@ class CableReportService(
     /** Send many attachments in parallel. */
     fun addAttachments(
         alluApplicationId: Int,
-        attachments: List<ApplicationAttachment>,
-        getContent: (ApplicationAttachment) -> ByteArray,
+        attachments: List<ApplicationAttachmentMetadata>,
+        getContent: (ApplicationAttachmentMetadata) -> ByteArray,
     ) = runBlocking {
         val semaphore = Semaphore(properties.concurrentUploads)
         withContext(ioDispatcher) {

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/CableReportService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/CableReportService.kt
@@ -1,7 +1,7 @@
 package fi.hel.haitaton.hanke.allu
 
 import fi.hel.haitaton.hanke.application.ApplicationDecisionNotFoundException
-import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentEntity
+import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachment
 import java.time.Duration.ofSeconds
 import java.time.ZonedDateTime
 import kotlinx.coroutines.CoroutineDispatcher
@@ -179,8 +179,8 @@ class CableReportService(
     /** Send many attachments in parallel. */
     fun addAttachments(
         alluApplicationId: Int,
-        attachments: List<ApplicationAttachmentEntity>,
-        getContent: (ApplicationAttachmentEntity) -> ByteArray,
+        attachments: List<ApplicationAttachment>,
+        getContent: (ApplicationAttachment) -> ByteArray,
     ) = runBlocking {
         val semaphore = Semaphore(properties.concurrentUploads)
         withContext(ioDispatcher) {
@@ -396,7 +396,16 @@ data class LoginInfo(val username: String, val password: String)
 data class Attachment(
     val metadata: AttachmentMetadata,
     @Suppress("ArrayInDataClass") val file: ByteArray
-)
+) {
+    constructor(
+        contentType: String,
+        fileName: String,
+        content: ByteArray
+    ) : this(
+        AttachmentMetadata(id = null, mimeType = contentType, name = fileName, description = null),
+        content
+    )
+}
 
 class AlluException(val errors: List<ErrorInfo>) : RuntimeException()
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentContentService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentContentService.kt
@@ -3,7 +3,7 @@ package fi.hel.haitaton.hanke.attachment.application
 import fi.hel.haitaton.hanke.attachment.azure.Container
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentContentEntity
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentContentRepository
-import fi.hel.haitaton.hanke.attachment.common.Attachment
+import fi.hel.haitaton.hanke.attachment.common.AttachmentMetadata
 import fi.hel.haitaton.hanke.attachment.common.AttachmentNotFoundException
 import fi.hel.haitaton.hanke.attachment.common.DownloadNotFoundException
 import fi.hel.haitaton.hanke.attachment.common.FileClient
@@ -23,7 +23,7 @@ class ApplicationAttachmentContentService(
         contentRepository.save(ApplicationAttachmentContentEntity(attachmentId, content))
     }
 
-    fun find(attachment: Attachment): ByteArray =
+    fun find(attachment: AttachmentMetadata): ByteArray =
         attachment.blobLocation?.let { readFromFile(it, attachment.id) }
             ?: readFromDatabase(attachment.id)
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentContentService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentContentService.kt
@@ -3,7 +3,7 @@ package fi.hel.haitaton.hanke.attachment.application
 import fi.hel.haitaton.hanke.attachment.azure.Container
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentContentEntity
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentContentRepository
-import fi.hel.haitaton.hanke.attachment.common.AttachmentEntity
+import fi.hel.haitaton.hanke.attachment.common.Attachment
 import fi.hel.haitaton.hanke.attachment.common.AttachmentNotFoundException
 import fi.hel.haitaton.hanke.attachment.common.DownloadNotFoundException
 import fi.hel.haitaton.hanke.attachment.common.FileClient
@@ -23,9 +23,9 @@ class ApplicationAttachmentContentService(
         contentRepository.save(ApplicationAttachmentContentEntity(attachmentId, content))
     }
 
-    fun find(attachment: AttachmentEntity): ByteArray =
-        attachment.blobLocation?.let { readFromFile(it, attachment.id!!) }
-            ?: readFromDatabase(attachment.id!!)
+    fun find(attachment: Attachment): ByteArray =
+        attachment.blobLocation?.let { readFromFile(it, attachment.id) }
+            ?: readFromDatabase(attachment.id)
 
     fun readFromFile(location: String, attachmentId: UUID): ByteArray {
         return try {

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentController.kt
@@ -1,7 +1,7 @@
 package fi.hel.haitaton.hanke.attachment.application
 
 import fi.hel.haitaton.hanke.HankeError
-import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentMetadata
+import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentMetadataDto
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType
 import fi.hel.haitaton.hanke.attachment.common.HeadersBuilder.buildHeaders
 import io.swagger.v3.oas.annotations.Operation
@@ -47,7 +47,7 @@ class ApplicationAttachmentController(
     @PreAuthorize("@applicationAuthorizer.authorizeApplicationId(#applicationId, 'VIEW')")
     fun getApplicationAttachments(
         @PathVariable applicationId: Long
-    ): List<ApplicationAttachmentMetadata> {
+    ): List<ApplicationAttachmentMetadataDto> {
         return applicationAttachmentService.getMetadataList(applicationId)
     }
 
@@ -112,7 +112,7 @@ class ApplicationAttachmentController(
         @PathVariable applicationId: Long,
         @RequestParam("tyyppi") tyyppi: ApplicationAttachmentType,
         @RequestParam("liite") attachment: MultipartFile
-    ): ApplicationAttachmentMetadata {
+    ): ApplicationAttachmentMetadataDto {
         return applicationAttachmentService.addAttachment(applicationId, tyyppi, attachment)
     }
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentMetadataService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentMetadataService.kt
@@ -1,9 +1,9 @@
 package fi.hel.haitaton.hanke.attachment.application
 
 import fi.hel.haitaton.hanke.ALLOWED_ATTACHMENT_COUNT
-import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachment
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentEntity
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentMetadata
+import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentMetadataDto
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentRepository
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType
 import fi.hel.haitaton.hanke.attachment.common.AttachmentLimitReachedException
@@ -23,15 +23,15 @@ class ApplicationAttachmentMetadataService(
     private val attachmentRepository: ApplicationAttachmentRepository,
 ) {
     @Transactional(readOnly = true)
-    fun getMetadataList(applicationId: Long): List<ApplicationAttachmentMetadata> =
+    fun getMetadataList(applicationId: Long): List<ApplicationAttachmentMetadataDto> =
         attachmentRepository.findByApplicationId(applicationId).map { it.toDto() }
 
     @Transactional(readOnly = true)
-    fun findAttachment(attachmentId: UUID): ApplicationAttachment =
+    fun findAttachment(attachmentId: UUID): ApplicationAttachmentMetadata =
         findAttachmentEntity(attachmentId).toDomain()
 
     @Transactional(readOnly = true)
-    fun findByApplicationId(applicationId: Long): List<ApplicationAttachment> =
+    fun findByApplicationId(applicationId: Long): List<ApplicationAttachmentMetadata> =
         attachmentRepository.findByApplicationId(applicationId).map { it.toDomain() }
 
     @Transactional
@@ -40,7 +40,7 @@ class ApplicationAttachmentMetadataService(
         contentType: String,
         attachmentType: ApplicationAttachmentType,
         applicationId: Long
-    ): ApplicationAttachment {
+    ): ApplicationAttachmentMetadata {
         val entity =
             ApplicationAttachmentEntity(
                 id = null,

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentMetadataService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentMetadataService.kt
@@ -1,0 +1,87 @@
+package fi.hel.haitaton.hanke.attachment.application
+
+import fi.hel.haitaton.hanke.ALLOWED_ATTACHMENT_COUNT
+import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachment
+import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentEntity
+import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentMetadata
+import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentRepository
+import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType
+import fi.hel.haitaton.hanke.attachment.common.AttachmentLimitReachedException
+import fi.hel.haitaton.hanke.attachment.common.AttachmentNotFoundException
+import fi.hel.haitaton.hanke.currentUserId
+import java.time.OffsetDateTime
+import java.util.UUID
+import mu.KotlinLogging
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+private val logger = KotlinLogging.logger {}
+
+@Service
+class ApplicationAttachmentMetadataService(
+    private val attachmentRepository: ApplicationAttachmentRepository,
+) {
+    @Transactional(readOnly = true)
+    fun getMetadataList(applicationId: Long): List<ApplicationAttachmentMetadata> =
+        attachmentRepository.findByApplicationId(applicationId).map { it.toDto() }
+
+    @Transactional(readOnly = true)
+    fun findAttachment(attachmentId: UUID): ApplicationAttachment =
+        findAttachmentEntity(attachmentId).toDomain()
+
+    @Transactional(readOnly = true)
+    fun findByApplicationId(applicationId: Long): List<ApplicationAttachment> =
+        attachmentRepository.findByApplicationId(applicationId).map { it.toDomain() }
+
+    @Transactional
+    fun create(
+        filename: String,
+        contentType: String,
+        attachmentType: ApplicationAttachmentType,
+        applicationId: Long
+    ): ApplicationAttachment {
+        val entity =
+            ApplicationAttachmentEntity(
+                id = null,
+                fileName = filename,
+                contentType = contentType,
+                blobLocation = null,
+                createdByUserId = currentUserId(),
+                createdAt = OffsetDateTime.now(),
+                attachmentType = attachmentType,
+                applicationId = applicationId,
+            )
+        return attachmentRepository.save(entity).toDomain()
+    }
+
+    @Transactional
+    fun deleteAttachmentById(attachmentId: UUID) {
+        attachmentRepository.deleteById(attachmentId)
+    }
+
+    @Transactional(readOnly = true)
+    fun ensureRoomForAttachment(applicationId: Long) {
+        if (attachmentAmountReached(applicationId)) {
+            logger.warn {
+                "Application $applicationId has reached the allowed amount of attachments."
+            }
+            throw AttachmentLimitReachedException(applicationId, ALLOWED_ATTACHMENT_COUNT)
+        }
+    }
+
+    private fun findAttachmentEntity(attachmentId: UUID): ApplicationAttachmentEntity =
+        attachmentRepository.findByIdOrNull(attachmentId)
+            ?: throw AttachmentNotFoundException(attachmentId)
+
+    private fun attachmentAmountReached(applicationId: Long): Boolean {
+        val attachmentCount = attachmentRepository.countByApplicationId(applicationId)
+        logger.info {
+            "Application $applicationId contains $attachmentCount attachments beforehand."
+        }
+        return attachmentCount >= ALLOWED_ATTACHMENT_COUNT
+    }
+}
+
+class ApplicationInAlluException(id: Long?, alluId: Int?) :
+    RuntimeException("Application is already sent to Allu, applicationId=$id, alluId=$alluId")

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentService.kt
@@ -9,7 +9,7 @@ import fi.hel.haitaton.hanke.application.Application
 import fi.hel.haitaton.hanke.application.ApplicationAlreadyProcessingException
 import fi.hel.haitaton.hanke.application.ApplicationNotFoundException
 import fi.hel.haitaton.hanke.application.ApplicationRepository
-import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentMetadata
+import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentMetadataDto
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType
 import fi.hel.haitaton.hanke.attachment.common.AttachmentContent
 import fi.hel.haitaton.hanke.attachment.common.AttachmentInvalidException
@@ -32,7 +32,7 @@ class ApplicationAttachmentService(
     private val attachmentContentService: ApplicationAttachmentContentService,
     private val scanClient: FileScanClient,
 ) {
-    fun getMetadataList(applicationId: Long): List<ApplicationAttachmentMetadata> =
+    fun getMetadataList(applicationId: Long): List<ApplicationAttachmentMetadataDto> =
         metadataService.getMetadataList(applicationId)
 
     fun getContent(attachmentId: UUID): AttachmentContent {
@@ -50,7 +50,7 @@ class ApplicationAttachmentService(
         applicationId: Long,
         attachmentType: ApplicationAttachmentType,
         attachment: MultipartFile
-    ): ApplicationAttachmentMetadata {
+    ): ApplicationAttachmentMetadataDto {
         logger.info {
             "Adding attachment to application, applicationId = $applicationId, " +
                 "attachment name = ${attachment.originalFilename}, size = ${attachment.bytes.size}, " +

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentService.kt
@@ -1,33 +1,25 @@
 package fi.hel.haitaton.hanke.attachment.application
 
-import fi.hel.haitaton.hanke.ALLOWED_ATTACHMENT_COUNT
 import fi.hel.haitaton.hanke.allu.ApplicationStatus
 import fi.hel.haitaton.hanke.allu.ApplicationStatus.PENDING
 import fi.hel.haitaton.hanke.allu.ApplicationStatus.PENDING_CLIENT
+import fi.hel.haitaton.hanke.allu.Attachment as AlluAttachment
 import fi.hel.haitaton.hanke.allu.CableReportService
+import fi.hel.haitaton.hanke.application.Application
 import fi.hel.haitaton.hanke.application.ApplicationAlreadyProcessingException
-import fi.hel.haitaton.hanke.application.ApplicationEntity
 import fi.hel.haitaton.hanke.application.ApplicationNotFoundException
 import fi.hel.haitaton.hanke.application.ApplicationRepository
-import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentEntity
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentMetadata
-import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentRepository
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType
 import fi.hel.haitaton.hanke.attachment.common.AttachmentContent
 import fi.hel.haitaton.hanke.attachment.common.AttachmentInvalidException
-import fi.hel.haitaton.hanke.attachment.common.AttachmentLimitReachedException
-import fi.hel.haitaton.hanke.attachment.common.AttachmentNotFoundException
 import fi.hel.haitaton.hanke.attachment.common.AttachmentValidator
 import fi.hel.haitaton.hanke.attachment.common.FileScanClient
 import fi.hel.haitaton.hanke.attachment.common.FileScanInput
 import fi.hel.haitaton.hanke.attachment.common.hasInfected
-import fi.hel.haitaton.hanke.currentUserId
-import java.time.OffsetDateTime.now
 import java.util.UUID
 import mu.KotlinLogging
-import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
-import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.multipart.MultipartFile
 
 private val logger = KotlinLogging.logger {}
@@ -35,18 +27,16 @@ private val logger = KotlinLogging.logger {}
 @Service
 class ApplicationAttachmentService(
     private val cableReportService: CableReportService,
+    private val metadataService: ApplicationAttachmentMetadataService,
     private val applicationRepository: ApplicationRepository,
-    private val attachmentRepository: ApplicationAttachmentRepository,
     private val attachmentContentService: ApplicationAttachmentContentService,
     private val scanClient: FileScanClient,
 ) {
-    @Transactional(readOnly = true)
     fun getMetadataList(applicationId: Long): List<ApplicationAttachmentMetadata> =
-        attachmentRepository.findByApplicationId(applicationId).map { it.toDto() }
+        metadataService.getMetadataList(applicationId)
 
-    @Transactional(readOnly = true)
     fun getContent(attachmentId: UUID): AttachmentContent {
-        val attachment = findAttachment(attachmentId)
+        val attachment = metadataService.findAttachment(attachmentId)
         val content = attachmentContentService.find(attachment)
 
         return AttachmentContent(attachment.fileName, attachment.contentType, content)
@@ -56,7 +46,6 @@ class ApplicationAttachmentService(
      * Attachment can be added if application has not proceeded to HANDLING or later status. It will
      * be sent immediately if application is in Allu (alluId present).
      */
-    @Transactional
     fun addAttachment(
         applicationId: Long,
         attachmentType: ApplicationAttachmentType,
@@ -68,42 +57,36 @@ class ApplicationAttachmentService(
                 "content type = ${attachment.contentType}"
         }
         val filename = AttachmentValidator.validFilename(attachment.originalFilename)
-        val application =
-            findApplication(applicationId).also { application ->
-                ensureApplicationIsPending(application)
-                ensureRoomForAttachment(applicationId)
-                ensureContentTypeIsSet(attachment.contentType)
-                scanAttachment(filename, attachment.bytes)
+        val application = findApplication(applicationId)
+
+        ensureApplicationIsPending(application)
+        val contentType = ensureContentTypeIsSet(attachment.contentType)
+        scanAttachment(filename, attachment.bytes)
+        metadataService.ensureRoomForAttachment(applicationId)
+
+        val newAttachment =
+            metadataService.create(filename, contentType, attachmentType, applicationId)
+        attachmentContentService.save(newAttachment.id, attachment.bytes)
+
+        try {
+            application.alluid?.let {
+                val alluAttachment = AlluAttachment(contentType, filename, attachment.bytes)
+                cableReportService.addAttachment(it, alluAttachment)
             }
-
-        val entity =
-            ApplicationAttachmentEntity(
-                id = null,
-                fileName = filename,
-                contentType = attachment.contentType!!,
-                blobLocation = null,
-                createdByUserId = currentUserId(),
-                createdAt = now(),
-                attachmentType = attachmentType,
-                applicationId = application.id!!,
-            )
-
-        val newAttachment = attachmentRepository.save(entity)
-        attachmentContentService.save(newAttachment.id!!, attachment.bytes)
-
-        application.alluid?.let {
-            cableReportService.addAttachment(it, newAttachment.toAlluAttachment(attachment.bytes))
+        } catch (e: Exception) {
+            logger.error(e) { "Allu upload failed, deleting attachment from DB." }
+            // No Blob upload yet, content will be deleted by SQL cascade
+            metadataService.deleteAttachmentById(newAttachment.id)
+            throw e
         }
 
-        return newAttachment.toDto().also {
-            logger.info { "Added attachment ${it.id} to application $applicationId" }
-        }
+        logger.info { "Added attachment ${newAttachment.id} to application $applicationId" }
+        return newAttachment.toDto()
     }
 
     /** Attachment can be deleted if the application has not been sent to Allu (alluId null). */
-    @Transactional
     fun deleteAttachment(attachmentId: UUID) {
-        val attachment = findAttachment(attachmentId)
+        val attachment = metadataService.findAttachment(attachmentId)
         val application = findApplication(attachment.applicationId)
 
         if (isInAllu(application)) {
@@ -113,14 +96,13 @@ class ApplicationAttachmentService(
             throw ApplicationInAlluException(application.id, application.alluid)
         }
 
-        attachmentRepository.deleteById(attachment.id!!)
+        metadataService.deleteAttachmentById(attachment.id)
         logger.info { "Deleted application attachment ${attachment.id}" }
     }
 
-    @Transactional(readOnly = true)
     fun sendInitialAttachments(alluId: Int, applicationId: Long) {
         logger.info { "Sending initial attachments for application, alluid=$alluId" }
-        val attachments = attachmentRepository.findByApplicationId(applicationId)
+        val attachments = metadataService.findByApplicationId(applicationId)
         if (attachments.isEmpty()) {
             logger.info { "No attachments to send for alluId $alluId" }
             return
@@ -129,14 +111,11 @@ class ApplicationAttachmentService(
         cableReportService.addAttachments(alluId, attachments) { attachmentContentService.find(it) }
     }
 
-    private fun findAttachment(attachmentId: UUID): ApplicationAttachmentEntity =
-        attachmentRepository.findByIdOrNull(attachmentId)
-            ?: throw AttachmentNotFoundException(attachmentId)
-
-    private fun findApplication(applicationId: Long): ApplicationEntity =
-        applicationRepository.findById(applicationId).orElseThrow {
-            ApplicationNotFoundException(applicationId)
-        }
+    private fun findApplication(applicationId: Long): Application =
+        applicationRepository
+            .findById(applicationId)
+            .orElseThrow { ApplicationNotFoundException(applicationId) }
+            .toApplication()
 
     private fun scanAttachment(filename: String, content: ByteArray) {
         val scanResult = scanClient.scan(listOf(FileScanInput(filename, content)))
@@ -145,25 +124,15 @@ class ApplicationAttachmentService(
         }
     }
 
-    private fun ensureApplicationIsPending(application: ApplicationEntity) {
+    private fun ensureApplicationIsPending(application: Application) {
         if (!isPending(application.alluid, application.alluStatus)) {
             logger.warn { "Application is processing, cannot add attachment." }
             throw ApplicationAlreadyProcessingException(application.id, application.alluid)
         }
     }
 
-    private fun ensureRoomForAttachment(applicationId: Long) {
-        if (attachmentAmountReached(applicationId)) {
-            logger.warn {
-                "Application $applicationId has reached the allowed amount of attachments."
-            }
-            throw AttachmentLimitReachedException(applicationId, ALLOWED_ATTACHMENT_COUNT)
-        }
-    }
-
-    private fun ensureContentTypeIsSet(contentType: String?) {
+    private fun ensureContentTypeIsSet(contentType: String?): String =
         contentType ?: throw AttachmentInvalidException("Content-type was not set")
-    }
 
     /** Application considered pending if no alluId or status null, pending, or pending_client. */
     private fun isPending(alluId: Int?, alluStatus: ApplicationStatus?): Boolean {
@@ -182,16 +151,5 @@ class ApplicationAttachmentService(
         return listOf(PENDING, PENDING_CLIENT).contains(status)
     }
 
-    private fun isInAllu(application: ApplicationEntity): Boolean = application.alluid != null
-
-    private fun attachmentAmountReached(applicationId: Long): Boolean {
-        val attachmentCount = attachmentRepository.countByApplicationId(applicationId)
-        logger.info {
-            "Application $applicationId contains $attachmentCount attachments beforehand."
-        }
-        return attachmentCount >= ALLOWED_ATTACHMENT_COUNT
-    }
+    private fun isInAllu(application: Application): Boolean = application.alluid != null
 }
-
-class ApplicationInAlluException(id: Long?, alluId: Int?) :
-    RuntimeException("Application is already sent to Allu, applicationId=$id, alluId=$alluId")

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/common/AttachmentEntity.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/common/AttachmentEntity.kt
@@ -1,8 +1,6 @@
 package fi.hel.haitaton.hanke.attachment.common
 
 import fi.hel.haitaton.hanke.HankeEntity
-import fi.hel.haitaton.hanke.allu.Attachment
-import fi.hel.haitaton.hanke.allu.AttachmentMetadata
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
@@ -64,7 +62,7 @@ class HankeAttachmentEntity(
     blobLocation: String?,
     @ManyToOne(fetch = FetchType.LAZY) @JoinColumn(name = "hanke_id") var hanke: HankeEntity,
 ) : AttachmentEntity(id, fileName, contentType, createdByUserId, createdAt, blobLocation) {
-    fun toDomain(): HankeAttachment {
+    fun toDto(): HankeAttachment {
         return HankeAttachment(
             id = id!!,
             fileName = fileName,
@@ -116,18 +114,17 @@ class ApplicationAttachmentEntity(
         )
     }
 
-    fun toAlluAttachment(content: ByteArray): Attachment {
-        return Attachment(
-            metadata =
-                AttachmentMetadata(
-                    id = null,
-                    mimeType = contentType,
-                    name = fileName,
-                    description = null,
-                ),
-            file = content
+    fun toDomain(): ApplicationAttachment =
+        ApplicationAttachment(
+            id!!,
+            fileName,
+            contentType,
+            createdByUserId,
+            createdAt,
+            blobLocation,
+            applicationId,
+            attachmentType,
         )
-    }
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/common/AttachmentEntity.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/common/AttachmentEntity.kt
@@ -62,8 +62,8 @@ class HankeAttachmentEntity(
     blobLocation: String?,
     @ManyToOne(fetch = FetchType.LAZY) @JoinColumn(name = "hanke_id") var hanke: HankeEntity,
 ) : AttachmentEntity(id, fileName, contentType, createdByUserId, createdAt, blobLocation) {
-    fun toDto(): HankeAttachment {
-        return HankeAttachment(
+    fun toDto(): HankeAttachmentMetadataDto {
+        return HankeAttachmentMetadataDto(
             id = id!!,
             fileName = fileName,
             createdAt = createdAt,
@@ -103,8 +103,8 @@ class ApplicationAttachmentEntity(
     @Column(name = "attachment_type")
     var attachmentType: ApplicationAttachmentType,
 ) : AttachmentEntity(id, fileName, contentType, createdByUserId, createdAt, blobLocation) {
-    fun toDto(): ApplicationAttachmentMetadata {
-        return ApplicationAttachmentMetadata(
+    fun toDto(): ApplicationAttachmentMetadataDto {
+        return ApplicationAttachmentMetadataDto(
             id = id!!,
             fileName = fileName,
             createdAt = createdAt,
@@ -114,16 +114,16 @@ class ApplicationAttachmentEntity(
         )
     }
 
-    fun toDomain(): ApplicationAttachment =
-        ApplicationAttachment(
-            id!!,
-            fileName,
-            contentType,
-            createdByUserId,
-            createdAt,
-            blobLocation,
-            applicationId,
-            attachmentType,
+    fun toDomain(): ApplicationAttachmentMetadata =
+        ApplicationAttachmentMetadata(
+            id = id!!,
+            fileName = fileName,
+            contentType = contentType,
+            createdByUserId = createdByUserId,
+            createdAt = createdAt,
+            blobLocation = blobLocation,
+            applicationId = applicationId,
+            attachmentType = attachmentType,
         )
 
     override fun equals(other: Any?): Boolean {

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/common/AttachmentUploadService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/common/AttachmentUploadService.kt
@@ -17,7 +17,7 @@ class AttachmentUploadService(
     fun uploadHankeAttachment(
         hankeTunnus: String,
         attachment: MultipartFile,
-    ): HankeAttachment {
+    ): HankeAttachmentMetadataDto {
         val hanke = hankeAttachmentService.hankeWithRoomForAttachment(hankeTunnus)
 
         val (filename, mediatype) = attachment.validNameAndType()

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/common/Domain.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/common/Domain.kt
@@ -1,0 +1,50 @@
+package fi.hel.haitaton.hanke.attachment.common
+
+import fi.hel.haitaton.hanke.allu.Attachment as AlluAttachment
+import fi.hel.haitaton.hanke.allu.AttachmentMetadata
+import java.time.OffsetDateTime
+import java.util.UUID
+
+sealed interface Attachment {
+    val id: UUID
+    val fileName: String
+    val contentType: String
+    val createdByUserId: String
+    val createdAt: OffsetDateTime
+    val blobLocation: String?
+}
+
+data class ApplicationAttachment(
+    override val id: UUID,
+    override val fileName: String,
+    override val contentType: String,
+    override val createdByUserId: String,
+    override val createdAt: OffsetDateTime,
+    override val blobLocation: String?,
+    val applicationId: Long,
+    val attachmentType: ApplicationAttachmentType,
+) : Attachment {
+    fun toDto(): ApplicationAttachmentMetadata {
+        return ApplicationAttachmentMetadata(
+            id = id,
+            fileName = fileName,
+            createdAt = createdAt,
+            createdByUserId = createdByUserId,
+            applicationId = applicationId,
+            attachmentType = attachmentType,
+        )
+    }
+
+    fun toAlluAttachment(content: ByteArray): AlluAttachment {
+        return AlluAttachment(
+            metadata =
+                AttachmentMetadata(
+                    id = null,
+                    mimeType = contentType,
+                    name = fileName,
+                    description = null,
+                ),
+            file = content
+        )
+    }
+}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/common/Domain.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/common/Domain.kt
@@ -1,11 +1,11 @@
 package fi.hel.haitaton.hanke.attachment.common
 
 import fi.hel.haitaton.hanke.allu.Attachment as AlluAttachment
-import fi.hel.haitaton.hanke.allu.AttachmentMetadata
+import fi.hel.haitaton.hanke.allu.AttachmentMetadata as AlluAttachmentMetadata
 import java.time.OffsetDateTime
 import java.util.UUID
 
-sealed interface Attachment {
+sealed interface AttachmentMetadata {
     val id: UUID
     val fileName: String
     val contentType: String
@@ -14,7 +14,7 @@ sealed interface Attachment {
     val blobLocation: String?
 }
 
-data class ApplicationAttachment(
+data class ApplicationAttachmentMetadata(
     override val id: UUID,
     override val fileName: String,
     override val contentType: String,
@@ -23,9 +23,9 @@ data class ApplicationAttachment(
     override val blobLocation: String?,
     val applicationId: Long,
     val attachmentType: ApplicationAttachmentType,
-) : Attachment {
-    fun toDto(): ApplicationAttachmentMetadata {
-        return ApplicationAttachmentMetadata(
+) : AttachmentMetadata {
+    fun toDto(): ApplicationAttachmentMetadataDto {
+        return ApplicationAttachmentMetadataDto(
             id = id,
             fileName = fileName,
             createdAt = createdAt,
@@ -38,7 +38,7 @@ data class ApplicationAttachment(
     fun toAlluAttachment(content: ByteArray): AlluAttachment {
         return AlluAttachment(
             metadata =
-                AttachmentMetadata(
+                AlluAttachmentMetadata(
                     id = null,
                     mimeType = contentType,
                     name = fileName,
@@ -48,3 +48,15 @@ data class ApplicationAttachment(
         )
     }
 }
+
+data class AttachmentContent(
+    val fileName: String,
+    val contentType: String,
+    @Suppress("ArrayInDataClass") val bytes: ByteArray
+)
+
+data class HankeAttachmentWithContent(
+    val id: UUID,
+    val hankeId: Int,
+    val content: AttachmentContent
+)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/common/Dto.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/common/Dto.kt
@@ -3,7 +3,7 @@ package fi.hel.haitaton.hanke.attachment.common
 import java.time.OffsetDateTime
 import java.util.UUID
 
-data class HankeAttachment(
+data class HankeAttachmentMetadataDto(
     val id: UUID,
     val fileName: String,
     val createdByUserId: String,
@@ -11,23 +11,11 @@ data class HankeAttachment(
     val hankeTunnus: String,
 )
 
-data class ApplicationAttachmentMetadata(
+data class ApplicationAttachmentMetadataDto(
     val id: UUID,
     val fileName: String,
     val createdByUserId: String,
     val createdAt: OffsetDateTime,
     val applicationId: Long,
     val attachmentType: ApplicationAttachmentType,
-)
-
-data class AttachmentContent(
-    val fileName: String,
-    val contentType: String,
-    @Suppress("ArrayInDataClass") val bytes: ByteArray
-)
-
-data class HankeAttachmentWithContent(
-    val id: UUID,
-    val hankeId: Int,
-    val content: AttachmentContent
 )

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentController.kt
@@ -2,7 +2,7 @@ package fi.hel.haitaton.hanke.attachment.hanke
 
 import fi.hel.haitaton.hanke.HankeError
 import fi.hel.haitaton.hanke.attachment.common.AttachmentUploadService
-import fi.hel.haitaton.hanke.attachment.common.HankeAttachment
+import fi.hel.haitaton.hanke.attachment.common.HankeAttachmentMetadataDto
 import fi.hel.haitaton.hanke.attachment.common.HeadersBuilder.buildHeaders
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
@@ -47,7 +47,7 @@ class HankeAttachmentController(
             ]
     )
     @PreAuthorize("@hankeAttachmentAuthorizer.authorizeHankeTunnus(#hankeTunnus,'VIEW')")
-    fun getMetadataList(@PathVariable hankeTunnus: String): List<HankeAttachment> {
+    fun getMetadataList(@PathVariable hankeTunnus: String): List<HankeAttachmentMetadataDto> {
         return hankeAttachmentService.getMetadataList(hankeTunnus)
     }
 
@@ -103,7 +103,7 @@ class HankeAttachmentController(
     fun postAttachment(
         @PathVariable hankeTunnus: String,
         @RequestParam("liite") attachment: MultipartFile,
-    ): HankeAttachment {
+    ): HankeAttachmentMetadataDto {
         logger.info {
             "Adding attachment to hanke, hankeTunnus = $hankeTunnus, " +
                 "attachment name = ${attachment.originalFilename}, size = ${attachment.bytes.size}, " +

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentService.kt
@@ -29,7 +29,7 @@ class HankeAttachmentService(
 
     @Transactional(readOnly = true)
     fun getMetadataList(hankeTunnus: String): List<HankeAttachment> =
-        findHanke(hankeTunnus).liitteet.map { it.toDomain() }
+        findHanke(hankeTunnus).liitteet.map { it.toDto() }
 
     @Transactional(readOnly = true)
     fun getContent(attachmentId: UUID): AttachmentContent {
@@ -60,7 +60,7 @@ class HankeAttachmentService(
                     hanke = hanke,
                 )
             )
-            .toDomain()
+            .toDto()
     }
 
     @Transactional

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentService.kt
@@ -7,8 +7,8 @@ import fi.hel.haitaton.hanke.HankeRepository
 import fi.hel.haitaton.hanke.attachment.common.AttachmentContent
 import fi.hel.haitaton.hanke.attachment.common.AttachmentInvalidException
 import fi.hel.haitaton.hanke.attachment.common.AttachmentNotFoundException
-import fi.hel.haitaton.hanke.attachment.common.HankeAttachment
 import fi.hel.haitaton.hanke.attachment.common.HankeAttachmentEntity
+import fi.hel.haitaton.hanke.attachment.common.HankeAttachmentMetadataDto
 import fi.hel.haitaton.hanke.attachment.common.HankeAttachmentRepository
 import fi.hel.haitaton.hanke.currentUserId
 import java.time.OffsetDateTime
@@ -28,7 +28,7 @@ class HankeAttachmentService(
 ) {
 
     @Transactional(readOnly = true)
-    fun getMetadataList(hankeTunnus: String): List<HankeAttachment> =
+    fun getMetadataList(hankeTunnus: String): List<HankeAttachmentMetadataDto> =
         findHanke(hankeTunnus).liitteet.map { it.toDto() }
 
     @Transactional(readOnly = true)
@@ -45,7 +45,7 @@ class HankeAttachmentService(
         name: String,
         type: String,
         blobPath: String,
-    ): HankeAttachment {
+    ): HankeAttachmentMetadataDto {
         val hanke = findHanke(hankeTunnus).also { checkRoomForAttachment(it.id) }
 
         return attachmentRepository

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/ApplicationAttachmentFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/ApplicationAttachmentFactory.kt
@@ -7,6 +7,7 @@ import fi.hel.haitaton.hanke.attachment.FILE_NAME_PDF
 import fi.hel.haitaton.hanke.attachment.USERNAME
 import fi.hel.haitaton.hanke.attachment.application.ApplicationAttachmentContentService
 import fi.hel.haitaton.hanke.attachment.azure.Container.HAKEMUS_LIITTEET
+import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachment
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentContentEntity
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentContentRepository
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentEntity
@@ -84,6 +85,27 @@ class ApplicationAttachmentFactory(
         val CREATED_AT: OffsetDateTime = OffsetDateTime.parse("2023-11-09T10:03:55+02:00")
 
         const val FILE_NAME = "file.pdf"
+
+        fun create(
+            id: UUID = defaultAttachmentId,
+            fileName: String = FILE_NAME,
+            contentType: String = APPLICATION_PDF_VALUE,
+            blobLocation: String? = null,
+            createdByUserId: String = USERNAME,
+            createdAt: OffsetDateTime = CREATED_AT,
+            attachmentType: ApplicationAttachmentType = MUU,
+            applicationId: Long = AlluDataFactory.defaultApplicationId,
+        ): ApplicationAttachment =
+            ApplicationAttachment(
+                id = id,
+                fileName = fileName,
+                contentType = contentType,
+                blobLocation = blobLocation,
+                createdByUserId = createdByUserId,
+                createdAt = createdAt,
+                attachmentType = attachmentType,
+                applicationId = applicationId,
+            )
 
         fun createEntity(
             id: UUID? = defaultAttachmentId,

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/ApplicationAttachmentFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/ApplicationAttachmentFactory.kt
@@ -7,11 +7,11 @@ import fi.hel.haitaton.hanke.attachment.FILE_NAME_PDF
 import fi.hel.haitaton.hanke.attachment.USERNAME
 import fi.hel.haitaton.hanke.attachment.application.ApplicationAttachmentContentService
 import fi.hel.haitaton.hanke.attachment.azure.Container.HAKEMUS_LIITTEET
-import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachment
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentContentEntity
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentContentRepository
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentEntity
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentMetadata
+import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentMetadataDto
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentRepository
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType.MUU
@@ -95,8 +95,8 @@ class ApplicationAttachmentFactory(
             createdAt: OffsetDateTime = CREATED_AT,
             attachmentType: ApplicationAttachmentType = MUU,
             applicationId: Long = AlluDataFactory.defaultApplicationId,
-        ): ApplicationAttachment =
-            ApplicationAttachment(
+        ): ApplicationAttachmentMetadata =
+            ApplicationAttachmentMetadata(
                 id = id,
                 fileName = fileName,
                 contentType = contentType,
@@ -135,8 +135,8 @@ class ApplicationAttachmentFactory(
             createdAt: OffsetDateTime = OffsetDateTime.now(),
             applicationId: Long = 1L,
             attachmentType: ApplicationAttachmentType = MUU,
-        ): ApplicationAttachmentMetadata =
-            ApplicationAttachmentMetadata(
+        ): ApplicationAttachmentMetadataDto =
+            ApplicationAttachmentMetadataDto(
                 id = attachmentId,
                 fileName = fileName,
                 createdByUserId = createdBy,

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeAttachmentFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeAttachmentFactory.kt
@@ -7,10 +7,10 @@ import fi.hel.haitaton.hanke.attachment.FILE_NAME_PDF
 import fi.hel.haitaton.hanke.attachment.USERNAME
 import fi.hel.haitaton.hanke.attachment.azure.Container.HANKE_LIITTEET
 import fi.hel.haitaton.hanke.attachment.common.FileClient
-import fi.hel.haitaton.hanke.attachment.common.HankeAttachment
 import fi.hel.haitaton.hanke.attachment.common.HankeAttachmentContentEntity
 import fi.hel.haitaton.hanke.attachment.common.HankeAttachmentContentRepository
 import fi.hel.haitaton.hanke.attachment.common.HankeAttachmentEntity
+import fi.hel.haitaton.hanke.attachment.common.HankeAttachmentMetadataDto
 import fi.hel.haitaton.hanke.attachment.common.HankeAttachmentRepository
 import fi.hel.haitaton.hanke.currentUserId
 import java.time.OffsetDateTime
@@ -69,14 +69,14 @@ class HankeAttachmentFactory(
         val CONTENT_TYPE = MEDIA_TYPE.toString()
         val CREATED_AT: OffsetDateTime = OffsetDateTime.parse("2023-11-09T10:03:55+02:00")
 
-        fun createMetadata(
+        fun createDto(
             attachmentId: UUID = ApplicationAttachmentFactory.defaultAttachmentId,
             fileName: String = ApplicationAttachmentFactory.FILE_NAME,
             createdByUser: String = currentUserId(),
             createdAt: OffsetDateTime = OffsetDateTime.now(),
             hankeTunnus: String = "HAI-1234",
-        ): HankeAttachment =
-            HankeAttachment(
+        ): HankeAttachmentMetadataDto =
+            HankeAttachmentMetadataDto(
                 id = attachmentId,
                 fileName = fileName,
                 createdByUserId = createdByUser,

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeAttachmentFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeAttachmentFactory.kt
@@ -69,7 +69,7 @@ class HankeAttachmentFactory(
         val CONTENT_TYPE = MEDIA_TYPE.toString()
         val CREATED_AT: OffsetDateTime = OffsetDateTime.parse("2023-11-09T10:03:55+02:00")
 
-        fun create(
+        fun createMetadata(
             attachmentId: UUID = ApplicationAttachmentFactory.defaultAttachmentId,
             fileName: String = ApplicationAttachmentFactory.FILE_NAME,
             createdByUser: String = currentUserId(),


### PR DESCRIPTION
# Description

Split DB operations from ApplicationAttachmentService to a new service, ApplicationAttachmentMetadataService. This allows us to do Allu and Blob operations without having a DB transaction running.

ApplicationAttachmentMetadataService is only called from ApplicationAttachmentService, so other services don't have to know the difference between the two.

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [X] Other

# Instructions for testing
Nothing should change.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 