### PR TITLE
HAI-1996 Delete application attachment blobs

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentServiceITest.kt
@@ -116,7 +116,7 @@ class ApplicationAttachmentServiceITest(
         }
 
         @Test
-        fun `Return empty when application doesn't have attachments`() {
+        fun `Returns empty when application doesn't have attachments`() {
             val application = alluDataFactory.saveApplicationEntity(USERNAME)
 
             val result = attachmentService.getMetadataList(application.id!!)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentContentService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentContentService.kt
@@ -23,6 +23,12 @@ class ApplicationAttachmentContentService(
         contentRepository.save(ApplicationAttachmentContentEntity(attachmentId, content))
     }
 
+    fun delete(attachment: AttachmentMetadata) =
+        with(attachment) {
+            logger.info { "Deleting attachment $id if blob defined. Blob=$blobLocation." }
+            blobLocation?.let { fileClient.delete(Container.HAKEMUS_LIITTEET, it) }
+        }
+
     fun find(attachment: AttachmentMetadata): ByteArray =
         attachment.blobLocation?.let { readFromFile(it, attachment.id) }
             ?: readFromDatabase(attachment.id)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentController.kt
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import java.util.UUID
+import mu.KotlinLogging
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.DeleteMapping
@@ -21,6 +22,8 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.multipart.MultipartFile
+
+private val logger = KotlinLogging.logger {}
 
 @RestController
 @RequestMapping("/hakemukset/{applicationId}/liitteet")
@@ -142,6 +145,7 @@ class ApplicationAttachmentController(
         "@applicationAuthorizer.authorizeAttachment(#applicationId, #attachmentId, 'EDIT_APPLICATIONS')"
     )
     fun removeAttachment(@PathVariable applicationId: Long, @PathVariable attachmentId: UUID) {
+        logger.info { "Deleting attachment $attachmentId from application $applicationId." }
         return applicationAttachmentService.deleteAttachment(attachmentId)
     }
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentService.kt
@@ -19,6 +19,7 @@ import fi.hel.haitaton.hanke.attachment.common.FileScanInput
 import fi.hel.haitaton.hanke.attachment.common.hasInfected
 import java.util.UUID
 import mu.KotlinLogging
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.web.multipart.MultipartFile
 
@@ -97,7 +98,9 @@ class ApplicationAttachmentService(
             throw ApplicationInAlluException(application.id, application.alluid)
         }
 
+        attachmentContentService.delete(attachment)
         metadataService.deleteAttachmentById(attachment.id)
+
         logger.info { "Deleted application attachment ${attachment.id}" }
     }
 
@@ -113,10 +116,8 @@ class ApplicationAttachmentService(
     }
 
     private fun findApplication(applicationId: Long): Application =
-        applicationRepository
-            .findById(applicationId)
-            .orElseThrow { ApplicationNotFoundException(applicationId) }
-            .toApplication()
+        applicationRepository.findByIdOrNull(applicationId)?.toApplication()
+            ?: throw ApplicationNotFoundException(applicationId)
 
     private fun scanAttachment(filename: String, content: ByteArray) {
         val scanResult = scanClient.scan(listOf(FileScanInput(filename, content)))


### PR DESCRIPTION
# Description

Add logic to delete application attachment blobs if the blob location is defined.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1996

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [x] Other

# Instructions for testing
The blob upload functionality for applications is not yet implemented. Hence, there is no blobs to delete. The attachment deletion should however work as before from the UI perspective.

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 

# Other relevant info
Please describe here if there is e.g. some requirements for this change or
 other info that the tester/user needs to know.