### PR TITLE
HAI-2209 Removed haitta columns from hanke

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeRepositoryITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeRepositoryITests.kt
@@ -4,11 +4,6 @@ import fi.hel.haitaton.hanke.domain.HankeStatus
 import fi.hel.haitaton.hanke.domain.Hankevaihe
 import fi.hel.haitaton.hanke.domain.TyomaaTyyppi
 import fi.hel.haitaton.hanke.domain.YhteystietoTyyppi.YRITYS
-import fi.hel.haitaton.hanke.tormaystarkastelu.AutoliikenteenKaistavaikutustenPituus
-import fi.hel.haitaton.hanke.tormaystarkastelu.Meluhaitta
-import fi.hel.haitaton.hanke.tormaystarkastelu.Polyhaitta
-import fi.hel.haitaton.hanke.tormaystarkastelu.Tarinahaitta
-import fi.hel.haitaton.hanke.tormaystarkastelu.VaikutusAutoliikenteenKaistamaariin
 import java.time.LocalDateTime
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -43,18 +38,11 @@ internal class HankeRepositoryITests : DatabaseTest() {
     }
 
     @Test
-    fun `basic fields, tyomaa and haitat fields can be round-trip saved and loaded`() {
+    fun `basic fields and tyomaa fields can be round-trip saved and loaded`() {
         val baseHankeEntity = createBaseHankeEntity("ABC-123")
         baseHankeEntity.tyomaaKatuosoite = "katu 1"
         baseHankeEntity.tyomaaTyyppi.add(TyomaaTyyppi.VESI)
         baseHankeEntity.tyomaaTyyppi.add(TyomaaTyyppi.MUU)
-        baseHankeEntity.kaistaHaitta =
-            VaikutusAutoliikenteenKaistamaariin.VAHENTAA_KAISTAN_YHDELLA_AJOSUUNNALLA
-        baseHankeEntity.kaistaPituusHaitta =
-            AutoliikenteenKaistavaikutustenPituus.PITUUS_10_99_METRIA
-        baseHankeEntity.meluHaitta = Meluhaitta.SATUNNAINEN_HAITTA
-        baseHankeEntity.polyHaitta = Polyhaitta.LYHYTAIKAINEN_TOISTUVA_HAITTA
-        baseHankeEntity.tarinaHaitta = Tarinahaitta.PITKAKESTOINEN_TOISTUVA_HAITTA
         hankeRepository.save(baseHankeEntity)
 
         val loadedHanke = hankeRepository.findByHankeTunnus("ABC-123")
@@ -66,13 +54,6 @@ internal class HankeRepositoryITests : DatabaseTest() {
         assertThat(loadedHanke.vaihe).isEqualTo(Hankevaihe.SUUNNITTELU)
         assertThat(loadedHanke.tyomaaKatuosoite).isEqualTo("katu 1")
         assertThat(loadedHanke.tyomaaTyyppi).contains(TyomaaTyyppi.VESI, TyomaaTyyppi.MUU)
-        assertThat(loadedHanke.kaistaHaitta)
-            .isEqualTo(VaikutusAutoliikenteenKaistamaariin.VAHENTAA_KAISTAN_YHDELLA_AJOSUUNNALLA)
-        assertThat(loadedHanke.kaistaPituusHaitta)
-            .isEqualTo(AutoliikenteenKaistavaikutustenPituus.PITUUS_10_99_METRIA)
-        assertThat(loadedHanke.meluHaitta).isEqualTo(Meluhaitta.SATUNNAINEN_HAITTA)
-        assertThat(loadedHanke.polyHaitta).isEqualTo(Polyhaitta.LYHYTAIKAINEN_TOISTUVA_HAITTA)
-        assertThat(loadedHanke.tarinaHaitta).isEqualTo(Tarinahaitta.PITKAKESTOINEN_TOISTUVA_HAITTA)
     }
 
     @Test

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Persistence.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Persistence.kt
@@ -6,12 +6,7 @@ import fi.hel.haitaton.hanke.domain.HankeStatus
 import fi.hel.haitaton.hanke.domain.Hankevaihe
 import fi.hel.haitaton.hanke.domain.HasId
 import fi.hel.haitaton.hanke.domain.TyomaaTyyppi
-import fi.hel.haitaton.hanke.tormaystarkastelu.AutoliikenteenKaistavaikutustenPituus
-import fi.hel.haitaton.hanke.tormaystarkastelu.Meluhaitta
-import fi.hel.haitaton.hanke.tormaystarkastelu.Polyhaitta
-import fi.hel.haitaton.hanke.tormaystarkastelu.Tarinahaitta
 import fi.hel.haitaton.hanke.tormaystarkastelu.TormaystarkasteluTulosEntity
-import fi.hel.haitaton.hanke.tormaystarkastelu.VaikutusAutoliikenteenKaistamaariin
 import jakarta.persistence.CascadeType
 import jakarta.persistence.CollectionTable
 import jakarta.persistence.ElementCollection
@@ -86,15 +81,6 @@ class HankeEntity(
     @CollectionTable(name = "hanketyomaatyyppi", joinColumns = [JoinColumn(name = "hankeid")])
     @Enumerated(EnumType.STRING)
     var tyomaaTyyppi: MutableSet<TyomaaTyyppi> = mutableSetOf()
-
-    // --------------- Hankkeen haitat -------------------
-    // These five fields have generic string values, so can just as well store them with the ordinal
-    // number.
-    var kaistaHaitta: VaikutusAutoliikenteenKaistamaariin? = null
-    var kaistaPituusHaitta: AutoliikenteenKaistavaikutustenPituus? = null
-    var meluHaitta: Meluhaitta? = null
-    var polyHaitta: Polyhaitta? = null
-    var tarinaHaitta: Tarinahaitta? = null
 
     // Made bidirectional relation mainly to allow cascaded delete.
     @OneToMany(

--- a/services/hanke-service/src/main/resources/db/changelog/changesets/063-drop-haitta-columns-from-hanke.yml
+++ b/services/hanke-service/src/main/resources/db/changelog/changesets/063-drop-haitta-columns-from-hanke.yml
@@ -3,24 +3,6 @@ databaseChangeLog:
       id: 063-drop-haitta-columns-from-hanke
       author: Teemu Hiltunen
       comment: Drop haitta columns from hanke
-      preConditions:
-        - onFail: MARK_RAN
-          and:
-            - columnExists:
-                tableName: hanke
-                columnName: kaistahaitta
-            - columnExists:
-                tableName: hanke
-                columnName: kaistapituushaitta
-            - columnExists:
-                tableName: hanke
-                columnName: meluhaitta
-            - columnExists:
-                tableName: hanke
-                columnName: polyhaitta
-            - columnExists:
-                tableName: hanke
-                columnName: tarinahaitta
       changes:
         - dropColumn:
             tableName: hanke

--- a/services/hanke-service/src/main/resources/db/changelog/changesets/063-drop-haitta-columns-from-hanke.yml
+++ b/services/hanke-service/src/main/resources/db/changelog/changesets/063-drop-haitta-columns-from-hanke.yml
@@ -1,0 +1,39 @@
+databaseChangeLog:
+  - changeSet:
+      id: 063-drop-haitta-columns-from-hanke
+      author: Teemu Hiltunen
+      comment: Drop haitta columns from hanke
+      preConditions:
+        - onFail: MARK_RAN
+          and:
+            - columnExists:
+                tableName: hanke
+                columnName: kaistahaitta
+            - columnExists:
+                tableName: hanke
+                columnName: kaistapituushaitta
+            - columnExists:
+                tableName: hanke
+                columnName: meluhaitta
+            - columnExists:
+                tableName: hanke
+                columnName: polyhaitta
+            - columnExists:
+                tableName: hanke
+                columnName: tarinahaitta
+      changes:
+        - dropColumn:
+            tableName: hanke
+            columnName: kaistahaitta
+        - dropColumn:
+            tableName: hanke
+            columnName: kaistapituushaitta
+        - dropColumn:
+            tableName: hanke
+            columnName: meluhaitta
+        - dropColumn:
+            tableName: hanke
+            columnName: polyhaitta
+        - dropColumn:
+            tableName: hanke
+            columnName: tarinahaitta

--- a/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -153,3 +153,5 @@ databaseChangeLog:
       file: db/changelog/changesets/061-hanke-attachment-migration-cleanup.yml
   - include:
       file: db/changelog/changesets/062-rename-tormaystarkastelutulos-columns.yml
+  - include:
+      file: db/changelog/changesets/063-drop-haitta-columns-from-hanke.yml


### PR DESCRIPTION
# Description

Removed unnecessary haitta columns from hanke:
```
        - dropColumn:
            tableName: hanke
            columnName: kaistahaitta
        - dropColumn:
            tableName: hanke
            columnName: kaistapituushaitta
        - dropColumn:
            tableName: hanke
            columnName: meluhaitta
        - dropColumn:
            tableName: hanke
            columnName: polyhaitta
        - dropColumn:
            tableName: hanke
            columnName: tarinahaitta
```

### Jira Issue: 

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [x] Other

# Instructions for testing
When backend is started the columns are deleted in database without errors.

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 

# Other relevant info
Please describe here if there is e.g. some requirements for this change or
 other info that the tester/user needs to know.