### PR TITLE
HAI-2159 Add endpoint for adding a new user

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/KayttooikeustasoEntityITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/KayttooikeustasoEntityITest.kt
@@ -33,6 +33,7 @@ class KayttooikeustasoEntityITest : DatabaseTest() {
                         PermissionCode.EDIT_APPLICATIONS,
                         PermissionCode.MODIFY_APPLICATION_PERMISSIONS,
                         PermissionCode.RESEND_INVITATION,
+                        PermissionCode.CREATE_USER,
                     )
                 ),
                 Arguments.of(
@@ -41,6 +42,7 @@ class KayttooikeustasoEntityITest : DatabaseTest() {
                         PermissionCode.VIEW,
                         PermissionCode.EDIT,
                         PermissionCode.RESEND_INVITATION,
+                        PermissionCode.CREATE_USER,
                     )
                 ),
                 Arguments.of(
@@ -49,6 +51,7 @@ class KayttooikeustasoEntityITest : DatabaseTest() {
                         PermissionCode.VIEW,
                         PermissionCode.EDIT_APPLICATIONS,
                         PermissionCode.RESEND_INVITATION,
+                        PermissionCode.CREATE_USER,
                     )
                 ),
                 Arguments.of(Kayttooikeustaso.KATSELUOIKEUS, listOf(PermissionCode.VIEW)),

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeError.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeError.kt
@@ -48,6 +48,7 @@ enum class HankeError(val errorMessage: String) {
     HAI4003("Permission data conflict"),
     HAI4004("Kayttajatunniste not found"),
     HAI4005("Could not verify user identity"),
+    HAI4006("Duplicate hankekayttaja"),
     ;
 
     val errorCode: String

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttaja.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttaja.kt
@@ -30,6 +30,8 @@ data class HankeKayttajaResponse(
 data class HankeKayttajaDto(
     @field:Schema(description = "Id, set by the service") val id: UUID,
     @field:Schema(description = "Email address") val sahkoposti: String,
+    @field:Schema(description = "First name") val etunimi: String,
+    @field:Schema(description = "Last name") val sukunimi: String,
     @field:Schema(description = "Full name") val nimi: String,
     @field:Schema(description = "Access level in Hanke") val kayttooikeustaso: Kayttooikeustaso?,
     @field:Schema(description = "Has user logged in to view Hanke") val tunnistautunut: Boolean,
@@ -76,6 +78,8 @@ class HankekayttajaEntity(
         HankeKayttajaDto(
             id = id,
             sahkoposti = sahkoposti,
+            etunimi = etunimi,
+            sukunimi = sukunimi,
             nimi = fullName(),
             kayttooikeustaso = deriveKayttooikeustaso(),
             tunnistautunut = permission != null,

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaController.kt
@@ -119,6 +119,38 @@ class HankeKayttajaController(
         return HankeKayttajaResponse(users)
     }
 
+    @PostMapping("/hankkeet/{hankeTunnus}/kayttajat")
+    @Operation(
+        summary = "Add a user for the hanke.",
+        description =
+            "Add a new user for the hanke. Adds an invitation with viewing permissions. Sends an invitation email to them.",
+    )
+    @ApiResponse(
+        description = "The user that was added",
+        responseCode = "200",
+    )
+    @ApiResponse(
+        description = "Hanke not found",
+        responseCode = "404",
+        content = [Content(schema = Schema(implementation = HankeError::class))],
+    )
+    @ApiResponse(
+        description = "User with duplicate email",
+        responseCode = "409",
+        content = [Content(schema = Schema(implementation = HankeError::class))],
+    )
+    @PreAuthorize(
+        "@featureService.isEnabled('USER_MANAGEMENT') && " +
+            "@hankeKayttajaAuthorizer.authorizeHankeTunnus(#hankeTunnus, 'CREATE_USER')"
+    )
+    fun createNewUser(
+        @ValidHanke @RequestBody request: NewUserRequest,
+        @PathVariable hankeTunnus: String
+    ): HankeKayttajaDto {
+        val hanke = hankeService.loadHanke(hankeTunnus)!!
+        return hankeKayttajaService.createNewUser(request, hanke, currentUserId())
+    }
+
     @PutMapping("/hankkeet/{hankeTunnus}/kayttajat")
     @Operation(
         summary = "Update permissions of the listed users.",
@@ -293,6 +325,14 @@ of the token and link will be reset.
         val hankeTunnus: String,
         val hankeNimi: String,
     )
+
+    @ExceptionHandler(UserAlreadyExistsException::class)
+    @ResponseStatus(HttpStatus.CONFLICT)
+    @Hidden
+    fun userAlreadyExistsException(ex: UserAlreadyExistsException): HankeError {
+        logger.warn(ex) { ex.message }
+        return HankeError.HAI4006
+    }
 
     @ExceptionHandler(MissingAdminPermissionException::class)
     @ResponseStatus(HttpStatus.FORBIDDEN)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaService.kt
@@ -71,7 +71,7 @@ class HankeKayttajaService(
                 hanke.hankeTunnus,
                 hanke.nimi,
                 inviter,
-                request.toDomain(),
+                request.toHankekayttajaInput(),
                 currentUserId
             )
             .toDto()

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/PermissionUpdate.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/PermissionUpdate.kt
@@ -11,3 +11,25 @@ data class PermissionDto(
     @field:Schema(description = "HankeKayttaja ID") val id: UUID,
     @field:Schema(description = "New access level in Hanke") val kayttooikeustaso: Kayttooikeustaso,
 )
+
+data class NewUserRequest(
+    @field:Schema(
+        description = "The first name of the user",
+    )
+    val etunimi: String,
+    @field:Schema(
+        description = "The last name of the user",
+    )
+    val sukunimi: String,
+    @field:Schema(
+        description = "The email address of the user. The invitation will be sent to this address.",
+    )
+    val sahkoposti: String,
+    @field:Schema(
+        description = "The phone number of the user.",
+    )
+    val puhelinnumero: String,
+) {
+    fun toDomain(): HankekayttajaInput =
+        HankekayttajaInput(etunimi, sukunimi, sahkoposti, puhelinnumero)
+}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/PermissionUpdate.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/PermissionUpdate.kt
@@ -30,6 +30,6 @@ data class NewUserRequest(
     )
     val puhelinnumero: String,
 ) {
-    fun toDomain(): HankekayttajaInput =
+    fun toHankekayttajaInput(): HankekayttajaInput =
         HankekayttajaInput(etunimi, sukunimi, sahkoposti, puhelinnumero)
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/Permissions.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/Permissions.kt
@@ -36,6 +36,7 @@ enum class PermissionCode(val code: Long) {
     EDIT_APPLICATIONS(64),
     MODIFY_APPLICATION_PERMISSIONS(128),
     RESEND_INVITATION(256),
+    CREATE_USER(512),
 }
 
 @Repository

--- a/services/hanke-service/src/main/resources/db/changelog/changesets/064-add-create-user-permission-code.sql
+++ b/services/hanke-service/src/main/resources/db/changelog/changesets/064-add-create-user-permission-code.sql
@@ -1,0 +1,7 @@
+--liquibase formatted sql
+--changeset Topias Heinonen:064-add-create-user-permission-code
+--comment: Add CREATE_USER permission code
+
+UPDATE kayttooikeustaso
+SET permissioncode = permissioncode | 512
+WHERE kayttooikeustaso IN ('KAIKKI_OIKEUDET','KAIKKIEN_MUOKKAUS', 'HANKEMUOKKAUS', 'HAKEMUSASIOINTI');

--- a/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -155,3 +155,5 @@ databaseChangeLog:
       file: db/changelog/changesets/062-rename-tormaystarkastelutulos-columns.yml
   - include:
       file: db/changelog/changesets/063-drop-haitta-columns-from-hanke.yml
+  - include:
+      file: db/changelog/changesets/064-add-create-user-permission-code.sql

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeKayttajaFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeKayttajaFactory.kt
@@ -170,15 +170,18 @@ class HankeKayttajaFactory(
                 kayttajakutsu = kutsu
             )
 
+        fun createDto(i: Int = 1, tunnistautunut: Boolean = false) =
+            HankeKayttajaDto(
+                id = UUID.randomUUID(),
+                sahkoposti = "email.$i.address.com",
+                etunimi = "test$i",
+                sukunimi = "name$i",
+                nimi = "test$i name$i",
+                kayttooikeustaso = KATSELUOIKEUS,
+                tunnistautunut = tunnistautunut
+            )
+
         fun generateHankeKayttajat(amount: Int = 3): List<HankeKayttajaDto> =
-            (1..amount).map {
-                HankeKayttajaDto(
-                    id = UUID.randomUUID(),
-                    sahkoposti = "email.$it.address.com",
-                    nimi = "test name$it",
-                    kayttooikeustaso = KATSELUOIKEUS,
-                    tunnistautunut = it % 2 == 0
-                )
-            }
+            (1..amount).map { createDto(it, it % 2 == 0) }
     }
 }

--- a/services/hanke-service/src/test/resources/application-test.yml
+++ b/services/hanke-service/src/test/resources/application-test.yml
@@ -19,6 +19,9 @@ haitaton:
   testdata:
     enabled: true
 
+#Disable sentry in tests by setting DSN to empty.
+sentry.dsn:
+
 spring:
   jpa:
     show-sql: false


### PR DESCRIPTION
# Description

Add an endpoint for adding a new user. The endpoint adds a hankekäyttäjä and a käyttäjäkutsu for the user and sends an invitation email to the hanke. The request is declined if a user already has the same email.

The invitation email is only sent if the caller has a hankekäyttäjä, and not just a permission. This limitation will not matter with a new hanke created with the kortisto-model.

Add first and last names as new fields to HankeKayttajaDto. With this, the response fields match the request fields. Keep the full name field in the DTO for compatibility.

Add a new permission code for adding a new user. The existing codes weren't a good match. The only one with the correct käyttöoikeustaso is RESEND_INVITATION, which is not descriptive of this task.

Override Sentry DSN to empty value in tests to disable Sentry completely.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2159

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
Create a hanke and call the endpoint from [Swagger-UI](http://localhost:3001/api/swagger-ui/index.html#/hanke-kayttaja-controller/createNewUser). Check that the new user is added from the access rights management page.

For checking that the invitation email is sent, use a generated hanke.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 