### PR TITLE
Hai 2131/tram line high speed

### DIFF
--- a/scripts/gis-material-update/README.md
+++ b/scripts/gis-material-update/README.md
@@ -260,14 +260,14 @@ Output files (names configured in `config.yaml`)
 
 ### `tram_lines`
 
-Prerequisite: fetched `hsl` -material.
+Prerequisite: fetched `hsl` and `hki` -materials.
 
 Docker example run (ensure that image build and file copying is
 already performed as instructed above):
 
 ```sh
 docker-compose up -d gis-db
-docker-compose run --rm gis-fetch hsl
+docker-compose run --rm gis-fetch hki hsl
 docker-compose run --rm gis-process tram_lines
 docker-compose stop gis-db
 ```

--- a/scripts/gis-material-update/process/modules/tram_lines.py
+++ b/scripts/gis-material-update/process/modules/tram_lines.py
@@ -10,9 +10,9 @@ import warnings
 from modules.config import Config
 from modules.gis_processing import GisProcessor
 
-# Select only following route_type values:
-# 0 = Tram, Streetcar, Light rail. Any light rail or street level system within a metropolitan area
-# 900 = Tram Service
+# Select only following route_type values(HSL):
+# 0 = Urban tram
+# 900 = Light rail
 
 TRAM_ROUTE_TYPE = [0, 900]
 


### PR DESCRIPTION
# Description

Adding high speed objects to tram lines:
Added new route_type value which will be included in tram_lines.
Added clipping by Helsinki area because some tram_lines are going outside of Helsinki.
Update scripts/gis-material-update/data/README.md

### Jira Issue: 
https://helsinkisolutionoffice.atlassian.net/browse/HAI-2131

## Type of change
- [ ] Bug fix 
- [ ] New feature 
- [x] Other

# Instructions for testing
Check instructions from scripts/gis-material-update/readme to process tram_lines data.
Then check data file (tormays_tram_lines_polys.gpkg) with QGIS:
* current feature count: 89 (this amount might be changed over time)
* geometries are looking ok (=areas)
* objects are having following attributes:
	"fid",
	"lines"

# Checklist:
- [ ] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [x] I have made necessary changes to the documentation, link to confluence
 or other location: 
 scripts/gis-material-update/data/README.md

# Other relevant info
Please describe here if there is e.g. some requirements for this change or
 other info that the tester/user needs to know.