### PR TITLE
HAI-1983 Add application attachments to blob storage instead of database

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentContentServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentContentServiceITest.kt
@@ -74,7 +74,7 @@ class ApplicationAttachmentContentServiceITest(
             assertThat(fileClient.listBlobs(HAKEMUS_LIITTEET).map { it.path })
                 .containsExactly(attachment.blobLocation!!)
 
-            attachmentContentService.delete(attachment)
+            attachmentContentService.delete(attachment.blobLocation!!)
 
             assertThat(fileClient.listBlobs(HAKEMUS_LIITTEET)).isEmpty()
         }
@@ -83,7 +83,8 @@ class ApplicationAttachmentContentServiceITest(
         fun `Doesn't throw an error if content is missing`() {
             val attachment = attachmentWithoutCloudContent().copy(blobLocation = "missing")
 
-            assertThat(runCatching { attachmentContentService.delete(attachment) }).isSuccess()
+            assertThat(runCatching { attachmentContentService.delete(attachment.blobLocation!!) })
+                .isSuccess()
         }
 
         @Test
@@ -91,7 +92,8 @@ class ApplicationAttachmentContentServiceITest(
             val attachment = attachmentWithoutCloudContent()
             assertThat(attachment.blobLocation).isNull()
 
-            assertThat(runCatching { attachmentContentService.delete(attachment) }).isSuccess()
+            assertThat(runCatching { attachmentContentService.delete(attachment.blobLocation) })
+                .isSuccess()
         }
     }
 

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentContentServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentContentServiceITest.kt
@@ -8,8 +8,8 @@ import assertk.assertions.hasClass
 import assertk.assertions.hasMessage
 import assertk.assertions.isEmpty
 import assertk.assertions.isEqualTo
-import assertk.assertions.isNull
-import assertk.assertions.isSuccess
+import assertk.assertions.isFalse
+import assertk.assertions.isTrue
 import fi.hel.haitaton.hanke.DatabaseTest
 import fi.hel.haitaton.hanke.attachment.USERNAME
 import fi.hel.haitaton.hanke.attachment.azure.Container.HAKEMUS_LIITTEET
@@ -74,26 +74,23 @@ class ApplicationAttachmentContentServiceITest(
             assertThat(fileClient.listBlobs(HAKEMUS_LIITTEET).map { it.path })
                 .containsExactly(attachment.blobLocation!!)
 
-            attachmentContentService.delete(attachment.blobLocation!!)
+            val deleted = attachmentContentService.delete(attachment.blobLocation!!)
 
+            assertThat(deleted).isTrue()
             assertThat(fileClient.listBlobs(HAKEMUS_LIITTEET)).isEmpty()
         }
 
         @Test
-        fun `Doesn't throw an error if content is missing`() {
-            val attachment = attachmentWithoutCloudContent().copy(blobLocation = "missing")
+        fun `Nothing is deleted if content is missing`() {
+            val attachment = attachmentWithCloudContent()
+            assertThat(fileClient.listBlobs(HAKEMUS_LIITTEET).map { it.path })
+                .containsExactly(attachment.blobLocation!!)
 
-            assertThat(runCatching { attachmentContentService.delete(attachment.blobLocation!!) })
-                .isSuccess()
-        }
+            val deleted = attachmentContentService.delete("missing")
 
-        @Test
-        fun `Doesn't do anything if blobLocation is not specified`() {
-            val attachment = attachmentWithoutCloudContent()
-            assertThat(attachment.blobLocation).isNull()
-
-            assertThat(runCatching { attachmentContentService.delete(attachment.blobLocation) })
-                .isSuccess()
+            assertThat(deleted).isFalse()
+            assertThat(fileClient.listBlobs(HAKEMUS_LIITTEET).map { it.path })
+                .containsExactly(attachment.blobLocation!!)
         }
     }
 

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentServiceITest.kt
@@ -13,6 +13,7 @@ import assertk.assertions.isEmpty
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNotNull
 import assertk.assertions.isPresent
+import assertk.assertions.isTrue
 import assertk.assertions.messageContains
 import assertk.assertions.prop
 import fi.hel.haitaton.hanke.ALLOWED_ATTACHMENT_COUNT
@@ -29,7 +30,6 @@ import fi.hel.haitaton.hanke.attachment.FILE_NAME_PDF
 import fi.hel.haitaton.hanke.attachment.USERNAME
 import fi.hel.haitaton.hanke.attachment.azure.Container.HAKEMUS_LIITTEET
 import fi.hel.haitaton.hanke.attachment.body
-import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentContentEntity
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentContentRepository
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentMetadataDto
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentRepository
@@ -40,6 +40,7 @@ import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType.VALTAKI
 import fi.hel.haitaton.hanke.attachment.common.AttachmentInvalidException
 import fi.hel.haitaton.hanke.attachment.common.AttachmentLimitReachedException
 import fi.hel.haitaton.hanke.attachment.common.AttachmentNotFoundException
+import fi.hel.haitaton.hanke.attachment.common.DownloadResponse
 import fi.hel.haitaton.hanke.attachment.common.MockFileClient
 import fi.hel.haitaton.hanke.attachment.common.MockFileClientExtension
 import fi.hel.haitaton.hanke.attachment.failResult
@@ -70,7 +71,6 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.data.repository.findByIdOrNull
 import org.springframework.http.MediaType
 import org.springframework.security.test.context.support.WithMockUser
 import org.springframework.test.context.ActiveProfiles
@@ -96,6 +96,7 @@ class ApplicationAttachmentServiceITest(
         clearAllMocks()
         mockClamAv = MockWebServer()
         mockClamAv.start(6789)
+        fileClient.recreateContainers()
     }
 
     @AfterEach
@@ -194,7 +195,9 @@ class ApplicationAttachmentServiceITest(
     inner class AddAttachment {
         @EnumSource(ApplicationAttachmentType::class)
         @ParameterizedTest
-        fun `Saves attachment and content to DB`(typeInput: ApplicationAttachmentType) {
+        fun `Saves attachment metadata to DB and content to blob storage`(
+            typeInput: ApplicationAttachmentType
+        ) {
             mockClamAv.enqueue(response(body(results = successResult())))
             val application = applicationFactory.saveApplicationEntity(USERNAME)
 
@@ -221,11 +224,13 @@ class ApplicationAttachmentServiceITest(
             assertThat(attachmentInDb.createdAt).isRecent()
             assertThat(attachmentInDb.applicationId).isEqualTo(application.id)
             assertThat(attachmentInDb.attachmentType).isEqualTo(typeInput)
+            assertThat(attachmentInDb.blobLocation!!.startsWith("${application.id!!}/")).isTrue()
 
-            val content = contentRepository.findByIdOrNull(attachmentInDb.id!!)
+            val content = fileClient.download(HAKEMUS_LIITTEET, attachmentInDb.blobLocation!!)
             assertThat(content)
                 .isNotNull()
-                .prop(ApplicationAttachmentContentEntity::content)
+                .prop(DownloadResponse::content)
+                .transform { it.toBytes() }
                 .isEqualTo(DEFAULT_DATA)
 
             verify { cableReportService wasNot Called }
@@ -400,7 +405,7 @@ class ApplicationAttachmentServiceITest(
                 .hasClass(AlluException::class)
 
             assertThat(attachmentRepository.findAll()).isEmpty()
-            assertThat(contentRepository.findAll()).isEmpty()
+            assertThat(fileClient.listBlobs(HAKEMUS_LIITTEET)).isEmpty()
             verifyOrder {
                 cableReportService.getApplicationInformation(ALLU_ID)
                 cableReportService.addAttachment(ALLU_ID, any())
@@ -448,7 +453,8 @@ class ApplicationAttachmentServiceITest(
 
             @Test
             fun `Throws when application has been sent to Allu`() {
-                val application = applicationFactory.saveApplicationEntity(USERNAME, alluId = ALLU_ID)
+                val application =
+                    applicationFactory.saveApplicationEntity(USERNAME, alluId = ALLU_ID)
                 val attachment =
                     attachmentFactory.save(application = application).withDbContent().value
 

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentServiceITest.kt
@@ -13,9 +13,9 @@ import assertk.assertions.isEmpty
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNotNull
 import assertk.assertions.isPresent
-import assertk.assertions.isTrue
 import assertk.assertions.messageContains
 import assertk.assertions.prop
+import assertk.assertions.startsWith
 import fi.hel.haitaton.hanke.ALLOWED_ATTACHMENT_COUNT
 import fi.hel.haitaton.hanke.DatabaseTest
 import fi.hel.haitaton.hanke.allu.AlluException
@@ -224,7 +224,7 @@ class ApplicationAttachmentServiceITest(
             assertThat(attachmentInDb.createdAt).isRecent()
             assertThat(attachmentInDb.applicationId).isEqualTo(application.id)
             assertThat(attachmentInDb.attachmentType).isEqualTo(typeInput)
-            assertThat(attachmentInDb.blobLocation!!.startsWith("${application.id!!}/")).isTrue()
+            assertThat(attachmentInDb.blobLocation).isNotNull().startsWith("${application.id!!}/")
 
             val content = fileClient.download(HAKEMUS_LIITTEET, attachmentInDb.blobLocation!!)
             assertThat(content)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentContentService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentContentService.kt
@@ -27,13 +27,22 @@ class ApplicationAttachmentContentService(
     ): String {
         val blobPath = generateBlobPath(applicationId)
         fileClient.upload(Container.HAKEMUS_LIITTEET, blobPath, filename, contentType, content)
+        logger.info { "Attachment content saved to $blobPath" }
         return blobPath
     }
 
-    fun delete(blobPath: String): Boolean = fileClient.delete(Container.HAKEMUS_LIITTEET, blobPath)
+    fun delete(blobPath: String): Boolean =
+        fileClient.delete(Container.HAKEMUS_LIITTEET, blobPath).also {
+            if (it) {
+                logger.info { "Attachment content at $blobPath deleted" }
+            } else {
+                logger.warn { "Attachment content at $blobPath not found" }
+            }
+        }
 
     fun deleteAllForApplication(applicationId: Long) {
         fileClient.deleteAllByPrefix(Container.HAKEMUS_LIITTEET, prefix(applicationId))
+        logger.info { "Deleted all attachment content from application $applicationId" }
     }
 
     fun find(attachment: AttachmentMetadata): ByteArray =

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentContentService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentContentService.kt
@@ -1,7 +1,6 @@
 package fi.hel.haitaton.hanke.attachment.application
 
 import fi.hel.haitaton.hanke.attachment.azure.Container
-import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentContentEntity
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentContentRepository
 import fi.hel.haitaton.hanke.attachment.common.AttachmentMetadata
 import fi.hel.haitaton.hanke.attachment.common.AttachmentNotFoundException
@@ -10,6 +9,7 @@ import fi.hel.haitaton.hanke.attachment.common.FileClient
 import java.util.UUID
 import mu.KotlinLogging
 import org.springframework.data.repository.findByIdOrNull
+import org.springframework.http.MediaType
 import org.springframework.stereotype.Service
 
 private val logger = KotlinLogging.logger {}
@@ -19,18 +19,26 @@ class ApplicationAttachmentContentService(
     val contentRepository: ApplicationAttachmentContentRepository,
     val fileClient: FileClient,
 ) {
-    fun save(attachmentId: UUID, content: ByteArray) {
-        contentRepository.save(ApplicationAttachmentContentEntity(attachmentId, content))
+    fun save(
+        filename: String,
+        contentType: MediaType,
+        applicationId: Long,
+        content: ByteArray
+    ): String {
+        val blobPath = generateBlobPath(applicationId)
+        fileClient.upload(Container.HAKEMUS_LIITTEET, blobPath, filename, contentType, content)
+        return blobPath
     }
 
-    fun delete(attachment: AttachmentMetadata) =
-        with(attachment) {
-            logger.info { "Deleting attachment $id if blob defined. Blob=$blobLocation." }
-            blobLocation?.let { fileClient.delete(Container.HAKEMUS_LIITTEET, it) }
+    fun delete(blobPath: String?) {
+        if (blobPath == null) {
+            logger.info { "Blob path is null, nothing to delete" }
+            return
         }
+        fileClient.delete(Container.HAKEMUS_LIITTEET, blobPath)
+    }
 
     fun deleteAllForApplication(applicationId: Long) {
-        logger.info { "Deleting all attachments from application $applicationId" }
         fileClient.deleteAllByPrefix(Container.HAKEMUS_LIITTEET, prefix(applicationId))
     }
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentContentService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentContentService.kt
@@ -30,13 +30,7 @@ class ApplicationAttachmentContentService(
         return blobPath
     }
 
-    fun delete(blobPath: String?) {
-        if (blobPath == null) {
-            logger.info { "Blob path is null, nothing to delete" }
-            return
-        }
-        fileClient.delete(Container.HAKEMUS_LIITTEET, blobPath)
-    }
+    fun delete(blobPath: String): Boolean = fileClient.delete(Container.HAKEMUS_LIITTEET, blobPath)
 
     fun deleteAllForApplication(applicationId: Long) {
         fileClient.deleteAllByPrefix(Container.HAKEMUS_LIITTEET, prefix(applicationId))

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentMetadataService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentMetadataService.kt
@@ -53,17 +53,21 @@ class ApplicationAttachmentMetadataService(
                 attachmentType = attachmentType,
                 applicationId = applicationId,
             )
-        return attachmentRepository.save(entity).toDomain()
+        return attachmentRepository.save(entity).toDomain().also {
+            logger.info { "Saved attachment metadata ${it.id} for application $applicationId" }
+        }
     }
 
     @Transactional
     fun deleteAttachmentById(attachmentId: UUID) {
         attachmentRepository.deleteById(attachmentId)
+        logger.info { "Deleted attachment metadata $attachmentId" }
     }
 
     @Transactional
     fun deleteAllAttachments(id: Long) {
         attachmentRepository.deleteByApplicationId(id)
+        logger.info { "Deleted all attachment metadata for application $id" }
     }
 
     @Transactional(readOnly = true)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentMetadataService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentMetadataService.kt
@@ -38,6 +38,7 @@ class ApplicationAttachmentMetadataService(
     fun create(
         filename: String,
         contentType: String,
+        blobLocation: String,
         attachmentType: ApplicationAttachmentType,
         applicationId: Long
     ): ApplicationAttachmentMetadata {
@@ -46,7 +47,7 @@ class ApplicationAttachmentMetadataService(
                 id = null,
                 fileName = filename,
                 contentType = contentType,
-                blobLocation = null,
+                blobLocation = blobLocation,
                 createdByUserId = currentUserId(),
                 createdAt = OffsetDateTime.now(),
                 attachmentType = attachmentType,

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentService.kt
@@ -121,7 +121,8 @@ class ApplicationAttachmentService(
         }
 
         metadataService.deleteAttachmentById(attachment.id)
-        attachmentContentService.delete(attachment.blobLocation)
+        attachment.blobLocation?.let { attachmentContentService.delete(it) }
+            ?: logger.warn { "Attachment ${attachment.id} has no blob content" }
 
         logger.info {
             "Deleted attachment metadata ${attachment.id} and content ${attachment.blobLocation} from application ${application.id}"
@@ -129,8 +130,8 @@ class ApplicationAttachmentService(
     }
 
     fun deleteAllAttachments(application: Application) {
-        attachmentContentService.deleteAllForApplication(application.id!!)
-        metadataService.deleteAllAttachments(application.id)
+        metadataService.deleteAllAttachments(application.id!!)
+        attachmentContentService.deleteAllForApplication(application.id)
         logger.info { "Deleted all attachments from application ${application.id}" }
     }
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/azure/BlobFileClient.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/azure/BlobFileClient.kt
@@ -104,6 +104,7 @@ class BlobFileClient(blobServiceClient: BlobServiceClient, containers: Container
         batchClient.deleteBlobs(blobUrls, DeleteSnapshotsOptionType.INCLUDE).forEach {
             logger.info { "Deleted blob ${it.request.url} with status ${it.statusCode}" }
         }
+        logger.info { "Deleted all Blobs from container $container with prefix $prefix" }
     }
 
     private fun getContainerClient(container: Container) =


### PR DESCRIPTION
# Description

Application attachments are stored in Azure blob storage instead of database.

### Jira Issue:  https://helsinkisolutionoffice.atlassian.net/browse/HAI-1983

## Type of change

- [ ] Bug fix 
- [x] New feature 
- [ ] Other

# Instructions for testing
1. Add an attachment for an application
2. Check blob storage with e.g. MS Azure Storage Explorer - the attachment should be there under `haitaton-hakemusliitteet-local` in path `<applicationId>/<uuid>`
3. Check the database - there should not be a new row in `application_attachment_content` table
4. Check the database - there should be a new row in `application_attachment` table with `blob_location` set to `<applicationId>/<uuid>` which is the path of the file in blob storage.
5. [OPTIONAL] Check that deletion of the attachment works as expected

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 

# Other relevant info
Please describe here if there is e.g. some requirements for this change or
 other info that the tester/user needs to know.