### PR TITLE
HAI-2157 Add phone number to user list API

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaControllerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaControllerITest.kt
@@ -245,6 +245,7 @@ class HankeKayttajaControllerITest(@Autowired override val mockMvc: MockMvc) : C
                 assertThat(etunimi).isEqualTo("test1")
                 assertThat(sukunimi).isEqualTo("name1")
                 assertThat(nimi).isEqualTo("test1 name1")
+                assertThat(puhelinnumero).isEqualTo("0405551111")
                 assertThat(sahkoposti).isEqualTo("email.1.address.com")
                 assertThat(tunnistautunut).isEqualTo(false)
             }

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaServiceITest.kt
@@ -144,7 +144,10 @@ class HankeKayttajaServiceITest : DatabaseTest() {
             val dto: HankeKayttajaDto = result.first().also { assertThat(result).hasSize(1) }
             with(dto) {
                 assertThat(id).isEqualTo(entity.id)
+                assertThat(etunimi).isEqualTo(entity.etunimi)
+                assertThat(sukunimi).isEqualTo(entity.sukunimi)
                 assertThat(nimi).isEqualTo(entity.fullName())
+                assertThat(puhelinnumero).isEqualTo(entity.puhelin)
                 assertThat(sahkoposti).isEqualTo(entity.sahkoposti)
                 assertThat(kayttooikeustaso).isEqualTo(entity.permission!!.kayttooikeustaso)
                 assertThat(tunnistautunut).isEqualTo(true)
@@ -333,6 +336,7 @@ class HankeKayttajaServiceITest : DatabaseTest() {
                 prop(HankeKayttajaDto::etunimi).isEqualTo("Joku")
                 prop(HankeKayttajaDto::sukunimi).isEqualTo("Jokunen")
                 prop(HankeKayttajaDto::nimi).isEqualTo("Joku Jokunen")
+                prop(HankeKayttajaDto::puhelinnumero).isEqualTo("0508889999")
                 prop(HankeKayttajaDto::kayttooikeustaso).isEqualTo(Kayttooikeustaso.KATSELUOIKEUS)
                 prop(HankeKayttajaDto::tunnistautunut).isFalse()
             }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttaja.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttaja.kt
@@ -32,7 +32,10 @@ data class HankeKayttajaDto(
     @field:Schema(description = "Email address") val sahkoposti: String,
     @field:Schema(description = "First name") val etunimi: String,
     @field:Schema(description = "Last name") val sukunimi: String,
-    @field:Schema(description = "Full name") val nimi: String,
+    @Deprecated("Use etunimi and sukunimi instead.")
+    @field:Schema(description = "Full name", deprecated = true)
+    val nimi: String,
+    @field:Schema(description = "Phone number") val puhelinnumero: String,
     @field:Schema(description = "Access level in Hanke") val kayttooikeustaso: Kayttooikeustaso?,
     @field:Schema(description = "Has user logged in to view Hanke") val tunnistautunut: Boolean,
 )
@@ -81,6 +84,7 @@ class HankekayttajaEntity(
             etunimi = etunimi,
             sukunimi = sukunimi,
             nimi = fullName(),
+            puhelinnumero = puhelin,
             kayttooikeustaso = deriveKayttooikeustaso(),
             tunnistautunut = permission != null,
         )

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeKayttajaFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeKayttajaFactory.kt
@@ -185,6 +185,7 @@ class HankeKayttajaFactory(
                 etunimi = "test$i",
                 sukunimi = "name$i",
                 nimi = "test$i name$i",
+                puhelinnumero = "040555$i$i$i$i",
                 kayttooikeustaso = KATSELUOIKEUS,
                 tunnistautunut = tunnistautunut
             )


### PR DESCRIPTION
# Description

Add phone number to user list response. The full name was left to the response since the front end still uses it. Mark it as deprecated instead of removing it.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2157

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
Call the API. Either with the Swagger UI or check the dev tools after opening the Käyttöoikeuksien hallinta page.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [X] I have made necessary changes to the documentation, link to confluence
 or other location: OpenAPI docs