### PR TITLE
HAI-2263 Add API for getting a single kayttaja

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaAuthorizerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaAuthorizerITest.kt
@@ -57,7 +57,7 @@ class HankeKayttajaAuthorizerITest(
         @Test
         fun `throws exception if user doesn't have the required permission for the hanke`() {
             val hankeId = hankeFactory.saveMinimal().id
-            val kayttajaId = hankeKayttajaFactory.saveUserAndPermission(hankeId).id
+            val kayttajaId = hankeKayttajaFactory.saveIdentifiedUser(hankeId).id
             permissionService.create(hankeId, USERNAME, Kayttooikeustaso.KATSELUOIKEUS)
 
             assertFailure { authorizer.authorizeKayttajaId(kayttajaId, PermissionCode.EDIT.name) }
@@ -70,7 +70,7 @@ class HankeKayttajaAuthorizerITest(
         @Test
         fun `return true if user has the required permission for the hanke`() {
             val hankeId = hankeFactory.saveMinimal().id
-            val kayttajaId = hankeKayttajaFactory.saveUserAndPermission(hankeId).id
+            val kayttajaId = hankeKayttajaFactory.saveIdentifiedUser(hankeId).id
             permissionService.create(hankeId, USERNAME, Kayttooikeustaso.HANKEMUOKKAUS)
 
             assertThat(authorizer.authorizeKayttajaId(kayttajaId, PermissionCode.EDIT.name))

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/ControllerExceptionHandler.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/ControllerExceptionHandler.kt
@@ -18,6 +18,7 @@ import org.springframework.http.converter.HttpMessageNotReadableException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException
 
 private val logger = KotlinLogging.logger {}
 
@@ -86,6 +87,15 @@ class ControllerExceptionHandler {
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     @Hidden
     fun illegalArgumentException(ex: IllegalArgumentException): HankeError {
+        logger.error(ex) { ex.message }
+        Sentry.captureException(ex)
+        return HankeError.HAI0003
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException::class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @Hidden
+    fun methodArgumentTypeMismatchException(ex: MethodArgumentTypeMismatchException): HankeError {
         logger.error(ex) { ex.message }
         Sentry.captureException(ex)
         return HankeError.HAI0003

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/DisclosureLogService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/DisclosureLogService.kt
@@ -118,6 +118,10 @@ class DisclosureLogService(private val auditLogService: AuditLogService) {
         )
     }
 
+    fun saveDisclosureLogsForHankeKayttaja(hankeKayttaja: HankeKayttajaDto, userId: String) {
+        saveDisclosureLogsForHankeKayttajat(listOf(hankeKayttaja), userId)
+    }
+
     fun saveDisclosureLogsForHankeKayttajat(
         hankeKayttajat: List<HankeKayttajaDto>,
         userId: String

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaController.kt
@@ -84,6 +84,33 @@ class HankeKayttajaController(
         return WhoamiResponse(hankeKayttaja?.id, permission.kayttooikeustasoEntity)
     }
 
+    @GetMapping("/kayttajat/{kayttajaId}")
+    @Operation(
+        summary = "Get a Hanke user",
+        description = "Returns a single user and their Hanke related information."
+    )
+    @ApiResponses(
+        value =
+            [
+                ApiResponse(description = "User info", responseCode = "200"),
+                ApiResponse(
+                    description = "Invalid UUID",
+                    responseCode = "400",
+                    content = [Content(schema = Schema(implementation = HankeError::class))]
+                ),
+                ApiResponse(
+                    description = "Hanke or user not found",
+                    responseCode = "404",
+                    content = [Content(schema = Schema(implementation = HankeError::class))]
+                ),
+            ]
+    )
+    @PreAuthorize("@hankeKayttajaAuthorizer.authorizeKayttajaId(#kayttajaId, 'VIEW')")
+    fun getHankeKayttaja(@PathVariable kayttajaId: UUID): HankeKayttajaDto =
+        hankeKayttajaService.getKayttaja(kayttajaId).also {
+            disclosureLogService.saveDisclosureLogsForHankeKayttaja(it, currentUserId())
+        }
+
     @GetMapping("/hankkeet/{hankeTunnus}/kayttajat")
     @Operation(
         summary = "Get Hanke users",

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaService.kt
@@ -14,6 +14,7 @@ import fi.hel.haitaton.hanke.profiili.ProfiiliClient
 import fi.hel.haitaton.hanke.userId
 import java.util.UUID
 import mu.KotlinLogging
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.security.core.context.SecurityContext
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -31,6 +32,11 @@ class HankeKayttajaService(
     private val emailSenderService: EmailSenderService,
     private val profiiliClient: ProfiiliClient,
 ) {
+    @Transactional(readOnly = true)
+    fun getKayttaja(kayttajaId: UUID): HankeKayttajaDto =
+        hankekayttajaRepository.findByIdOrNull(kayttajaId)?.toDto()
+            ?: throw HankeKayttajaNotFoundException(kayttajaId)
+
     @Transactional(readOnly = true)
     fun getKayttajatByHankeId(hankeId: Int): List<HankeKayttajaDto> =
         hankekayttajaRepository.findByHankeId(hankeId).map { it.toDto() }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/Permissions.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/Permissions.kt
@@ -37,6 +37,7 @@ enum class PermissionCode(val code: Long) {
     MODIFY_APPLICATION_PERMISSIONS(128),
     RESEND_INVITATION(256),
     CREATE_USER(512),
+    MODIFY_USER(1024),
 }
 
 @Repository

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/AuditLogEntryFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/AuditLogEntryFactory.kt
@@ -62,12 +62,13 @@ object AuditLogEntryFactory {
             objectBefore = CustomerWithRole(role, customer).toJsonString()
         )
 
+    fun createReadEntryForHankeKayttaja(kayttaja: HankeKayttajaDto): AuditLogEntry =
+        createReadEntry(
+            objectId = kayttaja.id,
+            objectType = ObjectType.HANKE_KAYTTAJA,
+            objectBefore = kayttaja.toJsonString()
+        )
+
     fun createReadEntryForHankeKayttajat(kayttajat: List<HankeKayttajaDto>): List<AuditLogEntry> =
-        kayttajat.map {
-            createReadEntry(
-                objectId = it.id,
-                objectType = ObjectType.HANKE_KAYTTAJA,
-                objectBefore = it.toJsonString()
-            )
-        }
+        kayttajat.map { createReadEntryForHankeKayttaja(it) }
 }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeKayttajaFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeKayttajaFactory.kt
@@ -24,9 +24,12 @@ class HankeKayttajaFactory(
     private val kayttajakutsuRepository: KayttajakutsuRepository
 ) {
 
-    fun saveUserAndToken(
+    fun saveUnidentifiedUser(
         hankeId: Int,
-        kayttajaInput: HankekayttajaInput = kayttajaInput(),
+        etunimi: String = KAKE,
+        sukunimi: String = KATSELIJA,
+        sahkoposti: String = KAKE_EMAIL,
+        puhelin: String = KAKE_PUHELIN,
         kayttooikeustaso: Kayttooikeustaso = KATSELUOIKEUS,
         tunniste: String = "existing",
     ): HankekayttajaEntity =
@@ -34,38 +37,50 @@ class HankeKayttajaFactory(
             hankeKayttaja =
                 saveUser(
                     hankeId = hankeId,
-                    kayttajaInput = kayttajaInput,
+                    etunimi = etunimi,
+                    sukunimi = sukunimi,
+                    sahkoposti = sahkoposti,
+                    puhelin = puhelin,
                     permissionEntity = null,
                 ),
             tunniste = tunniste,
             kayttooikeustaso = kayttooikeustaso,
         )
 
-    fun saveUserAndPermission(
+    fun saveIdentifiedUser(
         hankeId: Int,
-        kayttaja: HankekayttajaInput = kayttajaInput(),
+        etunimi: String = KAKE,
+        sukunimi: String = KATSELIJA,
+        sahkoposti: String = KAKE_EMAIL,
+        puhelin: String = KAKE_PUHELIN,
         kayttooikeustaso: Kayttooikeustaso = KATSELUOIKEUS,
         userId: String = "fake id",
     ): HankekayttajaEntity =
         saveUser(
             hankeId = hankeId,
-            kayttajaInput = kayttaja,
+            etunimi = etunimi,
+            sukunimi = sukunimi,
+            sahkoposti = sahkoposti,
+            puhelin = puhelin,
             permissionEntity = permissionService.create(hankeId, userId, kayttooikeustaso),
         )
 
     fun saveUser(
         hankeId: Int,
-        kayttajaInput: HankekayttajaInput = kayttajaInput(),
+        etunimi: String = KAKE,
+        sukunimi: String = KATSELIJA,
+        sahkoposti: String = KAKE_EMAIL,
+        puhelin: String = KAKE_PUHELIN,
         permissionEntity: PermissionEntity? = null,
         kayttajakutsuEntity: KayttajakutsuEntity? = null,
     ): HankekayttajaEntity =
         hankeKayttajaRepository.save(
             HankekayttajaEntity(
                 hankeId = hankeId,
-                etunimi = kayttajaInput.etunimi,
-                sukunimi = kayttajaInput.sukunimi,
-                sahkoposti = kayttajaInput.email,
-                puhelin = kayttajaInput.puhelin,
+                etunimi = etunimi,
+                sukunimi = sukunimi,
+                sahkoposti = sahkoposti,
+                puhelin = puhelin,
                 permission = permissionEntity,
                 kayttajakutsu = kayttajakutsuEntity,
             )
@@ -144,13 +159,6 @@ class HankeKayttajaFactory(
                 "0401234564",
             )
 
-        fun kayttajaInput(
-            etunimi: String = KAKE,
-            sukunimi: String = KATSELIJA,
-            email: String = KAKE_EMAIL,
-            puhelin: String = KAKE_PUHELIN,
-        ) = HankekayttajaInput(etunimi, sukunimi, email, puhelin)
-
         fun create(
             id: UUID = KAYTTAJA_ID,
             hankeId: Int = HankeFactory.defaultId,
@@ -163,17 +171,20 @@ class HankeKayttajaFactory(
         fun createEntity(
             id: UUID = KAYTTAJA_ID,
             hankeId: Int = HankeFactory.defaultId,
-            kayttaja: HankekayttajaInput = kayttajaInput(),
+            etunimi: String = KAKE,
+            sukunimi: String = KATSELIJA,
+            sahkoposti: String = KAKE_EMAIL,
+            puhelin: String = KAKE_PUHELIN,
             permission: PermissionEntity? = null,
             kutsu: KayttajakutsuEntity? = null,
         ): HankekayttajaEntity =
             HankekayttajaEntity(
                 id = id,
                 hankeId = hankeId,
-                etunimi = kayttaja.etunimi,
-                sukunimi = kayttaja.sukunimi,
-                sahkoposti = kayttaja.email,
-                puhelin = kayttaja.puhelin,
+                etunimi = etunimi,
+                sukunimi = sukunimi,
+                sahkoposti = sahkoposti,
+                puhelin = puhelin,
                 permission = permission,
                 kayttajakutsu = kutsu
             )

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeKayttajaFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeKayttajaFactory.kt
@@ -17,11 +17,6 @@ import java.time.OffsetDateTime
 import java.util.UUID
 import org.springframework.stereotype.Component
 
-private const val KAKE = "Kake"
-private const val KATSELIJA = "Katselija"
-private const val KAKE_EMAIL = "kake@katselu.test"
-private const val KAKE_PUHELIN = "0501234567"
-
 @Component
 class HankeKayttajaFactory(
     private val hankeKayttajaRepository: HankekayttajaRepository,
@@ -101,6 +96,11 @@ class HankeKayttajaFactory(
     companion object {
         val KAYTTAJA_ID = UUID.fromString("639870ab-533d-4172-8e97-e5b93a275514")
 
+        const val KAKE = "Kake"
+        const val KATSELIJA = "Katselija"
+        const val KAKE_EMAIL = "kake@katselu.test"
+        const val KAKE_PUHELIN = "0501234567"
+
         private const val PEKKA = "Pekka Peruskäyttäjä"
         private const val PEKKA_EMAIL = "pekka@peruskäyttäjä.test"
 
@@ -178,9 +178,9 @@ class HankeKayttajaFactory(
                 kayttajakutsu = kutsu
             )
 
-        fun createDto(i: Int = 1, tunnistautunut: Boolean = false) =
+        fun createDto(i: Int = 1, tunnistautunut: Boolean = false, id: UUID = UUID.randomUUID()) =
             HankeKayttajaDto(
-                id = UUID.randomUUID(),
+                id = id,
                 sahkoposti = "email.$i.address.com",
                 etunimi = "test$i",
                 sukunimi = "name$i",

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/logging/DisclosureLogServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/logging/DisclosureLogServiceTest.kt
@@ -182,6 +182,16 @@ internal class DisclosureLogServiceTest {
     }
 
     @Test
+    fun `saveDisclosureLogsForHankeKayttaja saves audit logs`() {
+        val hankeKayttaja = HankeKayttajaFactory.createDto()
+        val expectedLogs = AuditLogEntryFactory.createReadEntryForHankeKayttaja(hankeKayttaja)
+
+        disclosureLogService.saveDisclosureLogsForHankeKayttaja(hankeKayttaja, userId)
+
+        verify { auditLogService.createAll(listOf(expectedLogs)) }
+    }
+
+    @Test
     fun `saveDisclosureLogsForHankeKayttajat saves audit logs`() {
         val hankeKayttajat = HankeKayttajaFactory.generateHankeKayttajat(amount = 2)
         val expectedLogs = AuditLogEntryFactory.createReadEntryForHankeKayttajat(hankeKayttajat)


### PR DESCRIPTION
# Description

Add a new API for getting a single kayttaja at `GET /kayttajat/{kayttajaId}`.

The API writes each operation to the audit log.

Also, add an exception handler for `MethodArgumentTypeMismatchException` so that invalid path parameters return 400 Bad Request instead of 500 Internal Server Error.

Also, add a new permission for modifying users. This is given only to
KAIKKI_OIKEUDET users. (HAI-2265)

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2263 & https://helsinkisolutionoffice.atlassian.net/browse/HAI-2265

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
Call the API with Swagger UI (http://localhost:3001/api/swagger-ui/index.html#/hanke-kayttaja-controller/getHankeKayttaja).

# Checklist:
- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 

# Other relevant info
Merge #571 before this one.