### PR TITLE
Hai 2130/tram infra high speed

### DIFF
--- a/scripts/gis-material-update/process/modules/tram_infra.py
+++ b/scripts/gis-material-update/process/modules/tram_infra.py
@@ -5,6 +5,11 @@ from sqlalchemy import create_engine, text
 from modules.config import Config
 from modules.gis_processing import GisProcessor
 
+# Select only following tag values:
+# tram = Urban tram
+# light_rail = Light rail
+
+TRAM_TYPE = ["tram", "light_rail"]
 
 def dict_values_to_list(d: dict) -> dict:
     """Transform dict values to list."""
@@ -40,7 +45,7 @@ class TramInfra(GisProcessor):
             lambda r: other_tag_to_dict(r.other_tags), axis=1
         )
         lines_with_tags_tram_index = lines_with_tags.apply(
-            lambda r: r.tag_dict.get("railway") == "tram", axis=1
+            lambda r: any(tag_value in r.tag_dict.get("railway", []) for tag_value in TRAM_TYPE), axis=1
         )
         tram_lines = lines_with_tags[lines_with_tags_tram_index]
 
@@ -63,6 +68,18 @@ class TramInfra(GisProcessor):
         # buffer lines
         target_infra_polys = self._process_result_lines.copy()
         target_infra_polys["geometry"] = target_infra_polys.buffer(buffers[0])
+
+        # Only intersecting objects to Helsinki area are important
+        # read Helsinki geographical region and reproject
+        try:
+            helsinki_region_polygon = gpd.read_file(
+                filename=self._cfg.local_file("hki")
+            ).to_crs(self._cfg.crs())
+        except Exception as e:
+            print("Area polygon file not found!")
+            raise e
+        
+        target_infra_polys = gpd.clip(target_infra_polys, helsinki_region_polygon)
 
         # save to instance
         self._process_result_polygons = target_infra_polys

--- a/scripts/gis-material-update/process/modules/tram_infra.py
+++ b/scripts/gis-material-update/process/modules/tram_infra.py
@@ -9,7 +9,7 @@ from modules.gis_processing import GisProcessor
 # tram = Urban tram
 # light_rail = Light rail
 
-TRAM_TYPE = ["tram", "light_rail"]
+TRAM_TYPES = ["tram", "light_rail"]
 
 def dict_values_to_list(d: dict) -> dict:
     """Transform dict values to list."""
@@ -45,7 +45,7 @@ class TramInfra(GisProcessor):
             lambda r: other_tag_to_dict(r.other_tags), axis=1
         )
         lines_with_tags_tram_index = lines_with_tags.apply(
-            lambda r: any(tag_value in r.tag_dict.get("railway", []) for tag_value in TRAM_TYPE), axis=1
+            lambda r: any(tag_value in r.tag_dict.get("railway", []) for tag_value in TRAM_TYPES), axis=1
         )
         tram_lines = lines_with_tags[lines_with_tags_tram_index]
 


### PR DESCRIPTION
# Description

HAI-2130 Adding light rail objects to tram infra.

Added new tag value "light_rail" which will be included in tram_infra.
Also changed code so that it is easier to add tag values later on.
Added clipping by Helsinki area because some tram_infra objects are going outside of Helsinki.

### Jira Issue: 
https://helsinkisolutionoffice.atlassian.net/browse/HAI-2130

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [x] Other

# Instructions for testing
Check instructions from scripts/gis-material-update/readme to process tram_infra data (check also preparing part from instructions).
Then check data file (tormays_tram_infra_polys.gpkg) with QGIS:

* current feature count: 1848 (this amount might be changed over time)
* geometries are looking ok (=areas)
* objects are having following attributes:
	"fid",
	"infra"

# Checklist:

- [ ] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 

# Other relevant info
Please describe here if there is e.g. some requirements for this change or
 other info that the tester/user needs to know.