### PR TITLE
HAI-2166 Add contacts to hanke read APIs

### DIFF
--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeService.kt
@@ -48,13 +48,13 @@ class HankeService(
         } ?: throw HankeNotFoundException(hankeTunnus)
 
     @Transactional(readOnly = true)
-    fun loadHanke(hankeTunnus: String) =
+    fun loadHanke(hankeTunnus: String): Hanke? =
         hankeRepository.findByHankeTunnus(hankeTunnus)?.let {
             createHankeDomainObjectFromEntity(it)
         }
 
     @Transactional(readOnly = true)
-    fun loadPublicHanke() =
+    fun loadPublicHanke(): List<Hanke> =
         hankeRepository.findAllByStatus(HankeStatus.PUBLIC).map {
             createHankeDomainObjectFromEntity(it)
         }
@@ -517,25 +517,7 @@ class HankeService(
         if (validYhteystieto) {
             // ... it is valid, so create a new Yhteystieto
             val hankeYhtEntity =
-                HankeYhteystietoEntity(
-                    contactType = contactType,
-                    nimi = hankeYht.nimi,
-                    email = hankeYht.email,
-                    ytunnus = hankeYht.ytunnus,
-                    puhelinnumero = hankeYht.puhelinnumero,
-                    organisaatioNimi = hankeYht.organisaatioNimi,
-                    osasto = hankeYht.osasto,
-                    rooli = hankeYht.rooli,
-                    tyyppi = hankeYht.tyyppi,
-                    dataLocked = false,
-                    dataLockInfo = null,
-                    createdByUserId = userid,
-                    createdAt = getCurrentTimeUTCAsLocalTime(),
-                    modifiedByUserId = null,
-                    modifiedAt = null,
-                    id = null, // will be set by the database
-                    hanke = hankeEntity // reference back to parent hanke
-                )
+                HankeYhteystietoEntity.fromDomain(hankeYht, contactType, userid, hankeEntity)
             hankeEntity.addYhteystieto(hankeYhtEntity)
             // Logging of creating new yhteystietos is done after the hanke gets saved.
         } else {

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeYhteyshenkiloEntity.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeYhteyshenkiloEntity.kt
@@ -9,6 +9,7 @@ import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
 import java.util.UUID
+import org.springframework.data.jpa.repository.JpaRepository
 
 @Entity
 @Table(name = "hankeyhteyshenkilo")
@@ -30,3 +31,5 @@ class HankeYhteyshenkiloEntity(
             hankeKayttaja.puhelin,
         )
 }
+
+interface HankeYhteyshenkiloRepository : JpaRepository<HankeYhteyshenkiloEntity, UUID> {}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeYhteystietoEntity.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeYhteystietoEntity.kt
@@ -2,6 +2,7 @@ package fi.hel.haitaton.hanke
 
 import com.fasterxml.jackson.annotation.JsonView
 import fi.hel.haitaton.hanke.domain.HankeYhteystieto
+import fi.hel.haitaton.hanke.domain.Yhteystieto
 import fi.hel.haitaton.hanke.domain.YhteystietoTyyppi
 import jakarta.persistence.CascadeType
 import jakarta.persistence.Column
@@ -18,6 +19,7 @@ import jakarta.persistence.ManyToOne
 import jakarta.persistence.OneToMany
 import jakarta.persistence.Table
 import java.time.LocalDateTime
+import org.springframework.data.jpa.repository.JpaRepository
 
 enum class ContactType {
     OMISTAJA,
@@ -85,6 +87,7 @@ class HankeYhteystietoEntity(
             createdBy = createdByUserId,
             modifiedAt = modifiedAt?.zonedDateTime(),
             modifiedBy = modifiedByUserId,
+            yhteyshenkilot = yhteyshenkilot.map { it.toDomain() },
         )
 
     // Must consider both id and all non-audit fields for correct operations in certain collections
@@ -134,4 +137,32 @@ class HankeYhteystietoEntity(
             rooli = rooli,
             tyyppi = tyyppi,
         )
+
+    companion object {
+        fun fromDomain(
+            hankeYht: Yhteystieto,
+            contactType: ContactType,
+            createdByUserId: String,
+            hankeEntity: HankeEntity,
+        ) =
+            HankeYhteystietoEntity(
+                contactType = contactType,
+                nimi = hankeYht.nimi,
+                email = hankeYht.email,
+                ytunnus = hankeYht.ytunnus,
+                puhelinnumero = hankeYht.puhelinnumero,
+                organisaatioNimi = hankeYht.organisaatioNimi,
+                osasto = hankeYht.osasto,
+                rooli = hankeYht.rooli,
+                tyyppi = hankeYht.tyyppi,
+                dataLocked = false,
+                dataLockInfo = null,
+                createdByUserId = createdByUserId,
+                createdAt = getCurrentTimeUTCAsLocalTime(),
+                id = hankeYht.id,
+                hanke = hankeEntity, // reference back to parent hanke
+            )
+    }
 }
+
+interface HankeYhteystietoRepository : JpaRepository<HankeYhteystietoEntity, Int> {}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/HankeYhteystieto.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/HankeYhteystieto.kt
@@ -22,7 +22,6 @@ data class HankeYhteystieto(
     @JsonView(ChangeLogView::class)
     @field:Schema(description = "Contact name. Full name if an actual person.")
     override var nimi: String,
-    //
     @JsonView(ChangeLogView::class)
     @field:Schema(description = "Contact email address")
     override var email: String,
@@ -31,41 +30,36 @@ data class HankeYhteystieto(
     @JsonView(ChangeLogView::class)
     @field:Schema(description = "Phone number")
     override var puhelinnumero: String?,
-    //
     @JsonView(ChangeLogView::class)
     @field:Schema(description = "Organisation name")
     override var organisaatioNimi: String?,
-    //
     @JsonView(ChangeLogView::class)
     @field:Schema(description = "Contact department")
     override var osasto: String?,
-    //
     @JsonView(ChangeLogView::class)
     @field:Schema(description = "Role of the contact")
     override var rooli: String?,
-    //
     @JsonView(ChangeLogView::class)
     @field:Schema(description = "Contact type")
     override var tyyppi: YhteystietoTyyppi? = null,
-    //
     @JsonView(ChangeLogView::class)
     @field:Schema(description = "Business id, for contacts with tyyppi other than YKSITYISHENKILO")
     override val ytunnus: String? = null,
+    @JsonView(ChangeLogView::class)
+    @field:Schema(description = "Persons to contact for this contact")
+    val yhteyshenkilot: List<Yhteyshenkilo>,
 
     // Metadata
     @JsonView(NotInChangeLogView::class)
     @field:Schema(description = "User id of the creator, set by the service")
     var createdBy: String? = null,
-    //
     @JsonView(NotInChangeLogView::class)
     @field:Schema(description = "Timestamp of creation, set by the service")
     var createdAt: ZonedDateTime? = null,
-    //
     @JsonView(NotInChangeLogView::class)
     @field:Schema(description = "User id of the last modifier, set by the service")
     var modifiedBy: String? = null,
-    //
     @JsonView(NotInChangeLogView::class)
     @field:Schema(description = "Timestamp of last modification, set by the service")
-    var modifiedAt: ZonedDateTime? = null
+    var modifiedAt: ZonedDateTime? = null,
 ) : HasId<Int?>, Yhteystieto

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/HankeMapperTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/HankeMapperTest.kt
@@ -14,8 +14,8 @@ import fi.hel.haitaton.hanke.factory.ApplicationFactory.Companion.TEPPO_EMAIL
 import fi.hel.haitaton.hanke.factory.DateFactory
 import fi.hel.haitaton.hanke.factory.GeometriaFactory
 import fi.hel.haitaton.hanke.factory.HankeFactory
+import fi.hel.haitaton.hanke.factory.HankeYhteyshenkiloFactory.withYhteyshenkilo
 import fi.hel.haitaton.hanke.factory.HankeYhteystietoFactory
-import fi.hel.haitaton.hanke.factory.HankeYhteystietoFactory.defaultYtunnus
 import fi.hel.haitaton.hanke.factory.HankealueFactory
 import fi.hel.haitaton.hanke.factory.TEPPO_TESTI
 import java.time.ZonedDateTime
@@ -58,14 +58,16 @@ class HankeMapperTest {
     private fun expectedYhteystieto(hankeEntity: HankeEntity, type: ContactType, id: Int) =
         mutableListOf(
             HankeYhteystietoFactory.create(
-                id = id,
-                nimi = "$TEPPO_TESTI $type",
-                email = "$type.$TEPPO_EMAIL",
-                tyyppi = YRITYS,
-                ytunnus = defaultYtunnus,
-                createdAt = hankeEntity.yhteystietoCreatedAt(type),
-                modifiedAt = hankeEntity.yhteystietoModifiedAt(type),
-            )
+                    id = id,
+                    nimi = "$TEPPO_TESTI $type",
+                    email = "$type.$TEPPO_EMAIL",
+                    tyyppi = YRITYS,
+                    ytunnus = HankeYhteystietoFactory.DEFAULT_YTUNNUS,
+                    createdAt = hankeEntity.yhteystietoCreatedAt(type),
+                    modifiedAt = hankeEntity.yhteystietoModifiedAt(type),
+                )
+                .withYhteyshenkilo(id * 2)
+                .withYhteyshenkilo(id * 2 + 1)
         )
 
     private fun HankeEntity.yhteystietoCreatedAt(contactType: ContactType) =

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/TestExtensions.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/TestExtensions.kt
@@ -10,6 +10,7 @@ import jakarta.mail.internet.MimeMessage
 import java.nio.charset.StandardCharsets
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
+import java.util.UUID
 import org.junit.jupiter.api.Assertions
 import org.springframework.test.web.servlet.ResultActions
 
@@ -48,6 +49,13 @@ fun OffsetDateTime.asUtc(): OffsetDateTime = this.withOffsetSameInstant(ZoneOffs
 fun GreenMailExtension.firstReceivedMessage(): MimeMessage {
     Assertions.assertEquals(1, receivedMessages.size)
     return receivedMessages[0]
+}
+
+/** Creates a deterministic but "unpredictable" UUID from an int seed. */
+fun Int.toUUID(): UUID {
+    val bytes = ByteArray(4)
+    for (i in 0..3) bytes[i] = (this shr (i * 8)).toByte()
+    return UUID.nameUUIDFromBytes(bytes)
 }
 
 inline fun <reified T> Assert<Collection<T>>.hasSameElementsAs(elements: List<T>) =

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeKayttajaFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeKayttajaFactory.kt
@@ -65,6 +65,20 @@ class HankeKayttajaFactory(
             permissionEntity = permissionService.create(hankeId, userId, kayttooikeustaso),
         )
 
+    fun saveIdentifiedUser(
+        hankeId: Int,
+        input: HankekayttajaInput,
+        kayttooikeustaso: Kayttooikeustaso,
+    ): HankekayttajaEntity =
+        saveIdentifiedUser(
+            hankeId = hankeId,
+            etunimi = input.etunimi,
+            sukunimi = input.sukunimi,
+            sahkoposti = input.email,
+            puhelin = input.puhelin,
+            kayttooikeustaso = kayttooikeustaso
+        )
+
     fun saveUser(
         hankeId: Int,
         etunimi: String = KAKE,

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeYhteyshenkiloFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeYhteyshenkiloFactory.kt
@@ -1,0 +1,41 @@
+package fi.hel.haitaton.hanke.factory
+
+import fi.hel.haitaton.hanke.HankeYhteyshenkiloEntity
+import fi.hel.haitaton.hanke.HankeYhteystietoEntity
+import fi.hel.haitaton.hanke.domain.HankeYhteystieto
+import fi.hel.haitaton.hanke.domain.Yhteyshenkilo
+import fi.hel.haitaton.hanke.permissions.HankekayttajaEntity
+import fi.hel.haitaton.hanke.toUUID
+
+object HankeYhteyshenkiloFactory {
+
+    fun create(i: Int) =
+        Yhteyshenkilo(
+            id = i.toUUID(),
+            etunimi = "Etu$i",
+            sukunimi = "Suku$i",
+            email = "email$i",
+            puhelinnumero = "010$i",
+        )
+
+    fun HankeYhteystieto.withYhteyshenkilo(i: Int) =
+        copy(yhteyshenkilot = yhteyshenkilot + create(i))
+
+    fun createEntity(id: Int, hankeYhteystieto: HankeYhteystietoEntity): HankeYhteyshenkiloEntity =
+        with(create(id)) {
+            HankeYhteyshenkiloEntity(
+                id = this.id,
+                hankeKayttaja =
+                    HankekayttajaEntity(
+                        id = this.id,
+                        hankeId = hankeYhteystieto.hanke!!.id,
+                        etunimi = etunimi,
+                        sukunimi = sukunimi,
+                        sahkoposti = email,
+                        puhelin = puhelinnumero,
+                        permission = null,
+                    ),
+                hankeYhteystieto = hankeYhteystieto,
+            )
+        }
+}

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeYhteystietoFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeYhteystietoFactory.kt
@@ -4,18 +4,19 @@ import fi.hel.haitaton.hanke.ContactType
 import fi.hel.haitaton.hanke.HankeEntity
 import fi.hel.haitaton.hanke.HankeYhteystietoEntity
 import fi.hel.haitaton.hanke.domain.HankeYhteystieto
+import fi.hel.haitaton.hanke.domain.Yhteyshenkilo
 import fi.hel.haitaton.hanke.domain.YhteystietoTyyppi
 import fi.hel.haitaton.hanke.domain.YhteystietoTyyppi.YHTEISO
 import fi.hel.haitaton.hanke.domain.YhteystietoTyyppi.YKSITYISHENKILO
 import fi.hel.haitaton.hanke.domain.YhteystietoTyyppi.YRITYS
 import fi.hel.haitaton.hanke.factory.ApplicationFactory.Companion.TEPPO_EMAIL
-import fi.hel.haitaton.hanke.factory.HankeYhteystietoFactory.defaultYtunnus
+import fi.hel.haitaton.hanke.factory.HankeYhteystietoFactory.DEFAULT_YTUNNUS
 import fi.hel.haitaton.hanke.getCurrentTimeUTC
 import java.time.ZonedDateTime
 
 object HankeYhteystietoFactory {
 
-    const val defaultYtunnus = "1817548-2"
+    const val DEFAULT_YTUNNUS = "1817548-2"
 
     /** Create a test yhteystieto with values in all fields. */
     fun create(
@@ -23,7 +24,7 @@ object HankeYhteystietoFactory {
         nimi: String = "Teppo Testihenkilö",
         email: String = TEPPO_EMAIL,
         tyyppi: YhteystietoTyyppi = YRITYS,
-        ytunnus: String = defaultYtunnus,
+        ytunnus: String = DEFAULT_YTUNNUS,
         puhelinnumero: String = "04012345678",
         createdAt: ZonedDateTime? = getCurrentTimeUTC(),
         modifiedAt: ZonedDateTime? = getCurrentTimeUTC(),
@@ -42,51 +43,64 @@ object HankeYhteystietoFactory {
             modifiedBy = "test7358",
             modifiedAt = modifiedAt,
             rooli = "Isännöitsijä",
+            yhteyshenkilot = listOf(),
         )
     }
 
     fun createEntity(
-        id: Int? = 1,
+        id: Int = 1,
         contactType: ContactType,
         hanke: HankeEntity
     ): HankeYhteystietoEntity =
-        with(create(id = id)) {
+        with(create()) {
             HankeYhteystietoEntity(
-                id = id,
-                contactType = contactType,
-                nimi = "$nimi $contactType",
-                email = "$contactType.$email",
-                tyyppi = tyyppi,
-                ytunnus = ytunnus,
-                puhelinnumero = puhelinnumero,
-                organisaatioNimi = organisaatioNimi,
-                osasto = osasto,
-                rooli = rooli,
-                dataLocked = false,
-                dataLockInfo = "info",
-                createdByUserId = createdBy,
-                createdAt = createdAt?.toLocalDateTime(),
-                modifiedByUserId = modifiedBy,
-                modifiedAt = modifiedAt?.toLocalDateTime(),
-                hanke = hanke,
-            )
+                    id = id,
+                    contactType = contactType,
+                    nimi = "$nimi $contactType",
+                    email = "$contactType.$email",
+                    tyyppi = tyyppi,
+                    ytunnus = ytunnus,
+                    puhelinnumero = puhelinnumero,
+                    organisaatioNimi = organisaatioNimi,
+                    osasto = osasto,
+                    rooli = rooli,
+                    dataLocked = false,
+                    dataLockInfo = "info",
+                    createdByUserId = createdBy,
+                    createdAt = createdAt?.toLocalDateTime(),
+                    modifiedByUserId = modifiedBy,
+                    modifiedAt = modifiedAt?.toLocalDateTime(),
+                    hanke = hanke,
+                )
+                .apply {
+                    yhteyshenkilot =
+                        mutableListOf(
+                            HankeYhteyshenkiloFactory.createEntity(id * 2, this),
+                            HankeYhteyshenkiloFactory.createEntity(id * 2 + 1, this)
+                        )
+                }
         }
 
     /**
      * Create a new Yhteystieto with values differentiated by the given integer. The audit and id
      * fields are left null.
      */
-    fun createDifferentiated(i: Int, id: Int? = i): HankeYhteystieto {
+    fun createDifferentiated(
+        i: Int,
+        id: Int? = i,
+        yhteyshenkilot: List<Yhteyshenkilo> = listOf()
+    ): HankeYhteystieto {
         return HankeYhteystieto(
             id = id,
             nimi = "etu$i suku$i",
             email = "email$i",
-            ytunnus = defaultYtunnus,
+            ytunnus = DEFAULT_YTUNNUS,
             puhelinnumero = dummyPhoneNumber(i),
             organisaatioNimi = "org$i",
             osasto = "osasto$i",
             rooli = "Isännöitsijä$i",
             tyyppi = YHTEISO,
+            yhteyshenkilot = yhteyshenkilot,
         )
     }
 
@@ -106,6 +120,6 @@ object HankeYhteystietoFactory {
 }
 
 fun MutableList<HankeYhteystieto>.modify(
-    ytunnus: String? = defaultYtunnus,
+    ytunnus: String? = DEFAULT_YTUNNUS,
     tyyppi: YhteystietoTyyppi? = YRITYS
 ) = map { it.copy(ytunnus = ytunnus, tyyppi = tyyppi) }.toMutableList()

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/logging/DisclosureLogServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/logging/DisclosureLogServiceTest.kt
@@ -15,9 +15,9 @@ import fi.hel.haitaton.hanke.factory.ApplicationFactory.Companion.withApplicatio
 import fi.hel.haitaton.hanke.factory.ApplicationFactory.Companion.withContacts
 import fi.hel.haitaton.hanke.factory.AuditLogEntryFactory
 import fi.hel.haitaton.hanke.factory.HankeFactory
-import fi.hel.haitaton.hanke.factory.HankeFactory.Companion.withGeneratedOmistaja
-import fi.hel.haitaton.hanke.factory.HankeFactory.Companion.withGeneratedRakennuttaja
-import fi.hel.haitaton.hanke.factory.HankeFactory.Companion.withGeneratedToteuttaja
+import fi.hel.haitaton.hanke.factory.HankeFactory.Companion.withOmistaja
+import fi.hel.haitaton.hanke.factory.HankeFactory.Companion.withRakennuttaja
+import fi.hel.haitaton.hanke.factory.HankeFactory.Companion.withToteuttaja
 import fi.hel.haitaton.hanke.factory.HankeFactory.Companion.withYhteystiedot
 import fi.hel.haitaton.hanke.factory.HankeKayttajaFactory
 import fi.hel.haitaton.hanke.factory.HankeYhteystietoFactory
@@ -155,10 +155,7 @@ internal class DisclosureLogServiceTest {
         val hankkeet =
             listOf(
                 HankeFactory.create().withYhteystiedot(),
-                HankeFactory.create()
-                    .withGeneratedOmistaja(5)
-                    .withGeneratedRakennuttaja(6)
-                    .withGeneratedToteuttaja(7)
+                HankeFactory.create().withOmistaja(5).withRakennuttaja(6).withToteuttaja(7)
             )
         val expectedLogs = hankkeet.flatMap { AuditLogEntryFactory.createReadEntriesForHanke(it) }
 

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/validation/HankeValidatorTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/validation/HankeValidatorTest.kt
@@ -14,7 +14,7 @@ import fi.hel.haitaton.hanke.factory.DateFactory
 import fi.hel.haitaton.hanke.factory.HankeFactory
 import fi.hel.haitaton.hanke.factory.HankeFactory.Companion.withHankealue
 import fi.hel.haitaton.hanke.factory.HankeFactory.Companion.withYhteystiedot
-import fi.hel.haitaton.hanke.factory.HankeYhteystietoFactory.defaultYtunnus
+import fi.hel.haitaton.hanke.factory.HankeYhteystietoFactory.DEFAULT_YTUNNUS
 import fi.hel.haitaton.hanke.factory.modify
 import io.mockk.clearAllMocks
 import io.mockk.confirmVerified
@@ -243,7 +243,7 @@ class HankeValidatorTest {
     fun `when tyyppi is yksityishenkilo and ytunnus is not null should not return ok`() {
         val hanke =
             HankeFactory.create().withYhteystiedot().apply {
-                omistajat = omistajat.modify(ytunnus = defaultYtunnus, tyyppi = YKSITYISHENKILO)
+                omistajat = omistajat.modify(ytunnus = DEFAULT_YTUNNUS, tyyppi = YKSITYISHENKILO)
             }
 
         assertThat(hankeValidator.isValid(hanke, context)).isFalse()


### PR DESCRIPTION
# Description

Add contacts to hanke read APIs.

Add test factories to make adding yhteyshenkilöt to hanke easier.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2166

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
The only way to test the new API is by adding the new type of contact from DB.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 