### PR TITLE
HAI-2265 Grant MODIFY_USERS to correct käyttäoikeustasot

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/KayttooikeustasoEntityITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/KayttooikeustasoEntityITest.kt
@@ -34,6 +34,7 @@ class KayttooikeustasoEntityITest : DatabaseTest() {
                         PermissionCode.MODIFY_APPLICATION_PERMISSIONS,
                         PermissionCode.RESEND_INVITATION,
                         PermissionCode.CREATE_USER,
+                        PermissionCode.MODIFY_USER,
                     )
                 ),
                 Arguments.of(
@@ -43,6 +44,7 @@ class KayttooikeustasoEntityITest : DatabaseTest() {
                         PermissionCode.EDIT,
                         PermissionCode.RESEND_INVITATION,
                         PermissionCode.CREATE_USER,
+                        PermissionCode.MODIFY_USER,
                     )
                 ),
                 Arguments.of(
@@ -52,6 +54,7 @@ class KayttooikeustasoEntityITest : DatabaseTest() {
                         PermissionCode.EDIT_APPLICATIONS,
                         PermissionCode.RESEND_INVITATION,
                         PermissionCode.CREATE_USER,
+                        PermissionCode.MODIFY_USER,
                     )
                 ),
                 Arguments.of(Kayttooikeustaso.KATSELUOIKEUS, listOf(PermissionCode.VIEW)),

--- a/services/hanke-service/src/main/resources/db/changelog/changesets/068-grant-modify-user-permission-to-kayttooikeustasot.sql
+++ b/services/hanke-service/src/main/resources/db/changelog/changesets/068-grant-modify-user-permission-to-kayttooikeustasot.sql
@@ -1,0 +1,7 @@
+--liquibase formatted sql
+--changeset Topias Heinonen:068-grant-modify-user-permission-to-kayttooikeustasot
+--comment: Grant the MODIFY_USERS permission to all kayttooikeustasot except KATSELUOIKEUS
+
+UPDATE kayttooikeustaso
+SET permissioncode = permissioncode | 1024
+WHERE kayttooikeustaso IN ('KAIKKI_OIKEUDET','KAIKKIEN_MUOKKAUS', 'HANKEMUOKKAUS', 'HAKEMUSASIOINTI');

--- a/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -163,3 +163,5 @@ databaseChangeLog:
       file: db/changelog/changesets/066-drop-default-content-type-value-from-attachments.yml
   - include:
       file: db/changelog/changesets/067-create-hankeyhteyshenkilo-table.sql
+  - include:
+      file: db/changelog/changesets/068-grant-modify-user-permission-to-kayttooikeustasot.sql


### PR DESCRIPTION
# Description

All users except users with just view permissions should be able to modify the contact information of contact people. Grant the permission to these groups.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2265

## Type of change

- [X] Bug fix 
- [ ] New feature 
- [ ] Other