### PR TITLE
HAI-2283 Fixed invalid characters in ContentDisposition header (filename)

### DIFF
--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/azure/BlobFileClient.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/azure/BlobFileClient.kt
@@ -51,7 +51,8 @@ class BlobFileClient(blobServiceClient: BlobServiceClient, containers: Container
         val options = BlobParallelUploadOptions(BinaryData.fromBytes(content))
         options.headers = BlobHttpHeaders()
         options.headers.setContentType(contentType.toString())
-        options.headers.setContentDisposition("attachment; filename=$originalFilename")
+        val contentDisposition = "attachment; filename*=UTF-8''${encodeFilename(originalFilename)}"
+        options.headers.setContentDisposition(contentDisposition)
         getContainerClient(container).getBlobClient(path).uploadWithResponse(options, null, null)
         logger.info { "Uploaded Blob to container $container with path $path" }
     }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/common/FileClient.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/common/FileClient.kt
@@ -1,5 +1,6 @@
 package fi.hel.haitaton.hanke.attachment.common
 
+import com.azure.core.implementation.http.rest.UrlEscapers
 import com.azure.core.util.BinaryData
 import fi.hel.haitaton.hanke.attachment.azure.Container
 import org.springframework.http.MediaType
@@ -20,6 +21,10 @@ interface FileClient {
     fun delete(container: Container, path: String): Boolean
 
     fun deleteAllByPrefix(container: Container, prefix: String)
+
+    fun encodeFilename(filename: String): String {
+        return UrlEscapers.PATH_ESCAPER.escape(filename)
+    }
 }
 
 data class DownloadResponse(

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/attachment/common/MockFileClient.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/attachment/common/MockFileClient.kt
@@ -40,7 +40,7 @@ class MockFileClient : FileClient {
                 path,
                 contentType,
                 content.size,
-                "attachment; filename=$originalFilename",
+                "attachment; filename*=UTF-8''${encodeFilename(originalFilename)}",
                 BinaryData.fromBytes(content)
             )
     }


### PR DESCRIPTION
# Description

Fixes errors with attachment filanames with e.g. scandic letters or €.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2283

## Type of change

- [x] Bug fix 
- [ ] New feature 
- [ ] Other

# Instructions for testing
Attachments work with filanames containing e.g. scandic letters or €

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 

# Other relevant info
Please describe here if there is e.g. some requirements for this change or
 other info that the tester/user needs to know.