### PR TITLE
HAI-2260 Add user roles in user list api response

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
@@ -228,7 +228,7 @@ class HankeServiceITests(
 
             assertThat(hanke.omistajat.single()).all {
                 hasDefaultInfo()
-                hasOneYhteyshenkilo(HankeKayttajaFactory.KAYTTAJA_INPUT_HAKIJA)
+                hasOneYhteyshenkilo(HankeKayttajaFactory.KAYTTAJA_INPUT_OMISTAJA)
             }
             assertThat(hanke.rakennuttajat.single()).all {
                 hasDefaultInfo()

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaControllerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaControllerITest.kt
@@ -281,13 +281,13 @@ class HankeKayttajaControllerITest(@Autowired override val mockMvc: MockMvc) : C
             val hanke = HankeFactory.create()
             val testData =
                 listOf(
-                    HankeKayttajaFactory.generateHankeKayttaja(
+                    HankeKayttajaFactory.createHankeKayttaja(
                         1,
                         ContactType.OMISTAJA,
                         ContactType.MUU
                     ),
-                    HankeKayttajaFactory.generateHankeKayttaja(2),
-                    HankeKayttajaFactory.generateHankeKayttaja(3),
+                    HankeKayttajaFactory.createHankeKayttaja(2),
+                    HankeKayttajaFactory.createHankeKayttaja(3),
                 )
             every { authorizer.authorizeHankeTunnus(HANKE_TUNNUS, VIEW.name) } returns true
             every { hankeService.findIdentifier(HANKE_TUNNUS) } returns hanke.identifier()

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaControllerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaControllerITest.kt
@@ -2,12 +2,14 @@ package fi.hel.haitaton.hanke.permissions
 
 import assertk.all
 import assertk.assertThat
+import assertk.assertions.containsExactlyInAnyOrder
 import assertk.assertions.hasSize
 import assertk.assertions.isEmpty
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNotNull
 import assertk.assertions.isNull
 import assertk.assertions.prop
+import fi.hel.haitaton.hanke.ContactType
 import fi.hel.haitaton.hanke.ControllerTest
 import fi.hel.haitaton.hanke.HankeError
 import fi.hel.haitaton.hanke.HankeNotFoundException
@@ -277,7 +279,16 @@ class HankeKayttajaControllerITest(@Autowired override val mockMvc: MockMvc) : C
         @Test
         fun `With valid request returns users of given hanke and logs audit`() {
             val hanke = HankeFactory.create()
-            val testData = HankeKayttajaFactory.generateHankeKayttajat()
+            val testData =
+                listOf(
+                    HankeKayttajaFactory.generateHankeKayttaja(
+                        1,
+                        ContactType.OMISTAJA,
+                        ContactType.MUU
+                    ),
+                    HankeKayttajaFactory.generateHankeKayttaja(2),
+                    HankeKayttajaFactory.generateHankeKayttaja(3),
+                )
             every { authorizer.authorizeHankeTunnus(HANKE_TUNNUS, VIEW.name) } returns true
             every { hankeService.findIdentifier(HANKE_TUNNUS) } returns hanke.identifier()
             every { hankeKayttajaService.getKayttajatByHankeId(hanke.id) } returns testData
@@ -294,6 +305,7 @@ class HankeKayttajaControllerITest(@Autowired override val mockMvc: MockMvc) : C
                 assertThat(puhelinnumero).isEqualTo("0405551111")
                 assertThat(sahkoposti).isEqualTo("email.1.address.com")
                 assertThat(tunnistautunut).isEqualTo(false)
+                assertThat(roolit).containsExactlyInAnyOrder(ContactType.OMISTAJA, ContactType.MUU)
             }
             assertThat(response.kayttajat).hasSameElementsAs(testData)
             verifyOrder {

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttaja.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttaja.kt
@@ -1,5 +1,6 @@
 package fi.hel.haitaton.hanke.permissions
 
+import fi.hel.haitaton.hanke.ContactType
 import fi.hel.haitaton.hanke.HankeYhteyshenkiloEntity
 import fi.hel.haitaton.hanke.domain.HasId
 import io.swagger.v3.oas.annotations.media.Schema
@@ -41,6 +42,7 @@ data class HankeKayttajaDto(
     val nimi: String,
     @field:Schema(description = "Phone number") val puhelinnumero: String,
     @field:Schema(description = "Access level in Hanke") val kayttooikeustaso: Kayttooikeustaso?,
+    @field:Schema(description = "User roles in Hanke") val roolit: List<ContactType>,
     @field:Schema(description = "Has user logged in to view Hanke") val tunnistautunut: Boolean,
 )
 
@@ -97,6 +99,7 @@ class HankekayttajaEntity(
             nimi = fullName(),
             puhelinnumero = puhelin,
             kayttooikeustaso = deriveKayttooikeustaso(),
+            roolit = deriveRoolit(),
             tunnistautunut = permission != null,
         )
 
@@ -118,6 +121,14 @@ class HankekayttajaEntity(
      */
     fun deriveKayttooikeustaso(): Kayttooikeustaso? =
         permission?.kayttooikeustaso ?: kayttajakutsu?.kayttooikeustaso
+
+    /**
+     * Roles of the user are derived from the related [HankeYhteyshenkiloEntity]s. If there are no
+     * related [HankeYhteyshenkiloEntity]s, the user has no roles. This means that the user is not a
+     * contact person in any of the Hanke contacts.
+     */
+    private fun deriveRoolit(): List<ContactType> =
+        yhteyshenkilot.map { it.hankeYhteystieto.contactType }
 
     fun fullName() = listOf(etunimi, sukunimi).filter { it.isNotBlank() }.joinToString(" ")
 }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeKayttajaFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeKayttajaFactory.kt
@@ -241,10 +241,10 @@ class HankeKayttajaFactory(
                 tunnistautunut = tunnistautunut
             )
 
-        fun generateHankeKayttaja(i: Int = 1, vararg roolit: ContactType): HankeKayttajaDto =
+        fun createHankeKayttaja(i: Int = 1, vararg roolit: ContactType): HankeKayttajaDto =
             createDto(i, roolit = roolit.toList(), tunnistautunut = (i % 2 == 0))
 
-        fun generateHankeKayttajat(
+        fun createHankeKayttajat(
             amount: Int = 3,
             roolit: List<ContactType> = emptyList()
         ): List<HankeKayttajaDto> =

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeKayttajaFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeKayttajaFactory.kt
@@ -1,5 +1,6 @@
 package fi.hel.haitaton.hanke.factory
 
+import fi.hel.haitaton.hanke.ContactType
 import fi.hel.haitaton.hanke.factory.KayttajaTunnisteFactory.TUNNISTE_ID
 import fi.hel.haitaton.hanke.factory.PermissionFactory.PERMISSION_ID
 import fi.hel.haitaton.hanke.permissions.HankeKayttaja
@@ -65,19 +66,22 @@ class HankeKayttajaFactory(
             permissionEntity = permissionService.create(hankeId, userId, kayttooikeustaso),
         )
 
-    fun saveIdentifiedUser(
+    fun findOrSaveIdentifiedUser(
         hankeId: Int,
         input: HankekayttajaInput,
         kayttooikeustaso: Kayttooikeustaso,
     ): HankekayttajaEntity =
-        saveIdentifiedUser(
-            hankeId = hankeId,
-            etunimi = input.etunimi,
-            sukunimi = input.sukunimi,
-            sahkoposti = input.email,
-            puhelin = input.puhelin,
-            kayttooikeustaso = kayttooikeustaso
-        )
+        hankeKayttajaRepository
+            .findByHankeIdAndSahkopostiIn(hankeId, listOf(input.email))
+            .firstOrNull()
+            ?: saveIdentifiedUser(
+                hankeId = hankeId,
+                etunimi = input.etunimi,
+                sukunimi = input.sukunimi,
+                sahkoposti = input.email,
+                puhelin = input.puhelin,
+                kayttooikeustaso = kayttooikeustaso
+            )
 
     fun saveUser(
         hankeId: Int,
@@ -123,7 +127,7 @@ class HankeKayttajaFactory(
         )
 
     companion object {
-        val KAYTTAJA_ID = UUID.fromString("639870ab-533d-4172-8e97-e5b93a275514")
+        val KAYTTAJA_ID: UUID = UUID.fromString("639870ab-533d-4172-8e97-e5b93a275514")
 
         const val KAKE = "Kake"
         const val KATSELIJA = "Katselija"
@@ -141,12 +145,28 @@ class HankeKayttajaFactory(
                 "0401234567",
             )
 
+        val KAYTTAJA_INPUT_PERUSTAJA =
+            HankekayttajaInput(
+                "Piia",
+                "Perustaja",
+                "piia.perustaja@mail.com",
+                "0401234566",
+            )
+
+        val KAYTTAJA_INPUT_OMISTAJA =
+            HankekayttajaInput(
+                "Olivia",
+                "Omistaja",
+                "olivia.omistaja@mail.com",
+                "0401234565",
+            )
+
         val KAYTTAJA_INPUT_RAKENNUTTAJA =
             HankekayttajaInput(
                 "Rane",
                 "Rakennuttaja",
                 "rane.rakennuttaja@mail.com",
-                "0401234566",
+                "0401234564",
             )
 
         val KAYTTAJA_INPUT_ASIANHOITAJA =
@@ -154,7 +174,7 @@ class HankeKayttajaFactory(
                 "Anssi",
                 "Asianhoitaja",
                 "anssi.asianhoitaja@mail.com",
-                "0401234565",
+                "0401234563",
             )
 
         val KAYTTAJA_INPUT_SUORITTAJA =
@@ -162,7 +182,15 @@ class HankeKayttajaFactory(
                 "Timo",
                 "Työnsuorittaja",
                 "timo.tyonsuorittaja@mail.com",
-                "0401234564",
+                "0401234562",
+            )
+
+        val KAYTTAJA_INPUT_MUU =
+            HankekayttajaInput(
+                "Meeri",
+                "Muukäyttäjä",
+                "meeri.muukayttaja@mail.com",
+                "0401234561",
             )
 
         fun create(
@@ -195,7 +223,12 @@ class HankeKayttajaFactory(
                 kayttajakutsu = kutsu
             )
 
-        fun createDto(i: Int = 1, tunnistautunut: Boolean = false, id: UUID = UUID.randomUUID()) =
+        fun createDto(
+            i: Int = 1,
+            id: UUID = UUID.randomUUID(),
+            roolit: List<ContactType> = emptyList(),
+            tunnistautunut: Boolean = false
+        ) =
             HankeKayttajaDto(
                 id = id,
                 sahkoposti = "email.$i.address.com",
@@ -204,10 +237,17 @@ class HankeKayttajaFactory(
                 nimi = "test$i name$i",
                 puhelinnumero = "040555$i$i$i$i",
                 kayttooikeustaso = KATSELUOIKEUS,
+                roolit = roolit,
                 tunnistautunut = tunnistautunut
             )
 
-        fun generateHankeKayttajat(amount: Int = 3): List<HankeKayttajaDto> =
-            (1..amount).map { createDto(it, it % 2 == 0) }
+        fun generateHankeKayttaja(i: Int = 1, vararg roolit: ContactType): HankeKayttajaDto =
+            createDto(i, roolit = roolit.toList(), tunnistautunut = (i % 2 == 0))
+
+        fun generateHankeKayttajat(
+            amount: Int = 3,
+            roolit: List<ContactType> = emptyList()
+        ): List<HankeKayttajaDto> =
+            (1..amount).map { createDto(it, roolit = roolit, tunnistautunut = (it % 2 == 0)) }
     }
 }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/logging/DisclosureLogServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/logging/DisclosureLogServiceTest.kt
@@ -190,7 +190,7 @@ internal class DisclosureLogServiceTest {
 
     @Test
     fun `saveDisclosureLogsForHankeKayttajat saves audit logs`() {
-        val hankeKayttajat = HankeKayttajaFactory.generateHankeKayttajat(amount = 2)
+        val hankeKayttajat = HankeKayttajaFactory.createHankeKayttajat(amount = 2)
         val expectedLogs = AuditLogEntryFactory.createReadEntryForHankeKayttajat(hankeKayttajat)
 
         disclosureLogService.saveDisclosureLogsForHankeKayttajat(hankeKayttajat, userId)


### PR DESCRIPTION
# Description

`GET /hankkeet/{hankeTunnus}/kayttajat` returns user roles as in
```
{
  "kayttajat": [
    {
      "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
      "etunimi": "Pekka",
      "sukunimi": "Perustaja",
      "sahkoposti": "pekka@perustukset.example",
      "puhelinnumero": "0501234567",
      "kayttooikeustaso": "KAIKKI_OIKEUDET",
      "roolit": ["OMISTAJA", "RAKENNUTTAJA"],
      "tunnistautunut": true
    }
  ]
}
```

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2260

## Type of change

- [ ] Bug fix 
- [x] New feature 
- [ ] Other

# Instructions for testing
Not sure if this can be tested with Swagger UI or Haitaton UI yet because in Haitaton UI one cannot currently add contacts or contact persons.

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 

# Other relevant info
Please describe here if there is e.g. some requirements for this change or
 other info that the tester/user needs to know.