### PR TITLE
HAI-2168 Update user's name from Profiili

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaControllerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaControllerITest.kt
@@ -660,13 +660,13 @@ class HankeKayttajaControllerITest(@Autowired override val mockMvc: MockMvc) : C
         }
 
         @Test
-        fun `Returns 404 when cannot retrieve verified name from Profiil`() {
+        fun `Returns 500 when cannot retrieve verified name from Profiil`() {
             every {
                 hankeKayttajaService.createPermissionFromToken(USERNAME, tunniste, any())
             } throws VerifiedNameNotFound("Verified name not found from profile.")
 
             post(url, Tunnistautuminen(tunniste))
-                .andExpect(status().isNotFound)
+                .andExpect(status().isInternalServerError)
                 .andExpect(hankeError(HankeError.HAI4007))
 
             verify {

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaControllerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaControllerITest.kt
@@ -30,6 +30,7 @@ import fi.hel.haitaton.hanke.permissions.PermissionCode.EDIT
 import fi.hel.haitaton.hanke.permissions.PermissionCode.MODIFY_EDIT_PERMISSIONS
 import fi.hel.haitaton.hanke.permissions.PermissionCode.RESEND_INVITATION
 import fi.hel.haitaton.hanke.permissions.PermissionCode.VIEW
+import fi.hel.haitaton.hanke.profiili.VerifiedNameNotFound
 import io.mockk.Called
 import io.mockk.checkUnnecessaryStub
 import io.mockk.clearAllMocks
@@ -639,8 +640,9 @@ class HankeKayttajaControllerITest(@Autowired override val mockMvc: MockMvc) : C
         fun `Returns 200 with information on success`() {
             val kayttaja = HankeKayttajaFactory.create(id = kayttajaId)
             val hanke = HankeFactory.create(id = kayttaja.hankeId)
-            every { hankeKayttajaService.createPermissionFromToken(USERNAME, tunniste) } returns
-                kayttaja
+            every {
+                hankeKayttajaService.createPermissionFromToken(USERNAME, tunniste, any())
+            } returns kayttaja
             every { hankeService.loadHankeById(kayttaja.hankeId) } returns hanke
 
             val response: TunnistautuminenResponse =
@@ -652,45 +654,65 @@ class HankeKayttajaControllerITest(@Autowired override val mockMvc: MockMvc) : C
                 prop(TunnistautuminenResponse::hankeNimi).isEqualTo(hanke.nimi)
             }
             verify {
-                hankeKayttajaService.createPermissionFromToken(USERNAME, tunniste)
+                hankeKayttajaService.createPermissionFromToken(USERNAME, tunniste, any())
                 hankeService.loadHankeById(kayttaja.hankeId)
             }
         }
 
         @Test
+        fun `Returns 404 when cannot retrieve verified name from Profiil`() {
+            every {
+                hankeKayttajaService.createPermissionFromToken(USERNAME, tunniste, any())
+            } throws VerifiedNameNotFound("Verified name not found from profile.")
+
+            post(url, Tunnistautuminen(tunniste))
+                .andExpect(status().isNotFound)
+                .andExpect(hankeError(HankeError.HAI4007))
+
+            verify {
+                hankeKayttajaService.createPermissionFromToken(USERNAME, tunniste, any())
+                hankeService wasNot Called
+            }
+        }
+
+        @Test
         fun `Returns 404 when tunniste not found`() {
-            every { hankeKayttajaService.createPermissionFromToken(USERNAME, tunniste) } throws
-                TunnisteNotFoundException(USERNAME, tunniste)
+            every {
+                hankeKayttajaService.createPermissionFromToken(USERNAME, tunniste, any())
+            } throws TunnisteNotFoundException(USERNAME, tunniste)
 
             post(url, Tunnistautuminen(tunniste))
                 .andExpect(status().isNotFound)
                 .andExpect(hankeError(HankeError.HAI4004))
 
-            verify { hankeKayttajaService.createPermissionFromToken(USERNAME, tunniste) }
+            verify { hankeKayttajaService.createPermissionFromToken(USERNAME, tunniste, any()) }
         }
 
         @Test
         fun `Returns 409 when user already has a permission`() {
-            every { hankeKayttajaService.createPermissionFromToken(USERNAME, tunniste) } throws
-                UserAlreadyHasPermissionException(USERNAME, tunnisteId, permissionId)
+            every {
+                hankeKayttajaService.createPermissionFromToken(USERNAME, tunniste, any())
+            } throws UserAlreadyHasPermissionException(USERNAME, tunnisteId, permissionId)
 
             post(url, Tunnistautuminen(tunniste))
                 .andExpect(status().isConflict)
                 .andExpect(hankeError(HankeError.HAI4003))
 
-            verify { hankeKayttajaService.createPermissionFromToken(USERNAME, tunniste) }
+            verify { hankeKayttajaService.createPermissionFromToken(USERNAME, tunniste, any()) }
         }
 
         @Test
         fun `Returns 409 when other user already has a permission for the hanke kayttaja`() {
-            every { hankeKayttajaService.createPermissionFromToken(USERNAME, tunniste) } throws
+            every {
+                hankeKayttajaService.createPermissionFromToken(USERNAME, tunniste, any())
+            } throws
                 PermissionAlreadyExistsException(USERNAME, "Other user", kayttajaId, permissionId)
 
             post(url, Tunnistautuminen(tunniste))
                 .andExpect(status().isConflict)
                 .andExpect(hankeError(HankeError.HAI4003))
 
-            verify { hankeKayttajaService.createPermissionFromToken(USERNAME, tunniste) }
+            verify { hankeKayttajaService.createPermissionFromToken(USERNAME, tunniste, any()) }
         }
     }
 

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaServiceITest.kt
@@ -1381,7 +1381,8 @@ class HankeKayttajaServiceITest : DatabaseTest() {
             val kayttaja =
                 hankeKayttajaService.createPermissionFromToken(newUserId, tunniste, securityContext)
 
-            assertThat(kayttaja.nimi).isEqualTo("$DEFAULT_GIVEN_NAME $DEFAULT_LAST_NAME")
+            assertThat(kayttaja.etunimi).isEqualTo(DEFAULT_GIVEN_NAME)
+            assertThat(kayttaja.sukunimi).isEqualTo(DEFAULT_LAST_NAME)
             val hankeKayttaja = hankeKayttajaRepository.findById(kayttaja.id).get()
             assertThat(hankeKayttaja).all {
                 prop(HankekayttajaEntity::etunimi).isEqualTo(DEFAULT_GIVEN_NAME)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeError.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeError.kt
@@ -49,6 +49,7 @@ enum class HankeError(val errorMessage: String) {
     HAI4004("Kayttajatunniste not found"),
     HAI4005("Could not verify user identity"),
     HAI4006("Duplicate hankekayttaja"),
+    HAI4007("Verified name not found in Profiili"),
     ;
 
     val errorCode: String

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttaja.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttaja.kt
@@ -59,10 +59,10 @@ class HankekayttajaEntity(
     @Column(name = "hanke_id") val hankeId: Int,
 
     /** First name. */
-    val etunimi: String,
+    var etunimi: String,
 
     /** Last name. */
-    val sukunimi: String,
+    var sukunimi: String,
 
     /** Phone number. */
     var puhelin: String,

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaController.kt
@@ -286,7 +286,7 @@ Responds with information about the activated user and the hanke associated with
                 ),
                 ApiResponse(
                     description = "Name not found in Profiili",
-                    responseCode = "404",
+                    responseCode = "500",
                     content = [Content(schema = Schema(implementation = HankeError::class))]
                 ),
                 ApiResponse(
@@ -457,7 +457,7 @@ Returns the updated hankekayttaja.
     }
 
     @ExceptionHandler
-    @ResponseStatus(HttpStatus.NOT_FOUND)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     @Hidden
     fun verifiedNameNotFoundException(ex: VerifiedNameNotFound): HankeError {
         logger.warn(ex) { ex.message }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaController.kt
@@ -285,12 +285,8 @@ Responds with information about the activated user and the hanke associated with
                     content = [Content(schema = Schema(implementation = HankeError::class))]
                 ),
                 ApiResponse(
-                    description = "Name not found in Profiili",
-                    responseCode = "500",
-                    content = [Content(schema = Schema(implementation = HankeError::class))]
-                ),
-                ApiResponse(
-                    description = "Token doesn't have a user associated with it",
+                    description =
+                        "Token doesn't have a user associated with it or the verified name cannot be retrieved from Profiili",
                     responseCode = "500",
                     content = [Content(schema = Schema(implementation = HankeError::class))]
                 ),

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaController.kt
@@ -4,8 +4,10 @@ import fi.hel.haitaton.hanke.HankeError
 import fi.hel.haitaton.hanke.HankeService
 import fi.hel.haitaton.hanke.currentUserId
 import fi.hel.haitaton.hanke.logging.DisclosureLogService
+import fi.hel.haitaton.hanke.profiili.VerifiedNameNotFound
 import io.swagger.v3.oas.annotations.Hidden
 import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
@@ -15,6 +17,8 @@ import java.util.UUID
 import mu.KotlinLogging
 import org.springframework.http.HttpStatus
 import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.security.core.annotation.CurrentSecurityContext
+import org.springframework.security.core.context.SecurityContext
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -281,6 +285,11 @@ Responds with information about the activated user and the hanke associated with
                     content = [Content(schema = Schema(implementation = HankeError::class))]
                 ),
                 ApiResponse(
+                    description = "Name not found in Profiili",
+                    responseCode = "404",
+                    content = [Content(schema = Schema(implementation = HankeError::class))]
+                ),
+                ApiResponse(
                     description = "Token doesn't have a user associated with it",
                     responseCode = "500",
                     content = [Content(schema = Schema(implementation = HankeError::class))]
@@ -292,11 +301,15 @@ Responds with information about the activated user and the hanke associated with
                 ),
             ]
     )
-    fun identifyUser(@RequestBody tunnistautuminen: Tunnistautuminen): TunnistautuminenResponse {
+    fun identifyUser(
+        @RequestBody tunnistautuminen: Tunnistautuminen,
+        @Parameter(hidden = true) @CurrentSecurityContext securityContext: SecurityContext
+    ): TunnistautuminenResponse {
         val kayttaja =
             hankeKayttajaService.createPermissionFromToken(
                 currentUserId(),
-                tunnistautuminen.tunniste
+                tunnistautuminen.tunniste,
+                securityContext
             )
 
         val hanke = hankeService.loadHankeById(kayttaja.hankeId)!!
@@ -441,6 +454,14 @@ Returns the updated hankekayttaja.
     fun tunnisteNotFoundException(ex: TunnisteNotFoundException): HankeError {
         logger.warn(ex) { ex.message }
         return HankeError.HAI4004
+    }
+
+    @ExceptionHandler
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    @Hidden
+    fun verifiedNameNotFoundException(ex: VerifiedNameNotFound): HankeError {
+        logger.warn(ex) { ex.message }
+        return HankeError.HAI4007
     }
 
     @ExceptionHandler

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaService.kt
@@ -198,13 +198,19 @@ class HankeKayttajaService(
     }
 
     @Transactional
-    fun createPermissionFromToken(userId: String, tunniste: String): HankeKayttaja {
+    fun createPermissionFromToken(
+        userId: String,
+        tunniste: String,
+        securityContext: SecurityContext
+    ): HankeKayttaja {
         logger.info { "Trying to activate token $tunniste for user $userId" }
         val tunnisteEntity =
             kayttajakutsuRepository.findByTunniste(tunniste)
                 ?: throw TunnisteNotFoundException(userId, tunniste)
 
         val kayttaja = tunnisteEntity.hankekayttaja
+
+        updateVerifiedName(userId, kayttaja, securityContext)
 
         permissionService.findPermission(kayttaja.hankeId, userId)?.let { permission ->
             throw UserAlreadyHasPermissionException(userId, kayttaja.id, permission.id)
@@ -227,6 +233,19 @@ class HankeKayttajaService(
         logService.logDelete(tunnisteEntity.toDomain(), userId)
 
         return kayttaja.toDomain()
+    }
+
+    private fun updateVerifiedName(
+        userId: String,
+        kayttaja: HankekayttajaEntity,
+        securityContext: SecurityContext
+    ) {
+        val (_, lastName, givenName) = profiiliClient.getVerifiedName(securityContext)
+        if (givenName != kayttaja.etunimi || lastName != kayttaja.sukunimi) {
+            kayttaja.etunimi = givenName
+            kayttaja.sukunimi = lastName
+            logger.info { "Updated user's name from Profiili, userId = $userId" }
+        }
     }
 
     @Transactional


### PR DESCRIPTION
# Description

When user logs in via the invitation link, retrieve user's verified name from Profiili and if it differs from original name, update the name. Use given name as firstname. Do not alter names used in invitation.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2168

## Type of change

- [ ] Bug fix 
- [x] New feature 
- [ ] Other

# Instructions for testing
1. Using an access login of logged in Hanke user with `CREATE_USER` rights, create a new user ` POST /hankkeet/{hankeTunnus}/kayttajat` for Hanke. Take note of the data you provide, e.g. 
`{
  "etunimi": "Jaska",
  "sukunimi": "Jokunen",
  "sahkoposti": "jaska.jokunen@gmail.com",
  "puhelinnumero": "1234567"
}`
2. Log in with the invitation link. Use Suomi.fi test user that is not yet used in Hanke. 
3. Using the access token of this new log in, check that the user name is updated with Profiili data `GET /hankkeet/{hankeTunnus}/kayttajat` (There should also be an INFO log message starting `Updated user's name from Profiili`)

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 

# Other relevant info
Please describe here if there is e.g. some requirements for this change or
 other info that the tester/user needs to know.