### PR TITLE
HAI-2223 Add API for changing own contact information

### DIFF
--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/ContactUpdate.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/ContactUpdate.kt
@@ -1,0 +1,5 @@
+package fi.hel.haitaton.hanke.permissions
+
+import jakarta.validation.constraints.NotBlank
+
+data class ContactUpdate(@NotBlank val sahkoposti: String, @NotBlank val puhelinnumero: String)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttaja.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttaja.kt
@@ -65,10 +65,10 @@ class HankekayttajaEntity(
     val sukunimi: String,
 
     /** Phone number. */
-    val puhelin: String,
+    var puhelin: String,
 
     /** Email address. */
-    val sahkoposti: String,
+    var sahkoposti: String,
 
     /** Users first name used in a Hanke invitation. */
     @Column(name = "kutsuttu_etunimi") val kutsuttuEtunimi: String? = null,
@@ -111,8 +111,12 @@ class HankekayttajaEntity(
         HankeKayttaja(
             id = id,
             hankeId = hankeId,
-            nimi = fullName(),
+            etunimi = etunimi,
+            sukunimi = sukunimi,
             sahkoposti = sahkoposti,
+            puhelinnumero = puhelin,
+            kayttooikeustaso = deriveKayttooikeustaso(),
+            roolit = deriveRoolit(),
             permissionId = permission?.id,
             kayttajaTunnisteId = kayttajakutsu?.id,
         )
@@ -140,11 +144,30 @@ class HankekayttajaEntity(
 data class HankeKayttaja(
     override val id: UUID,
     val hankeId: Int,
-    val nimi: String,
+    val etunimi: String,
+    val sukunimi: String,
     val sahkoposti: String,
+    val puhelinnumero: String,
+    val kayttooikeustaso: Kayttooikeustaso?,
+    val roolit: List<ContactType>,
     val permissionId: Int?,
     val kayttajaTunnisteId: UUID?
-) : HasId<UUID>
+) : HasId<UUID> {
+    fun toDto(): HankeKayttajaDto =
+        HankeKayttajaDto(
+            id = id,
+            sahkoposti = sahkoposti,
+            etunimi = etunimi,
+            sukunimi = sukunimi,
+            nimi = fullName(),
+            puhelinnumero = puhelinnumero,
+            kayttooikeustaso = kayttooikeustaso,
+            roolit = roolit,
+            tunnistautunut = permissionId != null,
+        )
+
+    private fun fullName() = listOf(etunimi, sukunimi).filter { it.isNotBlank() }.joinToString(" ")
+}
 
 @Repository
 interface HankekayttajaRepository : JpaRepository<HankekayttajaEntity, UUID> {

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaService.kt
@@ -1,6 +1,7 @@
 package fi.hel.haitaton.hanke.permissions
 
 import fi.hel.haitaton.hanke.HankeIdentifier
+import fi.hel.haitaton.hanke.HankeNotFoundException
 import fi.hel.haitaton.hanke.HankeRepository
 import fi.hel.haitaton.hanke.application.ApplicationEntity
 import fi.hel.haitaton.hanke.configuration.Feature
@@ -242,6 +243,22 @@ class HankeKayttajaService(
         recreateKutsu(kayttaja, currentUserId)
         val hanke = hankeRepository.getReferenceById(kayttaja.hankeId)
         sendHankeInvitation(hanke.hankeTunnus, hanke.nimi, inviter, kayttaja)
+    }
+
+    @Transactional
+    fun updateOwnContactInfo(
+        hankeTunnus: String,
+        update: ContactUpdate,
+        currentUserId: String
+    ): HankeKayttaja {
+        hankeRepository
+            .findOneByHankeTunnus(hankeTunnus)
+            ?.let { getKayttajaByUserId(it.id, currentUserId) }
+            ?.let {
+                it.sahkoposti = update.sahkoposti
+                it.puhelin = update.puhelinnumero
+                return it.toDomain()
+            } ?: throw HankeNotFoundException(hankeTunnus)
     }
 
     /** Check that every user an update was requested for was found as a user of the hanke. */

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeKayttajaFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeKayttajaFactory.kt
@@ -196,11 +196,27 @@ class HankeKayttajaFactory(
         fun create(
             id: UUID = KAYTTAJA_ID,
             hankeId: Int = HankeFactory.defaultId,
-            nimi: String = PEKKA,
+            etunimi: String = KAKE,
+            sukunimi: String = KATSELIJA,
             sahkoposti: String = PEKKA_EMAIL,
+            puhelinnumero: String = KAKE_PUHELIN,
+            kayttooikeustaso: Kayttooikeustaso = KATSELUOIKEUS,
+            roolit: List<ContactType> = emptyList(),
             permissionId: Int? = PERMISSION_ID,
-            kutsuId: UUID? = TUNNISTE_ID,
-        ): HankeKayttaja = HankeKayttaja(id, hankeId, nimi, sahkoposti, permissionId, kutsuId)
+            kayttajaTunnisteId: UUID? = TUNNISTE_ID,
+        ): HankeKayttaja =
+            HankeKayttaja(
+                id = id,
+                hankeId = hankeId,
+                etunimi = etunimi,
+                sukunimi = sukunimi,
+                sahkoposti = sahkoposti,
+                puhelinnumero = puhelinnumero,
+                kayttooikeustaso = kayttooikeustaso,
+                roolit = roolit,
+                permissionId = permissionId,
+                kayttajaTunnisteId = kayttajaTunnisteId
+            )
 
         fun createEntity(
             id: UUID = KAYTTAJA_ID,


### PR DESCRIPTION
# Description

Add an endpoint that allows the user to change their contact information on the hanke.

Also, add missing fields to the HankeKayttaja domain object. This enables the DTO to be derived from the domain object and adds the missing fields to change audit logs.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2223

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
1. Create a hanke
2. Use the Swagger-UI to change your contact information
3. They should be changed in the Käyttäjähallinta page

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 