### PR TITLE
HAI-2305 Do not allow modify application after send

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationControllerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationControllerITest.kt
@@ -470,14 +470,16 @@ class ApplicationControllerITest(@Autowired override val mockMvc: MockMvc) : Con
         }
 
         @Test
-        fun `when application no longer pending should return 409`() {
+        fun `when application sent to Allu should return 409`() {
             val application = ApplicationFactory.createApplication(hankeTunnus = HANKE_TUNNUS)
             every { authorizer.authorizeApplicationId(id, EDIT_APPLICATIONS.name) } returns true
             every {
                 applicationService.updateApplicationData(id, application.applicationData, USERNAME)
-            } throws ApplicationAlreadyProcessingException(id, 21)
+            } throws ApplicationAlreadySentException(id, 21)
 
-            put("$BASE_URL/$id", application).andExpect(status().isConflict)
+            put("$BASE_URL/$id", application)
+                .andExpect(status().isConflict)
+                .andExpect(jsonPath("errorCode").value("HAI2009"))
 
             verify {
                 authorizer.authorizeApplicationId(id, EDIT_APPLICATIONS.name)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationController.kt
@@ -142,10 +142,8 @@ class ApplicationController(
         summary = "Update an application",
         description =
             """Returns the updated application.
-               The application can be updated until it has started processing in Allu, i.e. it's still pending.
+               The application can be updated until it has been sent to Allu.
                If the application hasn't changed since the last update, nothing more is done.
-               If the application has been sent to Allu, it will be updated there as well.
-               If an Allu-update is required, but it fails, the local version will not be updated.
                The pendingOnClient value can't be changed with this endpoint.
                Use [POST /hakemukset/{id}/send-application](#/application-controller/sendApplication) for that.
             """
@@ -166,7 +164,7 @@ class ApplicationController(
                 ),
                 ApiResponse(
                     description =
-                        "The application can't be updated because it has started processing in Allu",
+                        "The application can't be updated because it has been sent to Allu",
                     responseCode = "409",
                     content = [Content(schema = Schema(implementation = HankeError::class))]
                 ),
@@ -303,6 +301,14 @@ class ApplicationController(
     fun alluDataError(ex: AlluDataException): HankeError {
         logger.warn(ex) { ex.message }
         return HankeError.HAI2004
+    }
+
+    @ExceptionHandler(ApplicationAlreadySentException::class)
+    @ResponseStatus(HttpStatus.CONFLICT)
+    @Hidden
+    fun applicationAlreadySentException(ex: ApplicationAlreadySentException): HankeError {
+        logger.warn(ex) { ex.message }
+        return HankeError.HAI2009
     }
 
     @ExceptionHandler(ApplicationGeometryException::class)


### PR DESCRIPTION
# Description

Forbid application update if the application has been sent to Allu.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2305

## Type of change

- [ ] Bug fix 
- [x] New feature 
- [ ] Other

# Instructions for testing
1. Create new cable report application
2. Fill the application and send it
3. Try to modify the application (atm UI still allows this but that will change soon) - there should be a 409 HTTP error

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 

# Other relevant info
Please describe here if there is e.g. some requirements for this change or
 other info that the tester/user needs to know.