### PR TITLE
HAI-2306 Do not allow adding application attachments after send

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentControllerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentControllerITest.kt
@@ -9,7 +9,6 @@ import fi.hel.haitaton.hanke.ControllerTest
 import fi.hel.haitaton.hanke.HankeError.HAI0001
 import fi.hel.haitaton.hanke.IntegrationTestConfiguration
 import fi.hel.haitaton.hanke.andReturnBody
-import fi.hel.haitaton.hanke.application.ApplicationAlreadyProcessingException
 import fi.hel.haitaton.hanke.application.ApplicationAuthorizer
 import fi.hel.haitaton.hanke.application.ApplicationNotFoundException
 import fi.hel.haitaton.hanke.application.ApplicationService
@@ -37,6 +36,7 @@ import io.mockk.verifySequence
 import java.util.UUID
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
@@ -79,152 +79,192 @@ class ApplicationAttachmentControllerITest(@Autowired override val mockMvc: Mock
         confirmVerified(applicationAttachmentService, applicationService, authorizer)
     }
 
-    @Test
-    fun `getApplicationAttachments when application not found should return 404`() {
-        every { authorizer.authorizeApplicationId(APPLICATION_ID, VIEW.name) } throws
-            ApplicationNotFoundException(APPLICATION_ID)
+    @Nested
+    inner class GetAttachments {
+        @Test
+        fun `when application not found should return 404`() {
+            every { authorizer.authorizeApplicationId(APPLICATION_ID, VIEW.name) } throws
+                ApplicationNotFoundException(APPLICATION_ID)
 
-        get("/hakemukset/$APPLICATION_ID/liitteet").andExpect(status().isNotFound)
+            get("/hakemukset/$APPLICATION_ID/liitteet").andExpect(status().isNotFound)
 
-        verifySequence { authorizer.authorizeApplicationId(APPLICATION_ID, VIEW.name) }
-    }
-
-    @Test
-    fun `getApplicationAttachments when valid request should return metadata list`() {
-        val data =
-            (1..3).map { ApplicationAttachmentFactory.createMetadata(fileName = "${it}file.pdf") }
-        every { authorizer.authorizeApplicationId(APPLICATION_ID, VIEW.name) } returns true
-        every { applicationAttachmentService.getMetadataList(APPLICATION_ID) } returns data
-        val result: List<ApplicationAttachmentMetadataDto> =
-            get("/hakemukset/$APPLICATION_ID/liitteet").andExpect(status().isOk).andReturnBody()
-
-        assertThat(result).each { d ->
-            d.transform { it.id }.isNotNull()
-            d.transform { it.fileName }.endsWith(FILE_NAME_PDF)
-            d.transform { it.createdByUserId }.isEqualTo(USERNAME)
-            d.transform { it.createdAt }.isNotNull()
-            d.transform { it.applicationId }.isEqualTo(APPLICATION_ID)
-            d.transform { it.attachmentType }.isEqualTo(MUU)
-            d.transform { it.contentType }.isEqualTo(APPLICATION_PDF_VALUE)
-            d.transform { it.size }.isEqualTo(DEFAULT_SIZE)
+            verifySequence { authorizer.authorizeApplicationId(APPLICATION_ID, VIEW.name) }
         }
-        verifySequence {
-            authorizer.authorizeApplicationId(APPLICATION_ID, VIEW.name)
-            applicationAttachmentService.getMetadataList(APPLICATION_ID)
+
+        @Test
+        fun `when valid request should return metadata list`() {
+            val data =
+                (1..3).map {
+                    ApplicationAttachmentFactory.createMetadata(fileName = "${it}file.pdf")
+                }
+            every { authorizer.authorizeApplicationId(APPLICATION_ID, VIEW.name) } returns true
+            every { applicationAttachmentService.getMetadataList(APPLICATION_ID) } returns data
+            val result: List<ApplicationAttachmentMetadataDto> =
+                get("/hakemukset/$APPLICATION_ID/liitteet").andExpect(status().isOk).andReturnBody()
+
+            assertThat(result).each { d ->
+                d.transform { it.id }.isNotNull()
+                d.transform { it.fileName }.endsWith(FILE_NAME_PDF)
+                d.transform { it.createdByUserId }.isEqualTo(USERNAME)
+                d.transform { it.createdAt }.isNotNull()
+                d.transform { it.applicationId }.isEqualTo(APPLICATION_ID)
+                d.transform { it.attachmentType }.isEqualTo(MUU)
+                d.transform { it.contentType }.isEqualTo(APPLICATION_PDF_VALUE)
+                d.transform { it.size }.isEqualTo(DEFAULT_SIZE)
+            }
+            verifySequence {
+                authorizer.authorizeApplicationId(APPLICATION_ID, VIEW.name)
+                applicationAttachmentService.getMetadataList(APPLICATION_ID)
+            }
         }
-    }
 
-    @Test
-    fun `getAttachmentContent when valid request should return attachment file`() {
-        val attachmentId = UUID.fromString("afc778b1-eb7c-4bad-951c-de70e173a757")
-        every { authorizer.authorizeAttachment(APPLICATION_ID, attachmentId, VIEW.name) } returns
-            true
-        every { applicationAttachmentService.getContent(attachmentId) } returns
-            AttachmentContent(FILE_NAME_PDF, APPLICATION_PDF_VALUE, DUMMY_DATA)
-
-        getAttachmentContent(attachmentId = attachmentId)
-            .andExpect(status().isOk)
-            .andExpect(header().string(CONTENT_DISPOSITION, "attachment; filename=$FILE_NAME_PDF"))
-            .andExpect(content().bytes(DUMMY_DATA))
-
-        verifySequence {
-            authorizer.authorizeAttachment(APPLICATION_ID, attachmentId, VIEW.name)
-            applicationAttachmentService.getContent(attachmentId)
+        @Test
+        @WithAnonymousUser
+        fun `unauthorized should return error`() {
+            get("/hakemukset/$APPLICATION_ID/liitteet").andExpectError(HAI0001)
+            getAttachmentContent(resultType = APPLICATION_JSON).andExpectError(HAI0001)
+            postAttachment().andExpectError(HAI0001)
+            deleteAttachment().andExpectError(HAI0001)
         }
     }
 
-    @Test
-    fun `postAttachment when valid request should succeed`() {
-        val file = testFile()
-        every { authorizer.authorizeApplicationId(APPLICATION_ID, EDIT_APPLICATIONS.name) } returns
-            true
-        every { applicationAttachmentService.addAttachment(APPLICATION_ID, MUU, file) } returns
-            ApplicationAttachmentFactory.createMetadata()
+    @Nested
+    inner class GetAttachmentContent {
+        @Test
+        fun `when valid request should return attachment file`() {
+            val attachmentId = UUID.fromString("afc778b1-eb7c-4bad-951c-de70e173a757")
+            every {
+                authorizer.authorizeAttachment(APPLICATION_ID, attachmentId, VIEW.name)
+            } returns true
+            every { applicationAttachmentService.getContent(attachmentId) } returns
+                AttachmentContent(FILE_NAME_PDF, APPLICATION_PDF_VALUE, DUMMY_DATA)
 
-        val result: ApplicationAttachmentMetadataDto =
-            postAttachment(file = file).andExpect(status().isOk).andReturnBody()
+            getAttachmentContent(attachmentId = attachmentId)
+                .andExpect(status().isOk)
+                .andExpect(
+                    header().string(CONTENT_DISPOSITION, "attachment; filename=$FILE_NAME_PDF")
+                )
+                .andExpect(content().bytes(DUMMY_DATA))
 
-        with(result) {
-            assertThat(id).isNotNull()
-            assertThat(fileName).isEqualTo(FILE_NAME_PDF)
-            assertThat(createdByUserId).isEqualTo(USERNAME)
-            assertThat(createdAt).isNotNull()
-            assertThat(applicationId).isEqualTo(APPLICATION_ID)
-            assertThat(attachmentType).isEqualTo(MUU)
+            verifySequence {
+                authorizer.authorizeAttachment(APPLICATION_ID, attachmentId, VIEW.name)
+                applicationAttachmentService.getContent(attachmentId)
+            }
         }
-        verifyOrder {
-            authorizer.authorizeApplicationId(APPLICATION_ID, EDIT_APPLICATIONS.name)
-            applicationAttachmentService.addAttachment(APPLICATION_ID, MUU, file)
-        }
-    }
 
-    @Test
-    fun `postAttachment when application processing should return conflict`() {
-        val file = testFile()
-        every { authorizer.authorizeApplicationId(APPLICATION_ID, EDIT_APPLICATIONS.name) } returns
-            true
-        every { applicationAttachmentService.addAttachment(APPLICATION_ID, MUU, file) } throws
-            ApplicationAlreadyProcessingException(APPLICATION_ID, 123)
-
-        postAttachment(file = file).andExpect(status().isConflict)
-
-        verifyOrder {
-            authorizer.authorizeApplicationId(APPLICATION_ID, EDIT_APPLICATIONS.name)
-            applicationAttachmentService.addAttachment(APPLICATION_ID, MUU, file)
+        @Test
+        @WithAnonymousUser
+        fun `unauthorized should return error`() {
+            getAttachmentContent(resultType = APPLICATION_JSON).andExpectError(HAI0001)
         }
     }
 
-    @Test
-    fun `postAttachment when no rights for hanke should fail`() {
-        every { authorizer.authorizeApplicationId(APPLICATION_ID, EDIT_APPLICATIONS.name) } throws
-            ApplicationNotFoundException(APPLICATION_ID)
+    @Nested
+    inner class PostAttachment {
+        @Test
+        fun `when valid request should succeed`() {
+            val file = testFile()
+            every {
+                authorizer.authorizeApplicationId(APPLICATION_ID, EDIT_APPLICATIONS.name)
+            } returns true
+            every { applicationAttachmentService.addAttachment(APPLICATION_ID, MUU, file) } returns
+                ApplicationAttachmentFactory.createMetadata()
 
-        postAttachment().andExpect(status().isNotFound)
+            val result: ApplicationAttachmentMetadataDto =
+                postAttachment(file = file).andExpect(status().isOk).andReturnBody()
 
-        verifyOrder { authorizer.authorizeApplicationId(APPLICATION_ID, EDIT_APPLICATIONS.name) }
-    }
+            with(result) {
+                assertThat(id).isNotNull()
+                assertThat(fileName).isEqualTo(FILE_NAME_PDF)
+                assertThat(createdByUserId).isEqualTo(USERNAME)
+                assertThat(createdAt).isNotNull()
+                assertThat(applicationId).isEqualTo(APPLICATION_ID)
+                assertThat(attachmentType).isEqualTo(MUU)
+            }
+            verifyOrder {
+                authorizer.authorizeApplicationId(APPLICATION_ID, EDIT_APPLICATIONS.name)
+                applicationAttachmentService.addAttachment(APPLICATION_ID, MUU, file)
+            }
+        }
 
-    @Test
-    fun `deleteAttachment when valid request should succeed`() {
-        val attachmentId = UUID.fromString("5c97dcf2-686f-4cd6-9b9d-4124aff23a07")
-        every {
-            authorizer.authorizeAttachment(APPLICATION_ID, attachmentId, EDIT_APPLICATIONS.name)
-        } returns true
-        justRun { applicationAttachmentService.deleteAttachment(attachmentId) }
+        @Test
+        fun `when application is sent to Allu should return conflict`() {
+            val file = testFile()
+            every {
+                authorizer.authorizeApplicationId(APPLICATION_ID, EDIT_APPLICATIONS.name)
+            } returns true
+            every { applicationAttachmentService.addAttachment(APPLICATION_ID, MUU, file) } throws
+                ApplicationInAlluException(APPLICATION_ID, 123)
 
-        deleteAttachment(attachmentId = attachmentId).andExpect(status().isOk)
+            postAttachment(file = file).andExpect(status().isConflict)
 
-        verifySequence {
-            authorizer.authorizeAttachment(APPLICATION_ID, attachmentId, EDIT_APPLICATIONS.name)
-            applicationAttachmentService.deleteAttachment(attachmentId)
+            verifyOrder {
+                authorizer.authorizeApplicationId(APPLICATION_ID, EDIT_APPLICATIONS.name)
+                applicationAttachmentService.addAttachment(APPLICATION_ID, MUU, file)
+            }
+        }
+
+        @Test
+        fun `when no rights for hanke should fail`() {
+            every {
+                authorizer.authorizeApplicationId(APPLICATION_ID, EDIT_APPLICATIONS.name)
+            } throws ApplicationNotFoundException(APPLICATION_ID)
+
+            postAttachment().andExpect(status().isNotFound)
+
+            verifyOrder {
+                authorizer.authorizeApplicationId(APPLICATION_ID, EDIT_APPLICATIONS.name)
+            }
+        }
+
+        @Test
+        @WithAnonymousUser
+        fun `unauthorized should return error`() {
+            postAttachment().andExpectError(HAI0001)
         }
     }
 
-    @Test
-    fun `deleteAttachment when application is sent to Allu should return conflict`() {
-        val attachmentId = UUID.fromString("48de0b68-1070-47c1-b760-195bac6261f4")
-        val alluId = 123
-        every {
-            authorizer.authorizeAttachment(APPLICATION_ID, attachmentId, EDIT_APPLICATIONS.name)
-        } returns true
-        every { applicationAttachmentService.deleteAttachment(attachmentId) } throws
-            ApplicationInAlluException(APPLICATION_ID, alluId)
+    @Nested
+    inner class DeleteAttachment {
+        @Test
+        fun `when valid request should succeed`() {
+            val attachmentId = UUID.fromString("5c97dcf2-686f-4cd6-9b9d-4124aff23a07")
+            every {
+                authorizer.authorizeAttachment(APPLICATION_ID, attachmentId, EDIT_APPLICATIONS.name)
+            } returns true
+            justRun { applicationAttachmentService.deleteAttachment(attachmentId) }
 
-        deleteAttachment(attachmentId = attachmentId).andExpect(status().isConflict)
+            deleteAttachment(attachmentId = attachmentId).andExpect(status().isOk)
 
-        verifySequence {
-            authorizer.authorizeAttachment(APPLICATION_ID, attachmentId, EDIT_APPLICATIONS.name)
-            applicationAttachmentService.deleteAttachment(attachmentId)
+            verifySequence {
+                authorizer.authorizeAttachment(APPLICATION_ID, attachmentId, EDIT_APPLICATIONS.name)
+                applicationAttachmentService.deleteAttachment(attachmentId)
+            }
         }
-    }
 
-    @Test
-    @WithAnonymousUser
-    fun `unauthorized without authenticated user`() {
-        get("/hakemukset/$APPLICATION_ID/liitteet").andExpectError(HAI0001)
-        getAttachmentContent(resultType = APPLICATION_JSON).andExpectError(HAI0001)
-        postAttachment().andExpectError(HAI0001)
-        deleteAttachment().andExpectError(HAI0001)
+        @Test
+        fun `when application is sent to Allu should return conflict`() {
+            val attachmentId = UUID.fromString("48de0b68-1070-47c1-b760-195bac6261f4")
+            val alluId = 123
+            every {
+                authorizer.authorizeAttachment(APPLICATION_ID, attachmentId, EDIT_APPLICATIONS.name)
+            } returns true
+            every { applicationAttachmentService.deleteAttachment(attachmentId) } throws
+                ApplicationInAlluException(APPLICATION_ID, alluId)
+
+            deleteAttachment(attachmentId = attachmentId).andExpect(status().isConflict)
+
+            verifySequence {
+                authorizer.authorizeAttachment(APPLICATION_ID, attachmentId, EDIT_APPLICATIONS.name)
+                applicationAttachmentService.deleteAttachment(attachmentId)
+            }
+        }
+
+        @Test
+        @WithAnonymousUser
+        fun `unauthorized should return error`() {
+            deleteAttachment().andExpectError(HAI0001)
+        }
     }
 
     private fun getAttachmentContent(

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentController.kt
@@ -4,6 +4,7 @@ import fi.hel.haitaton.hanke.HankeError
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentMetadataDto
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType
 import fi.hel.haitaton.hanke.attachment.common.HeadersBuilder.buildHeaders
+import io.swagger.v3.oas.annotations.Hidden
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
@@ -12,14 +13,17 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import java.util.UUID
 import mu.KotlinLogging
+import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.multipart.MultipartFile
 
@@ -102,7 +106,7 @@ class ApplicationAttachmentController(
                     content = [Content(schema = Schema(implementation = HankeError::class))]
                 ),
                 ApiResponse(
-                    description = "Application already processing",
+                    description = "Application already in Allu",
                     responseCode = "409",
                     content = [Content(schema = Schema(implementation = HankeError::class))]
                 ),
@@ -147,5 +151,13 @@ class ApplicationAttachmentController(
     fun removeAttachment(@PathVariable applicationId: Long, @PathVariable attachmentId: UUID) {
         logger.info { "Deleting attachment $attachmentId from application $applicationId." }
         return applicationAttachmentService.deleteAttachment(attachmentId)
+    }
+
+    @ExceptionHandler(ApplicationInAlluException::class)
+    @ResponseStatus(HttpStatus.CONFLICT)
+    @Hidden
+    fun alluDataError(ex: ApplicationInAlluException): HankeError {
+        logger.warn(ex) { ex.message }
+        return HankeError.HAI2009
     }
 }


### PR DESCRIPTION
# Description

After sending application to Allu no attachments can be added to it.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2306

## Type of change

- [ ] Bug fix 
- [x] New feature 
- [ ] Other

# Instructions for testing
1. Create new cable report application, fill it and send it
2. Try to add new attachment to the application - it should return HTTP 409 error

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 

# Other relevant info
Please describe here if there is e.g. some requirements for this change or
 other info that the tester/user needs to know.