### PR TITLE
HAI-2223 Add validation for changing own contact info

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaControllerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaControllerITest.kt
@@ -783,6 +783,24 @@ class HankeKayttajaControllerITest(@Autowired override val mockMvc: MockMvc) : C
         private val update = ContactUpdate("updated@email.test", "9991111")
 
         @Test
+        fun `Returns 400 when email is blank`() {
+            val incompleteUpdate = update.copy(sahkoposti = " ")
+
+            put(url, incompleteUpdate)
+                .andExpect(status().isBadRequest)
+                .andExpect(hankeError(HankeError.HAI0003))
+        }
+
+        @Test
+        fun `Returns 400 when phone number is empty`() {
+            val incompleteUpdate = update.copy(puhelinnumero = "")
+
+            put(url, incompleteUpdate)
+                .andExpect(status().isBadRequest)
+                .andExpect(hankeError(HankeError.HAI0003))
+        }
+
+        @Test
         fun `Returns 404 if hanke not found or user doesn't have permission for it`() {
             every { authorizer.authorizeHankeTunnus(hanketunnus, VIEW.name) } throws
                 HankeNotFoundException(hanketunnus)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/ControllerExceptionHandler.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/ControllerExceptionHandler.kt
@@ -11,10 +11,10 @@ import fi.hel.haitaton.hanke.geometria.UnsupportedCoordinateSystemException
 import io.sentry.Sentry
 import io.swagger.v3.oas.annotations.Hidden
 import io.swagger.v3.oas.annotations.responses.ApiResponse
-import java.lang.RuntimeException
 import mu.KotlinLogging
 import org.springframework.http.HttpStatus
 import org.springframework.http.converter.HttpMessageNotReadableException
+import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestControllerAdvice
@@ -180,6 +180,15 @@ class ControllerExceptionHandler {
         logger.warn { ex.message }
         Sentry.captureException(ex)
         return HankeError.HAI3003
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException::class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @Hidden
+    fun methodArgumentNotValidException(ex: MethodArgumentNotValidException): HankeError {
+        logger.warn { ex.message }
+        Sentry.captureException(ex)
+        return HankeError.HAI0003
     }
 
     @ExceptionHandler(Throwable::class)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/ContactUpdate.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/ContactUpdate.kt
@@ -2,4 +2,7 @@ package fi.hel.haitaton.hanke.permissions
 
 import jakarta.validation.constraints.NotBlank
 
-data class ContactUpdate(@NotBlank val sahkoposti: String, @NotBlank val puhelinnumero: String)
+data class ContactUpdate(
+    @field:NotBlank val sahkoposti: String,
+    @field:NotBlank val puhelinnumero: String
+)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaController.kt
@@ -374,6 +374,10 @@ Returns the updated hankekayttaja.
                     responseCode = "200",
                 ),
                 ApiResponse(
+                    description = "Email or telephone number is missing",
+                    responseCode = "400",
+                ),
+                ApiResponse(
                     description = "Hanke not found or not authorized",
                     responseCode = "404",
                 ),

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaController.kt
@@ -13,6 +13,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
+import jakarta.validation.Valid
 import java.util.UUID
 import mu.KotlinLogging
 import org.springframework.http.HttpStatus
@@ -360,6 +361,8 @@ of the token and link will be reset.
             """
 Updates the contact information of the hankekayttaja the user has in the hanke.
 
+The sahkoposti and puhelinnumero are mandatory and can't be empty or blank.
+
 Returns the updated hankekayttaja.
 """
     )
@@ -378,7 +381,7 @@ Returns the updated hankekayttaja.
     )
     @PreAuthorize("@hankeKayttajaAuthorizer.authorizeHankeTunnus(#hankeTunnus, 'VIEW')")
     fun updateOwnContactInfo(
-        @RequestBody update: ContactUpdate,
+        @Valid @RequestBody update: ContactUpdate,
         @PathVariable hankeTunnus: String
     ): HankeKayttajaDto {
         return hankeKayttajaService


### PR DESCRIPTION
# Description

Add validation that user can't change their own phone number or email to be empty or blank.

## Type of change

- [X] Bug fix 
- [ ] New feature 
- [ ] Other

# Instructions for testing
Try to update sahkoposti or email to "" or " " in Swagger UI.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 