### PR TITLE
HAI-2227 Update index calculations for street classes

### DIFF
--- a/scripts/gis-material-update/README.md
+++ b/scripts/gis-material-update/README.md
@@ -55,7 +55,7 @@ External volumes are set up
 
 Initialize volumes:
 
-```
+```sh
 docker volume create --name=haitaton_gis_prepare
 docker volume create --name=haitaton_gis_db
 ```
@@ -64,7 +64,7 @@ N.b. haitaton_gis_prepare volume is automatically generated during data copying 
 
 Removal of external volumes (destructive):
 
-```
+```sh
 docker volume rm haitaton_gis_prepare
 docker volume rm haitaton_gis_db
 ```
@@ -87,7 +87,7 @@ When done, leave shell with `exit` command.
 
 ## Build images
 
-```
+```sh
 docker-compose build
 ```
 
@@ -98,7 +98,7 @@ to copy actual script files to external volume.
 
 Script files are copied to external disk using:
 
-```
+```sh
 sh copy-files.sh
 ```
 
@@ -107,14 +107,14 @@ copying in `Dockerfile`s and avoid explicit copying.
 
 Fill out following secrets in gis-material-update/.env:
 
-```sh
+```
 HELSINKI_EXTRANET_USERNAME=
 HELSINKI_EXTRANET_PASSWORD=
 ```
 
 ## Run data fetch
 
-```
+```sh
 docker-compose run --rm gis-fetch <source_1> ... <source_N>
 ```
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluTormaysService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluTormaysService.kt
@@ -8,16 +8,16 @@ import org.springframework.stereotype.Service
 class TormaystarkasteluTormaysService(private val jdbcOperations: JdbcOperations) {
 
     /** yleinen katuosa, ylre_parts */
-    fun anyIntersectsYleinenKatuosa(geometriaIds: Set<Int>) =
+    fun anyIntersectsYleinenKatuosa(geometriaIds: Set<Int>): Boolean =
         anyIntersectsWith(geometriaIds, "tormays_ylre_parts_polys")
 
     /** yleinen katualue, ylre_classes */
-    fun maxIntersectingYleinenkatualueKatuluokka(geometriaIds: Set<Int>) =
+    fun maxIntersectingYleinenkatualueKatuluokka(geometriaIds: Set<Int>): Int? =
         getDistinctValuesIntersectingRows(geometriaIds, "tormays_ylre_classes_polys", "ylre_class")
             .maxOfOrNull { TormaystarkasteluKatuluokka.valueOfKatuluokka(it).value }
 
     /** liikenteellinen katuluokka, street_classes */
-    fun maxIntersectingLiikenteellinenKatuluokka(geometriaIds: Set<Int>) =
+    fun maxIntersectingLiikenteellinenKatuluokka(geometriaIds: Set<Int>): Int? =
         getDistinctValuesIntersectingRows(
                 geometriaIds,
                 "tormays_street_classes_polys",
@@ -143,10 +143,23 @@ class TormaystarkasteluTormaysService(private val jdbcOperations: JdbcOperations
 // values
 
 enum class TormaystarkasteluKatuluokka(val value: Int, val katuluokka: String) {
-    TONTTIKATU_TAI_AJOYHTEYS(1, "Tonttikatu tai ajoyhteys"),
+    /**
+     * @deprecated This will be replaced in data by the [TONTTIKATU_TAI_AJOYHTEYS] and
+     *   [KANTAKAUPUNGIN_ASUNTOKATU_HUOLTAVAYLA_TAI_VAHALIIKENTEINEN_KATU] values. This can be
+     *   removed when both street classes and ylre classes have been updated to use the new classes.
+     *   As of writing (9.2.2024), the street classes just need deploying, but the ylre classes need
+     *   updates to the material processing.
+     */
+    OLD_TONTTIKATU_TAI_AJOYHTEYS(1, "Tonttikatu tai ajoyhteys"),
+    TONTTIKATU_TAI_AJOYHTEYS(1, "Asuntokatu, huoltoväylä tai vähäliikenteinen katu"),
+    KANTAKAUPUNGIN_ASUNTOKATU_HUOLTAVAYLA_TAI_VAHALIIKENTEINEN_KATU(
+        2,
+        "Kantakaupungin asuntokatu, huoltoväylä tai vähäliikenteinen katu"
+    ),
     PAIKALLINEN_KOKOOJAKATU(3, "Paikallinen kokoojakatu"),
     ALUEELLINEN_KOKOOJAKATU(4, "Alueellinen kokoojakatu"),
-    PAAKATU_TAI_MOOTTORIVAYLA(5, "Pääkatu tai moottoriväylä");
+    PAAKATU_TAI_MOOTTORIVAYLA(5, "Pääkatu tai moottoriväylä"),
+    ;
 
     companion object {
         fun valueOfKatuluokka(katuluokka: String): TormaystarkasteluKatuluokka {


### PR DESCRIPTION
# Description

The street classes have changed somewhat. These changes should be reflected in our code. The old, replaced value was left in place as deprecated to give backwards compatibility.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2227

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [X] Other

# Instructions for testing
1. Before update the local törmäys-data, check that the car traffic index is calculated correctly.
2. Recreate the tormays_street_classes_polys table data according to the instructions. (Fileshare has been updated)
3. Check that the index calculations are calculated correctly.

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 