### PR TITLE
HAI-2336 Fix saving hanke geometries

### DIFF
--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/ModifyHankealueRequest.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/ModifyHankealueRequest.kt
@@ -28,7 +28,7 @@ data class ModifyHankealueRequest(
         maximum = "2099-12-31T23:59:59.99Z",
     )
     override val haittaLoppuPvm: ZonedDateTime?,
-    override val geometriat: HasFeatures?,
+    override val geometriat: ModifyGeometriaRequest?,
     @field:Schema(
         description = "Street lane hindrance value and explanation",
     )

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeBuilder.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeBuilder.kt
@@ -16,6 +16,7 @@ import fi.hel.haitaton.hanke.domain.CreateHankeRequest
 import fi.hel.haitaton.hanke.domain.Hanke
 import fi.hel.haitaton.hanke.domain.HankePerustaja
 import fi.hel.haitaton.hanke.domain.HankeYhteystieto
+import fi.hel.haitaton.hanke.domain.ModifyGeometriaRequest
 import fi.hel.haitaton.hanke.domain.ModifyHankeRequest
 import fi.hel.haitaton.hanke.domain.ModifyHankeYhteystietoRequest
 import fi.hel.haitaton.hanke.domain.ModifyHankealueRequest
@@ -194,7 +195,8 @@ data class HankeBuilder(
                 nimi = nimi,
                 haittaAlkuPvm = haittaAlkuPvm,
                 haittaLoppuPvm = haittaLoppuPvm,
-                geometriat = geometriat,
+                geometriat =
+                    geometriat?.let { ModifyGeometriaRequest(it.id, it.featureCollection) },
                 kaistaHaitta = kaistaHaitta,
                 kaistaPituusHaitta = kaistaPituusHaitta,
                 meluHaitta = meluHaitta,


### PR DESCRIPTION
# Description

There is a bug with saving hanke areas. Json deserializer doesn't know how to create an instance of HasFeatures, since it's an interface.

Change the type of `ModifyHankealueRequest.geometriat` to `ModifyGeometriaRequest`, which is was probably meant to be in the first place.

Add a test that reproduces the bug without the fix.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2336

## Type of change

- [X] Bug fix 
- [ ] New feature 
- [ ] Other

# Instructions for testing
1. Create a hanke.
2. Add an area to it.
3. Saving the hanke succeeds after pressing the next button.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 