### PR TITLE
HAI-2337 Return first and last names separately from GDPR API

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
@@ -1120,10 +1120,10 @@ class HankeServiceITests(
                     .flatMap { it.contacts }
                     .find { it.orderer }
             assertThat(orderer).isNotNull().all {
-                prop(Contact::firstName).isEqualTo("Teppo")
-                prop(Contact::lastName).isEqualTo("Testihenkilö")
+                prop(Contact::firstName).isEqualTo(ApplicationFactory.TEPPO)
+                prop(Contact::lastName).isEqualTo(ApplicationFactory.TESTIHENKILO)
                 prop(Contact::email).isEqualTo(ApplicationFactory.TEPPO_EMAIL)
-                prop(Contact::phone).isEqualTo("04012345678")
+                prop(Contact::phone).isEqualTo(ApplicationFactory.TEPPO_PHONE)
             }
 
             val application =
@@ -1134,7 +1134,7 @@ class HankeServiceITests(
             assertThat(users.first()).all {
                 prop(HankekayttajaEntity::id).isNotNull()
                 prop(HankekayttajaEntity::sahkoposti).isEqualTo(ApplicationFactory.TEPPO_EMAIL)
-                prop(HankekayttajaEntity::puhelin).isEqualTo("04012345678")
+                prop(HankekayttajaEntity::puhelin).isEqualTo(ApplicationFactory.TEPPO_PHONE)
                 prop(HankekayttajaEntity::etunimi).isEqualTo(ProfiiliFactory.DEFAULT_GIVEN_NAME)
                 prop(HankekayttajaEntity::sukunimi).isEqualTo(ProfiiliFactory.DEFAULT_LAST_NAME)
                 prop(HankekayttajaEntity::permission)
@@ -1835,7 +1835,7 @@ class HankeServiceITests(
         prop(HankeYhteystieto::email).isEqualTo(ApplicationFactory.TEPPO_EMAIL)
         prop(HankeYhteystieto::tyyppi).isEqualTo(YhteystietoTyyppi.YRITYS)
         prop(HankeYhteystieto::ytunnus).isEqualTo(HankeYhteystietoFactory.DEFAULT_YTUNNUS)
-        prop(HankeYhteystieto::puhelinnumero).isEqualTo("04012345678")
+        prop(HankeYhteystieto::puhelinnumero).isEqualTo(ApplicationFactory.TEPPO_PHONE)
         prop(HankeYhteystieto::organisaatioNimi).isEqualTo("Organisaatio")
         prop(HankeYhteystieto::osasto).isEqualTo("Osasto")
         prop(HankeYhteystieto::createdBy).isEqualTo("test7358")

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceITest.kt
@@ -53,7 +53,10 @@ import fi.hel.haitaton.hanke.email.textBody
 import fi.hel.haitaton.hanke.factory.AlluFactory.createAlluApplicationResponse
 import fi.hel.haitaton.hanke.factory.ApplicationAttachmentFactory
 import fi.hel.haitaton.hanke.factory.ApplicationFactory
+import fi.hel.haitaton.hanke.factory.ApplicationFactory.Companion.TEPPO
 import fi.hel.haitaton.hanke.factory.ApplicationFactory.Companion.TEPPO_EMAIL
+import fi.hel.haitaton.hanke.factory.ApplicationFactory.Companion.TEPPO_PHONE
+import fi.hel.haitaton.hanke.factory.ApplicationFactory.Companion.TESTIHENKILO
 import fi.hel.haitaton.hanke.factory.ApplicationFactory.Companion.asianHoitajaCustomerContact
 import fi.hel.haitaton.hanke.factory.ApplicationFactory.Companion.createApplication
 import fi.hel.haitaton.hanke.factory.ApplicationFactory.Companion.createApplicationArea
@@ -779,9 +782,9 @@ class ApplicationServiceITest : DatabaseTest() {
             val inviter = findKayttaja(hanke.id, KAYTTAJA_INPUT_HAKIJA.email)
             assertThat(kutsut.first().hankekayttaja).all {
                 prop(HankekayttajaEntity::fullName).isEqualTo(TEPPO_TESTI)
-                prop(HankekayttajaEntity::puhelin).isEqualTo("04012345678")
-                prop(HankekayttajaEntity::kutsuttuEtunimi).isEqualTo("Teppo")
-                prop(HankekayttajaEntity::kutsuttuSukunimi).isEqualTo("Testihenkilö")
+                prop(HankekayttajaEntity::puhelin).isEqualTo(TEPPO_PHONE)
+                prop(HankekayttajaEntity::kutsuttuEtunimi).isEqualTo(TEPPO)
+                prop(HankekayttajaEntity::kutsuttuSukunimi).isEqualTo(TESTIHENKILO)
                 prop(HankekayttajaEntity::sahkoposti).isEqualTo(TEPPO_EMAIL)
                 prop(HankekayttajaEntity::hankeId).isEqualTo(hanke.id)
                 prop(HankekayttajaEntity::permission).isNull() // user not logged in yet

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/gdpr/GdprServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/gdpr/GdprServiceITest.kt
@@ -15,10 +15,13 @@ import fi.hel.haitaton.hanke.application.Application
 import fi.hel.haitaton.hanke.application.ApplicationEntity
 import fi.hel.haitaton.hanke.application.ApplicationRepository
 import fi.hel.haitaton.hanke.factory.ApplicationFactory
+import fi.hel.haitaton.hanke.factory.ApplicationFactory.Companion.TEPPO
+import fi.hel.haitaton.hanke.factory.ApplicationFactory.Companion.TEPPO_EMAIL
+import fi.hel.haitaton.hanke.factory.ApplicationFactory.Companion.TEPPO_PHONE
+import fi.hel.haitaton.hanke.factory.ApplicationFactory.Companion.TESTIHENKILO
 import fi.hel.haitaton.hanke.factory.ApplicationFactory.Companion.withContacts
 import fi.hel.haitaton.hanke.factory.ApplicationFactory.Companion.withCustomer
 import fi.hel.haitaton.hanke.factory.HankeFactory
-import fi.hel.haitaton.hanke.factory.TEPPO_TESTI
 import fi.hel.haitaton.hanke.hasSameElementsAs
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -67,7 +70,7 @@ class GdprServiceITest : DatabaseTest() {
                     application.setOrdererName("Other", "User")
                 } else {
                     application.userId = USERID
-                    application.setOrdererName("Teppo", "Testihenkilö")
+                    application.setOrdererName(TEPPO, TESTIHENKILO)
                 }
             }
 
@@ -78,9 +81,10 @@ class GdprServiceITest : DatabaseTest() {
                     "user",
                     listOf(
                         StringNode("id", USERID),
-                        StringNode("nimi", TEPPO_TESTI),
-                        StringNode("puhelinnumero", "04012345678"),
-                        StringNode("sahkoposti", "teppo@example.test"),
+                        StringNode("etunimi", TEPPO),
+                        StringNode("sukunimi", TESTIHENKILO),
+                        StringNode("puhelinnumero", TEPPO_PHONE),
+                        StringNode("sahkoposti", TEPPO_EMAIL),
                         CollectionNode(
                             "organisaatio",
                             listOf(

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaServiceITest.kt
@@ -31,8 +31,9 @@ import fi.hel.haitaton.hanke.HankeNotFoundException
 import fi.hel.haitaton.hanke.application.ApplicationRepository
 import fi.hel.haitaton.hanke.domain.Hanke
 import fi.hel.haitaton.hanke.email.textBody
-import fi.hel.haitaton.hanke.factory.ApplicationFactory
 import fi.hel.haitaton.hanke.factory.ApplicationFactory.Companion.DEFAULT_APPLICATION_IDENTIFIER
+import fi.hel.haitaton.hanke.factory.ApplicationFactory.Companion.TEPPO
+import fi.hel.haitaton.hanke.factory.ApplicationFactory.Companion.TESTIHENKILO
 import fi.hel.haitaton.hanke.factory.ApplicationFactory.Companion.asianHoitajaCustomerContact
 import fi.hel.haitaton.hanke.factory.ApplicationFactory.Companion.createApplicationEntity
 import fi.hel.haitaton.hanke.factory.ApplicationFactory.Companion.createCableReportApplicationData
@@ -592,8 +593,8 @@ class HankeKayttajaServiceITest : DatabaseTest() {
             val kayttajat = hankeKayttajaRepository.findAll()
             assertThat(kayttajat).hasSize(4)
             assertThat(kayttajat).each { kayttaja ->
-                kayttaja.transform { it.etunimi }.isEqualTo(ApplicationFactory.TEPPO)
-                kayttaja.transform { it.sukunimi }.isEqualTo(ApplicationFactory.TESTIHENKILO)
+                kayttaja.transform { it.etunimi }.isEqualTo(TEPPO)
+                kayttaja.transform { it.sukunimi }.isEqualTo(TESTIHENKILO)
                 kayttaja.transform { it.hankeId }.isEqualTo(hanke.id)
                 kayttaja.transform { it.permission }.isNull()
                 kayttaja.transform { it.kayttajakutsu }.isNotNull()

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaServiceITest.kt
@@ -31,6 +31,7 @@ import fi.hel.haitaton.hanke.HankeNotFoundException
 import fi.hel.haitaton.hanke.application.ApplicationRepository
 import fi.hel.haitaton.hanke.domain.Hanke
 import fi.hel.haitaton.hanke.email.textBody
+import fi.hel.haitaton.hanke.factory.ApplicationFactory
 import fi.hel.haitaton.hanke.factory.ApplicationFactory.Companion.DEFAULT_APPLICATION_IDENTIFIER
 import fi.hel.haitaton.hanke.factory.ApplicationFactory.Companion.asianHoitajaCustomerContact
 import fi.hel.haitaton.hanke.factory.ApplicationFactory.Companion.createApplicationEntity
@@ -591,8 +592,8 @@ class HankeKayttajaServiceITest : DatabaseTest() {
             val kayttajat = hankeKayttajaRepository.findAll()
             assertThat(kayttajat).hasSize(4)
             assertThat(kayttajat).each { kayttaja ->
-                kayttaja.transform { it.etunimi }.isEqualTo("Teppo")
-                kayttaja.transform { it.sukunimi }.isEqualTo("Testihenkilö")
+                kayttaja.transform { it.etunimi }.isEqualTo(ApplicationFactory.TEPPO)
+                kayttaja.transform { it.sukunimi }.isEqualTo(ApplicationFactory.TESTIHENKILO)
                 kayttaja.transform { it.hankeId }.isEqualTo(hanke.id)
                 kayttaja.transform { it.permission }.isNull()
                 kayttaja.transform { it.kayttajakutsu }.isNotNull()

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/gdpr/GdprInfo.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/gdpr/GdprInfo.kt
@@ -1,7 +1,8 @@
 package fi.hel.haitaton.hanke.gdpr
 
 data class GdprInfo(
-    val name: String? = null,
+    val firstName: String? = null,
+    val lastName: String? = null,
     val phone: String? = null,
     val email: String? = null,
     val ipAddress: String? = null,

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/gdpr/GdprJsonConverter.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/gdpr/GdprJsonConverter.kt
@@ -25,21 +25,24 @@ object GdprJsonConverter {
         if (infos.isEmpty()) {
             return listOf()
         }
-        val names = infos.mapNotNull { it.name }.toSet()
+        val firstNames = infos.mapNotNull { it.firstName }.toSet()
+        val lastNames = infos.mapNotNull { it.lastName }.toSet()
         val phones = infos.mapNotNull { it.phone }.toSet()
         val emails = infos.mapNotNull { it.email }.toSet()
         val ipAddresses = infos.mapNotNull { it.ipAddress }.toSet()
         val organisations = infos.mapNotNull { it.organisation }.toSet()
 
         val idNode = StringNode("id", userId)
-        val namesNode = combineStrings(names, "nimi", "nimet")
+        val firstNamesNode = combineStrings(firstNames, "etunimi", "etunimet")
+        val lastNamesNode = combineStrings(lastNames, "sukunimi", "sukunimet")
         val phonesNode = combineStrings(phones, "puhelinnumero", "puhelinnumerot")
         val emailsNode = combineStrings(emails, "sahkoposti", "sahkopostit")
         val ipAddressesNode = combineStrings(ipAddresses, "ipOsoite", "ipOsoitteet")
         val organisationsNode = combineOrganisations(organisations)
         return listOfNotNull(
             idNode,
-            namesNode,
+            firstNamesNode,
+            lastNamesNode,
             phonesNode,
             emailsNode,
             ipAddressesNode,
@@ -125,7 +128,8 @@ object GdprJsonConverter {
         organisation: GdprOrganisation?,
     ): GdprInfo {
         return GdprInfo(
-            name = contact.fullName(),
+            firstName = contact.firstName,
+            lastName = contact.lastName,
             phone = contact.phone,
             email = contact.email,
             organisation = organisation,

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/application/ContactTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/application/ContactTest.kt
@@ -5,6 +5,10 @@ import assertk.assertions.hasSize
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNull
 import fi.hel.haitaton.hanke.factory.ApplicationFactory
+import fi.hel.haitaton.hanke.factory.ApplicationFactory.Companion.TEPPO
+import fi.hel.haitaton.hanke.factory.ApplicationFactory.Companion.TEPPO_EMAIL
+import fi.hel.haitaton.hanke.factory.ApplicationFactory.Companion.TEPPO_PHONE
+import fi.hel.haitaton.hanke.factory.ApplicationFactory.Companion.TESTIHENKILO
 import fi.hel.haitaton.hanke.factory.ApplicationFactory.Companion.createContact
 import fi.hel.haitaton.hanke.factory.ApplicationFactory.Companion.withContacts
 import java.util.stream.Stream
@@ -71,10 +75,10 @@ class ContactTest {
         assertThat(allContacts).hasSize(4)
         val expectedResult =
             Contact(
-                firstName = "Teppo",
-                lastName = "Testihenkilö",
-                email = "teppo@example.test",
-                phone = "04012345678",
+                firstName = TEPPO,
+                lastName = TESTIHENKILO,
+                email = TEPPO_EMAIL,
+                phone = TEPPO_PHONE,
                 orderer = true,
             )
         assertThat(result).isEqualTo(expectedResult)

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/ApplicationFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/ApplicationFactory.kt
@@ -36,7 +36,11 @@ class ApplicationFactory(
         const val DEFAULT_APPLICATION_ID: Long = 1
         const val DEFAULT_APPLICATION_NAME: String = "Johtoselvityksen oletusnimi"
         const val DEFAULT_APPLICATION_IDENTIFIER: String = "JS230014"
+        const val TEPPO = "Teppo"
+        const val TESTIHENKILO = "Testihenkilö"
         const val TEPPO_EMAIL = "teppo@example.test"
+        const val TEPPO_PHONE = "04012345678"
+
         val expectedRecipients =
             arrayOf(
                 "timo.tyonsuorittaja@mail.com",
@@ -56,7 +60,7 @@ class ApplicationFactory(
             name: String = TEPPO_TESTI,
             country: String = "FI",
             email: String? = TEPPO_EMAIL,
-            phone: String? = "04012345678",
+            phone: String? = TEPPO_PHONE,
             registryKey: String? = "281192-937W",
             ovt: String? = null,
             invoicingOperator: String? = null,
@@ -115,18 +119,18 @@ class ApplicationFactory(
             CustomerWithContacts(this, contacts.asList())
 
         fun Customer.withContact(
-            firstName: String? = "Teppo",
-            lastName: String? = "Testihenkilö",
+            firstName: String? = TEPPO,
+            lastName: String? = TESTIHENKILO,
             email: String? = TEPPO_EMAIL,
-            phone: String? = "04012345678",
+            phone: String? = TEPPO_PHONE,
             orderer: Boolean = false,
         ) = withContacts(createContact(firstName, lastName, email, phone, orderer))
 
         fun createContact(
-            firstName: String? = "Teppo",
-            lastName: String? = "Testihenkilö",
+            firstName: String? = TEPPO,
+            lastName: String? = TESTIHENKILO,
             email: String? = TEPPO_EMAIL,
-            phone: String? = "04012345678",
+            phone: String? = TEPPO_PHONE,
             orderer: Boolean = false
         ) = Contact(firstName, lastName, email, phone, orderer)
 

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeYhteystietoFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeYhteystietoFactory.kt
@@ -10,6 +10,7 @@ import fi.hel.haitaton.hanke.domain.YhteystietoTyyppi.YHTEISO
 import fi.hel.haitaton.hanke.domain.YhteystietoTyyppi.YKSITYISHENKILO
 import fi.hel.haitaton.hanke.domain.YhteystietoTyyppi.YRITYS
 import fi.hel.haitaton.hanke.factory.ApplicationFactory.Companion.TEPPO_EMAIL
+import fi.hel.haitaton.hanke.factory.ApplicationFactory.Companion.TEPPO_PHONE
 import fi.hel.haitaton.hanke.factory.HankeYhteystietoFactory.DEFAULT_YTUNNUS
 import fi.hel.haitaton.hanke.getCurrentTimeUTC
 import java.time.ZonedDateTime
@@ -21,11 +22,11 @@ object HankeYhteystietoFactory {
     /** Create a test yhteystieto with values in all fields. */
     fun create(
         id: Int? = 1,
-        nimi: String = "Teppo Testihenkilö",
+        nimi: String = TEPPO_TESTI,
         email: String = TEPPO_EMAIL,
         tyyppi: YhteystietoTyyppi = YRITYS,
         ytunnus: String = DEFAULT_YTUNNUS,
-        puhelinnumero: String = "04012345678",
+        puhelinnumero: String = TEPPO_PHONE,
         createdAt: ZonedDateTime? = getCurrentTimeUTC(),
         modifiedAt: ZonedDateTime? = getCurrentTimeUTC(),
     ): HankeYhteystieto {

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/logging/DisclosureLogServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/logging/DisclosureLogServiceTest.kt
@@ -11,6 +11,10 @@ import fi.hel.haitaton.hanke.application.Contact
 import fi.hel.haitaton.hanke.application.Customer
 import fi.hel.haitaton.hanke.application.CustomerWithContacts
 import fi.hel.haitaton.hanke.factory.ApplicationFactory
+import fi.hel.haitaton.hanke.factory.ApplicationFactory.Companion.TEPPO
+import fi.hel.haitaton.hanke.factory.ApplicationFactory.Companion.TEPPO_EMAIL
+import fi.hel.haitaton.hanke.factory.ApplicationFactory.Companion.TEPPO_PHONE
+import fi.hel.haitaton.hanke.factory.ApplicationFactory.Companion.TESTIHENKILO
 import fi.hel.haitaton.hanke.factory.ApplicationFactory.Companion.withApplicationData
 import fi.hel.haitaton.hanke.factory.ApplicationFactory.Companion.withContacts
 import fi.hel.haitaton.hanke.factory.AuditLogEntryFactory
@@ -67,9 +71,10 @@ internal class DisclosureLogServiceTest {
                 "user",
                 listOf(
                     StringNode("id", "4f15afe1-51dc-4015-bb66-3a536295abea"),
-                    StringNode("nimi", "Teppo Testihenkilö"),
-                    StringNode("sahkoposti", "teppo@example.test"),
-                    StringNode("puhelin", "04012345678"),
+                    StringNode("etunimi", TEPPO),
+                    StringNode("sukunimi", TESTIHENKILO),
+                    StringNode("sahkoposti", TEPPO_EMAIL),
+                    StringNode("puhelin", TEPPO_PHONE),
                 )
             )
 
@@ -80,9 +85,10 @@ internal class DisclosureLogServiceTest {
             {"key":"user","children":
               [
                 {"key":"id","value":"4f15afe1-51dc-4015-bb66-3a536295abea"},
-                {"key":"nimi","value":"Teppo Testihenkilö"},
-                {"key":"sahkoposti","value":"teppo@example.test"},
-                {"key":"puhelin","value":"04012345678"}
+                {"key":"etunimi","value":"$TEPPO"},
+                {"key":"sukunimi","value":"$TESTIHENKILO"},
+                {"key":"sahkoposti","value":"$TEPPO_EMAIL"},
+                {"key":"puhelin","value":"$TEPPO_PHONE"}
               ]
             }"""
                 .reformatJson()


### PR DESCRIPTION
# Description

First and last names are tracked separately everywhere in Haitaton now, so we should return them separately from the GDPR API.

Also, add constants for the names and phone number of TEPPO_TESTI and use those constants where ever applicable.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2337

## Type of change

- [ ] Bug fix
- [ ] New feature 
- [X] Other

# Other relevant info
The story itself will be implemented in a later PR.