### PR TITLE
HAI-2243 New API for getting hakemukset for hanke

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeControllerHankeEditingDisabledITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeControllerHankeEditingDisabledITests.kt
@@ -43,7 +43,6 @@ class HankeControllerHankeEditingDisabledITests(@Autowired override val mockMvc:
 
     @Test
     fun `delete hanke works even if hanke editing is disabled`() {
-        every { hankeService.getHankeApplications(HANKE_TUNNUS) }.returns(listOf())
         every { authorizer.authorizeHankeTunnus(HANKE_TUNNUS, PermissionCode.DELETE.name) } returns
             true
         justRun { hankeService.deleteHanke(HANKE_TUNNUS, USERNAME) }

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeControllerITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeControllerITests.kt
@@ -2,11 +2,9 @@ package fi.hel.haitaton.hanke
 
 import assertk.assertThat
 import assertk.assertions.isTrue
-import fi.hel.haitaton.hanke.application.ApplicationsResponse
 import fi.hel.haitaton.hanke.domain.HankeStatus
 import fi.hel.haitaton.hanke.domain.SavedHankealue
 import fi.hel.haitaton.hanke.domain.TyomaaTyyppi
-import fi.hel.haitaton.hanke.factory.ApplicationFactory
 import fi.hel.haitaton.hanke.factory.DateFactory
 import fi.hel.haitaton.hanke.factory.HankeFactory
 import fi.hel.haitaton.hanke.factory.HankeFactory.Companion.withHankealue
@@ -36,8 +34,6 @@ import java.time.temporal.ChronoUnit
 import org.geojson.FeatureCollection
 import org.hamcrest.Matchers.containsInAnyOrder
 import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -358,83 +354,6 @@ class HankeControllerITests(@Autowired override val mockMvc: MockMvc) : Controll
                 permissionService.getAllowedHankeIds(USERNAME, PermissionCode.VIEW)
                 hankeService.loadHankkeetByIds(hankeIds)
                 disclosureLogService.saveDisclosureLogsForHankkeet(hankkeet, USERNAME)
-            }
-        }
-    }
-
-    @Nested
-    inner class GetHankeHakemukset {
-        private val url = "$BASE_URL/$HANKE_TUNNUS/hakemukset"
-
-        @Test
-        @WithAnonymousUser
-        fun `Without authenticated user return unauthorized (401) `() {
-            get(url)
-                .andExpect(SecurityMockMvcResultMatchers.unauthenticated())
-                .andExpect(status().isUnauthorized)
-                .andExpect(hankeError(HankeError.HAI0001))
-        }
-
-        @Test
-        fun `With unknown hanke tunnus return 404`() {
-            every {
-                authorizer.authorizeHankeTunnus(HANKE_TUNNUS, PermissionCode.VIEW.name)
-            } returns true
-            every { hankeService.getHankeApplications(HANKE_TUNNUS) } throws
-                HankeNotFoundException(HANKE_TUNNUS)
-
-            get(url).andExpect(status().isNotFound).andExpect(hankeError(HankeError.HAI1001))
-
-            verifySequence {
-                authorizer.authorizeHankeTunnus(HANKE_TUNNUS, PermissionCode.VIEW.name)
-                hankeService.getHankeApplications(HANKE_TUNNUS)
-            }
-        }
-
-        @Test
-        fun `When user does not have permission return 404`() {
-            every { authorizer.authorizeHankeTunnus(HANKE_TUNNUS, PermissionCode.VIEW.name) } throws
-                HankeNotFoundException(HANKE_TUNNUS)
-
-            get(url).andExpect(status().isNotFound).andExpect(hankeError(HankeError.HAI1001))
-
-            verifySequence {
-                authorizer.authorizeHankeTunnus(HANKE_TUNNUS, PermissionCode.VIEW.name)
-            }
-        }
-
-        @Test
-        fun `With no applications return empty list`() {
-            every { hankeService.getHankeApplications(HANKE_TUNNUS) } returns listOf()
-            every {
-                authorizer.authorizeHankeTunnus(HANKE_TUNNUS, PermissionCode.VIEW.name)
-            } returns true
-
-            val response: ApplicationsResponse = get(url).andExpect(status().isOk).andReturnBody()
-
-            assertTrue(response.applications.isEmpty())
-            verifySequence {
-                authorizer.authorizeHankeTunnus(HANKE_TUNNUS, PermissionCode.VIEW.name)
-                hankeService.getHankeApplications(HANKE_TUNNUS)
-            }
-        }
-
-        @Test
-        fun `With known hanketunnus return applications`() {
-            val applications = ApplicationFactory.createApplications(5)
-            every { hankeService.getHankeApplications(HANKE_TUNNUS) } returns applications
-            every {
-                authorizer.authorizeHankeTunnus(HANKE_TUNNUS, PermissionCode.VIEW.name)
-            } returns true
-
-            val response: ApplicationsResponse = get(url).andExpect(status().isOk).andReturnBody()
-
-            assertTrue(response.applications.isNotEmpty())
-            assertEquals(ApplicationsResponse(applications), response)
-            verifySequence {
-                authorizer.authorizeHankeTunnus(HANKE_TUNNUS, PermissionCode.VIEW.name)
-                hankeService.getHankeApplications(HANKE_TUNNUS)
-                disclosureLogService.saveDisclosureLogsForApplications(applications, USERNAME)
             }
         }
     }

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
@@ -108,7 +108,6 @@ import io.mockk.justRun
 import io.mockk.mockk
 import io.mockk.verify
 import io.mockk.verifySequence
-import jakarta.persistence.EntityManager
 import java.time.Duration
 import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoUnit
@@ -164,7 +163,6 @@ class HankeServiceITests(
     @Autowired private val hankeAttachmentFactory: HankeAttachmentFactory,
     @Autowired private val hankeKayttajaFactory: HankeKayttajaFactory,
     @Autowired private val cableReportService: CableReportService,
-    @Autowired private val entityManager: EntityManager,
 ) : DatabaseTest() {
 
     companion object {
@@ -331,8 +329,7 @@ class HankeServiceITests(
 
             // Verify privileges
             PermissionCode.entries.forEach {
-                assertk
-                    .assertThat(permissionService.hasPermission(returnedHanke.id, USER_NAME, it))
+                assertThat(permissionService.hasPermission(returnedHanke.id, USER_NAME, it))
                     .isTrue()
             }
             val hankeKayttajat = hankekayttajaRepository.findAll()

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusControllerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusControllerITest.kt
@@ -1,11 +1,20 @@
 package fi.hel.haitaton.hanke.hakemus
 
+import assertk.assertThat
+import assertk.assertions.isEmpty
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotEmpty
 import fi.hel.haitaton.hanke.ControllerTest
+import fi.hel.haitaton.hanke.HankeError
+import fi.hel.haitaton.hanke.HankeNotFoundException
 import fi.hel.haitaton.hanke.HankeService
 import fi.hel.haitaton.hanke.IntegrationTestConfiguration
+import fi.hel.haitaton.hanke.andReturnBody
 import fi.hel.haitaton.hanke.application.ApplicationAuthorizer
 import fi.hel.haitaton.hanke.application.ApplicationNotFoundException
+import fi.hel.haitaton.hanke.factory.ApplicationFactory
 import fi.hel.haitaton.hanke.factory.HakemusFactory
+import fi.hel.haitaton.hanke.hankeError
 import fi.hel.haitaton.hanke.permissions.PermissionCode
 import io.mockk.Called
 import io.mockk.checkUnnecessaryStub
@@ -13,6 +22,7 @@ import io.mockk.clearAllMocks
 import io.mockk.confirmVerified
 import io.mockk.every
 import io.mockk.verify
+import io.mockk.verifySequence
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
@@ -22,13 +32,13 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.security.test.context.support.WithAnonymousUser
 import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.security.test.web.servlet.response.SecurityMockMvcResultMatchers
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers
 
 private const val USERNAME = "testUser"
 private const val HANKE_TUNNUS = "HAI-1234"
-private const val BASE_URL = "/hakemukset"
 
 @WebMvcTest(
     controllers = [HakemusController::class],
@@ -41,7 +51,7 @@ class HakemusControllerITest(@Autowired override val mockMvc: MockMvc) : Control
 
     @Autowired private lateinit var hakemusService: HakemusService
     @Autowired private lateinit var hankeService: HankeService
-    @Autowired private lateinit var authorizer: ApplicationAuthorizer
+    @Autowired private lateinit var applicationAuthorizer: ApplicationAuthorizer
 
     private val id = 1234L
 
@@ -53,36 +63,41 @@ class HakemusControllerITest(@Autowired override val mockMvc: MockMvc) : Control
     @AfterEach
     fun checkMocks() {
         checkUnnecessaryStub()
-        confirmVerified(hakemusService, hankeService, authorizer)
+        confirmVerified(hakemusService, hankeService, applicationAuthorizer)
     }
 
     @Nested
     inner class GetById {
+        private val url = "/hakemukset/$id"
+
         @Test
         @WithAnonymousUser
         fun `when unknown user should return 401`() {
-            get("$BASE_URL/$id").andExpect(MockMvcResultMatchers.status().isUnauthorized)
+            get(url).andExpect(MockMvcResultMatchers.status().isUnauthorized)
 
             verify { hakemusService wasNot Called }
         }
 
         @Test
         fun `when application does not exist should return 404`() {
-            every { authorizer.authorizeApplicationId(id, PermissionCode.VIEW.name) } throws
-                ApplicationNotFoundException(id)
+            every {
+                applicationAuthorizer.authorizeApplicationId(id, PermissionCode.VIEW.name)
+            } throws ApplicationNotFoundException(id)
 
-            get("$BASE_URL/$id").andExpect(MockMvcResultMatchers.status().isNotFound)
+            get(url).andExpect(MockMvcResultMatchers.status().isNotFound)
 
-            verify { authorizer.authorizeApplicationId(id, PermissionCode.VIEW.name) }
+            verify { applicationAuthorizer.authorizeApplicationId(id, PermissionCode.VIEW.name) }
         }
 
         @Test
         fun `when application exists should return it`() {
-            every { authorizer.authorizeApplicationId(id, PermissionCode.VIEW.name) } returns true
+            every {
+                applicationAuthorizer.authorizeApplicationId(id, PermissionCode.VIEW.name)
+            } returns true
             every { hakemusService.hakemusResponse(id) } returns
                 HakemusFactory.createHakemusResponse(applicationId = id, hankeTunnus = HANKE_TUNNUS)
 
-            get("$BASE_URL/$id")
+            get(url)
                 .andExpect(MockMvcResultMatchers.status().isOk)
                 .andExpect(MockMvcResultMatchers.jsonPath("$.hankeTunnus").value(HANKE_TUNNUS))
                 .andExpect(
@@ -94,8 +109,94 @@ class HakemusControllerITest(@Autowired override val mockMvc: MockMvc) : Control
                 )
 
             verify {
-                authorizer.authorizeApplicationId(id, PermissionCode.VIEW.name)
+                applicationAuthorizer.authorizeApplicationId(id, PermissionCode.VIEW.name)
                 hakemusService.hakemusResponse(id)
+            }
+        }
+    }
+
+    @Nested
+    inner class GetHankkeenHakemukset {
+        private val url = "/hankkeet/$HANKE_TUNNUS/hakemukset"
+
+        @Test
+        @WithAnonymousUser
+        fun `Without authenticated user return unauthorized (401) `() {
+            get(url)
+                .andExpect(SecurityMockMvcResultMatchers.unauthenticated())
+                .andExpect(MockMvcResultMatchers.status().isUnauthorized)
+                .andExpect(hankeError(HankeError.HAI0001))
+        }
+
+        @Test
+        fun `With unknown hanke tunnus return 404`() {
+            every {
+                applicationAuthorizer.authorizeHankeTunnus(HANKE_TUNNUS, PermissionCode.VIEW.name)
+            } returns true
+            every { hakemusService.hankkeenHakemuksetResponse(HANKE_TUNNUS) } throws
+                HankeNotFoundException(HANKE_TUNNUS)
+
+            get(url)
+                .andExpect(MockMvcResultMatchers.status().isNotFound)
+                .andExpect(hankeError(HankeError.HAI1001))
+
+            verifySequence {
+                applicationAuthorizer.authorizeHankeTunnus(HANKE_TUNNUS, PermissionCode.VIEW.name)
+                hakemusService.hankkeenHakemuksetResponse(HANKE_TUNNUS)
+            }
+        }
+
+        @Test
+        fun `When user does not have permission return 404`() {
+            every {
+                applicationAuthorizer.authorizeHankeTunnus(HANKE_TUNNUS, PermissionCode.VIEW.name)
+            } throws HankeNotFoundException(HANKE_TUNNUS)
+
+            get(url)
+                .andExpect(MockMvcResultMatchers.status().isNotFound)
+                .andExpect(hankeError(HankeError.HAI1001))
+
+            verifySequence {
+                applicationAuthorizer.authorizeHankeTunnus(HANKE_TUNNUS, PermissionCode.VIEW.name)
+            }
+        }
+
+        @Test
+        fun `With no applications return empty list`() {
+            every { hakemusService.hankkeenHakemuksetResponse(HANKE_TUNNUS) } returns
+                HankkeenHakemuksetResponse(emptyList())
+            every {
+                applicationAuthorizer.authorizeHankeTunnus(HANKE_TUNNUS, PermissionCode.VIEW.name)
+            } returns true
+
+            val response: HankkeenHakemuksetResponse =
+                get(url).andExpect(MockMvcResultMatchers.status().isOk).andReturnBody()
+
+            assertThat(response.applications).isEmpty()
+            verifySequence {
+                applicationAuthorizer.authorizeHankeTunnus(HANKE_TUNNUS, PermissionCode.VIEW.name)
+                hakemusService.hankkeenHakemuksetResponse(HANKE_TUNNUS)
+            }
+        }
+
+        @Test
+        fun `With known hanketunnus return applications`() {
+            val applicationResponses =
+                ApplicationFactory.createApplicationEntities(5).map { HankkeenHakemusResponse(it) }
+            every { hakemusService.hankkeenHakemuksetResponse(HANKE_TUNNUS) } returns
+                HankkeenHakemuksetResponse(applicationResponses)
+            every {
+                applicationAuthorizer.authorizeHankeTunnus(HANKE_TUNNUS, PermissionCode.VIEW.name)
+            } returns true
+
+            val response: HankkeenHakemuksetResponse =
+                get(url).andExpect(MockMvcResultMatchers.status().isOk).andReturnBody()
+
+            assertThat(response.applications).isNotEmpty()
+            assertThat(response).isEqualTo(HankkeenHakemuksetResponse(applicationResponses))
+            verifySequence {
+                applicationAuthorizer.authorizeHankeTunnus(HANKE_TUNNUS, PermissionCode.VIEW.name)
+                hakemusService.hankkeenHakemuksetResponse(HANKE_TUNNUS)
             }
         }
     }

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceITest.kt
@@ -1,18 +1,27 @@
 package fi.hel.haitaton.hanke.hakemus
 
 import assertk.Assert
+import assertk.all
+import assertk.assertFailure
 import assertk.assertThat
+import assertk.assertions.hasClass
 import assertk.assertions.isEmpty
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNotNull
+import assertk.assertions.messageContains
 import assertk.assertions.prop
 import assertk.assertions.single
 import fi.hel.haitaton.hanke.DatabaseTest
+import fi.hel.haitaton.hanke.HankeEntity
+import fi.hel.haitaton.hanke.HankeNotFoundException
+import fi.hel.haitaton.hanke.allu.ApplicationStatus
 import fi.hel.haitaton.hanke.allu.CustomerType
 import fi.hel.haitaton.hanke.application.ApplicationNotFoundException
 import fi.hel.haitaton.hanke.application.ApplicationRepository
+import fi.hel.haitaton.hanke.factory.ApplicationFactory
 import fi.hel.haitaton.hanke.factory.HakemusFactory
 import fi.hel.haitaton.hanke.factory.HankeFactory
+import fi.hel.haitaton.hanke.hasSameElementsAs
 import fi.hel.haitaton.hanke.permissions.Kayttooikeustaso
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -61,6 +70,53 @@ class HakemusServiceITest : DatabaseTest() {
 
             assertThat(response.applicationData as JohtoselvitysHakemusDataResponse)
                 .hasAllCustomersWithContacts()
+        }
+    }
+
+    @Nested
+    inner class HankkeenHakemuksetResponse {
+        @Test
+        fun `return applications`() {
+            val hanke = initHankeWithHakemus()
+
+            val result = hakemusService.hankkeenHakemuksetResponse(hanke.hankeTunnus)
+
+            val expectedHakemus = HankkeenHakemusResponse(applicationRepository.findAll().first())
+            assertThat(result.applications).hasSameElementsAs(listOf(expectedHakemus))
+        }
+
+        @Test
+        fun `when hanke does not exist throws not found`() {
+            val hankeTunnus = "HAI-1234"
+
+            assertFailure { hakemusService.hankkeenHakemuksetResponse(hankeTunnus) }
+                .all {
+                    hasClass(HankeNotFoundException::class)
+                    messageContains(hankeTunnus)
+                }
+        }
+
+        @Test
+        fun `when no applications returns an empty result`() {
+            val hankeInitial = hankeFactory.builder(USERNAME).save()
+
+            val result = hakemusService.hankkeenHakemuksetResponse(hankeInitial.hankeTunnus)
+
+            assertThat(result.applications).isEmpty()
+        }
+
+        private fun initHankeWithHakemus(): HankeEntity {
+            val hanke = hankeFactory.saveMinimal(hankeTunnus = "HAI23-1")
+            val application =
+                applicationRepository.save(
+                    ApplicationFactory.createApplicationEntity(
+                        hanke = hanke,
+                        alluStatus = ApplicationStatus.PENDING,
+                        alluid = null,
+                        userId = USERNAME
+                    )
+                )
+            return hanke.apply { hakemukset = mutableSetOf(application) }
         }
     }
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeController.kt
@@ -1,6 +1,5 @@
 package fi.hel.haitaton.hanke
 
-import fi.hel.haitaton.hanke.application.ApplicationsResponse
 import fi.hel.haitaton.hanke.domain.CreateHankeRequest
 import fi.hel.haitaton.hanke.domain.Hanke
 import fi.hel.haitaton.hanke.domain.ModifyHankeRequest
@@ -118,28 +117,6 @@ class HankeController(
 
         disclosureLogService.saveDisclosureLogsForHankkeet(hankeList, userid)
         return hankeList
-    }
-
-    @GetMapping("/{hankeTunnus}/hakemukset")
-    @Operation(
-        summary = "Get hanke applications",
-        description = "Returns list of applications belonging to a given hanke."
-    )
-    @PreAuthorize("@hankeAuthorizer.authorizeHankeTunnus(#hankeTunnus, 'VIEW')")
-    fun getHankeHakemukset(@PathVariable hankeTunnus: String): ApplicationsResponse {
-        logger.info { "Finding applications for hanke $hankeTunnus" }
-
-        val userId = currentUserId()
-
-        hankeService.getHankeApplications(hankeTunnus).let { hakemukset ->
-            if (hakemukset.isNotEmpty()) {
-                disclosureLogService.saveDisclosureLogsForApplications(hakemukset, userId)
-            }
-
-            return ApplicationsResponse(hakemukset).also {
-                logger.info { "Found ${it.applications.size} applications for hanke $hankeTunnus" }
-            }
-        }
     }
 
     @PostMapping

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
@@ -1,5 +1,7 @@
 package fi.hel.haitaton.hanke.hakemus
 
+import fi.hel.haitaton.hanke.HankeNotFoundException
+import fi.hel.haitaton.hanke.HankeRepository
 import fi.hel.haitaton.hanke.application.ApplicationContactType
 import fi.hel.haitaton.hanke.application.ApplicationData
 import fi.hel.haitaton.hanke.application.ApplicationEntity
@@ -12,6 +14,7 @@ import org.springframework.transaction.annotation.Transactional
 @Service
 class HakemusService(
     private val applicationRepository: ApplicationRepository,
+    private val hankeRepository: HankeRepository,
 ) {
     @Transactional(readOnly = true)
     fun hakemusResponse(applicationId: Long): HakemusResponse {
@@ -20,6 +23,14 @@ class HakemusService(
                 ?: throw ApplicationNotFoundException(applicationId)
         return hakemusResponseWithYhteystiedot(applicationEntity)
     }
+
+    @Transactional(readOnly = true)
+    fun hankkeenHakemuksetResponse(hankeTunnus: String): HankkeenHakemuksetResponse =
+        HankkeenHakemuksetResponse(
+            hankeRepository.findByHankeTunnus(hankeTunnus)?.let { entity ->
+                entity.hakemukset.map { hakemus -> HankkeenHakemusResponse(hakemus) }
+            } ?: throw HankeNotFoundException(hankeTunnus)
+        )
 
     private fun hakemusResponseWithYhteystiedot(applicationEntity: ApplicationEntity) =
         HakemusResponse(

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HankkeenHakemuksetResponse.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HankkeenHakemuksetResponse.kt
@@ -1,0 +1,50 @@
+package fi.hel.haitaton.hanke.hakemus
+
+import fi.hel.haitaton.hanke.allu.ApplicationStatus
+import fi.hel.haitaton.hanke.application.ApplicationEntity
+import fi.hel.haitaton.hanke.application.ApplicationType
+import fi.hel.haitaton.hanke.application.CableReportApplicationData
+import java.time.ZonedDateTime
+
+data class HankkeenHakemuksetResponse(val applications: List<HankkeenHakemusResponse>)
+
+data class HankkeenHakemusResponse(
+    val id: Long,
+    val alluid: Int?,
+    val alluStatus: ApplicationStatus?,
+    val applicationIdentifier: String?,
+    val applicationType: ApplicationType,
+    val applicationData: HankkeenHakemusDataResponse,
+) {
+    constructor(
+        application: ApplicationEntity
+    ) : this(
+        application.id!!,
+        application.alluid,
+        application.alluStatus,
+        application.applicationIdentifier,
+        application.applicationType,
+        HankkeenHakemusDataResponse(
+            when (application.applicationData) {
+                is CableReportApplicationData ->
+                    application.applicationData as CableReportApplicationData
+            },
+        ),
+    )
+}
+
+data class HankkeenHakemusDataResponse(
+    val name: String,
+    val startTime: ZonedDateTime?,
+    val endTime: ZonedDateTime?,
+    val pendingOnClient: Boolean,
+) {
+    constructor(
+        cableReportApplicationData: CableReportApplicationData
+    ) : this(
+        cableReportApplicationData.name,
+        cableReportApplicationData.startTime,
+        cableReportApplicationData.endTime,
+        cableReportApplicationData.pendingOnClient,
+    )
+}

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/ApplicationFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/ApplicationFactory.kt
@@ -309,6 +309,11 @@ class ApplicationFactory(
                 hanke = hanke,
             )
 
+        fun createApplicationEntities(
+            n: Long,
+            hanke: HankeEntity = HankeFactory.createMinimalEntity(),
+        ) = (1..n).map { i -> createApplicationEntity(id = i, hanke = hanke) }
+
         val hakijaCustomerContact: CustomerWithContacts =
             with(KAYTTAJA_INPUT_HAKIJA) {
                 createCompanyCustomer()


### PR DESCRIPTION
# Description
Move API endpoint `/hankkeet/<hankeid>/hakemukset` from HankeController to new HakemusController.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2243

## Type of change

- [ ] Bug fix 
- [x] New feature 
- [ ] Other

# Instructions for testing
Endpoint `/hankkeet/<hankeid>/hakemukset` should work as before.

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 

# Other relevant info
Please describe here if there is e.g. some requirements for this change or
 other info that the tester/user needs to know.