### PR TITLE
HAITATON-17 Update email template johtoselvitys-valmis (#603)

### DIFF
--- a/email/johtoselvitys-valmis.mjml
+++ b/email/johtoselvitys-valmis.mjml
@@ -14,16 +14,18 @@
                 </mj-text>
                 <mj-text mj-class="basic-txt">
                     Miten onnistuimme? Kerro mielipiteesi <a
-                        href="https://response.questback.com/isa/qbv.dll/bylink?p=x6TIpQ4sCcJt9Dv1T-AuuKa-DssX27rx6er2ohTVVipooPTA8H0u-weNFWY9GsVI0">
+                        href="https://ecv.microsoft.com/zepZlZSdnT">
                     täällä</a>.
                 </mj-text>
                 <mj-text mj-class="basic-txt">
                     Ystävällisin terveisin,
                 </mj-text>
                 <mj-text mj-class="signature">
-                    Helsingin kaupunkiympäristön asukas- ja yrityspalvelut
+                    Helsingin kaupunki
                     <br/>
-                    Alueidenkäyttö ja -valvonta
+					Kaupunkiympäristön asukas- ja yrityspalvelut
+					<br/>
+                    Alueiden käyttö ja valvonta
                     <br/>
                     Johtotietopalvelu
                     <br/>
@@ -45,15 +47,17 @@
                 </mj-text>
                 <mj-text mj-class="basic-txt">
                     Hur lyckades vi? Ge din åsikt <a
-                        href="https://response.questback.com/isa/qbv.dll/bylink?p=x6TIpQ4sCcJt9Dv1T-AuuKa-DssX27rx6er2ohTVVipooPTA8H0u-weNFWY9GsVI0">
+                        href="https://ecv.microsoft.com/zepZlZSdnT">
                     här</a>.
                 </mj-text>
                 <mj-text mj-class="basic-txt">
                     Med vänlig hälsning,
                 </mj-text>
                 <mj-text mj-class="signature">
-                    Helsingfors stadsmiljös boende- och företagstjänster
+                    Helsingfors stad
                     <br/>
+					Stadsmiljös boende- och företagstjänster
+					<br/>
                     Användning och tillsyn av områden
                     <br/>
                     Ledningstjänsten
@@ -74,15 +78,17 @@
                 </mj-text>
                 <mj-text mj-class="basic-txt">
                     How did we do? Please share your opinion <a
-                        href="https://response.questback.com/isa/qbv.dll/bylink?p=x6TIpQ4sCcJt9Dv1T-AuuKa-DssX27rx6er2ohTVVipooPTA8H0u-weNFWY9GsVI0">
+                        href="https://ecv.microsoft.com/zepZlZSdnT">
                     here</a>.
                 </mj-text>
                 <mj-text mj-class="basic-txt">
                     Kind regards,
                 </mj-text>
                 <mj-text mj-class="signature">
-                    Helsinki Urban Environment Resident and Business Services
+                    City of Helsinki
                     <br/>
+					Urban Environment Resident and Business Services
+					<br/>
                     Land Use and Monitoring
                     <br/>
                     Cable Location Service

--- a/services/hanke-service/build.gradle.kts
+++ b/services/hanke-service/build.gradle.kts
@@ -7,7 +7,7 @@ group = "fi.hel.haitaton"
 
 version = "0.0.1-SNAPSHOT"
 
-val sentryVersion = "7.2.0"
+val sentryVersion = "7.3.0"
 
 repositories { mavenCentral() }
 
@@ -51,7 +51,7 @@ plugins {
     val kotlinVersion = "1.9.22"
     id("org.springframework.boot") version "3.1.6"
     id("io.spring.dependency-management") version "1.1.4"
-    id("com.diffplug.spotless") version "6.24.0"
+    id("com.diffplug.spotless") version "6.25.0"
     kotlin("jvm") version kotlinVersion
     // Gives kotlin-allopen, which auto-opens classes with certain annotations
     kotlin("plugin.spring") version kotlinVersion
@@ -79,9 +79,9 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.liquibase:liquibase-core")
     implementation("com.github.blagerweij:liquibase-sessionlock:1.6.9")
-    implementation("io.hypersistence:hypersistence-utils-hibernate-60:3.7.0")
+    implementation("io.hypersistence:hypersistence-utils-hibernate-60:3.7.2")
     implementation("commons-io:commons-io:2.15.1")
-    implementation("com.github.librepdf:openpdf:1.3.39")
+    implementation("com.github.librepdf:openpdf:1.3.40")
     implementation("net.pwall.mustache:kotlin-mustache:0.11")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3")
 
@@ -98,7 +98,7 @@ dependencies {
     testImplementation("com.icegreen:greenmail-junit5:2.0.1")
 
     // Testcontainers
-    implementation(platform("org.testcontainers:testcontainers-bom:1.19.3"))
+    implementation(platform("org.testcontainers:testcontainers-bom:1.19.5"))
     testImplementation("org.testcontainers:junit-jupiter")
     testImplementation("org.testcontainers:postgresql")
 
@@ -113,7 +113,7 @@ dependencies {
     implementation("io.sentry:sentry-logback:$sentryVersion")
 
     // Azure
-    implementation(platform("com.azure:azure-sdk-bom:1.2.19"))
+    implementation(platform("com.azure:azure-sdk-bom:1.2.20"))
     implementation("com.azure:azure-storage-blob")
     implementation("com.azure:azure-storage-blob-batch")
     implementation("com.azure:azure-identity")
@@ -155,7 +155,7 @@ tasks {
     create("copyEmailTemplates", Copy::class) {
         group = "other"
         description = "Installs shared git hooks"
-        from(file("$buildDir/mjml/main/"))
+        from(file("${layout.buildDirectory.get()}/mjml/main/"))
         into(file("${sourceSets.main.get().resources.srcDirs.first()}/email/template"))
         rename { "$it.mustache" }
         dependsOn(compileMjml)
@@ -165,7 +165,7 @@ tasks {
         mustRunAfter("test", "integrationTest")
         reports { xml.required.set(true) }
         executionData.setFrom(
-            fileTree(buildDir).include("/jacoco/test.exec", "/jacoco/integrationTest.exec")
+            fileTree(layout.buildDirectory).include("/jacoco/test.exec", "/jacoco/integrationTest.exec")
         )
     }
 

--- a/services/hanke-service/src/main/resources/email/template/johtoselvitys-valmis.html.mustache
+++ b/services/hanke-service/src/main/resources/email/template/johtoselvitys-valmis.html.mustache
@@ -80,7 +80,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0;padding:16px 24px 0 24px;word-break:break-word">
-                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">Miten onnistuimme? Kerro mielipiteesi <a href="https://response.questback.com/isa/qbv.dll/bylink?p=x6TIpQ4sCcJt9Dv1T-AuuKa-DssX27rx6er2ohTVVipooPTA8H0u-weNFWY9GsVI0"> täällä</a>.</div>
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">Miten onnistuimme? Kerro mielipiteesi <a href="https://ecv.microsoft.com/zepZlZSdnT"> täällä</a>.</div>
                       </td>
                     </tr>
                     <tr>
@@ -90,7 +90,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0;padding:16px 24px 16px 24px;word-break:break-word">
-                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">Helsingin kaupunkiympäristön asukas- ja yrityspalvelut <br> Alueidenkäyttö ja -valvonta <br> Johtotietopalvelu <br> Puh. 09 310 31940 <br> johtotietopalvelu@hel.fi</div>
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">Helsingin kaupunki <br> Kaupunkiympäristön asukas- ja yrityspalvelut <br> Alueiden käyttö ja valvonta <br> Johtotietopalvelu <br> Puh. 09 310 31940 <br> johtotietopalvelu@hel.fi</div>
                       </td>
                     </tr>
                     <tr>
@@ -110,7 +110,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0;padding:16px 24px 0 24px;word-break:break-word">
-                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">Hur lyckades vi? Ge din åsikt <a href="https://response.questback.com/isa/qbv.dll/bylink?p=x6TIpQ4sCcJt9Dv1T-AuuKa-DssX27rx6er2ohTVVipooPTA8H0u-weNFWY9GsVI0"> här</a>.</div>
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">Hur lyckades vi? Ge din åsikt <a href="https://ecv.microsoft.com/zepZlZSdnT"> här</a>.</div>
                       </td>
                     </tr>
                     <tr>
@@ -120,7 +120,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0;padding:16px 24px 16px 24px;word-break:break-word">
-                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">Helsingfors stadsmiljös boende- och företagstjänster <br> Användning och tillsyn av områden <br> Ledningstjänsten <br> Tfn 09 310 31940 <br> johtotietopalvelu@hel.fi</div>
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">Helsingfors stad <br> Stadsmiljös boende- och företagstjänster <br> Användning och tillsyn av områden <br> Ledningstjänsten <br> Tfn 09 310 31940 <br> johtotietopalvelu@hel.fi</div>
                       </td>
                     </tr>
                     <tr>
@@ -140,7 +140,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0;padding:16px 24px 0 24px;word-break:break-word">
-                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">How did we do? Please share your opinion <a href="https://response.questback.com/isa/qbv.dll/bylink?p=x6TIpQ4sCcJt9Dv1T-AuuKa-DssX27rx6er2ohTVVipooPTA8H0u-weNFWY9GsVI0"> here</a>.</div>
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">How did we do? Please share your opinion <a href="https://ecv.microsoft.com/zepZlZSdnT"> here</a>.</div>
                       </td>
                     </tr>
                     <tr>
@@ -150,7 +150,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0;padding:16px 24px 16px 24px;word-break:break-word">
-                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">Helsinki Urban Environment Resident and Business Services <br> Land Use and Monitoring <br> Cable Location Service <br> Tel. +358 9 310 31940 <br> johtotietopalvelu@hel.fi</div>
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">City of Helsinki <br> Urban Environment Resident and Business Services <br> Land Use and Monitoring <br> Cable Location Service <br> Tel. +358 9 310 31940 <br> johtotietopalvelu@hel.fi</div>
                       </td>
                     </tr>
                   </tbody>

--- a/services/hanke-service/src/main/resources/email/template/johtoselvitys-valmis.text.mustache
+++ b/services/hanke-service/src/main/resources/email/template/johtoselvitys-valmis.text.mustache
@@ -1,10 +1,11 @@
 Hakemanne johtoselvitys {{applicationIdentifier}} on käsitelty. Lataa selvitys Haitattomasta ({{baseUrl}}/fi/hakemus/{{applicationId}}) ja tutustu sen sisältöön huolellisesti.
 
-Miten onnistuimme? Kerro mielipiteesi täällä: https://response.questback.com/isa/qbv.dll/bylink?p=x6TIpQ4sCcJt9Dv1T-AuuKa-DssX27rx6er2ohTVVipooPTA8H0u-weNFWY9GsVI0.
+Miten onnistuimme? Kerro mielipiteesi täällä: https://ecv.microsoft.com/zepZlZSdnT.
 
 Ystävällisin terveisin,
-Helsingin kaupunkiympäristön asukas- ja yrityspalvelut
-Alueidenkäyttö ja -valvonta
+Helsingin kaupunki
+Kaupunkiympäristön asukas- ja yrityspalvelut
+Alueiden käyttö ja valvonta
 Johtotietopalvelu
 Puh. 09 310 31940
 johtotietopalvelu@hel.fi
@@ -12,10 +13,11 @@ johtotietopalvelu@hel.fi
 
 Ledningsutredningen {{applicationIdentifier}} ni ansökt om har behandlats. Ladda ned utredningen från Haitaton ({{baseUrl}}/sv/ansokan/{{applicationId}}) och läs innehållet i den noggrannt.
 
-Hur lyckades vi? Ge din åsikt här: https://response.questback.com/isa/qbv.dll/bylink?p=x6TIpQ4sCcJt9Dv1T-AuuKa-DssX27rx6er2ohTVVipooPTA8H0u-weNFWY9GsVI0.
+Hur lyckades vi? Ge din åsikt här: https://ecv.microsoft.com/zepZlZSdnT.
 
 Med vänlig hälsning,
-Helsingfors stadsmiljös boende- och företagstjänster
+Helsingfors stad
+Stadsmiljös boende- och företagstjänster
 Användning och tillsyn av områden
 Ledningstjänsten
 Tfn 09 310 31940
@@ -24,10 +26,11 @@ johtotietopalvelu@hel.fi
 
 Cable report {{applicationIdentifier}} that you requested has been processed. Download the report via Haitaton ({{baseUrl}}/en/application/{{applicationId}}) and read it carefully.
 
-How did we do? Please share your opinion here: https://response.questback.com/isa/qbv.dll/bylink?p=x6TIpQ4sCcJt9Dv1T-AuuKa-DssX27rx6er2ohTVVipooPTA8H0u-weNFWY9GsVI0.
+How did we do? Please share your opinion here: https://ecv.microsoft.com/zepZlZSdnT.
 
 Kind regards,
-Helsinki Urban Environment Resident and Business Services
+City of Helsinki
+Urban Environment Resident and Business Services
 Land Use and Monitoring
 Cable Location Service
 Tel. +358 9 310 31940


### PR DESCRIPTION
# Description

Cherry picked from dev merged HAITATON-17 branch.

Change based on Gofore maintenance ticket HAITATON-17

> Moi, https://github.com/City-of-Helsinki/haitaton-backend/blob/main/email/johtoselvitys-valmis.mjml -tiedosto pitäisi vaihtaa uuteen. Uudessa tiedostossa palautelinkin osoite ja allekirjoitus vaihdettu. Uusi tiedosto löytyy liitteenä.


### Jira Issue: 

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [x] Other

# Instructions for testing
Please describe tests how this change or new feature can be tested.

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 

# Other relevant info
Please describe here if there is e.g. some requirements for this change or
 other info that the tester/user needs to know.