### PR TITLE
HAI Add COMMENT_ADDED application status

### DIFF
--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/ApplicationHistory.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/ApplicationHistory.kt
@@ -41,6 +41,7 @@ enum class ApplicationStatus {
     CANCELLED, // // Application cancelled
     ARCHIVED, // Application archived
     REPLACED, // Application decision has been replaced with a new one
+    COMMENT_ADDED, // A comment has been sent to Haitaton from Allu
 }
 
 data class SupervisionEvent(


### PR DESCRIPTION
# Description

Allu has an undocumented status that it sends when a comment has been sent to the client system. If such a message is added, this will break fetching the application history, i.e. all application updates.

## Type of change

- [X] Bug fix 
- [ ] New feature 
- [ ] Other

# Instructions for testing
Staging logs have constant errors of this.

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 