### PR TITLE
HAI-2338 Implement gdpr delete dry-run for kortisto

### DIFF
--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/gdpr/GdprService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/gdpr/GdprService.kt
@@ -155,8 +155,8 @@ class OldGdprService(private val applicationService: ApplicationService) : GdprS
 
     @Transactional(readOnly = true)
     override fun canDelete(userId: String): Boolean {
-        findApplicationsToDelete(userId)
         // Will throw an exception if the information can't be deleted
+        findApplicationsToDelete(userId)
         return true
     }
 

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/gdpr/OldGdprServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/gdpr/OldGdprServiceTest.kt
@@ -1,13 +1,17 @@
 package fi.hel.haitaton.hanke.gdpr
 
+import assertk.assertFailure
 import fi.hel.haitaton.hanke.application.ApplicationDeletionResultDto
 import fi.hel.haitaton.hanke.application.ApplicationService
 import fi.hel.haitaton.hanke.factory.ApplicationFactory
-import io.mockk.Called
+import io.mockk.checkUnnecessaryStub
+import io.mockk.clearAllMocks
+import io.mockk.confirmVerified
 import io.mockk.every
 import io.mockk.mockk
-import io.mockk.verify
-import io.mockk.verifyAll
+import io.mockk.verifySequence
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
@@ -18,29 +22,68 @@ class OldGdprServiceTest {
     private val applicationService: ApplicationService = mockk(relaxUnitFun = true)
     private val gdprService = OldGdprService(applicationService)
 
+    @BeforeEach
+    fun clearMocks() {
+        clearAllMocks()
+    }
+
+    @AfterEach
+    fun checkMocks() {
+        checkUnnecessaryStub()
+        confirmVerified(applicationService)
+    }
+
     @Nested
     inner class DeleteApplications {
         @Test
         fun `Does nothing with an empty list`() {
-            gdprService.deleteApplications(listOf(), USERID)
+            every { applicationService.getAllApplicationsCreatedByUser(USERID) } returns listOf()
 
-            verify { applicationService wasNot Called }
+            gdprService.deleteInfo(USERID)
+
+            verifySequence { applicationService.getAllApplicationsCreatedByUser(USERID) }
         }
 
         @Test
-        fun `Deletes all given applications`() {
+        fun `Deletes all user's applications`() {
             val applications = ApplicationFactory.createApplications(4)
+            every { applicationService.getAllApplicationsCreatedByUser(USERID) } returns
+                applications
+            every { applicationService.isStillPending(null, null) } returns true
             every {
                 applicationService.deleteWithOrphanGeneratedHankeRemoval(any(), USERID)
             } returns ApplicationDeletionResultDto(hankeDeleted = false)
 
-            gdprService.deleteApplications(applications, USERID)
+            gdprService.deleteInfo(USERID)
 
-            verifyAll {
+            verifySequence {
+                applicationService.getAllApplicationsCreatedByUser(USERID)
+                applicationService.isStillPending(null, null)
+                applicationService.isStillPending(null, null)
+                applicationService.isStillPending(null, null)
+                applicationService.isStillPending(null, null)
                 applicationService.deleteWithOrphanGeneratedHankeRemoval(1, USERID)
                 applicationService.deleteWithOrphanGeneratedHankeRemoval(2, USERID)
                 applicationService.deleteWithOrphanGeneratedHankeRemoval(3, USERID)
                 applicationService.deleteWithOrphanGeneratedHankeRemoval(4, USERID)
+            }
+        }
+
+        @Test
+        fun `Throws exception if any applications are no longer pending`() {
+            val applications = ApplicationFactory.createApplications(4)
+            every { applicationService.getAllApplicationsCreatedByUser(USERID) } returns
+                applications
+            every { applicationService.isStillPending(null, null) } returns false
+
+            assertFailure { gdprService.deleteInfo(USERID) }
+
+            verifySequence {
+                applicationService.getAllApplicationsCreatedByUser(USERID)
+                applicationService.isStillPending(null, null)
+                applicationService.isStillPending(null, null)
+                applicationService.isStillPending(null, null)
+                applicationService.isStillPending(null, null)
             }
         }
     }


### PR DESCRIPTION
# Description

Refactor the GDPR service dry-run to not return a list of applications. Instead, return true if the information can be deleted and throw an exception if it can't. This also means that the delete call needs to be refactored to not receive a list of applications, but fetch them from the DB again.

Besides supporting both the old and Kortisto model of GDPR service, this also has the added benefit of loading the information to be deleted in the same transaction as they are deleted in, so there's no chance of the information changing between the loading and deleting.

Implement the canDelete method for `KortistoGdprService`. This checks that the user is not on any active applications, and is not the only admin user (user with KAIKKI_OIKEUDET privileges) in the hanke. If the user shouldn't be deleted, all the conflicting applications are gathered and thrown in an exception. The controller returns the errors in the correct format to Profiili.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2338

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
Can be tested with the profile-gdpr-api-tester.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [X] I have made necessary changes to the documentation, link to confluence
 or other location: https://helsinkisolutionoffice.atlassian.net/wiki/spaces/HAI/pages/8075476993/GDPR+API#Kortiston-my%C3%B6t%C3%A4

# Other relevant info
The `deleteInfo` method will be implemented in the next PR.