### PR TITLE
HAI-2338 Implement GDRP delete API for kortisto

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
@@ -53,6 +53,7 @@ import fi.hel.haitaton.hanke.factory.ApplicationFactory.Companion.withArea
 import fi.hel.haitaton.hanke.factory.ApplicationFactory.Companion.withContacts
 import fi.hel.haitaton.hanke.factory.DateFactory
 import fi.hel.haitaton.hanke.factory.GeometriaFactory
+import fi.hel.haitaton.hanke.factory.HakemusFactory
 import fi.hel.haitaton.hanke.factory.HankeAttachmentFactory
 import fi.hel.haitaton.hanke.factory.HankeBuilder.Companion.toModifyRequest
 import fi.hel.haitaton.hanke.factory.HankeFactory
@@ -159,6 +160,7 @@ class HankeServiceITests(
     @Autowired private val hankeFactory: HankeFactory,
     @Autowired private val hankeAttachmentFactory: HankeAttachmentFactory,
     @Autowired private val hankeKayttajaFactory: HankeKayttajaFactory,
+    @Autowired private val hakemusFactory: HakemusFactory,
     @Autowired private val cableReportService: CableReportService,
 ) : DatabaseTest() {
 
@@ -1481,6 +1483,17 @@ class HankeServiceITests(
 
             assertThat(hankeRepository.findByIdOrNull(hanke.id)).isNotNull()
             verify { cableReportService.getApplicationInformation(hakemusAlluId) }
+        }
+
+        @Test
+        fun `when hakemus has yhteyshenkilot, those are removed as well`() {
+            val hanke =
+                hankeFactory.builder(USER_NAME).withYhteystiedot().withHankealue().saveEntity()
+            hakemusFactory.builder(USER_NAME, hanke).saveWithYhteystiedot { hakija() }
+
+            hankeService.deleteHanke(hanke.hankeTunnus, USER_NAME)
+
+            assertThat(hankeRepository.findByIdOrNull(hanke.id)).isNull()
         }
 
         @Test

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/gdpr/KortistoGdprServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/gdpr/KortistoGdprServiceITest.kt
@@ -6,31 +6,43 @@ import assertk.assertFailure
 import assertk.assertThat
 import assertk.assertions.any
 import assertk.assertions.contains
+import assertk.assertions.containsExactly
 import assertk.assertions.containsExactlyInAnyOrder
+import assertk.assertions.extracting
 import assertk.assertions.first
-import assertk.assertions.hasClass
 import assertk.assertions.hasSize
 import assertk.assertions.isEmpty
 import assertk.assertions.isEqualTo
 import assertk.assertions.isInstanceOf
+import assertk.assertions.isNotEqualTo
 import assertk.assertions.isNotNull
 import assertk.assertions.isNull
 import assertk.assertions.isTrue
 import assertk.assertions.prop
 import assertk.assertions.single
 import fi.hel.haitaton.hanke.DatabaseTest
+import fi.hel.haitaton.hanke.HankeEntity
+import fi.hel.haitaton.hanke.HankeRepository
+import fi.hel.haitaton.hanke.application.ApplicationEntity
+import fi.hel.haitaton.hanke.application.ApplicationRepository
+import fi.hel.haitaton.hanke.attachment.common.MockFileClientExtension
 import fi.hel.haitaton.hanke.factory.HakemusFactory
 import fi.hel.haitaton.hanke.factory.HakemusyhteystietoFactory
 import fi.hel.haitaton.hanke.factory.HankeFactory
 import fi.hel.haitaton.hanke.factory.HankeKayttajaFactory
+import fi.hel.haitaton.hanke.factory.HankeKayttajaFactory.Companion.KAYTTAJA_INPUT_HAKIJA
 import fi.hel.haitaton.hanke.factory.HankeYhteystietoFactory
 import fi.hel.haitaton.hanke.factory.PermissionFactory
+import fi.hel.haitaton.hanke.permissions.HankeKayttajaDto
 import fi.hel.haitaton.hanke.permissions.HankeKayttajaService
+import fi.hel.haitaton.hanke.permissions.HankekayttajaEntity
+import fi.hel.haitaton.hanke.permissions.HankekayttajaRepository
 import fi.hel.haitaton.hanke.permissions.Kayttooikeustaso
 import fi.hel.haitaton.hanke.permissions.PermissionEntity
 import fi.hel.haitaton.hanke.permissions.PermissionRepository
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.security.test.context.support.WithMockUser
@@ -44,11 +56,16 @@ private const val USERID = "test-user"
 class KortistoGdprServiceITest(
     @Autowired val gdprService: GdprService,
     @Autowired val hankeKayttajaService: HankeKayttajaService,
+    @Autowired val hankekayttajaRepository: HankekayttajaRepository,
+    @Autowired val permissionRepository: PermissionRepository,
+    @Autowired val hankeRepository: HankeRepository,
+    @Autowired val applicationRepository: ApplicationRepository,
     @Autowired val hakemusFactory: HakemusFactory,
     @Autowired val hankeFactory: HankeFactory,
     @Autowired val hankekayttajaFactory: HankeKayttajaFactory,
-    @Autowired val permissionRepository: PermissionRepository,
 ) : DatabaseTest() {
+    val OTHER_USER_ID = "Other user"
+
     @Test
     fun `Test class loads correct service`() {
         assertThat(gdprService).isInstanceOf(KortistoGdprService::class)
@@ -319,12 +336,248 @@ class KortistoGdprServiceITest(
     }
 
     @Nested
+    @ExtendWith(MockFileClientExtension::class)
     inner class DeleteInfo {
         @Test
-        fun `throws not implemented exception`() {
+        fun `doesn't throw an exception when there's no data for the user`() {
+            gdprService.deleteInfo(USERID)
+        }
+
+        @Test
+        fun `deletes hanke with applications when there are no other users`() {
+            lateinit var kayttaja: HankekayttajaEntity
+            val hanke =
+                hankeFactory.builder(USERID).withHankealue().saveWithYhteystiedot {
+                    kayttaja =
+                        hankeKayttajaService.getKayttajaByUserId(this.hankeEntity.id, USERID)!!
+                    omistaja { addYhteyshenkilo(it, kayttaja) }
+                }
+            hakemusFactory.builder(USERID, hanke).saveWithYhteystiedot {
+                hakija { addYhteyshenkilo(it, kayttaja) }
+            }
+
+            gdprService.deleteInfo(USERID)
+
+            assertThat(hankeRepository.findAll()).isEmpty()
+            assertThat(applicationRepository.findAll()).isEmpty()
+        }
+
+        @Test
+        fun `deletes hankekayttaja when there are other non-admin users`() {
+            val hanke =
+                hankeFactory.builder(USERID).withHankealue().saveWithYhteystiedot {
+                    val kayttaja =
+                        hankeKayttajaService.getKayttajaByUserId(this.hankeEntity.id, USERID)!!
+                    omistaja { addYhteyshenkilo(it, kayttaja) }
+                }
+            val hakemus =
+                hakemusFactory.builder(USERID, hanke).saveWithYhteystiedot {
+                    hakija(kayttooikeustaso = Kayttooikeustaso.HAKEMUSASIOINTI)
+                }
+
+            gdprService.deleteInfo(USERID)
+
+            assertThat(hankeRepository.findAll()).single().prop(HankeEntity::id).isEqualTo(hanke.id)
+            assertThat(applicationRepository.findAll())
+                .single()
+                .prop(ApplicationEntity::id)
+                .isEqualTo(hakemus.id)
+            assertThat(hankeKayttajaService.getKayttajatByHankeId(hanke.id)).single().all {
+                prop(HankeKayttajaDto::kayttooikeustaso).isEqualTo(Kayttooikeustaso.HAKEMUSASIOINTI)
+                prop(HankeKayttajaDto::sukunimi).isEqualTo(KAYTTAJA_INPUT_HAKIJA.sukunimi)
+            }
+        }
+
+        @Test
+        fun `throws an exception when the user is the only admin and there's an active application without the user`() {
+            val hanke =
+                hankeFactory.builder(USERID).withHankealue().saveWithYhteystiedot {
+                    val kayttaja =
+                        hankeKayttajaService.getKayttajaByUserId(this.hankeEntity.id, USERID)!!
+                    omistaja { addYhteyshenkilo(it, kayttaja) }
+                }
+            val hakemus =
+                hakemusFactory.builder(USERID, hanke).inHandling().saveWithYhteystiedot {
+                    hakija(kayttooikeustaso = Kayttooikeustaso.HAKEMUSASIOINTI)
+                }
+
             val failure = assertFailure { gdprService.deleteInfo(USERID) }
 
-            failure.hasClass(NotImplementedError::class)
+            failure
+                .isInstanceOf(DeleteForbiddenException::class)
+                .prop(DeleteForbiddenException::errors)
+                .single()
+                .prop(GdprError::message)
+                .prop(LocalizedMessage::fi)
+                .contains(hakemus.applicationIdentifier!!)
+        }
+
+        @Test
+        fun `deletes hankekayttaja when there's another admin in the hanke`() {
+            lateinit var kayttaja: HankekayttajaEntity
+            val hanke =
+                hankeFactory.builder(USERID).withHankealue().saveWithYhteystiedot {
+                    kayttaja =
+                        hankeKayttajaService.getKayttajaByUserId(this.hankeEntity.id, USERID)!!
+                    omistaja { addYhteyshenkilo(it, kayttaja) }
+                }
+            val hakemus =
+                hakemusFactory.builder(USERID, hanke).inHandling().saveWithYhteystiedot {
+                    hakija(
+                        hakija = KAYTTAJA_INPUT_HAKIJA,
+                        kayttooikeustaso = Kayttooikeustaso.KAIKKI_OIKEUDET,
+                    )
+                }
+
+            gdprService.deleteInfo(USERID)
+
+            assertThat(hankeRepository.findAll()).single().prop(HankeEntity::id).isEqualTo(hanke.id)
+            assertThat(applicationRepository.findAll())
+                .single()
+                .prop(ApplicationEntity::id)
+                .isEqualTo(hakemus.id)
+            assertThat(hankeKayttajaService.getKayttajatByHankeId(hanke.id)).single().all {
+                prop(HankeKayttajaDto::kayttooikeustaso).isEqualTo(Kayttooikeustaso.KAIKKI_OIKEUDET)
+                prop(HankeKayttajaDto::sukunimi).isEqualTo(KAYTTAJA_INPUT_HAKIJA.sukunimi)
+                prop(HankeKayttajaDto::id).isNotEqualTo(kayttaja.id)
+            }
+        }
+
+        @Test
+        fun `deletes hankekayttaja when the kayttaja is not an admin`() {
+            lateinit var kayttaja: HankekayttajaEntity
+            val hanke =
+                hankeFactory.builder(OTHER_USER_ID).withHankealue().saveWithYhteystiedot {
+                    kayttaja =
+                        kayttaja(
+                            kayttooikeustaso = Kayttooikeustaso.HAKEMUSASIOINTI,
+                            userId = USERID
+                        )
+                    omistaja { addYhteyshenkilo(it, kayttaja) }
+                }
+            val hakemus =
+                hakemusFactory.builder(USERID, hanke).saveWithYhteystiedot {
+                    hakija { addYhteyshenkilo(it, kayttaja) }
+                }
+            val founder: HankekayttajaEntity =
+                hankeKayttajaService.getKayttajaByUserId(hanke.id, OTHER_USER_ID)!!
+
+            gdprService.deleteInfo(USERID)
+
+            assertThat(hankeRepository.findAll()).single().prop(HankeEntity::id).isEqualTo(hanke.id)
+            assertThat(applicationRepository.findAll())
+                .single()
+                .prop(ApplicationEntity::id)
+                .isEqualTo(hakemus.id)
+            assertThat(hankeKayttajaService.getKayttajatByHankeId(hanke.id))
+                .single()
+                .prop(HankeKayttajaDto::id)
+                .isEqualTo(founder.id)
+        }
+
+        @Test
+        fun `throws an exception when the kayttaja is on an active application`() {
+            val hanke =
+                hankeFactory.builder(OTHER_USER_ID).withHankealue().saveWithYhteystiedot {
+                    omistaja()
+                }
+            val kayttaja = hankekayttajaFactory.saveIdentifiedUser(hanke.id, userId = USERID)
+            val hakemus =
+                hakemusFactory.builder(USERID, hanke).inHandling().saveWithYhteystiedot {
+                    hakija { addYhteyshenkilo(it, kayttaja) }
+                }
+
+            val failure = assertFailure { gdprService.deleteInfo(USERID) }
+
+            failure
+                .isInstanceOf(DeleteForbiddenException::class)
+                .prop(DeleteForbiddenException::errors)
+                .single()
+                .prop(GdprError::message)
+                .prop(LocalizedMessage::fi)
+                .contains(hakemus.applicationIdentifier!!)
+        }
+
+        @Test
+        fun `deletes the correct kayttajat and hankkeet when there are several`() {
+            val unrelatedHanke = hankeFactory.builder(OTHER_USER_ID).withHankealue().saveEntity()
+            val unrelatedHakemus =
+                hakemusFactory.builder(OTHER_USER_ID, unrelatedHanke).saveWithYhteystiedot {
+                    hakija()
+                }
+            lateinit var nonAdminKayttaja: HankekayttajaEntity
+            val nonAdminHanke =
+                hankeFactory.builder(OTHER_USER_ID).withHankealue().saveWithYhteystiedot {
+                    nonAdminKayttaja = kayttaja(userId = USERID)
+                    omistaja { addYhteyshenkilo(it, nonAdminKayttaja) }
+                }
+            val nonAdminHakemus =
+                hakemusFactory.builder(USERID, nonAdminHanke).saveWithYhteystiedot {
+                    hakija { addYhteyshenkilo(it, nonAdminKayttaja) }
+                }
+            lateinit var twoAdminKayttaja: HankekayttajaEntity
+            val twoAdminHanke =
+                hankeFactory.builder(USERID).withHankealue().saveWithYhteystiedot {
+                    twoAdminKayttaja =
+                        hankeKayttajaService.getKayttajaByUserId(this.hankeEntity.id, USERID)!!
+                    omistaja { addYhteyshenkilo(it, twoAdminKayttaja) }
+                }
+            val twoAdminHakemus =
+                hakemusFactory.builder(USERID, twoAdminHanke).inHandling().saveWithYhteystiedot {
+                    hakija(kayttooikeustaso = Kayttooikeustaso.KAIKKI_OIKEUDET)
+                }
+            lateinit var soloKayttaja: HankekayttajaEntity
+            val soloHanke =
+                hankeFactory.builder(USERID).withHankealue().saveWithYhteystiedot {
+                    soloKayttaja =
+                        hankeKayttajaService.getKayttajaByUserId(this.hankeEntity.id, USERID)!!
+                    omistaja { addYhteyshenkilo(it, soloKayttaja) }
+                }
+            hakemusFactory.builder(USERID, soloHanke).saveWithYhteystiedot {
+                hakija { addYhteyshenkilo(it, soloKayttaja) }
+            }
+            val oneAdminHanke =
+                hankeFactory.builder(USERID).withHankealue().saveWithYhteystiedot {
+                    val kayttaja =
+                        hankeKayttajaService.getKayttajaByUserId(this.hankeEntity.id, USERID)!!
+                    omistaja { addYhteyshenkilo(it, kayttaja) }
+                }
+            val oneAdminHakemus =
+                hakemusFactory.builder(USERID, oneAdminHanke).saveWithYhteystiedot {
+                    hakija(kayttooikeustaso = Kayttooikeustaso.HAKEMUSASIOINTI)
+                }
+
+            gdprService.deleteInfo(USERID)
+
+            assertThat(hankeRepository.findAll())
+                .extracting { it.id }
+                .containsExactlyInAnyOrder(
+                    unrelatedHanke.id,
+                    nonAdminHanke.id,
+                    twoAdminHanke.id,
+                    oneAdminHanke.id,
+                    // No soloHanke
+                )
+            assertThat(applicationRepository.findAll())
+                .extracting { it.id }
+                .containsExactlyInAnyOrder(
+                    unrelatedHakemus.id,
+                    nonAdminHakemus.id,
+                    twoAdminHakemus.id,
+                    oneAdminHakemus.id,
+                )
+            assertThat(hankekayttajaRepository.findByHankeId(unrelatedHanke.id))
+                .extracting { it.permission!!.userId }
+                .containsExactly(OTHER_USER_ID, HankeKayttajaFactory.FAKE_USERID)
+            assertThat(hankekayttajaRepository.findByHankeId(nonAdminHanke.id))
+                .extracting { it.permission!!.userId }
+                .containsExactly(OTHER_USER_ID)
+            assertThat(hankekayttajaRepository.findByHankeId(twoAdminHanke.id))
+                .extracting { it.permission!!.userId }
+                .containsExactly(HankeKayttajaFactory.FAKE_USERID)
+            assertThat(hankekayttajaRepository.findByHankeId(oneAdminHanke.id))
+                .extracting { it.permission!!.userId }
+                .containsExactly(HankeKayttajaFactory.FAKE_USERID)
         }
     }
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Persistence.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Persistence.kt
@@ -130,6 +130,8 @@ class HankeEntity(
 }
 
 interface HankeRepository : JpaRepository<HankeEntity, Int> {
+    fun findOneById(id: Int): HankeIdentifier?
+
     fun findOneByHankeTunnus(hankeTunnus: String): HankeIdentifier?
 
     fun findByHankeTunnus(hankeTunnus: String): HankeEntity?

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/gdpr/GdprController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/gdpr/GdprController.kt
@@ -154,6 +154,7 @@ class GdprController(
             logger.info { "Not deleting information, GDPR request was a dry run." }
         } else {
             gdprService.deleteInfo(userId)
+            logger.info { "Deleted all information we could find on user $userId" }
         }
     }
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusyhteystietoEntity.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusyhteystietoEntity.kt
@@ -4,6 +4,7 @@ import fi.hel.haitaton.hanke.allu.CustomerType
 import fi.hel.haitaton.hanke.application.ApplicationContactType
 import fi.hel.haitaton.hanke.application.ApplicationEntity
 import fi.hel.haitaton.hanke.permissions.HankekayttajaEntity
+import jakarta.persistence.CascadeType
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
@@ -33,7 +34,12 @@ class HakemusyhteystietoEntity(
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "application_id")
     var application: ApplicationEntity,
-    @OneToMany(fetch = FetchType.LAZY, mappedBy = "hakemusyhteystieto")
+    @OneToMany(
+        fetch = FetchType.LAZY,
+        mappedBy = "hakemusyhteystieto",
+        cascade = [CascadeType.REMOVE],
+        orphanRemoval = true
+    )
     @BatchSize(size = 100)
     var yhteyshenkilot: List<HakemusyhteyshenkiloEntity> = listOf(),
 ) {

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeBuilder.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeBuilder.kt
@@ -207,7 +207,7 @@ data class HankeBuilder(
 }
 
 data class HankeYhteystietoBuilder(
-    private val hankeEntity: HankeEntity,
+    val hankeEntity: HankeEntity,
     private val userId: String,
     private val hankeService: HankeService? = null,
     private val hankeKayttajaFactory: HankeKayttajaFactory,
@@ -216,12 +216,14 @@ data class HankeYhteystietoBuilder(
 ) {
     fun kayttaja(
         sahkoposti: String = HankeKayttajaFactory.KAKE_EMAIL,
-        userId: String = HankeKayttajaFactory.FAKE_USERID
+        userId: String = HankeKayttajaFactory.FAKE_USERID,
+        kayttooikeustaso: Kayttooikeustaso = Kayttooikeustaso.KATSELUOIKEUS,
     ): HankekayttajaEntity =
         hankeKayttajaFactory.saveIdentifiedUser(
             hankeEntity.id,
             sahkoposti = sahkoposti,
-            userId = userId
+            userId = userId,
+            kayttooikeustaso = kayttooikeustaso,
         )
 
     fun omistaja(


### PR DESCRIPTION
# Description

Follow the procedure described in https://helsinkisolutionoffice.atlassian.net/wiki/spaces/HAI/pages/8075476993/GDPR+API to delete either the hankekayttaja or the whole hanke when the user asks for their information to be removed.

Add cascade and orphan removal for
`HakemusyhteystietoEntity.yhteyshenkilot`. This fixes a bug when removing a hanke with an application with yhteyshenkilot.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2338

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
Can be tested with the profile-gdpr-api-tester.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [X] I have made necessary changes to the documentation, link to confluence
 or other location: https://helsinkisolutionoffice.atlassian.net/wiki/spaces/HAI/pages/8075476993/GDPR+API