### PR TITLE
HAI-2377 Add invitation date to hankekayttaja response

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
@@ -268,7 +268,7 @@ class HankeServiceITests(
                 prop(Hanke::kuvaus).isNull()
                 prop(Hanke::vaihe).isNull()
                 prop(Hanke::version).isEqualTo(0)
-                prop(Hanke::createdAt).isNotNull().isRecentZDT()
+                prop(Hanke::createdAt).isRecentZDT()
                 prop(Hanke::createdBy).isNotNull().isEqualTo(USER_NAME)
                 prop(Hanke::modifiedAt).isNull()
                 prop(Hanke::modifiedBy).isNull()
@@ -308,7 +308,7 @@ class HankeServiceITests(
                 prop(HankeEntity::onYKTHanke).isNull()
                 prop(HankeEntity::version).isEqualTo(0)
                 prop(HankeEntity::createdByUserId).isNotNull().isEqualTo(USER_NAME)
-                prop(HankeEntity::createdAt).isNotNull().isRecentUTC()
+                prop(HankeEntity::createdAt).isRecentUTC()
                 prop(HankeEntity::modifiedByUserId).isNull()
                 prop(HankeEntity::modifiedAt).isNull()
                 prop(HankeEntity::generated).isFalse()
@@ -520,7 +520,7 @@ class HankeServiceITests(
             prop(Hanke::version).isEqualTo(1)
             prop(Hanke::createdAt).isEqualTo(hanke.createdAt)
             prop(Hanke::createdBy).isEqualTo(hanke.createdBy)
-            prop(Hanke::modifiedAt).isNotNull().isRecentZDT(Duration.ofMinutes(10))
+            prop(Hanke::modifiedAt).isRecentZDT(Duration.ofMinutes(10))
             prop(Hanke::modifiedBy).isNotNull().isEqualTo(USER_NAME)
         }
         val loadedHanke = hankeService.loadHanke(result.hankeTunnus)
@@ -528,7 +528,7 @@ class HankeServiceITests(
             prop(Hanke::version).isEqualTo(1)
             prop(Hanke::createdAt).isEqualTo(hanke.createdAt)
             prop(Hanke::createdBy).isEqualTo(hanke.createdBy)
-            prop(Hanke::modifiedAt).isNotNull().isRecentZDT(Duration.ofMinutes(10))
+            prop(Hanke::modifiedAt).isRecentZDT(Duration.ofMinutes(10))
             prop(Hanke::modifiedBy).isNotNull().isEqualTo(USER_NAME)
         }
     }
@@ -555,7 +555,7 @@ class HankeServiceITests(
         assertThat(result.omistajat[1]).all {
             prop(HankeYhteystieto::id).isEqualTo(ytid2)
             prop(HankeYhteystieto::nimi).isEqualTo(NAME_SOMETHING)
-            prop(HankeYhteystieto::modifiedAt).isNotNull().isRecentZDT(Duration.ofMinutes(10))
+            prop(HankeYhteystieto::modifiedAt).isRecentZDT(Duration.ofMinutes(10))
             prop(HankeYhteystieto::modifiedBy).isNotNull().isEqualTo(USER_NAME)
         }
 

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceITest.kt
@@ -1504,7 +1504,7 @@ class ApplicationServiceITest : DatabaseTest() {
     }
 
     private fun Assert<MimeMessage>.isValid(type: ApplicationType, hankeTunnus: String?) {
-        val name = KAYTTAJA_INPUT_HAKIJA.fullName()
+        val name = "${KAYTTAJA_INPUT_HAKIJA.etunimi} ${KAYTTAJA_INPUT_HAKIJA.sukunimi}"
         val email = KAYTTAJA_INPUT_HAKIJA.email
         prop(MimeMessage::textBody).all {
             contains("$name ($email) on tehnyt")

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaControllerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaControllerITest.kt
@@ -262,10 +262,10 @@ class HankeKayttajaControllerITest(@Autowired override val mockMvc: MockMvc) : C
                 prop(HankeKayttajaDto::sahkoposti).isEqualTo("email.1.address.com")
                 prop(HankeKayttajaDto::etunimi).isEqualTo("test1")
                 prop(HankeKayttajaDto::sukunimi).isEqualTo("name1")
-                prop(HankeKayttajaDto::nimi).isEqualTo("test1 name1")
                 prop(HankeKayttajaDto::puhelinnumero).isEqualTo("0405551111")
                 prop(HankeKayttajaDto::kayttooikeustaso).isEqualTo(Kayttooikeustaso.KATSELUOIKEUS)
                 prop(HankeKayttajaDto::tunnistautunut).isEqualTo(false)
+                prop(HankeKayttajaDto::kutsuttu).isEqualTo(HankeKayttajaFactory.INVITATION_DATE)
             }
             verifySequence {
                 authorizer.authorizeKayttajaId(kayttajaId, "VIEW")
@@ -303,10 +303,10 @@ class HankeKayttajaControllerITest(@Autowired override val mockMvc: MockMvc) : C
                 assertThat(id).isNotNull()
                 assertThat(etunimi).isEqualTo("test1")
                 assertThat(sukunimi).isEqualTo("name1")
-                assertThat(nimi).isEqualTo("test1 name1")
                 assertThat(puhelinnumero).isEqualTo("0405551111")
                 assertThat(sahkoposti).isEqualTo("email.1.address.com")
                 assertThat(tunnistautunut).isEqualTo(false)
+                assertThat(kutsuttu).isEqualTo(HankeKayttajaFactory.INVITATION_DATE)
                 assertThat(roolit).containsExactlyInAnyOrder(ContactType.OMISTAJA, ContactType.MUU)
             }
             assertThat(response.kayttajat).hasSameElementsAs(testData)

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaServiceITest.kt
@@ -146,11 +146,10 @@ class HankeKayttajaServiceITest : DatabaseTest() {
                 prop(HankeKayttajaDto::sahkoposti).isEqualTo(HankeKayttajaFactory.KAKE_EMAIL)
                 prop(HankeKayttajaDto::etunimi).isEqualTo(HankeKayttajaFactory.KAKE)
                 prop(HankeKayttajaDto::sukunimi).isEqualTo(HankeKayttajaFactory.KATSELIJA)
-                prop(HankeKayttajaDto::nimi)
-                    .isEqualTo("${HankeKayttajaFactory.KAKE} ${HankeKayttajaFactory.KATSELIJA}")
                 prop(HankeKayttajaDto::puhelinnumero).isEqualTo(HankeKayttajaFactory.KAKE_PUHELIN)
                 prop(HankeKayttajaDto::kayttooikeustaso).isEqualTo(Kayttooikeustaso.KATSELUOIKEUS)
                 prop(HankeKayttajaDto::tunnistautunut).isEqualTo(true)
+                prop(HankeKayttajaDto::kutsuttu).isNull()
             }
         }
 
@@ -164,6 +163,7 @@ class HankeKayttajaServiceITest : DatabaseTest() {
             assertThat(response).all {
                 prop(HankeKayttajaDto::id).isEqualTo(kayttajaEntity.id)
                 prop(HankeKayttajaDto::tunnistautunut).isEqualTo(false)
+                prop(HankeKayttajaDto::kutsuttu).isEqualTo(HankeKayttajaFactory.INVITATION_DATE)
             }
         }
     }
@@ -202,12 +202,12 @@ class HankeKayttajaServiceITest : DatabaseTest() {
                 prop(HankeKayttajaDto::id).isEqualTo(entity.id)
                 prop(HankeKayttajaDto::etunimi).isEqualTo(entity.etunimi)
                 prop(HankeKayttajaDto::sukunimi).isEqualTo(entity.sukunimi)
-                prop(HankeKayttajaDto::nimi).isEqualTo(entity.fullName())
                 prop(HankeKayttajaDto::puhelinnumero).isEqualTo(entity.puhelin)
                 prop(HankeKayttajaDto::sahkoposti).isEqualTo(entity.sahkoposti)
                 prop(HankeKayttajaDto::kayttooikeustaso)
                     .isEqualTo(entity.permission!!.kayttooikeustaso)
                 prop(HankeKayttajaDto::tunnistautunut).isEqualTo(true)
+                prop(HankeKayttajaDto::kutsuttu).isNull()
             }
         }
 
@@ -431,10 +431,10 @@ class HankeKayttajaServiceITest : DatabaseTest() {
                 prop(HankeKayttajaDto::sahkoposti).isEqualTo(email)
                 prop(HankeKayttajaDto::etunimi).isEqualTo("Joku")
                 prop(HankeKayttajaDto::sukunimi).isEqualTo("Jokunen")
-                prop(HankeKayttajaDto::nimi).isEqualTo("Joku Jokunen")
                 prop(HankeKayttajaDto::puhelinnumero).isEqualTo("0508889999")
                 prop(HankeKayttajaDto::kayttooikeustaso).isEqualTo(Kayttooikeustaso.KATSELUOIKEUS)
                 prop(HankeKayttajaDto::tunnistautunut).isFalse()
+                prop(HankeKayttajaDto::kutsuttu).isRecent()
             }
         }
 
@@ -664,7 +664,7 @@ class HankeKayttajaServiceITest : DatabaseTest() {
             assertThat(capturedEmails).hasSize(3)
             assertThat(capturedEmails)
                 .areValidHankeInvitations(
-                    KAYTTAJA_INPUT_HAKIJA.fullName(),
+                    "${KAYTTAJA_INPUT_HAKIJA.etunimi} ${KAYTTAJA_INPUT_HAKIJA.sukunimi}",
                     KAYTTAJA_INPUT_HAKIJA.email,
                     hanke
                 )

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeKayttajaFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeKayttajaFactory.kt
@@ -120,7 +120,7 @@ class HankeKayttajaFactory(
         kayttajakutsuRepository.save(
             KayttajakutsuEntity(
                 tunniste = tunniste,
-                createdAt = OffsetDateTime.parse("2023-03-31T15:41:21Z"),
+                createdAt = INVITATION_DATE,
                 kayttooikeustaso = kayttooikeustaso,
                 hankekayttaja = this,
             )
@@ -138,6 +138,8 @@ class HankeKayttajaFactory(
 
         private const val PEKKA = "Pekka Peruskäyttäjä"
         private const val PEKKA_EMAIL = "pekka@peruskäyttäjä.test"
+
+        val INVITATION_DATE: OffsetDateTime = OffsetDateTime.parse("2024-02-29T15:43:12Z")
 
         val KAYTTAJA_INPUT_HAKIJA =
             HankekayttajaInput(
@@ -217,7 +219,8 @@ class HankeKayttajaFactory(
                 kayttooikeustaso = kayttooikeustaso,
                 roolit = roolit,
                 permissionId = permissionId,
-                kayttajaTunnisteId = kayttajaTunnisteId
+                kayttajaTunnisteId = kayttajaTunnisteId,
+                kutsuttu = if (permissionId != null) INVITATION_DATE else null,
             )
 
         fun createEntity(
@@ -252,11 +255,11 @@ class HankeKayttajaFactory(
                 sahkoposti = "email.$i.address.com",
                 etunimi = "test$i",
                 sukunimi = "name$i",
-                nimi = "test$i name$i",
                 puhelinnumero = "040555$i$i$i$i",
                 kayttooikeustaso = KATSELUOIKEUS,
                 roolit = roolit,
-                tunnistautunut = tunnistautunut
+                tunnistautunut = tunnistautunut,
+                kutsuttu = if (tunnistautunut) null else INVITATION_DATE,
             )
 
         fun createHankeKayttaja(i: Int = 1, vararg roolit: ContactType): HankeKayttajaDto =

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/test/Asserts.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/test/Asserts.kt
@@ -4,7 +4,6 @@ import assertk.Assert
 import assertk.assertions.contains
 import assertk.assertions.containsExactlyInAnyOrder
 import assertk.assertions.extracting
-import assertk.assertions.first
 import assertk.assertions.isBetween
 import assertk.assertions.isEqualTo
 import assertk.assertions.isInstanceOf
@@ -27,22 +26,18 @@ import org.geojson.Geometry
 
 object Asserts {
 
-    fun Assert<OffsetDateTime?>.isRecent(offset: TemporalAmount = Duration.ofMinutes(1)) =
-        given { actual ->
-            if (actual == null) return
-            val now = OffsetDateTime.now()
-            assertThat(actual).isBetween(now.minus(offset), now)
-        }
+    fun Assert<OffsetDateTime?>.isRecent(offset: TemporalAmount = Duration.ofMinutes(1)) {
+        val now = OffsetDateTime.now()
+        isNotNull().isBetween(now.minus(offset), now)
+    }
 
-    fun Assert<ZonedDateTime?>.isRecentZDT(offset: TemporalAmount = Duration.ofMinutes(1)) =
-        given { actual ->
-            if (actual == null) return
-            val now = ZonedDateTime.now()
-            assertThat(actual).isBetween(now.minus(offset), now)
-        }
+    fun Assert<ZonedDateTime?>.isRecentZDT(offset: TemporalAmount = Duration.ofMinutes(1)) {
+        val now = ZonedDateTime.now()
+        isNotNull().isBetween(now.minus(offset), now)
+    }
 
-    fun Assert<LocalDateTime>.isRecentUTC(offset: TemporalAmount = Duration.ofMinutes(1)) =
-        prop(LocalDateTime::zonedDateTime).isRecentZDT(offset)
+    fun Assert<LocalDateTime?>.isRecentUTC(offset: TemporalAmount = Duration.ofMinutes(1)) =
+        isNotNull().prop(LocalDateTime::zonedDateTime).isRecentZDT(offset)
 
     fun Assert<OffsetDateTime>.isSameInstantAs(expected: OffsetDateTime) {
         this.prop(OffsetDateTime::toInstant).isEqualTo(expected.toInstant())


### PR DESCRIPTION
# Description

Add the date and time the latest invitation to a user was sent. If the invitation is resent, the date and time will reset as well.

Also, remove the deprecated `nimi` field from HankeKayttaja and the DTO. The frontend doesn't use that field anymore, so it's safe to delete it now.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2377

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 