### PR TITLE
HAI-2392 Add an API for checking if a hankekayttaja can be deleted

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/gdpr/KortistoGdprServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/gdpr/KortistoGdprServiceITest.kt
@@ -247,7 +247,7 @@ class KortistoGdprServiceITest(
 
         @Test
         fun `returns true when there are only draft applications`() {
-            val hanke = hankeFactory.builder(USERID).withHankealue().saveEntity()
+            val hanke = hankeFactory.saveWithAlue(USERID)
             val kayttaja = hankeKayttajaService.getKayttajaByUserId(hanke.id, USERID)!!
             hakemusFactory.builder(USERID, hanke).saveWithYhteystiedot {
                 asianhoitaja { addYhteyshenkilo(it, kayttaja) }
@@ -263,7 +263,7 @@ class KortistoGdprServiceITest(
 
         @Test
         fun `throws exception when there's an active application`() {
-            val hanke = hankeFactory.builder(USERID).withHankealue().saveEntity()
+            val hanke = hankeFactory.saveWithAlue(USERID)
             val kayttaja = hankeKayttajaService.getKayttajaByUserId(hanke.id, USERID)!!
             hakemusFactory.builder(USERID, hanke).saveWithYhteystiedot {
                 asianhoitaja { addYhteyshenkilo(it, kayttaja) }
@@ -306,7 +306,7 @@ class KortistoGdprServiceITest(
 
         @Test
         fun `throws exception when user is the only admin and there's an active application on the hanke`() {
-            val hanke = hankeFactory.builder(USERID).withHankealue().saveEntity()
+            val hanke = hankeFactory.saveWithAlue(USERID)
             hakemusFactory.builder(USERID, hanke).saveWithYhteystiedot { asianhoitaja() }
             val activeHakemus =
                 hakemusFactory.builder(USERID, hanke).inHandling().saveWithYhteystiedot {
@@ -323,7 +323,7 @@ class KortistoGdprServiceITest(
 
         @Test
         fun `returns true when there's another admin even if there's an active application`() {
-            val hanke = hankeFactory.builder(USERID).withHankealue().saveEntity()
+            val hanke = hankeFactory.saveWithAlue(USERID)
             hakemusFactory.builder(USERID, hanke).saveWithYhteystiedot { asianhoitaja() }
             hakemusFactory.builder(USERID, hanke).inHandling().saveWithYhteystiedot {
                 rakennuttaja(kayttooikeustaso = Kayttooikeustaso.KAIKKI_OIKEUDET)

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaServiceITest.kt
@@ -142,14 +142,17 @@ class HankeKayttajaServiceITest : DatabaseTest() {
             val response = hankeKayttajaService.getKayttaja(kayttajaEntity.id)
 
             assertThat(response).all {
-                prop(HankeKayttajaDto::id).isEqualTo(kayttajaEntity.id)
-                prop(HankeKayttajaDto::sahkoposti).isEqualTo(HankeKayttajaFactory.KAKE_EMAIL)
-                prop(HankeKayttajaDto::etunimi).isEqualTo(HankeKayttajaFactory.KAKE)
-                prop(HankeKayttajaDto::sukunimi).isEqualTo(HankeKayttajaFactory.KATSELIJA)
-                prop(HankeKayttajaDto::puhelinnumero).isEqualTo(HankeKayttajaFactory.KAKE_PUHELIN)
-                prop(HankeKayttajaDto::kayttooikeustaso).isEqualTo(Kayttooikeustaso.KATSELUOIKEUS)
-                prop(HankeKayttajaDto::tunnistautunut).isEqualTo(true)
-                prop(HankeKayttajaDto::kutsuttu).isNull()
+                prop(HankeKayttaja::id).isEqualTo(kayttajaEntity.id)
+                prop(HankeKayttaja::hankeId).isEqualTo(hanke.id)
+                prop(HankeKayttaja::etunimi).isEqualTo(HankeKayttajaFactory.KAKE)
+                prop(HankeKayttaja::sukunimi).isEqualTo(HankeKayttajaFactory.KATSELIJA)
+                prop(HankeKayttaja::sahkoposti).isEqualTo(HankeKayttajaFactory.KAKE_EMAIL)
+                prop(HankeKayttaja::puhelinnumero).isEqualTo(HankeKayttajaFactory.KAKE_PUHELIN)
+                prop(HankeKayttaja::kayttooikeustaso).isEqualTo(Kayttooikeustaso.KATSELUOIKEUS)
+                prop(HankeKayttaja::roolit).isEmpty()
+                prop(HankeKayttaja::permissionId).isNotNull()
+                prop(HankeKayttaja::kayttajaTunnisteId).isNull()
+                prop(HankeKayttaja::kutsuttu).isNull()
             }
         }
 
@@ -161,9 +164,8 @@ class HankeKayttajaServiceITest : DatabaseTest() {
             val response = hankeKayttajaService.getKayttaja(kayttajaEntity.id)
 
             assertThat(response).all {
-                prop(HankeKayttajaDto::id).isEqualTo(kayttajaEntity.id)
-                prop(HankeKayttajaDto::tunnistautunut).isEqualTo(false)
-                prop(HankeKayttajaDto::kutsuttu).isEqualTo(HankeKayttajaFactory.INVITATION_DATE)
+                prop(HankeKayttaja::id).isEqualTo(kayttajaEntity.id)
+                prop(HankeKayttaja::permissionId).isNull()
             }
         }
     }

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/KayttooikeustasoEntityITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/KayttooikeustasoEntityITest.kt
@@ -35,6 +35,7 @@ class KayttooikeustasoEntityITest : DatabaseTest() {
                         PermissionCode.RESEND_INVITATION,
                         PermissionCode.CREATE_USER,
                         PermissionCode.MODIFY_USER,
+                        PermissionCode.DELETE_USER,
                     )
                 ),
                 Arguments.of(

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationData.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationData.kt
@@ -9,6 +9,7 @@ import fi.hel.haitaton.hanke.NotInChangeLogView
 import fi.hel.haitaton.hanke.allu.AlluApplicationData
 import fi.hel.haitaton.hanke.allu.AlluCableReportApplicationData
 import fi.hel.haitaton.hanke.hakemus.HakemusData
+import fi.hel.haitaton.hanke.hakemus.Hakemusyhteystieto
 import fi.hel.haitaton.hanke.hakemus.JohtoselvityshakemusData
 import java.time.ZonedDateTime
 
@@ -112,7 +113,7 @@ data class CableReportApplicationData(
     fun findOrderer(): Contact? =
         customersWithContacts().flatMap { it.contacts }.find { it.orderer }
 
-    fun toHakemusData(applicationEntity: ApplicationEntity): HakemusData =
+    fun toHakemusData(yhteystiedot: Map<ApplicationContactType, Hakemusyhteystieto>): HakemusData =
         JohtoselvityshakemusData(
             name = name,
             postalAddress = postalAddress,
@@ -125,14 +126,10 @@ data class CableReportApplicationData(
             startTime = startTime,
             endTime = endTime,
             areas = areas,
-            customerWithContacts =
-                applicationEntity.yhteystiedot[ApplicationContactType.HAKIJA]?.toDomain(),
-            contractorWithContacts =
-                applicationEntity.yhteystiedot[ApplicationContactType.TYON_SUORITTAJA]?.toDomain(),
-            propertyDeveloperWithContacts =
-                applicationEntity.yhteystiedot[ApplicationContactType.RAKENNUTTAJA]?.toDomain(),
-            representativeWithContacts =
-                applicationEntity.yhteystiedot[ApplicationContactType.ASIANHOITAJA]?.toDomain(),
+            customerWithContacts = yhteystiedot[ApplicationContactType.HAKIJA],
+            contractorWithContacts = yhteystiedot[ApplicationContactType.TYON_SUORITTAJA],
+            propertyDeveloperWithContacts = yhteystiedot[ApplicationContactType.RAKENNUTTAJA],
+            representativeWithContacts = yhteystiedot[ApplicationContactType.ASIANHOITAJA],
         )
 }
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationData.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationData.kt
@@ -8,6 +8,8 @@ import fi.hel.haitaton.hanke.ChangeLogView
 import fi.hel.haitaton.hanke.NotInChangeLogView
 import fi.hel.haitaton.hanke.allu.AlluApplicationData
 import fi.hel.haitaton.hanke.allu.AlluCableReportApplicationData
+import fi.hel.haitaton.hanke.hakemus.HakemusData
+import fi.hel.haitaton.hanke.hakemus.JohtoselvityshakemusData
 import java.time.ZonedDateTime
 
 enum class ApplicationContactType {
@@ -34,7 +36,9 @@ sealed interface ApplicationData {
     val areas: List<ApplicationArea>?
 
     fun copy(pendingOnClient: Boolean): ApplicationData
+
     fun toAlluData(hankeTunnus: String): AlluApplicationData
+
     fun customersWithContacts(): List<CustomerWithContacts>
 
     /**
@@ -107,6 +111,29 @@ data class CableReportApplicationData(
 
     fun findOrderer(): Contact? =
         customersWithContacts().flatMap { it.contacts }.find { it.orderer }
+
+    fun toHakemusData(applicationEntity: ApplicationEntity): HakemusData =
+        JohtoselvityshakemusData(
+            name = name,
+            postalAddress = postalAddress,
+            constructionWork = constructionWork,
+            maintenanceWork = maintenanceWork,
+            propertyConnectivity = propertyConnectivity,
+            emergencyWork = emergencyWork,
+            rockExcavation = rockExcavation,
+            workDescription = workDescription,
+            startTime = startTime,
+            endTime = endTime,
+            areas = areas,
+            customerWithContacts =
+                applicationEntity.yhteystiedot[ApplicationContactType.HAKIJA]?.toDomain(),
+            contractorWithContacts =
+                applicationEntity.yhteystiedot[ApplicationContactType.TYON_SUORITTAJA]?.toDomain(),
+            propertyDeveloperWithContacts =
+                applicationEntity.yhteystiedot[ApplicationContactType.RAKENNUTTAJA]?.toDomain(),
+            representativeWithContacts =
+                applicationEntity.yhteystiedot[ApplicationContactType.ASIANHOITAJA]?.toDomain(),
+        )
 }
 
 fun List<CustomerWithContacts>.ordererCount() = flatMap { it.contacts }.count { it.orderer }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationEntity.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationEntity.kt
@@ -2,6 +2,7 @@ package fi.hel.haitaton.hanke.application
 
 import fi.hel.haitaton.hanke.HankeEntity
 import fi.hel.haitaton.hanke.allu.ApplicationStatus
+import fi.hel.haitaton.hanke.hakemus.Hakemus
 import fi.hel.haitaton.hanke.hakemus.HakemusyhteystietoEntity
 import io.hypersistence.utils.hibernate.type.json.JsonType
 import jakarta.persistence.CascadeType
@@ -49,5 +50,20 @@ data class ApplicationEntity(
             applicationType,
             applicationData,
             hanke.hankeTunnus,
+        )
+
+    fun toHakemus(): Hakemus =
+        Hakemus(
+            id = id!!,
+            alluid = alluid,
+            alluStatus = alluStatus,
+            applicationIdentifier = applicationIdentifier,
+            applicationType = applicationType,
+            applicationData =
+                when (applicationData) {
+                    is CableReportApplicationData ->
+                        (this.applicationData as CableReportApplicationData).toHakemusData(this)
+                },
+            hankeTunnus = hanke.hankeTunnus
         )
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationEntity.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationEntity.kt
@@ -52,18 +52,21 @@ data class ApplicationEntity(
             hanke.hankeTunnus,
         )
 
-    fun toHakemus(): Hakemus =
-        Hakemus(
+    fun toHakemus(): Hakemus {
+        val yhteystiedot = yhteystiedot.mapValues { it.value.toDomain() }
+        val applicationData =
+            when (applicationData) {
+                is CableReportApplicationData ->
+                    (this.applicationData as CableReportApplicationData).toHakemusData(yhteystiedot)
+            }
+        return Hakemus(
             id = id!!,
             alluid = alluid,
             alluStatus = alluStatus,
             applicationIdentifier = applicationIdentifier,
             applicationType = applicationType,
-            applicationData =
-                when (applicationData) {
-                    is CableReportApplicationData ->
-                        (this.applicationData as CableReportApplicationData).toHakemusData(this)
-                },
+            applicationData = applicationData,
             hankeTunnus = hanke.hankeTunnus
         )
+    }
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/Hakemus.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/Hakemus.kt
@@ -1,0 +1,44 @@
+package fi.hel.haitaton.hanke.hakemus
+
+import fi.hel.haitaton.hanke.allu.ApplicationStatus
+import fi.hel.haitaton.hanke.application.ApplicationArea
+import fi.hel.haitaton.hanke.application.ApplicationType
+import fi.hel.haitaton.hanke.application.PostalAddress
+import java.time.ZonedDateTime
+
+data class Hakemus(
+    val id: Long?,
+    val alluid: Int?,
+    val alluStatus: ApplicationStatus?,
+    val applicationIdentifier: String?,
+    val applicationType: ApplicationType,
+    val applicationData: HakemusData,
+    val hankeTunnus: String
+)
+
+sealed interface HakemusData {
+    val name: String
+    val postalAddress: PostalAddress?
+    val startTime: ZonedDateTime?
+    val endTime: ZonedDateTime?
+    val areas: List<ApplicationArea>?
+    val customerWithContacts: Hakemusyhteystieto?
+}
+
+data class JohtoselvityshakemusData(
+    override val name: String,
+    override val postalAddress: PostalAddress? = null,
+    val constructionWork: Boolean? = null,
+    val maintenanceWork: Boolean? = null,
+    val propertyConnectivity: Boolean? = null,
+    val emergencyWork: Boolean? = null,
+    val rockExcavation: Boolean? = null,
+    val workDescription: String? = null,
+    override val startTime: ZonedDateTime? = null,
+    override val endTime: ZonedDateTime? = null,
+    override val areas: List<ApplicationArea>? = null,
+    override val customerWithContacts: Hakemusyhteystieto? = null,
+    val contractorWithContacts: Hakemusyhteystieto? = null,
+    val propertyDeveloperWithContacts: Hakemusyhteystieto? = null,
+    val representativeWithContacts: Hakemusyhteystieto? = null,
+) : HakemusData

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/Hakemusyhteystieto.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/Hakemusyhteystieto.kt
@@ -8,8 +8,19 @@ data class Hakemusyhteystieto(
     val id: UUID,
     val tyyppi: CustomerType,
     val rooli: ApplicationContactType,
-    var nimi: String,
-    var sahkoposti: String?,
-    var puhelinnumero: String?,
-    var ytunnus: String?,
+    val nimi: String,
+    val sahkoposti: String?,
+    val puhelinnumero: String?,
+    val ytunnus: String?,
+    val yhteyshenkilot: List<Hakemusyhteyshenkilo>,
+)
+
+data class Hakemusyhteyshenkilo(
+    val id: UUID,
+    val hankekayttajaId: UUID,
+    val etunimi: String,
+    val sukunimi: String,
+    val sahkoposti: String,
+    val puhelin: String,
+    val tilaaja: Boolean,
 )

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusyhteystietoEntity.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusyhteystietoEntity.kt
@@ -57,7 +57,28 @@ class HakemusyhteystietoEntity(
             null
         )
 
-    fun toDomain() = Hakemusyhteystieto(id, tyyppi, rooli, nimi, sahkoposti, puhelinnumero, ytunnus)
+    fun toDomain() =
+        Hakemusyhteystieto(
+            id = id,
+            tyyppi = tyyppi,
+            rooli = rooli,
+            nimi = nimi,
+            sahkoposti = sahkoposti,
+            puhelinnumero = puhelinnumero,
+            ytunnus = ytunnus,
+            yhteyshenkilot =
+                yhteyshenkilot.map { yhteyshenkilo ->
+                    Hakemusyhteyshenkilo(
+                        id = id,
+                        hankekayttajaId = yhteyshenkilo.hankekayttaja.id,
+                        etunimi = yhteyshenkilo.hankekayttaja.etunimi,
+                        sukunimi = yhteyshenkilo.hankekayttaja.sukunimi,
+                        sahkoposti = yhteyshenkilo.hankekayttaja.sahkoposti,
+                        puhelin = yhteyshenkilo.hankekayttaja.puhelin,
+                        tilaaja = yhteyshenkilo.tilaaja,
+                    )
+                }
+        )
 }
 
 @Entity

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaController.kt
@@ -477,7 +477,9 @@ user.
     )
     fun checkForDelete(@PathVariable kayttajaId: UUID): DeleteInfo {
         val kayttaja = hankeKayttajaService.getKayttaja(kayttajaId)
-        val hanke = hankeService.loadHankeById(kayttaja.hankeId)!!
+        val hanke =
+            hankeService.loadHankeById(kayttaja.hankeId)
+                ?: throw HankeKayttajaNotFoundException(kayttajaId)
         val onlyOmistajanYhteyshenkilo =
             hanke.omistajat.any {
                 it.yhteyshenkilot.size == 1 && it.yhteyshenkilot.first().id == kayttajaId

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaController.kt
@@ -2,7 +2,10 @@ package fi.hel.haitaton.hanke.permissions
 
 import fi.hel.haitaton.hanke.HankeError
 import fi.hel.haitaton.hanke.HankeService
+import fi.hel.haitaton.hanke.allu.ApplicationStatus
 import fi.hel.haitaton.hanke.currentUserId
+import fi.hel.haitaton.hanke.hakemus.Hakemus
+import fi.hel.haitaton.hanke.hakemus.HakemusService
 import fi.hel.haitaton.hanke.logging.DisclosureLogService
 import fi.hel.haitaton.hanke.profiili.VerifiedNameNotFound
 import io.swagger.v3.oas.annotations.Hidden
@@ -36,6 +39,7 @@ private val logger = KotlinLogging.logger {}
 class HankeKayttajaController(
     private val hankeService: HankeService,
     private val hankeKayttajaService: HankeKayttajaService,
+    private val hakemusService: HakemusService,
     private val permissionService: PermissionService,
     private val disclosureLogService: DisclosureLogService,
 ) {
@@ -111,7 +115,7 @@ class HankeKayttajaController(
     )
     @PreAuthorize("@hankeKayttajaAuthorizer.authorizeKayttajaId(#kayttajaId, 'VIEW')")
     fun getHankeKayttaja(@PathVariable kayttajaId: UUID): HankeKayttajaDto =
-        hankeKayttajaService.getKayttaja(kayttajaId).also {
+        hankeKayttajaService.getKayttaja(kayttajaId).toDto().also {
             disclosureLogService.saveDisclosureLogsForHankeKayttaja(it, currentUserId())
         }
 
@@ -432,6 +436,78 @@ Returns the updated hankekayttaja.
         @PathVariable kayttajaId: UUID
     ): HankeKayttajaDto {
         return hankeKayttajaService.updateKayttajaInfo(hankeTunnus, update, kayttajaId).toDto()
+    }
+
+    @GetMapping("/kayttajat/{kayttajaId}/deleteInfo")
+    @Operation(
+        summary = "Check if user can be deleted",
+        description =
+            """
+Check if there are active applications the user is a contact in that would
+prevent their deletion. Deleting would also be prevented if the user is the only
+contact in the applicant customer role, so check that as well.
+
+Also, collect draft applications the user is a contact in, since the frontend
+needs to show them when asking for confirmation.
+
+Does not check if the caller needs KAIKKI_OIKEUDET to delete this particular
+user.
+"""
+    )
+    @ApiResponses(
+        value =
+            [
+                ApiResponse(
+                    description = "Return the results",
+                    responseCode = "200",
+                ),
+                ApiResponse(
+                    description = "kayttajaId is not a proper UUID",
+                    responseCode = "400",
+                ),
+                ApiResponse(
+                    description = "Hankekayttaja not found or not authorized",
+                    responseCode = "404",
+                ),
+            ]
+    )
+    @PreAuthorize(
+        "@featureService.isEnabled('USER_MANAGEMENT') && " +
+            "@hankeKayttajaAuthorizer.authorizeKayttajaId(#kayttajaId, 'DELETE_USER')"
+    )
+    fun checkForDelete(@PathVariable kayttajaId: UUID): DeleteInfo {
+        val kayttaja = hankeKayttajaService.getKayttaja(kayttajaId)
+        val hanke = hankeService.loadHankeById(kayttaja.hankeId)!!
+        val onlyOmistajanYhteyshenkilo =
+            hanke.omistajat.any {
+                it.yhteyshenkilot.size == 1 && it.yhteyshenkilot.first().id == kayttajaId
+            }
+
+        val hakemukset = hakemusService.getHakemuksetForKayttaja(kayttajaId)
+        val (draftHakemukset, activeHakemukset) =
+            hakemukset.map { DeleteInfo.HakemusDetails(it) }.partition { it.alluStatus == null }
+
+        return DeleteInfo(activeHakemukset, draftHakemukset, onlyOmistajanYhteyshenkilo)
+    }
+
+    data class DeleteInfo(
+        val activeHakemukset: List<HakemusDetails>,
+        val draftHakemukset: List<HakemusDetails>,
+        val onlyOmistajanYhteyshenkilo: Boolean,
+    ) {
+        data class HakemusDetails(
+            val nimi: String,
+            val applicationIdentifier: String?,
+            val alluStatus: ApplicationStatus?,
+        ) {
+            constructor(
+                hakemus: Hakemus
+            ) : this(
+                hakemus.applicationData.name,
+                hakemus.applicationIdentifier,
+                hakemus.alluStatus,
+            )
+        }
     }
 
     data class Tunnistautuminen(val tunniste: String)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaService.kt
@@ -34,8 +34,8 @@ class HankeKayttajaService(
     private val profiiliClient: ProfiiliClient,
 ) {
     @Transactional(readOnly = true)
-    fun getKayttaja(kayttajaId: UUID): HankeKayttajaDto =
-        hankekayttajaRepository.findByIdOrNull(kayttajaId)?.toDto()
+    fun getKayttaja(kayttajaId: UUID): HankeKayttaja =
+        hankekayttajaRepository.findByIdOrNull(kayttajaId)?.toDomain()
             ?: throw HankeKayttajaNotFoundException(kayttajaId)
 
     @Transactional(readOnly = true)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/Permissions.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/Permissions.kt
@@ -38,6 +38,7 @@ enum class PermissionCode(val code: Long) {
     RESEND_INVITATION(256),
     CREATE_USER(512),
     MODIFY_USER(1024),
+    DELETE_USER(2048),
 }
 
 @Repository

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/validation/HankeValidator.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/validation/HankeValidator.kt
@@ -55,7 +55,10 @@ private fun HankeRequest.validate() =
         .whenNotNull(tyomaaKatuosoite) {
             it.notLongerThan(MAXIMUM_TYOMAAKATUOSOITE_LENGTH, "tyomaaKatuosoite")
         }
-        .and { validateYhteystiedot(yhteystiedotByType()) }
+        .whenNotNull(omistajat) { allIn(it, "omistajat", ::validateYhteystieto) }
+        .whenNotNull(toteuttajat) { allIn(it, "toteuttajat", ::validateYhteystieto) }
+        .whenNotNull(rakennuttajat) { allIn(it, "rakennuttajat", ::validateYhteystieto) }
+        .whenNotNull(muut) { allIn(it, "muut", ::validateYhteystieto) }
 
 private fun validateHankeAlue(hankealue: Hankealue, path: String) = hankealue.validate(path)
 

--- a/services/hanke-service/src/main/resources/db/changelog/changesets/071-grant-delete-user-permission-to-kayttooikeustasot.sql
+++ b/services/hanke-service/src/main/resources/db/changelog/changesets/071-grant-delete-user-permission-to-kayttooikeustasot.sql
@@ -1,6 +1,6 @@
 --liquibase formatted sql
 --changeset Topias Heinonen:071-grant-delete-user-permission-to-kayttooikeustasot
---comment: Grant the MODIFY_USERS permission to all kayttooikeustasot except KATSELUOIKEUS
+--comment: Grant the DELETE_USER permission to the two highest kayttooikeustaso.
 
 UPDATE kayttooikeustaso
 SET permissioncode = permissioncode | 2048

--- a/services/hanke-service/src/main/resources/db/changelog/changesets/071-grant-delete-user-permission-to-kayttooikeustasot.sql
+++ b/services/hanke-service/src/main/resources/db/changelog/changesets/071-grant-delete-user-permission-to-kayttooikeustasot.sql
@@ -1,0 +1,7 @@
+--liquibase formatted sql
+--changeset Topias Heinonen:071-grant-delete-user-permission-to-kayttooikeustasot
+--comment: Grant the MODIFY_USERS permission to all kayttooikeustasot except KATSELUOIKEUS
+
+UPDATE kayttooikeustaso
+SET permissioncode = permissioncode | 2048
+WHERE kayttooikeustaso IN ('KAIKKI_OIKEUDET','KAIKKIEN_MUOKKAUS');

--- a/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -169,3 +169,5 @@ databaseChangeLog:
       file: db/changelog/changesets/069-application-attachment-migration-cleanup.yml
   - include:
       file: db/changelog/changesets/070-create-hakemusyhteystieto-tables.sql
+  - include:
+      file: db/changelog/changesets/071-grant-delete-user-permission-to-kayttooikeustasot.sql

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusFactory.kt
@@ -1,12 +1,21 @@
 package fi.hel.haitaton.hanke.factory
 
 import fi.hel.haitaton.hanke.HankeEntity
+import fi.hel.haitaton.hanke.allu.ApplicationStatus
+import fi.hel.haitaton.hanke.application.ApplicationArea
 import fi.hel.haitaton.hanke.application.ApplicationRepository
 import fi.hel.haitaton.hanke.application.ApplicationService
+import fi.hel.haitaton.hanke.application.ApplicationType
+import fi.hel.haitaton.hanke.application.PostalAddress
 import fi.hel.haitaton.hanke.factory.ApplicationFactory.Companion.createApplication
+import fi.hel.haitaton.hanke.hakemus.Hakemus
+import fi.hel.haitaton.hanke.hakemus.HakemusData
 import fi.hel.haitaton.hanke.hakemus.HakemusyhteyshenkiloRepository
+import fi.hel.haitaton.hanke.hakemus.Hakemusyhteystieto
 import fi.hel.haitaton.hanke.hakemus.HakemusyhteystietoRepository
+import fi.hel.haitaton.hanke.hakemus.JohtoselvityshakemusData
 import fi.hel.haitaton.hanke.profiili.ProfiiliClient
+import java.time.ZonedDateTime
 import org.springframework.stereotype.Component
 
 @Component
@@ -31,5 +40,57 @@ class HakemusFactory(
             hakemusyhteystietoRepository,
             hakemusyhteyshenkiloRepository,
         )
+    }
+
+    companion object {
+        fun create(
+            id: Long? = 1,
+            alluid: Int? = null,
+            alluStatus: ApplicationStatus? = null,
+            applicationIdentifier: String? = null,
+            applicationType: ApplicationType = ApplicationType.CABLE_REPORT,
+            applicationData: HakemusData = createJohtoselvityshakemusData(),
+            hankeTunnus: String = "HAI-1234",
+        ): Hakemus =
+            Hakemus(
+                id = id,
+                alluid = alluid,
+                alluStatus = alluStatus,
+                applicationIdentifier = applicationIdentifier,
+                applicationType = applicationType,
+                applicationData = applicationData,
+                hankeTunnus = hankeTunnus
+            )
+
+        fun createJohtoselvityshakemusData(
+            name: String = ApplicationFactory.DEFAULT_APPLICATION_NAME,
+            postalAddress: PostalAddress? = null,
+            rockExcavation: Boolean = false,
+            workDescription: String = "Work description.",
+            startTime: ZonedDateTime? = DateFactory.getStartDatetime(),
+            endTime: ZonedDateTime? = DateFactory.getEndDatetime(),
+            areas: List<ApplicationArea>? = listOf(ApplicationFactory.createApplicationArea()),
+            customerWithContacts: Hakemusyhteystieto? = null,
+            contractorWithContacts: Hakemusyhteystieto? = null,
+            representativeWithContacts: Hakemusyhteystieto? = null,
+            propertyDeveloperWithContacts: Hakemusyhteystieto? = null,
+        ): JohtoselvityshakemusData =
+            JohtoselvityshakemusData(
+                name = name,
+                postalAddress = postalAddress,
+                constructionWork = false,
+                maintenanceWork = false,
+                propertyConnectivity = false,
+                emergencyWork = false,
+                rockExcavation = rockExcavation,
+                workDescription = workDescription,
+                startTime = startTime,
+                endTime = endTime,
+                areas = areas,
+                customerWithContacts = customerWithContacts,
+                contractorWithContacts = contractorWithContacts,
+                representativeWithContacts = representativeWithContacts,
+                propertyDeveloperWithContacts = propertyDeveloperWithContacts,
+            )
     }
 }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusyhteystietoFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusyhteystietoFactory.kt
@@ -3,6 +3,7 @@ package fi.hel.haitaton.hanke.factory
 import fi.hel.haitaton.hanke.allu.CustomerType
 import fi.hel.haitaton.hanke.application.ApplicationContactType
 import fi.hel.haitaton.hanke.application.ApplicationEntity
+import fi.hel.haitaton.hanke.hakemus.Hakemusyhteyshenkilo
 import fi.hel.haitaton.hanke.hakemus.Hakemusyhteystieto
 import fi.hel.haitaton.hanke.hakemus.HakemusyhteystietoEntity
 import java.util.UUID
@@ -44,5 +45,16 @@ object HakemusyhteystietoFactory {
         sahkoposti: String = DEFAULT_SAHKOPOSTI,
         puhelinnumero: String = DEFAULT_PUHELINNUMERO,
         ytunnus: String? = DEFAULT_YTUNNUS,
-    ) = Hakemusyhteystieto(id, tyyppi, rooli, nimi, sahkoposti, puhelinnumero, ytunnus)
+        yhteyshenkilot: List<Hakemusyhteyshenkilo> = listOf()
+    ) =
+        Hakemusyhteystieto(
+            id,
+            tyyppi,
+            rooli,
+            nimi,
+            sahkoposti,
+            puhelinnumero,
+            ytunnus,
+            yhteyshenkilot,
+        )
 }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeBuilder.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeBuilder.kt
@@ -98,7 +98,6 @@ data class HankeBuilder(
             HankeYhteystietoBuilder(
                 entity,
                 userId,
-                hankeService,
                 hankeKayttajaFactory,
                 hankeYhteystietoRepository,
                 hankeYhteyshenkiloRepository,
@@ -209,7 +208,6 @@ data class HankeBuilder(
 data class HankeYhteystietoBuilder(
     val hankeEntity: HankeEntity,
     private val userId: String,
-    private val hankeService: HankeService? = null,
     private val hankeKayttajaFactory: HankeKayttajaFactory,
     private val hankeYhteystietoRepository: HankeYhteystietoRepository,
     private val hankeYhteyshenkiloRepository: HankeYhteyshenkiloRepository,

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeFactory.kt
@@ -64,6 +64,9 @@ class HankeFactory(
         return hankeService.loadHanke(hankeTunnus)!!
     }
 
+    /** Convenience method for storing a hanke with a hankealue. */
+    fun saveWithAlue(userId: String): HankeEntity = builder(userId).withHankealue().saveEntity()
+
     fun builder(userId: String): HankeBuilder {
         val hanke =
             create(

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeKayttajaFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeKayttajaFactory.kt
@@ -278,16 +278,14 @@ class HankeKayttajaFactory(
             roolit: List<ContactType> = emptyList(),
             tunnistautunut: Boolean = false
         ) =
-            HankeKayttajaDto(
+            createDto(
                 id = id,
                 sahkoposti = "email.$i.address.com",
                 etunimi = "test$i",
                 sukunimi = "name$i",
                 puhelinnumero = "040555$i$i$i$i",
-                kayttooikeustaso = KATSELUOIKEUS,
                 roolit = roolit,
                 tunnistautunut = tunnistautunut,
-                kutsuttu = if (tunnistautunut) null else INVITATION_DATE,
             )
     }
 }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeKayttajaFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeKayttajaFactory.kt
@@ -136,9 +136,6 @@ class HankeKayttajaFactory(
 
         const val FAKE_USERID = "fake id"
 
-        private const val PEKKA = "Pekka Peruskäyttäjä"
-        private const val PEKKA_EMAIL = "pekka@peruskäyttäjä.test"
-
         val INVITATION_DATE: OffsetDateTime = OffsetDateTime.parse("2024-02-29T15:43:12Z")
 
         val KAYTTAJA_INPUT_HAKIJA =
@@ -202,7 +199,7 @@ class HankeKayttajaFactory(
             hankeId: Int = HankeFactory.defaultId,
             etunimi: String = KAKE,
             sukunimi: String = KATSELIJA,
-            sahkoposti: String = PEKKA_EMAIL,
+            sahkoposti: String = KAKE_EMAIL,
             puhelinnumero: String = KAKE_PUHELIN,
             kayttooikeustaso: Kayttooikeustaso = KATSELUOIKEUS,
             roolit: List<ContactType> = emptyList(),
@@ -245,7 +242,38 @@ class HankeKayttajaFactory(
             )
 
         fun createDto(
-            i: Int = 1,
+            id: UUID = KAYTTAJA_ID,
+            etunimi: String = KAKE,
+            sukunimi: String = KATSELIJA,
+            sahkoposti: String = KAKE_EMAIL,
+            puhelinnumero: String = KAKE_PUHELIN,
+            kayttooikeustaso: Kayttooikeustaso = KATSELUOIKEUS,
+            roolit: List<ContactType> = emptyList(),
+            tunnistautunut: Boolean = true,
+        ) =
+            HankeKayttajaDto(
+                id = id,
+                etunimi = etunimi,
+                sukunimi = sukunimi,
+                sahkoposti = sahkoposti,
+                puhelinnumero = puhelinnumero,
+                kayttooikeustaso = kayttooikeustaso,
+                roolit = roolit,
+                tunnistautunut = tunnistautunut,
+                kutsuttu = if (tunnistautunut) null else INVITATION_DATE,
+            )
+
+        fun createHankeKayttaja(i: Int = 1, vararg roolit: ContactType): HankeKayttajaDto =
+            createDto(i, roolit = roolit.toList(), tunnistautunut = (i % 2 == 0))
+
+        fun createHankeKayttajat(
+            amount: Int = 3,
+            roolit: List<ContactType> = emptyList()
+        ): List<HankeKayttajaDto> =
+            (1..amount).map { createDto(it, roolit = roolit, tunnistautunut = (it % 2 == 0)) }
+
+        private fun createDto(
+            i: Int,
             id: UUID = UUID.randomUUID(),
             roolit: List<ContactType> = emptyList(),
             tunnistautunut: Boolean = false
@@ -261,14 +289,5 @@ class HankeKayttajaFactory(
                 tunnistautunut = tunnistautunut,
                 kutsuttu = if (tunnistautunut) null else INVITATION_DATE,
             )
-
-        fun createHankeKayttaja(i: Int = 1, vararg roolit: ContactType): HankeKayttajaDto =
-            createDto(i, roolit = roolit.toList(), tunnistautunut = (i % 2 == 0))
-
-        fun createHankeKayttajat(
-            amount: Int = 3,
-            roolit: List<ContactType> = emptyList()
-        ): List<HankeKayttajaDto> =
-            (1..amount).map { createDto(it, roolit = roolit, tunnistautunut = (it % 2 == 0)) }
     }
 }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeYhteyshenkiloFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeYhteyshenkiloFactory.kt
@@ -10,6 +10,14 @@ import java.util.UUID
 
 object HankeYhteyshenkiloFactory {
 
+    fun create(
+        id: UUID = UUID.fromString("ed1d0ea2-c5de-4298-859a-9d02eb828668"),
+        etunimi: String = HankeKayttajaFactory.KAKE,
+        sukunimi: String = HankeKayttajaFactory.KATSELIJA,
+        sahkoposti: String = HankeKayttajaFactory.KAKE_EMAIL,
+        puhelinnumero: String = HankeKayttajaFactory.KAKE_EMAIL
+    ) = Yhteyshenkilo(id, etunimi, sukunimi, sahkoposti, puhelinnumero)
+
     fun create(i: Int) =
         Yhteyshenkilo(
             id = i.toUUID(),


### PR DESCRIPTION
# Description

The API returns names, identifiers and statuses of all applications the hankekayttaja is a contact in, partitioned to active applications and drafts. It also returns a boolean that's true when the hankekayttaja is the only contact in one of the omistaja customers.

Add domain classes for Hakemus and HakemusData. The classes and methods for creating them from entities and in factories are loaned from #637.

Add a new permission code for deleting users. It's given to KAIKKI_OIKEUDET and KAIKKIEN_MUOKKAUS privileges.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2392

## Type of change

- [X] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
The endpoint can be called from e.g. Swagger UI, but there's no method yet 

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [X] I have made necessary changes to the documentation, link to confluence
 or other location: https://helsinkisolutionoffice.atlassian.net/wiki/spaces/HAI/pages/8417968152/Uusi+malli+yhteystietoihin+ja+k+ytt+oikeuksiin#Henkil%C3%B6iden-poistaminen-kortistosta