### PR TITLE
HAI Allow wildcards in test environment email filters

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/email/FilteredEmailSenderServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/email/FilteredEmailSenderServiceITest.kt
@@ -19,12 +19,12 @@ import org.springframework.test.context.ActiveProfiles
     properties =
         [
             "haitaton.email.filter.use=true",
-            "haitaton.email.filter.allow-list=test@test.test;something@mail.com",
+            "haitaton.email.filter.allow-list=test@test.test;something@mail.com;.*@wildcard.com",
             "haitaton.features.user-management=false"
         ]
 )
 @ActiveProfiles("test")
-class EmailSenderServicePropertiesITest : DatabaseTest() {
+class FilteredEmailSenderServiceITest : DatabaseTest() {
 
     companion object {
         @JvmField
@@ -53,12 +53,28 @@ class EmailSenderServicePropertiesITest : DatabaseTest() {
     }
 
     @Test
+    fun `sendJohtoselvitysCompleteEmail blocks send when recipient is close to an allowed email`() {
+        emailSenderService.sendJohtoselvitysCompleteEmail("atest@test.test", 13L, "JS2300001")
+
+        assertThat(greenMail.receivedMessages.size).isEqualTo(0)
+    }
+
+    @Test
+    fun `sendJohtoselvitysCompleteEmail sends email when email matches wildcard`() {
+        emailSenderService.sendJohtoselvitysCompleteEmail("test@wildcard.com", 15L, "JS2300001")
+
+        val email = greenMail.firstReceivedMessage()
+        assertThat(email.allRecipients).hasSize(1)
+        assertThat(email.allRecipients[0].toString()).isEqualTo("test@wildcard.com")
+    }
+
+    @Test
     fun `sendApplicationNotificationEmail when user management not enabled does not send`() {
         emailSenderService.sendApplicationNotificationEmail(
             ApplicationNotificationData(
                 senderName = "Kalle Kutsuja",
                 senderEmail = "kalle.kutsuja@mail.com",
-                recipientEmail = "matti.meikalainen@mail.com",
+                recipientEmail = "test@test.test",
                 applicationType = CABLE_REPORT,
                 applicationIdentifier = "JS002",
                 hankeTunnus = "HAI24-1",

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/email/EmailSenderService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/email/EmailSenderService.kt
@@ -144,7 +144,8 @@ class EmailSenderService(
             "$templatePath/common/signature-en.mustache".getResourceAsText(),
         )
 
-    private fun emailNotAllowed(email: String) = !emailConfig.filter.allowList.contains(email)
+    private fun emailNotAllowed(email: String) =
+        !emailConfig.filter.allowList.any { it.toRegex().matches(email) }
 
     private fun parseTemplate(path: String, contextObject: Any): String =
         Template.parse(path.getResource().openStream()).processToString(contextObject)


### PR DESCRIPTION
# Description

Allow wildcards in the list of allowed emails, so it can have an address like `*@hel.fi`. This will reduce the amount of manual maintenance of the filter lists. It will also enable the use of `person+tag@domain.com` type emails for testing multiple users and contacts with a single email account.

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [X] Other