### PR TITLE
HAI Unite username constants in tests

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeControllerHankeEditingDisabledITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeControllerHankeEditingDisabledITests.kt
@@ -2,6 +2,7 @@ package fi.hel.haitaton.hanke
 
 import fi.hel.haitaton.hanke.factory.HankeFactory
 import fi.hel.haitaton.hanke.permissions.PermissionCode
+import fi.hel.haitaton.hanke.test.USERNAME
 import io.mockk.every
 import io.mockk.justRun
 import org.junit.jupiter.api.Test
@@ -13,7 +14,6 @@ import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers
 
-private const val USERNAME = "test"
 private const val HANKE_TUNNUS = HankeFactory.defaultHankeTunnus
 private const val BASE_URL = "/hankkeet"
 

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeControllerITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeControllerITests.kt
@@ -18,6 +18,7 @@ import fi.hel.haitaton.hanke.geometria.Geometriat
 import fi.hel.haitaton.hanke.logging.DisclosureLogService
 import fi.hel.haitaton.hanke.permissions.PermissionCode
 import fi.hel.haitaton.hanke.permissions.PermissionService
+import fi.hel.haitaton.hanke.test.USERNAME
 import fi.hel.haitaton.hanke.tormaystarkastelu.AutoliikenteenKaistavaikutustenPituus
 import fi.hel.haitaton.hanke.tormaystarkastelu.IndeksiType
 import fi.hel.haitaton.hanke.tormaystarkastelu.Meluhaitta
@@ -49,7 +50,6 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
-private const val USERNAME = "test"
 private const val HANKE_TUNNUS = HankeFactory.defaultHankeTunnus
 private const val BASE_URL = "/hankkeet"
 
@@ -122,7 +122,7 @@ class HankeControllerITests(@Autowired override val mockMvc: MockMvc) : Controll
             verifySequence {
                 authorizer.authorizeHankeTunnus(HANKE_TUNNUS, PermissionCode.VIEW.name)
                 hankeService.loadHanke(HANKE_TUNNUS)
-                disclosureLogService.saveDisclosureLogsForHanke(hanke, "test")
+                disclosureLogService.saveDisclosureLogsForHanke(hanke, USERNAME)
             }
         }
 
@@ -176,7 +176,7 @@ class HankeControllerITests(@Autowired override val mockMvc: MockMvc) : Controll
             verifySequence {
                 authorizer.authorizeHankeTunnus(HANKE_TUNNUS, PermissionCode.VIEW.name)
                 hankeService.loadHanke(HANKE_TUNNUS)
-                disclosureLogService.saveDisclosureLogsForHanke(hanke, "test")
+                disclosureLogService.saveDisclosureLogsForHanke(hanke, USERNAME)
             }
         }
 
@@ -275,7 +275,7 @@ class HankeControllerITests(@Autowired override val mockMvc: MockMvc) : Controll
             verifySequence {
                 permissionService.getAllowedHankeIds(USERNAME, PermissionCode.VIEW)
                 hankeService.loadHankkeetByIds(hankeIds)
-                disclosureLogService.saveDisclosureLogsForHankkeet(hankkeet, "test")
+                disclosureLogService.saveDisclosureLogsForHankkeet(hankkeet, USERNAME)
             }
         }
 

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationAuthorizerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationAuthorizerITest.kt
@@ -17,6 +17,7 @@ import fi.hel.haitaton.hanke.permissions.PermissionCode
 import fi.hel.haitaton.hanke.permissions.PermissionCode.EDIT
 import fi.hel.haitaton.hanke.permissions.PermissionCode.VIEW
 import fi.hel.haitaton.hanke.permissions.PermissionService
+import fi.hel.haitaton.hanke.test.USERNAME
 import java.util.UUID
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -24,8 +25,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.security.test.context.support.WithMockUser
 import org.springframework.test.context.ActiveProfiles
-
-private const val USERNAME = "test7358"
 
 @SpringBootTest
 @ActiveProfiles("test")

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationControllerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationControllerITest.kt
@@ -20,6 +20,7 @@ import fi.hel.haitaton.hanke.hankeError
 import fi.hel.haitaton.hanke.logging.DisclosureLogService
 import fi.hel.haitaton.hanke.permissions.PermissionCode.EDIT_APPLICATIONS
 import fi.hel.haitaton.hanke.permissions.PermissionCode.VIEW
+import fi.hel.haitaton.hanke.test.USERNAME
 import fi.hel.haitaton.hanke.toJsonString
 import fi.hel.haitaton.hanke.validation.InvalidApplicationDataException
 import io.mockk.Called
@@ -52,7 +53,6 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.header
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
-private const val USERNAME = "testUser"
 private const val HANKE_TUNNUS = "HAI-1234"
 private const val BASE_URL = "/hakemukset"
 private const val HANKKEET_BASE_URL = "/hankkeet"

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceITest.kt
@@ -97,6 +97,7 @@ import fi.hel.haitaton.hanke.test.AuditLogEntryEntityAsserts.isSuccess
 import fi.hel.haitaton.hanke.test.AuditLogEntryEntityAsserts.withTarget
 import fi.hel.haitaton.hanke.test.TestUtils
 import fi.hel.haitaton.hanke.test.TestUtils.nextYear
+import fi.hel.haitaton.hanke.test.USERNAME
 import fi.hel.haitaton.hanke.toJsonString
 import io.mockk.Called
 import io.mockk.checkUnnecessaryStub
@@ -133,7 +134,6 @@ import org.springframework.security.test.context.support.WithMockUser
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.jdbc.Sql
 
-private const val USERNAME = "test7358"
 private const val HANKE_TUNNUS = "HAI23-5"
 
 private val dataWithoutAreas = createCableReportApplicationData(areas = listOf())

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentContentServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentContentServiceITest.kt
@@ -11,13 +11,13 @@ import assertk.assertions.isEqualTo
 import fi.hel.haitaton.hanke.DatabaseTest
 import fi.hel.haitaton.hanke.attachment.DEFAULT_DATA
 import fi.hel.haitaton.hanke.attachment.FILE_NAME_PDF
-import fi.hel.haitaton.hanke.attachment.USERNAME
 import fi.hel.haitaton.hanke.attachment.azure.Container
 import fi.hel.haitaton.hanke.attachment.common.AttachmentNotFoundException
 import fi.hel.haitaton.hanke.attachment.common.MockFileClient
 import fi.hel.haitaton.hanke.attachment.common.MockFileClientExtension
 import fi.hel.haitaton.hanke.factory.ApplicationAttachmentFactory
 import fi.hel.haitaton.hanke.test.Asserts.isValidBlobLocation
+import fi.hel.haitaton.hanke.test.USERNAME
 import java.util.UUID
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentControllerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentControllerITest.kt
@@ -16,7 +16,6 @@ import fi.hel.haitaton.hanke.attachment.APPLICATION_ID
 import fi.hel.haitaton.hanke.attachment.DEFAULT_SIZE
 import fi.hel.haitaton.hanke.attachment.DUMMY_DATA
 import fi.hel.haitaton.hanke.attachment.FILE_NAME_PDF
-import fi.hel.haitaton.hanke.attachment.USERNAME
 import fi.hel.haitaton.hanke.attachment.andExpectError
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentMetadataDto
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType
@@ -26,6 +25,7 @@ import fi.hel.haitaton.hanke.attachment.testFile
 import fi.hel.haitaton.hanke.factory.ApplicationAttachmentFactory
 import fi.hel.haitaton.hanke.permissions.PermissionCode.EDIT_APPLICATIONS
 import fi.hel.haitaton.hanke.permissions.PermissionCode.VIEW
+import fi.hel.haitaton.hanke.test.USERNAME
 import io.mockk.checkUnnecessaryStub
 import io.mockk.clearAllMocks
 import io.mockk.confirmVerified

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentServiceITest.kt
@@ -24,7 +24,6 @@ import fi.hel.haitaton.hanke.application.ApplicationNotFoundException
 import fi.hel.haitaton.hanke.attachment.DEFAULT_DATA
 import fi.hel.haitaton.hanke.attachment.DEFAULT_SIZE
 import fi.hel.haitaton.hanke.attachment.FILE_NAME_PDF
-import fi.hel.haitaton.hanke.attachment.USERNAME
 import fi.hel.haitaton.hanke.attachment.azure.Container.HAKEMUS_LIITTEET
 import fi.hel.haitaton.hanke.attachment.body
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentEntity
@@ -47,6 +46,7 @@ import fi.hel.haitaton.hanke.factory.ApplicationAttachmentFactory
 import fi.hel.haitaton.hanke.factory.ApplicationFactory
 import fi.hel.haitaton.hanke.test.Asserts.isRecent
 import fi.hel.haitaton.hanke.test.Asserts.isSameInstantAs
+import fi.hel.haitaton.hanke.test.USERNAME
 import io.mockk.Called
 import io.mockk.checkUnnecessaryStub
 import io.mockk.clearAllMocks

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentAuthorizerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentAuthorizerITest.kt
@@ -8,7 +8,6 @@ import assertk.assertions.isTrue
 import assertk.assertions.messageContains
 import fi.hel.haitaton.hanke.DatabaseTest
 import fi.hel.haitaton.hanke.HankeNotFoundException
-import fi.hel.haitaton.hanke.attachment.USERNAME
 import fi.hel.haitaton.hanke.attachment.common.AttachmentNotFoundException
 import fi.hel.haitaton.hanke.factory.HankeAttachmentFactory
 import fi.hel.haitaton.hanke.factory.HankeFactory
@@ -16,6 +15,7 @@ import fi.hel.haitaton.hanke.permissions.Kayttooikeustaso
 import fi.hel.haitaton.hanke.permissions.PermissionCode.EDIT
 import fi.hel.haitaton.hanke.permissions.PermissionCode.VIEW
 import fi.hel.haitaton.hanke.permissions.PermissionService
+import fi.hel.haitaton.hanke.test.USERNAME
 import java.util.UUID
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentContentServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentContentServiceITest.kt
@@ -11,13 +11,13 @@ import assertk.assertions.isEqualTo
 import fi.hel.haitaton.hanke.DatabaseTest
 import fi.hel.haitaton.hanke.attachment.DEFAULT_DATA
 import fi.hel.haitaton.hanke.attachment.FILE_NAME_PDF
-import fi.hel.haitaton.hanke.attachment.USERNAME
 import fi.hel.haitaton.hanke.attachment.azure.Container.HANKE_LIITTEET
 import fi.hel.haitaton.hanke.attachment.common.AttachmentNotFoundException
 import fi.hel.haitaton.hanke.attachment.common.MockFileClient
 import fi.hel.haitaton.hanke.attachment.common.MockFileClientExtension
 import fi.hel.haitaton.hanke.factory.HankeAttachmentFactory
 import fi.hel.haitaton.hanke.test.Asserts.isValidBlobLocation
+import fi.hel.haitaton.hanke.test.USERNAME
 import java.util.UUID
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentControllerITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentControllerITests.kt
@@ -8,7 +8,6 @@ import fi.hel.haitaton.hanke.IntegrationTestConfiguration
 import fi.hel.haitaton.hanke.attachment.DUMMY_DATA
 import fi.hel.haitaton.hanke.attachment.FILE_NAME_PDF
 import fi.hel.haitaton.hanke.attachment.HANKE_TUNNUS
-import fi.hel.haitaton.hanke.attachment.USERNAME
 import fi.hel.haitaton.hanke.attachment.andExpectError
 import fi.hel.haitaton.hanke.attachment.common.AttachmentContent
 import fi.hel.haitaton.hanke.attachment.common.AttachmentInvalidException
@@ -18,6 +17,7 @@ import fi.hel.haitaton.hanke.factory.TestHankeIdentifier
 import fi.hel.haitaton.hanke.hankeError
 import fi.hel.haitaton.hanke.permissions.PermissionCode.EDIT
 import fi.hel.haitaton.hanke.permissions.PermissionCode.VIEW
+import fi.hel.haitaton.hanke.test.USERNAME
 import io.mockk.checkUnnecessaryStub
 import io.mockk.clearAllMocks
 import io.mockk.confirmVerified

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentMetadataServiceITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentMetadataServiceITests.kt
@@ -19,7 +19,6 @@ import fi.hel.haitaton.hanke.HankeIdentifier
 import fi.hel.haitaton.hanke.HankeNotFoundException
 import fi.hel.haitaton.hanke.attachment.DEFAULT_SIZE
 import fi.hel.haitaton.hanke.attachment.FILE_NAME_PDF
-import fi.hel.haitaton.hanke.attachment.USERNAME
 import fi.hel.haitaton.hanke.attachment.common.AttachmentInvalidException
 import fi.hel.haitaton.hanke.attachment.common.HankeAttachmentEntity
 import fi.hel.haitaton.hanke.attachment.common.HankeAttachmentMetadataDto
@@ -27,6 +26,7 @@ import fi.hel.haitaton.hanke.attachment.common.HankeAttachmentRepository
 import fi.hel.haitaton.hanke.factory.HankeAttachmentFactory
 import fi.hel.haitaton.hanke.factory.HankeFactory
 import fi.hel.haitaton.hanke.test.Asserts.isRecent
+import fi.hel.haitaton.hanke.test.USERNAME
 import java.time.OffsetDateTime
 import java.util.UUID
 import org.junit.jupiter.api.Nested

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentRepositoryITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentRepositoryITests.kt
@@ -9,13 +9,13 @@ import assertk.assertions.single
 import fi.hel.haitaton.hanke.DatabaseTest
 import fi.hel.haitaton.hanke.HankeEntity
 import fi.hel.haitaton.hanke.attachment.DEFAULT_SIZE
-import fi.hel.haitaton.hanke.attachment.USERNAME
 import fi.hel.haitaton.hanke.attachment.common.HankeAttachmentEntity
 import fi.hel.haitaton.hanke.attachment.common.HankeAttachmentRepository
 import fi.hel.haitaton.hanke.factory.ApplicationAttachmentFactory
 import fi.hel.haitaton.hanke.factory.HankeAttachmentFactory
 import fi.hel.haitaton.hanke.factory.HankeFactory
 import fi.hel.haitaton.hanke.test.Asserts.isSameInstantAs
+import fi.hel.haitaton.hanke.test.USERNAME
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentServiceITest.kt
@@ -18,7 +18,6 @@ import fi.hel.haitaton.hanke.DatabaseTest
 import fi.hel.haitaton.hanke.attachment.DEFAULT_DATA
 import fi.hel.haitaton.hanke.attachment.DEFAULT_SIZE
 import fi.hel.haitaton.hanke.attachment.FILE_NAME_PDF
-import fi.hel.haitaton.hanke.attachment.USERNAME
 import fi.hel.haitaton.hanke.attachment.azure.Container
 import fi.hel.haitaton.hanke.attachment.body
 import fi.hel.haitaton.hanke.attachment.common.AttachmentInvalidException
@@ -35,6 +34,7 @@ import fi.hel.haitaton.hanke.factory.HankeAttachmentFactory
 import fi.hel.haitaton.hanke.factory.HankeFactory
 import fi.hel.haitaton.hanke.factory.HankeIdentifierFactory
 import fi.hel.haitaton.hanke.test.Asserts.isRecent
+import fi.hel.haitaton.hanke.test.USERNAME
 import java.util.UUID
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.jupiter.api.AfterEach

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusControllerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusControllerITest.kt
@@ -26,6 +26,7 @@ import fi.hel.haitaton.hanke.factory.HakemusUpdateRequestFactory.withTimes
 import fi.hel.haitaton.hanke.factory.HakemusUpdateRequestFactory.withWorkDescription
 import fi.hel.haitaton.hanke.hankeError
 import fi.hel.haitaton.hanke.permissions.PermissionCode
+import fi.hel.haitaton.hanke.test.USERNAME
 import fi.hel.haitaton.hanke.toJsonString
 import io.mockk.Called
 import io.mockk.checkUnnecessaryStub
@@ -53,7 +54,6 @@ import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers
 
-private const val USERNAME = "testUser"
 private const val HANKE_TUNNUS = "HAI-1234"
 
 @WebMvcTest(

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceITest.kt
@@ -43,6 +43,7 @@ import fi.hel.haitaton.hanke.permissions.HankeKayttajaNotFoundException
 import fi.hel.haitaton.hanke.permissions.HankeKayttajaService
 import fi.hel.haitaton.hanke.permissions.HankekayttajaRepository
 import fi.hel.haitaton.hanke.permissions.Kayttooikeustaso
+import fi.hel.haitaton.hanke.test.USERNAME
 import fi.hel.haitaton.hanke.toJsonString
 import java.util.UUID
 import org.junit.jupiter.api.Nested
@@ -51,8 +52,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.security.test.context.support.WithMockUser
 import org.springframework.test.context.ActiveProfiles
-
-private const val USERNAME = "test7358"
 
 @SpringBootTest
 @ActiveProfiles("test")

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeAuthorizerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeAuthorizerITest.kt
@@ -10,14 +10,13 @@ import fi.hel.haitaton.hanke.DatabaseTest
 import fi.hel.haitaton.hanke.HankeAuthorizer
 import fi.hel.haitaton.hanke.HankeNotFoundException
 import fi.hel.haitaton.hanke.factory.HankeFactory
+import fi.hel.haitaton.hanke.test.USERNAME
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.security.test.context.support.WithMockUser
 import org.springframework.test.context.ActiveProfiles
-
-private const val USERNAME = "test7358"
 
 @SpringBootTest
 @ActiveProfiles("test")

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaAuthorizerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaAuthorizerITest.kt
@@ -9,6 +9,7 @@ import assertk.assertions.messageContains
 import fi.hel.haitaton.hanke.DatabaseTest
 import fi.hel.haitaton.hanke.factory.HankeFactory
 import fi.hel.haitaton.hanke.factory.HankeKayttajaFactory
+import fi.hel.haitaton.hanke.test.USERNAME
 import java.util.UUID
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -16,8 +17,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.security.test.context.support.WithMockUser
 import org.springframework.test.context.ActiveProfiles
-
-private const val USERNAME = "test7358"
 
 @SpringBootTest
 @ActiveProfiles("test")

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaControllerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaControllerITest.kt
@@ -46,6 +46,7 @@ import fi.hel.haitaton.hanke.permissions.PermissionCode.MODIFY_USER
 import fi.hel.haitaton.hanke.permissions.PermissionCode.RESEND_INVITATION
 import fi.hel.haitaton.hanke.permissions.PermissionCode.VIEW
 import fi.hel.haitaton.hanke.profiili.VerifiedNameNotFound
+import fi.hel.haitaton.hanke.test.USERNAME
 import fi.hel.haitaton.hanke.touch
 import io.mockk.Called
 import io.mockk.checkUnnecessaryStub
@@ -77,7 +78,6 @@ import org.springframework.test.web.servlet.ResultActions
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
-private const val USERNAME = "testUser"
 private const val HANKE_TUNNUS = HankeFactory.defaultHankeTunnus
 
 @WebMvcTest(HankeKayttajaController::class)

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaServiceITest.kt
@@ -74,6 +74,7 @@ import fi.hel.haitaton.hanke.test.AuditLogEntryEntityAsserts.hasTargetType
 import fi.hel.haitaton.hanke.test.AuditLogEntryEntityAsserts.hasUserActor
 import fi.hel.haitaton.hanke.test.AuditLogEntryEntityAsserts.isSuccess
 import fi.hel.haitaton.hanke.test.AuditLogEntryEntityAsserts.withTarget
+import fi.hel.haitaton.hanke.test.USERNAME
 import fi.hel.haitaton.hanke.toChangeLogJsonString
 import fi.hel.haitaton.hanke.userId
 import io.mockk.every
@@ -90,7 +91,6 @@ import org.springframework.security.core.context.SecurityContext
 import org.springframework.security.test.context.support.WithMockUser
 import org.springframework.test.context.ActiveProfiles
 
-private const val USERNAME = "test7358"
 const val kayttajaTunnistePattern = "[a-zA-z0-9]{24}"
 
 @SpringBootTest

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/profiili/ProfiiliControllerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/profiili/ProfiiliControllerITest.kt
@@ -9,6 +9,7 @@ import fi.hel.haitaton.hanke.IntegrationTestConfiguration
 import fi.hel.haitaton.hanke.andReturnBody
 import fi.hel.haitaton.hanke.factory.ProfiiliFactory
 import fi.hel.haitaton.hanke.logging.DisclosureLogService
+import fi.hel.haitaton.hanke.test.USERNAME
 import io.mockk.Called
 import io.mockk.Runs
 import io.mockk.checkUnnecessaryStub
@@ -31,7 +32,6 @@ import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers
 
-private const val USERNAME = "testUser"
 private const val BASE_URL = "/profiili"
 
 @WebMvcTest(

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/testdata/TestDataControllerDisabledITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/testdata/TestDataControllerDisabledITest.kt
@@ -2,6 +2,7 @@ package fi.hel.haitaton.hanke.testdata
 
 import fi.hel.haitaton.hanke.ControllerTest
 import fi.hel.haitaton.hanke.IntegrationTestConfiguration
+import fi.hel.haitaton.hanke.test.USERNAME
 import io.mockk.Called
 import io.mockk.checkUnnecessaryStub
 import io.mockk.clearAllMocks
@@ -20,7 +21,6 @@ import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers
 
-private const val USERNAME = "testUser"
 private const val BASE_URL = "/testdata"
 
 @WebMvcTest(

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/testdata/TestDataControllerEnabledITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/testdata/TestDataControllerEnabledITest.kt
@@ -2,6 +2,7 @@ package fi.hel.haitaton.hanke.testdata
 
 import fi.hel.haitaton.hanke.ControllerTest
 import fi.hel.haitaton.hanke.IntegrationTestConfiguration
+import fi.hel.haitaton.hanke.test.USERNAME
 import io.mockk.checkUnnecessaryStub
 import io.mockk.clearAllMocks
 import io.mockk.confirmVerified
@@ -19,7 +20,6 @@ import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers
 
-private const val USERNAME = "testUser"
 private const val BASE_URL = "/testdata"
 
 @WebMvcTest(

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/testdata/TestDataServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/testdata/TestDataServiceITest.kt
@@ -10,14 +10,13 @@ import fi.hel.haitaton.hanke.allu.ApplicationStatus
 import fi.hel.haitaton.hanke.application.ApplicationRepository
 import fi.hel.haitaton.hanke.factory.ApplicationFactory
 import fi.hel.haitaton.hanke.factory.HankeFactory
+import fi.hel.haitaton.hanke.test.USERNAME
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.security.test.context.support.WithMockUser
 import org.springframework.test.context.ActiveProfiles
-
-private const val USERNAME = "testUser"
 
 @SpringBootTest
 @ActiveProfiles("test")

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/HankeControllerTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/HankeControllerTest.kt
@@ -21,6 +21,7 @@ import fi.hel.haitaton.hanke.factory.HankeFactory
 import fi.hel.haitaton.hanke.logging.DisclosureLogService
 import fi.hel.haitaton.hanke.permissions.PermissionCode
 import fi.hel.haitaton.hanke.permissions.PermissionService
+import fi.hel.haitaton.hanke.test.USERNAME
 import io.mockk.Called
 import io.mockk.clearAllMocks
 import io.mockk.every
@@ -38,11 +39,9 @@ import org.springframework.security.test.context.support.WithMockUser
 import org.springframework.test.context.junit.jupiter.SpringExtension
 import org.springframework.validation.beanvalidation.MethodValidationPostProcessor
 
-private const val username = "testuser"
-
 @ExtendWith(SpringExtension::class)
 @Import(HankeControllerTest.TestConfiguration::class)
-@WithMockUser(username)
+@WithMockUser(USERNAME)
 class HankeControllerTest {
 
     @Configuration
@@ -92,7 +91,7 @@ class HankeControllerTest {
     fun `test that the getHankeByTunnus returns ok`() {
         val hankeId = 1234
 
-        every { permissionService.hasPermission(hankeId, username, PermissionCode.VIEW) }
+        every { permissionService.hasPermission(hankeId, USERNAME, PermissionCode.VIEW) }
             .returns(true)
         every { hankeService.loadHanke(mockedHankeTunnus) }
             .returns(
@@ -119,7 +118,7 @@ class HankeControllerTest {
 
         assertThat(response).isNotNull()
         assertThat(response.nimi).isNotEmpty()
-        verify { disclosureLogService.saveDisclosureLogsForHanke(any(), eq(username)) }
+        verify { disclosureLogService.saveDisclosureLogsForHanke(any(), eq(USERNAME)) }
     }
 
     @Test
@@ -155,7 +154,7 @@ class HankeControllerTest {
                     HankeStatus.DRAFT
                 )
             )
-        every { permissionService.getAllowedHankeIds(username, PermissionCode.VIEW) }
+        every { permissionService.getAllowedHankeIds(USERNAME, PermissionCode.VIEW) }
             .returns(listOf(1234, 50))
         every { hankeService.loadHankkeetByIds(listOf(1234, 50)) }.returns(listOfHanke)
 
@@ -165,7 +164,7 @@ class HankeControllerTest {
         assertThat(hankeList[1].nimi).isEqualTo("Hämeenlinnanväylän uudistus")
         assertThat(hankeList[0].alueet.geometriat()).isEmpty()
         assertThat(hankeList[1].alueet.geometriat()).isEmpty()
-        verify { disclosureLogService.saveDisclosureLogsForHankkeet(any(), eq(username)) }
+        verify { disclosureLogService.saveDisclosureLogsForHankkeet(any(), eq(USERNAME)) }
     }
 
     @Test
@@ -188,14 +187,14 @@ class HankeControllerTest {
             )
         val request = partialHanke.toModifyRequest()
         every { hankeService.updateHanke(hanketunnus, request) }
-            .returns(partialHanke.copy(modifiedBy = username, modifiedAt = getCurrentTimeUTC()))
-        every { permissionService.hasPermission(123, username, PermissionCode.EDIT) }.returns(true)
+            .returns(partialHanke.copy(modifiedBy = USERNAME, modifiedAt = getCurrentTimeUTC()))
+        every { permissionService.hasPermission(123, USERNAME, PermissionCode.EDIT) }.returns(true)
 
         val response: Hanke = hankeController.updateHanke(request, hanketunnus)
 
         assertThat(response).isNotNull()
         assertThat(response.nimi).isEqualTo("hankkeen nimi")
-        verify { disclosureLogService.saveDisclosureLogsForHanke(any(), eq(username)) }
+        verify { disclosureLogService.saveDisclosureLogsForHanke(any(), eq(USERNAME)) }
     }
 
     @Test

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/application/ApplicationControllerTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/application/ApplicationControllerTest.kt
@@ -3,6 +3,7 @@ package fi.hel.haitaton.hanke.application
 import fi.hel.haitaton.hanke.HankeService
 import fi.hel.haitaton.hanke.factory.ApplicationFactory
 import fi.hel.haitaton.hanke.logging.DisclosureLogService
+import fi.hel.haitaton.hanke.test.USERNAME
 import io.mockk.checkUnnecessaryStub
 import io.mockk.clearAllMocks
 import io.mockk.confirmVerified
@@ -17,11 +18,10 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.security.test.context.support.WithMockUser
 import org.springframework.test.context.junit.jupiter.SpringExtension
 
-private const val username = "testUser"
 private const val hankeTunnus = "HAI-1234"
 
 @ExtendWith(SpringExtension::class)
-@WithMockUser(username)
+@WithMockUser(USERNAME)
 class ApplicationControllerTest {
 
     private val applicationService: ApplicationService = mockk()
@@ -60,13 +60,13 @@ class ApplicationControllerTest {
                         )
                 ),
             )
-        every { applicationService.getAllApplicationsForUser(username) } returns applications
+        every { applicationService.getAllApplicationsForUser(USERNAME) } returns applications
 
         applicationController.getAll()
 
         verify {
-            disclosureLogService.saveDisclosureLogsForApplications(applications, username)
-            applicationService.getAllApplicationsForUser(username)
+            disclosureLogService.saveDisclosureLogsForApplications(applications, USERNAME)
+            applicationService.getAllApplicationsForUser(USERNAME)
         }
     }
 
@@ -80,7 +80,7 @@ class ApplicationControllerTest {
 
         verifySequence {
             applicationService.getApplicationById(1)
-            disclosureLogService.saveDisclosureLogsForApplication(application, username)
+            disclosureLogService.saveDisclosureLogsForApplication(application, USERNAME)
         }
     }
 
@@ -90,13 +90,13 @@ class ApplicationControllerTest {
         val requestApplication =
             ApplicationFactory.createApplication(id = null, hankeTunnus = hankeTunnus)
         val createdApplication = requestApplication.copy(id = 1)
-        every { applicationService.create(requestApplication, username) } returns createdApplication
+        every { applicationService.create(requestApplication, USERNAME) } returns createdApplication
 
         applicationController.create(requestApplication)
 
         verifySequence {
-            applicationService.create(requestApplication, username)
-            disclosureLogService.saveDisclosureLogsForApplication(createdApplication, username)
+            applicationService.create(requestApplication, USERNAME)
+            disclosureLogService.saveDisclosureLogsForApplication(createdApplication, USERNAME)
         }
     }
 
@@ -105,14 +105,14 @@ class ApplicationControllerTest {
         val hankeTunnus = "HAI-1234"
         val application = ApplicationFactory.createApplication(id = 1, hankeTunnus = hankeTunnus)
         every {
-            applicationService.updateApplicationData(1, application.applicationData, username)
+            applicationService.updateApplicationData(1, application.applicationData, USERNAME)
         } returns application
 
         applicationController.update(1, application)
 
         verifySequence {
-            applicationService.updateApplicationData(1, application.applicationData, username)
-            disclosureLogService.saveDisclosureLogsForApplication(application, username)
+            applicationService.updateApplicationData(1, application.applicationData, USERNAME)
+            disclosureLogService.saveDisclosureLogsForApplication(application, USERNAME)
         }
     }
 }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceTest.kt
@@ -37,6 +37,7 @@ import fi.hel.haitaton.hanke.logging.HankeLoggingService
 import fi.hel.haitaton.hanke.logging.Status
 import fi.hel.haitaton.hanke.permissions.HankeKayttajaService
 import fi.hel.haitaton.hanke.permissions.PermissionService
+import fi.hel.haitaton.hanke.test.USERNAME
 import fi.hel.haitaton.hanke.validation.InvalidApplicationDataException
 import io.mockk.Called
 import io.mockk.called
@@ -64,7 +65,6 @@ import org.junit.jupiter.params.provider.MethodSource
 import org.springframework.boot.test.system.CapturedOutput
 import org.springframework.boot.test.system.OutputCaptureExtension
 
-private const val USERNAME = "test"
 private const val HANKE_TUNNUS = HankeFactory.defaultHankeTunnus
 
 class ApplicationServiceTest {

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/attachment/AttachmentTestUtil.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/attachment/AttachmentTestUtil.kt
@@ -15,7 +15,6 @@ import org.springframework.security.test.web.servlet.response.SecurityMockMvcRes
 import org.springframework.test.web.servlet.ResultActions
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
-const val USERNAME = "username"
 const val FILE_NAME_PDF = "file.pdf"
 const val FILE_PARAM = "liite"
 const val HANKE_TUNNUS = "HAI-1234"

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/ApplicationAttachmentFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/ApplicationAttachmentFactory.kt
@@ -4,7 +4,6 @@ import fi.hel.haitaton.hanke.application.ApplicationEntity
 import fi.hel.haitaton.hanke.attachment.DEFAULT_DATA
 import fi.hel.haitaton.hanke.attachment.DEFAULT_SIZE
 import fi.hel.haitaton.hanke.attachment.FILE_NAME_PDF
-import fi.hel.haitaton.hanke.attachment.USERNAME
 import fi.hel.haitaton.hanke.attachment.application.ApplicationAttachmentContentService.Companion.generateBlobPath
 import fi.hel.haitaton.hanke.attachment.azure.Container.HAKEMUS_LIITTEET
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentEntity
@@ -16,6 +15,7 @@ import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType.MUU
 import fi.hel.haitaton.hanke.attachment.common.FileClient
 import fi.hel.haitaton.hanke.currentUserId
 import fi.hel.haitaton.hanke.factory.ApplicationFactory.Companion.DEFAULT_APPLICATION_ID
+import fi.hel.haitaton.hanke.test.USERNAME
 import java.time.OffsetDateTime
 import java.util.UUID
 import org.springframework.http.MediaType

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeAttachmentFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeAttachmentFactory.kt
@@ -4,7 +4,6 @@ import fi.hel.haitaton.hanke.HankeEntity
 import fi.hel.haitaton.hanke.attachment.DEFAULT_DATA
 import fi.hel.haitaton.hanke.attachment.DEFAULT_SIZE
 import fi.hel.haitaton.hanke.attachment.FILE_NAME_PDF
-import fi.hel.haitaton.hanke.attachment.USERNAME
 import fi.hel.haitaton.hanke.attachment.azure.Container.HANKE_LIITTEET
 import fi.hel.haitaton.hanke.attachment.common.FileClient
 import fi.hel.haitaton.hanke.attachment.common.HankeAttachmentEntity
@@ -13,6 +12,7 @@ import fi.hel.haitaton.hanke.attachment.common.HankeAttachmentMetadataDto
 import fi.hel.haitaton.hanke.attachment.common.HankeAttachmentRepository
 import fi.hel.haitaton.hanke.attachment.hanke.HankeAttachmentContentService
 import fi.hel.haitaton.hanke.currentUserId
+import fi.hel.haitaton.hanke.test.USERNAME
 import java.time.OffsetDateTime
 import java.util.UUID
 import org.springframework.http.MediaType

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/gdpr/OldGdprServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/gdpr/OldGdprServiceTest.kt
@@ -4,6 +4,7 @@ import assertk.assertFailure
 import fi.hel.haitaton.hanke.application.ApplicationDeletionResultDto
 import fi.hel.haitaton.hanke.application.ApplicationService
 import fi.hel.haitaton.hanke.factory.ApplicationFactory
+import fi.hel.haitaton.hanke.test.USERNAME
 import io.mockk.checkUnnecessaryStub
 import io.mockk.clearAllMocks
 import io.mockk.confirmVerified
@@ -14,8 +15,6 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-
-private const val USERID = "test-user"
 
 class OldGdprServiceTest {
 
@@ -37,49 +36,49 @@ class OldGdprServiceTest {
     inner class DeleteApplications {
         @Test
         fun `Does nothing with an empty list`() {
-            every { applicationService.getAllApplicationsCreatedByUser(USERID) } returns listOf()
+            every { applicationService.getAllApplicationsCreatedByUser(USERNAME) } returns listOf()
 
-            gdprService.deleteInfo(USERID)
+            gdprService.deleteInfo(USERNAME)
 
-            verifySequence { applicationService.getAllApplicationsCreatedByUser(USERID) }
+            verifySequence { applicationService.getAllApplicationsCreatedByUser(USERNAME) }
         }
 
         @Test
         fun `Deletes all user's applications`() {
             val applications = ApplicationFactory.createApplications(4)
-            every { applicationService.getAllApplicationsCreatedByUser(USERID) } returns
+            every { applicationService.getAllApplicationsCreatedByUser(USERNAME) } returns
                 applications
             every { applicationService.isStillPending(null, null) } returns true
             every {
-                applicationService.deleteWithOrphanGeneratedHankeRemoval(any(), USERID)
+                applicationService.deleteWithOrphanGeneratedHankeRemoval(any(), USERNAME)
             } returns ApplicationDeletionResultDto(hankeDeleted = false)
 
-            gdprService.deleteInfo(USERID)
+            gdprService.deleteInfo(USERNAME)
 
             verifySequence {
-                applicationService.getAllApplicationsCreatedByUser(USERID)
+                applicationService.getAllApplicationsCreatedByUser(USERNAME)
                 applicationService.isStillPending(null, null)
                 applicationService.isStillPending(null, null)
                 applicationService.isStillPending(null, null)
                 applicationService.isStillPending(null, null)
-                applicationService.deleteWithOrphanGeneratedHankeRemoval(1, USERID)
-                applicationService.deleteWithOrphanGeneratedHankeRemoval(2, USERID)
-                applicationService.deleteWithOrphanGeneratedHankeRemoval(3, USERID)
-                applicationService.deleteWithOrphanGeneratedHankeRemoval(4, USERID)
+                applicationService.deleteWithOrphanGeneratedHankeRemoval(1, USERNAME)
+                applicationService.deleteWithOrphanGeneratedHankeRemoval(2, USERNAME)
+                applicationService.deleteWithOrphanGeneratedHankeRemoval(3, USERNAME)
+                applicationService.deleteWithOrphanGeneratedHankeRemoval(4, USERNAME)
             }
         }
 
         @Test
         fun `Throws exception if any applications are no longer pending`() {
             val applications = ApplicationFactory.createApplications(4)
-            every { applicationService.getAllApplicationsCreatedByUser(USERID) } returns
+            every { applicationService.getAllApplicationsCreatedByUser(USERNAME) } returns
                 applications
             every { applicationService.isStillPending(null, null) } returns false
 
-            assertFailure { gdprService.deleteInfo(USERID) }
+            assertFailure { gdprService.deleteInfo(USERNAME) }
 
             verifySequence {
-                applicationService.getAllApplicationsCreatedByUser(USERID)
+                applicationService.getAllApplicationsCreatedByUser(USERNAME)
                 applicationService.isStillPending(null, null)
                 applicationService.isStillPending(null, null)
                 applicationService.isStillPending(null, null)

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/geometria/GeometriatServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/geometria/GeometriatServiceTest.kt
@@ -11,6 +11,7 @@ import assertk.assertions.prop
 import fi.hel.haitaton.hanke.asJsonResource
 import fi.hel.haitaton.hanke.factory.GeometriaFactory
 import fi.hel.haitaton.hanke.test.Asserts.isRecentZDT
+import fi.hel.haitaton.hanke.test.USERNAME
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
@@ -22,8 +23,6 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.security.test.context.support.WithMockUser
 import org.springframework.test.context.junit.jupiter.SpringExtension
-
-private const val USERNAME = "tester"
 
 @ExtendWith(SpringExtension::class)
 @WithMockUser(USERNAME)

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/test/Constants.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/test/Constants.kt
@@ -1,0 +1,3 @@
+package fi.hel.haitaton.hanke.test
+
+const val USERNAME = "test7358"


### PR DESCRIPTION
# Description

Almost every integration test file starts with something like:
```
private consta val USERNAME = "test-user"
```

Combine all these different username constants into one constant that's shared between different tests. This means that the user ID of the mocked user will be the same in all tests.

This enables things like using the constant as a default value for factories. This is outside the scope of this PR, however.

### Jira Issue: -

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [X] Other