### PR TITLE
HAI-2393 Move checkForDelete logic to new service

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/DatabaseTest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/DatabaseTest.kt
@@ -1,6 +1,10 @@
 package fi.hel.haitaton.hanke
 
+import fi.hel.haitaton.hanke.test.USERNAME
+import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.jdbc.Sql
 import org.springframework.test.context.jdbc.SqlMergeMode
 import org.testcontainers.containers.PostgreSQLContainer
@@ -19,6 +23,9 @@ import org.testcontainers.utility.MountableFile
  */
 @Sql("/clear-db.sql")
 @SqlMergeMode(SqlMergeMode.MergeMode.MERGE)
+@SpringBootTest
+@ActiveProfiles("test")
+@WithMockUser(USERNAME)
 abstract class DatabaseTest {
     companion object {
         @ServiceConnection

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
@@ -225,7 +225,12 @@ class HankeServiceITests(
         fun `returns yhteystiedot and yhteyshenkilot if they're present`() {
             val entity =
                 hankeFactory.builder(USERNAME).saveWithYhteystiedot {
-                    omistaja(kayttooikeustaso = Kayttooikeustaso.KAIKKI_OIKEUDET)
+                    omistaja(
+                        kayttaja(
+                            HankeKayttajaFactory.KAYTTAJA_INPUT_OMISTAJA,
+                            Kayttooikeustaso.KAIKKI_OIKEUDET
+                        )
+                    )
                     rakennuttaja(kayttooikeustaso = Kayttooikeustaso.KAIKKIEN_MUOKKAUS)
                     toteuttaja(kayttooikeustaso = Kayttooikeustaso.HAKEMUSASIOINTI)
                     muuYhteystieto()
@@ -730,10 +735,7 @@ class HankeServiceITests(
                     kayttaja1 = kayttaja("kayttaja1")
                     kayttaja2 = kayttaja("kayttaja2")
                     kayttaja3 = kayttaja("kayttaja3")
-                    omistaja {
-                        addYhteyshenkilo(it, kayttaja1)
-                        addYhteyshenkilo(it, kayttaja2)
-                    }
+                    omistaja(kayttaja1, kayttaja2)
                     rakennuttaja {}
                     rakennuttaja {}
                     toteuttaja { addYhteyshenkilo(it, kayttaja3) }

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/IntegrationTestConfiguration.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/IntegrationTestConfiguration.kt
@@ -18,6 +18,7 @@ import fi.hel.haitaton.hanke.logging.AuditLogRepository
 import fi.hel.haitaton.hanke.logging.DisclosureLogService
 import fi.hel.haitaton.hanke.permissions.HankeKayttajaAuthorizer
 import fi.hel.haitaton.hanke.permissions.HankeKayttajaService
+import fi.hel.haitaton.hanke.permissions.HankekayttajaDeleteService
 import fi.hel.haitaton.hanke.permissions.PermissionService
 import fi.hel.haitaton.hanke.profiili.ProfiiliClient
 import fi.hel.haitaton.hanke.security.AccessRules
@@ -86,6 +87,8 @@ class IntegrationTestConfiguration {
     @Bean fun applicationAttachmentService(): ApplicationAttachmentService = mockk()
 
     @Bean fun hankeKayttajaService(): HankeKayttajaService = mockk()
+
+    @Bean fun hankekayttajaDeleteService(): HankekayttajaDeleteService = mockk()
 
     @Bean fun hankeKayttajaAuthorizer(): HankeKayttajaAuthorizer = mockk(relaxUnitFun = true)
 

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/gdpr/KortistoGdprServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/gdpr/KortistoGdprServiceITest.kt
@@ -156,7 +156,7 @@ class KortistoGdprServiceITest(
                 )
             hankeFactory.builder("other").saveWithYhteystiedot {
                 val kayttaja = kayttaja(userId = USERNAME)
-                omistaja(yhteystieto = omistajaYhteystieto) { addYhteyshenkilo(it, kayttaja) }
+                omistaja(yhteystieto = omistajaYhteystieto, kayttaja)
                 toteuttaja(yhteystieto = toteuttajaYhteystieto) { addYhteyshenkilo(it, kayttaja) }
                 rakennuttaja(yhteystieto = toteuttajaYhteystieto) { addYhteyshenkilo(it, kayttaja) }
                 rakennuttaja(yhteystieto = toteuttajaYhteystieto) { addYhteyshenkilo(it, kayttaja) }
@@ -347,9 +347,8 @@ class KortistoGdprServiceITest(
             lateinit var kayttaja: HankekayttajaEntity
             val hanke =
                 hankeFactory.builder(USERNAME).withHankealue().saveWithYhteystiedot {
-                    kayttaja =
-                        hankeKayttajaService.getKayttajaByUserId(this.hankeEntity.id, USERNAME)!!
-                    omistaja { addYhteyshenkilo(it, kayttaja) }
+                    kayttaja = hankeKayttajaService.getKayttajaByUserId(hankeEntity.id, USERNAME)!!
+                    omistaja(kayttaja)
                 }
             hakemusFactory.builder(USERNAME, hanke).saveWithYhteystiedot {
                 hakija { addYhteyshenkilo(it, kayttaja) }
@@ -366,8 +365,8 @@ class KortistoGdprServiceITest(
             val hanke =
                 hankeFactory.builder(USERNAME).withHankealue().saveWithYhteystiedot {
                     val kayttaja =
-                        hankeKayttajaService.getKayttajaByUserId(this.hankeEntity.id, USERNAME)!!
-                    omistaja { addYhteyshenkilo(it, kayttaja) }
+                        hankeKayttajaService.getKayttajaByUserId(hankeEntity.id, USERNAME)!!
+                    omistaja(kayttaja)
                 }
             val hakemus =
                 hakemusFactory.builder(USERNAME, hanke).saveWithYhteystiedot {
@@ -392,8 +391,8 @@ class KortistoGdprServiceITest(
             val hanke =
                 hankeFactory.builder(USERNAME).withHankealue().saveWithYhteystiedot {
                     val kayttaja =
-                        hankeKayttajaService.getKayttajaByUserId(this.hankeEntity.id, USERNAME)!!
-                    omistaja { addYhteyshenkilo(it, kayttaja) }
+                        hankeKayttajaService.getKayttajaByUserId(hankeEntity.id, USERNAME)!!
+                    omistaja(kayttaja)
                 }
             val hakemus =
                 hakemusFactory.builder(USERNAME, hanke).inHandling().saveWithYhteystiedot {
@@ -416,9 +415,8 @@ class KortistoGdprServiceITest(
             lateinit var kayttaja: HankekayttajaEntity
             val hanke =
                 hankeFactory.builder(USERNAME).withHankealue().saveWithYhteystiedot {
-                    kayttaja =
-                        hankeKayttajaService.getKayttajaByUserId(this.hankeEntity.id, USERNAME)!!
-                    omistaja { addYhteyshenkilo(it, kayttaja) }
+                    kayttaja = hankeKayttajaService.getKayttajaByUserId(hankeEntity.id, USERNAME)!!
+                    omistaja(kayttaja)
                 }
             val hakemus =
                 hakemusFactory.builder(USERNAME, hanke).inHandling().saveWithYhteystiedot {
@@ -452,7 +450,7 @@ class KortistoGdprServiceITest(
                             kayttooikeustaso = Kayttooikeustaso.HAKEMUSASIOINTI,
                             userId = USERNAME
                         )
-                    omistaja { addYhteyshenkilo(it, kayttaja) }
+                    omistaja(kayttaja)
                 }
             val hakemus =
                 hakemusFactory.builder(USERNAME, hanke).saveWithYhteystiedot {
@@ -508,7 +506,7 @@ class KortistoGdprServiceITest(
             val nonAdminHanke =
                 hankeFactory.builder(OTHER_USER_ID).withHankealue().saveWithYhteystiedot {
                     nonAdminKayttaja = kayttaja(userId = USERNAME)
-                    omistaja { addYhteyshenkilo(it, nonAdminKayttaja) }
+                    omistaja(nonAdminKayttaja)
                 }
             val nonAdminHakemus =
                 hakemusFactory.builder(USERNAME, nonAdminHanke).saveWithYhteystiedot {
@@ -518,8 +516,8 @@ class KortistoGdprServiceITest(
             val twoAdminHanke =
                 hankeFactory.builder(USERNAME).withHankealue().saveWithYhteystiedot {
                     twoAdminKayttaja =
-                        hankeKayttajaService.getKayttajaByUserId(this.hankeEntity.id, USERNAME)!!
-                    omistaja { addYhteyshenkilo(it, twoAdminKayttaja) }
+                        hankeKayttajaService.getKayttajaByUserId(hankeEntity.id, USERNAME)!!
+                    omistaja(twoAdminKayttaja)
                 }
             val twoAdminHakemus =
                 hakemusFactory.builder(USERNAME, twoAdminHanke).inHandling().saveWithYhteystiedot {
@@ -529,8 +527,8 @@ class KortistoGdprServiceITest(
             val soloHanke =
                 hankeFactory.builder(USERNAME).withHankealue().saveWithYhteystiedot {
                     soloKayttaja =
-                        hankeKayttajaService.getKayttajaByUserId(this.hankeEntity.id, USERNAME)!!
-                    omistaja { addYhteyshenkilo(it, soloKayttaja) }
+                        hankeKayttajaService.getKayttajaByUserId(hankeEntity.id, USERNAME)!!
+                    omistaja(soloKayttaja)
                 }
             hakemusFactory.builder(USERNAME, soloHanke).saveWithYhteystiedot {
                 hakija { addYhteyshenkilo(it, soloKayttaja) }
@@ -538,8 +536,8 @@ class KortistoGdprServiceITest(
             val oneAdminHanke =
                 hankeFactory.builder(USERNAME).withHankealue().saveWithYhteystiedot {
                     val kayttaja =
-                        hankeKayttajaService.getKayttajaByUserId(this.hankeEntity.id, USERNAME)!!
-                    omistaja { addYhteyshenkilo(it, kayttaja) }
+                        hankeKayttajaService.getKayttajaByUserId(hankeEntity.id, USERNAME)!!
+                    omistaja(kayttaja)
                 }
             val oneAdminHakemus =
                 hakemusFactory.builder(USERNAME, oneAdminHanke).saveWithYhteystiedot {

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HankekayttajaDeleteServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HankekayttajaDeleteServiceITest.kt
@@ -1,0 +1,224 @@
+package fi.hel.haitaton.hanke.hakemus
+
+import assertk.all
+import assertk.assertFailure
+import assertk.assertThat
+import assertk.assertions.containsExactlyInAnyOrder
+import assertk.assertions.extracting
+import assertk.assertions.hasClass
+import assertk.assertions.hasSize
+import assertk.assertions.isEmpty
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isNull
+import assertk.assertions.isTrue
+import assertk.assertions.messageContains
+import assertk.assertions.prop
+import assertk.assertions.single
+import fi.hel.haitaton.hanke.DatabaseTest
+import fi.hel.haitaton.hanke.allu.ApplicationStatus
+import fi.hel.haitaton.hanke.factory.HakemusFactory
+import fi.hel.haitaton.hanke.factory.HankeFactory
+import fi.hel.haitaton.hanke.permissions.HankeKayttajaNotFoundException
+import fi.hel.haitaton.hanke.permissions.HankeKayttajaService
+import fi.hel.haitaton.hanke.permissions.HankekayttajaDeleteService
+import fi.hel.haitaton.hanke.permissions.HankekayttajaDeleteService.DeleteInfo
+import fi.hel.haitaton.hanke.permissions.HankekayttajaEntity
+import fi.hel.haitaton.hanke.test.USERNAME
+import java.util.UUID
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.springframework.beans.factory.annotation.Autowired
+
+class HankekayttajaDeleteServiceITest(
+    @Autowired val deleteService: HankekayttajaDeleteService,
+    @Autowired val hankeKayttajaService: HankeKayttajaService,
+    @Autowired val hankeFactory: HankeFactory,
+    @Autowired val hakemusFactory: HakemusFactory,
+) : DatabaseTest() {
+
+    @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    inner class CheckForDelete {
+        @Test
+        fun `throws exception when hankekayttaja does not exist`() {
+            val kayttajaId = UUID.fromString("750b4207-2c5f-49a0-9b80-4829c807abeb")
+
+            val failure = assertFailure { deleteService.checkForDelete(kayttajaId) }
+
+            failure.all {
+                hasClass(HankeKayttajaNotFoundException::class)
+                messageContains(kayttajaId.toString())
+            }
+        }
+
+        @Test
+        fun `returns true for onlyOmistajanYhteyshenkilo when the user is only contact for omistaja`() {
+            lateinit var perustaja: HankekayttajaEntity
+            hankeFactory.builder().saveWithYhteystiedot {
+                perustaja = hankeKayttajaService.getKayttajaByUserId(hankeEntity.id, USERNAME)!!
+                omistaja(perustaja)
+            }
+
+            val response: DeleteInfo = deleteService.checkForDelete(perustaja.id)
+
+            assertThat(response).all {
+                prop(DeleteInfo::onlyOmistajanYhteyshenkilo).isTrue()
+                prop(DeleteInfo::activeHakemukset).isEmpty()
+                prop(DeleteInfo::draftHakemukset).isEmpty()
+            }
+        }
+
+        @Test
+        fun `returns true for onlyOmistajanYhteyshenkilo when the user is only contact for one omistaja`() {
+            lateinit var perustaja: HankekayttajaEntity
+            hankeFactory.builder().saveWithYhteystiedot {
+                perustaja = hankeKayttajaService.getKayttajaByUserId(hankeEntity.id, USERNAME)!!
+                omistaja(perustaja)
+                omistaja(perustaja, kayttaja())
+            }
+
+            val response: DeleteInfo = deleteService.checkForDelete(perustaja.id)
+
+            assertThat(response).all {
+                prop(DeleteInfo::onlyOmistajanYhteyshenkilo).isTrue()
+                prop(DeleteInfo::activeHakemukset).isEmpty()
+                prop(DeleteInfo::draftHakemukset).isEmpty()
+            }
+        }
+
+        @Test
+        fun `returns false for onlyOmistajanYhteyshenkilo when there are no contacts`() {
+            val hanke = hankeFactory.builder().save()
+            val perustaja = hankeKayttajaService.getKayttajaByUserId(hanke.id, USERNAME)!!
+
+            val response: DeleteInfo = deleteService.checkForDelete(perustaja.id)
+
+            assertThat(response).all {
+                prop(DeleteInfo::onlyOmistajanYhteyshenkilo).isFalse()
+                prop(DeleteInfo::activeHakemukset).isEmpty()
+                prop(DeleteInfo::draftHakemukset).isEmpty()
+            }
+        }
+
+        @Test
+        fun `returns false for onlyOmistajanYhteyshenkilo when someone else is the contact`() {
+            val hanke = hankeFactory.builder().saveWithYhteystiedot { omistaja() }
+            val perustaja = hankeKayttajaService.getKayttajaByUserId(hanke.id, USERNAME)!!
+
+            val response: DeleteInfo = deleteService.checkForDelete(perustaja.id)
+
+            assertThat(response).all {
+                prop(DeleteInfo::onlyOmistajanYhteyshenkilo).isFalse()
+                prop(DeleteInfo::activeHakemukset).isEmpty()
+                prop(DeleteInfo::draftHakemukset).isEmpty()
+            }
+        }
+
+        @Test
+        fun `returns false for onlyOmistajanYhteyshenkilo when there is another contact as well`() {
+            lateinit var perustaja: HankekayttajaEntity
+            hankeFactory.builder().saveWithYhteystiedot {
+                perustaja = hankeKayttajaService.getKayttajaByUserId(hankeEntity.id, USERNAME)!!
+                omistaja()
+            }
+
+            val response: DeleteInfo = deleteService.checkForDelete(perustaja.id)
+
+            assertThat(response).all {
+                prop(DeleteInfo::onlyOmistajanYhteyshenkilo).isFalse()
+                prop(DeleteInfo::activeHakemukset).isEmpty()
+                prop(DeleteInfo::draftHakemukset).isEmpty()
+            }
+        }
+
+        @Test
+        fun `divides active and draft applications correctly`() {
+            val hanke = hankeFactory.saveWithAlue()
+            val perustaja = hankeKayttajaService.getKayttajaByUserId(hanke.id, USERNAME)!!
+            hakemusFactory.builder(hankeEntity = hanke).withName("Draft").saveWithYhteystiedot {
+                hakija { addYhteyshenkilo(it, perustaja) }
+            }
+            hakemusFactory
+                .builder(hankeEntity = hanke)
+                .withName("Pending")
+                .withStatus(ApplicationStatus.PENDING, alluId = 1, identifier = "JS230001")
+                .saveWithYhteystiedot { hakija { addYhteyshenkilo(it, perustaja) } }
+            hakemusFactory
+                .builder(hankeEntity = hanke)
+                .withName("Decision")
+                .withStatus(ApplicationStatus.DECISION, alluId = 2, identifier = "JS230002")
+                .saveWithYhteystiedot { hakija { addYhteyshenkilo(it, perustaja) } }
+
+            val response: DeleteInfo = deleteService.checkForDelete(perustaja.id)
+
+            assertThat(response).prop(DeleteInfo::draftHakemukset).single().all {
+                prop(DeleteInfo.HakemusDetails::nimi).isEqualTo("Draft")
+                prop(DeleteInfo.HakemusDetails::alluStatus).isNull()
+                prop(DeleteInfo.HakemusDetails::applicationIdentifier).isNull()
+            }
+            assertThat(response).prop(DeleteInfo::activeHakemukset).all {
+                hasSize(2)
+                extracting { it.nimi }.containsExactlyInAnyOrder("Pending", "Decision")
+                extracting { it.alluStatus }
+                    .containsExactlyInAnyOrder(
+                        ApplicationStatus.PENDING,
+                        ApplicationStatus.DECISION,
+                    )
+                extracting { it.applicationIdentifier }
+                    .containsExactlyInAnyOrder("JS230001", "JS230002")
+            }
+            assertThat(response).prop(DeleteInfo::onlyOmistajanYhteyshenkilo).isFalse()
+        }
+    }
+
+    @Nested
+    inner class GetHakemuksetForKayttaja {
+        @Test
+        fun `throws an exception when hankekayttaja does not exist`() {
+            val kayttajaId = UUID.fromString("750b4207-2c5f-49a0-9b80-4829c807abeb")
+
+            val failure = assertFailure { deleteService.getHakemuksetForKayttaja(kayttajaId) }
+
+            failure.all {
+                hasClass(HankeKayttajaNotFoundException::class)
+                messageContains(kayttajaId.toString())
+            }
+        }
+
+        @Test
+        fun `returns an empty list when the kayttaja exists but there are no applications`() {
+            val hanke = hankeFactory.builder(USERNAME).save()
+            val founder = hankeKayttajaService.getKayttajaByUserId(hanke.id, USERNAME)!!
+
+            val result = deleteService.getHakemuksetForKayttaja(founder.id)
+
+            assertThat(result).isEmpty()
+        }
+
+        @Test
+        fun `returns applications when the kayttaja is an yhteyshenkilo`() {
+            val hanke = hankeFactory.saveWithAlue(USERNAME)
+            val founder = hankeKayttajaService.getKayttajaByUserId(hanke.id, USERNAME)!!
+            val application1 =
+                hakemusFactory.builder(USERNAME, hanke).saveWithYhteystiedot {
+                    hakija { addYhteyshenkilo(it, founder) }
+                    rakennuttaja()
+                    tyonSuorittaja()
+                }
+            val application2 =
+                hakemusFactory.builder(USERNAME, hanke).saveWithYhteystiedot {
+                    hakija()
+                    rakennuttaja()
+                    tyonSuorittaja { addYhteyshenkilo(it, founder) }
+                }
+
+            val result = deleteService.getHakemuksetForKayttaja(founder.id)
+
+            assertThat(result)
+                .extracting { it.id }
+                .containsExactlyInAnyOrder(application1.id, application2.id)
+        }
+    }
+}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeService.kt
@@ -44,6 +44,9 @@ class HankeService(
         hankeRepository.findOneByHankeTunnus(hankeTunnus)
 
     @Transactional(readOnly = true)
+    fun findIdentifier(hankeId: Int): HankeIdentifier? = hankeRepository.findOneById(hankeId)
+
+    @Transactional(readOnly = true)
     fun getHankeApplications(hankeTunnus: String): List<Application> =
         hankeRepository.findByHankeTunnus(hankeTunnus)?.let { entity ->
             entity.hakemukset.map { hakemus -> hakemus.toApplication() }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
@@ -16,14 +16,11 @@ import fi.hel.haitaton.hanke.application.ApplicationRepository
 import fi.hel.haitaton.hanke.application.CableReportApplicationData
 import fi.hel.haitaton.hanke.geometria.GeometriatDao
 import fi.hel.haitaton.hanke.logging.ApplicationLoggingService
-import fi.hel.haitaton.hanke.permissions.HankeKayttajaNotFoundException
 import fi.hel.haitaton.hanke.permissions.HankeKayttajaService
-import fi.hel.haitaton.hanke.permissions.HankekayttajaRepository
 import fi.hel.haitaton.hanke.toJsonString
 import java.util.UUID
 import kotlin.reflect.KClass
 import mu.KotlinLogging
-import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -33,24 +30,12 @@ private val logger = KotlinLogging.logger {}
 class HakemusService(
     private val applicationRepository: ApplicationRepository,
     private val hankeRepository: HankeRepository,
-    private val hankekayttajaRepository: HankekayttajaRepository,
     private val geometriatDao: GeometriatDao,
     private val hankealueService: HankealueService,
     private val applicationLoggingService: ApplicationLoggingService,
     private val hankeKayttajaService: HankeKayttajaService,
     private val hakemusyhteyshenkiloRepository: HakemusyhteyshenkiloRepository,
 ) {
-    @Transactional(readOnly = true)
-    fun getHakemuksetForKayttaja(kayttajaId: UUID): List<Hakemus> {
-        val kayttaja =
-            hankekayttajaRepository.findByIdOrNull(kayttajaId)
-                ?: throw HankeKayttajaNotFoundException(kayttajaId)
-        return kayttaja.hakemusyhteyshenkilot
-            .map { it.hakemusyhteystieto }
-            .map { it.application }
-            .map { it.toHakemus() }
-    }
-
     @Transactional(readOnly = true)
     fun hakemusResponse(applicationId: Long): HakemusResponse {
         val applicationEntity =

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankekayttajaDeleteService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankekayttajaDeleteService.kt
@@ -1,0 +1,76 @@
+package fi.hel.haitaton.hanke.permissions
+
+import fi.hel.haitaton.hanke.HankeService
+import fi.hel.haitaton.hanke.allu.ApplicationStatus
+import fi.hel.haitaton.hanke.domain.HankeYhteystieto
+import fi.hel.haitaton.hanke.hakemus.Hakemus
+import java.util.UUID
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+/** Split from [HankeKayttajaService] to avoid cyclic dependencies. */
+@Service
+class HankekayttajaDeleteService(
+    private val hankekayttajaRepository: HankekayttajaRepository,
+    private val hankeService: HankeService,
+) {
+    @Transactional(readOnly = true)
+    fun checkForDelete(kayttajaId: UUID): DeleteInfo {
+        val kayttaja = getKayttaja(kayttajaId)
+
+        val isOnlyOmistajanYhteyshenkilo = onlyOmistajanYhteyshenkiloIn(kayttaja).isNotEmpty()
+
+        val (draftHakemukset, activeHakemukset) =
+            getHakemuksetForKayttaja(kayttaja)
+                .map { DeleteInfo.HakemusDetails(it) }
+                .partition { it.alluStatus == null }
+
+        return DeleteInfo(activeHakemukset, draftHakemukset, isOnlyOmistajanYhteyshenkilo)
+    }
+
+    @Transactional(readOnly = true)
+    fun getHakemuksetForKayttaja(kayttajaId: UUID): List<Hakemus> =
+        getHakemuksetForKayttaja(getKayttaja(kayttajaId))
+
+    private fun getKayttaja(kayttajaId: UUID): HankekayttajaEntity =
+        hankekayttajaRepository.findByIdOrNull(kayttajaId)
+            ?: throw HankeKayttajaNotFoundException(kayttajaId)
+
+    private fun onlyOmistajanYhteyshenkiloIn(
+        kayttaja: HankekayttajaEntity,
+    ): List<HankeYhteystieto> {
+        val hanke =
+            hankeService.loadHankeById(kayttaja.hankeId)
+                ?: throw HankeKayttajaNotFoundException(kayttaja.id)
+        return hanke.omistajat.filter {
+            it.yhteyshenkilot.size == 1 && it.yhteyshenkilot.first().id == kayttaja.id
+        }
+    }
+
+    private fun getHakemuksetForKayttaja(kayttaja: HankekayttajaEntity): List<Hakemus> =
+        kayttaja.hakemusyhteyshenkilot
+            .map { it.hakemusyhteystieto }
+            .map { it.application }
+            .map { it.toHakemus() }
+
+    data class DeleteInfo(
+        val activeHakemukset: List<HakemusDetails>,
+        val draftHakemukset: List<HakemusDetails>,
+        val onlyOmistajanYhteyshenkilo: Boolean,
+    ) {
+        data class HakemusDetails(
+            val nimi: String,
+            val applicationIdentifier: String?,
+            val alluStatus: ApplicationStatus?,
+        ) {
+            constructor(
+                hakemus: Hakemus
+            ) : this(
+                hakemus.applicationData.name,
+                hakemus.applicationIdentifier,
+                hakemus.alluStatus,
+            )
+        }
+    }
+}

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusBuilder.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusBuilder.kt
@@ -51,15 +51,19 @@ data class HakemusBuilder(
         return this
     }
 
-    fun withWorkDescription(workDescription: String) = apply {
+    fun inHandling(alluId: Int = 1) = withStatus(ApplicationStatus.HANDLING, alluId)
+
+    fun withName(name: String): HakemusBuilder = apply { onCableReport { copy(name = name) } }
+
+    fun withWorkDescription(workDescription: String): HakemusBuilder = apply {
+        onCableReport { copy(workDescription = workDescription) }
+    }
+
+    private fun onCableReport(f: CableReportApplicationData.() -> CableReportApplicationData) {
         applicationEntity.applicationData =
             when (applicationEntity.applicationData) {
                 is CableReportApplicationData ->
-                    (applicationEntity.applicationData as CableReportApplicationData).copy(
-                        workDescription = workDescription
-                    )
+                    (applicationEntity.applicationData as CableReportApplicationData).f()
             }
     }
-
-    fun inHandling(alluId: Int = 1) = withStatus(ApplicationStatus.HANDLING, alluId)
 }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusFactory.kt
@@ -16,6 +16,7 @@ import fi.hel.haitaton.hanke.hakemus.Hakemusyhteystieto
 import fi.hel.haitaton.hanke.hakemus.HakemusyhteystietoRepository
 import fi.hel.haitaton.hanke.hakemus.JohtoselvityshakemusData
 import fi.hel.haitaton.hanke.permissions.HankeKayttajaService
+import fi.hel.haitaton.hanke.test.USERNAME
 import java.time.ZonedDateTime
 import org.springframework.stereotype.Component
 
@@ -30,7 +31,7 @@ class HakemusFactory(
     private val hankeKayttajaFactory: HankeKayttajaFactory,
 ) {
     fun builder(
-        userId: String,
+        userId: String = USERNAME,
         hankeEntity: HankeEntity = hankeFactory.builder(userId).withHankealue().saveEntity()
     ): HakemusBuilder {
         val applicationEntity = createHakemus(userId = userId, hanke = hankeEntity)

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeFactory.kt
@@ -22,6 +22,7 @@ import fi.hel.haitaton.hanke.domain.Yhteyshenkilo
 import fi.hel.haitaton.hanke.factory.HankealueFactory.createHankeAlueEntity
 import fi.hel.haitaton.hanke.factory.ProfiiliFactory.DEFAULT_NAMES
 import fi.hel.haitaton.hanke.profiili.ProfiiliClient
+import fi.hel.haitaton.hanke.test.USERNAME
 import fi.hel.haitaton.hanke.tormaystarkastelu.TormaystarkasteluTulos
 import fi.hel.haitaton.hanke.tormaystarkastelu.TormaystarkasteluTulosEntity
 import java.time.ZonedDateTime
@@ -65,9 +66,10 @@ class HankeFactory(
     }
 
     /** Convenience method for storing a hanke with a hankealue. */
-    fun saveWithAlue(userId: String): HankeEntity = builder(userId).withHankealue().saveEntity()
+    fun saveWithAlue(userId: String = USERNAME): HankeEntity =
+        builder(userId).withHankealue().saveEntity()
 
-    fun builder(userId: String): HankeBuilder {
+    fun builder(userId: String = USERNAME): HankeBuilder {
         val hanke =
             create(
                 nimi = defaultNimi,


### PR DESCRIPTION
# Description

Move the logic behind `checkForDelete` from the controller to a new service. This will make it easier to reuse the logic for the actual delete endpoint. The service needs to be a new one because adding the logic in HankeKayttajaService would result in a circular dependency.

Rethink creating yhteyshenkilot in HankeYhteystietoBuilder. Implement a new approach for the `omistaja()` method. The others will be implemented later.

### Jira Issue:  https://helsinkisolutionoffice.atlassian.net/browse/HAI-2393

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [X] Other

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 

# Other relevant info
More PRs are coming.