### PR TITLE
HAI-2393 Add delete endpoint for hankekayttaja

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
@@ -725,26 +725,21 @@ class HankeServiceITests(
 
     @Test
     fun `updateHanke adds and removes correct yhteyshenkilot in a complex setting`() {
-        lateinit var kayttaja1: HankekayttajaEntity
-        lateinit var kayttaja2: HankekayttajaEntity
-        lateinit var kayttaja3: HankekayttajaEntity
-        val hankeId =
-            hankeFactory
-                .builder(USERNAME)
-                .saveWithYhteystiedot {
-                    kayttaja1 = kayttaja("kayttaja1")
-                    kayttaja2 = kayttaja("kayttaja2")
-                    kayttaja3 = kayttaja("kayttaja3")
-                    omistaja(kayttaja1, kayttaja2)
-                    rakennuttaja {}
-                    rakennuttaja {}
-                    toteuttaja { addYhteyshenkilo(it, kayttaja3) }
-                    muuYhteystieto {
-                        addYhteyshenkilo(it, kayttaja1)
-                        addYhteyshenkilo(it, kayttaja("kayttaja4"))
-                    }
-                }
-                .id
+        val hankeEntity = hankeFactory.builder().saveEntity()
+        val hankeId = hankeEntity.id
+        val kayttaja1 = hankeKayttajaFactory.saveIdentifiedUser(hankeId, sahkoposti = "kayttaja1")
+        val kayttaja2 = hankeKayttajaFactory.saveIdentifiedUser(hankeId, sahkoposti = "kayttaja2")
+        val kayttaja3 = hankeKayttajaFactory.saveIdentifiedUser(hankeId, sahkoposti = "kayttaja3")
+        hankeFactory.addYhteystiedotTo(hankeEntity) {
+            omistaja(kayttaja1, kayttaja2)
+            rakennuttaja {}
+            rakennuttaja {}
+            toteuttaja { addYhteyshenkilo(it, kayttaja3) }
+            muuYhteystieto {
+                addYhteyshenkilo(it, kayttaja1)
+                addYhteyshenkilo(it, kayttaja("kayttaja4"))
+            }
+        }
         val hanke = hankeService.loadHankeById(hankeId)!!
         val newEmail = "new kayttaja"
         val newKayttaja = hankeKayttajaFactory.saveIdentifiedUser(hanke.id, sahkoposti = newEmail)

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HankekayttajaDeleteServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HankekayttajaDeleteServiceITest.kt
@@ -10,20 +10,29 @@ import assertk.assertions.hasSize
 import assertk.assertions.isEmpty
 import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
+import assertk.assertions.isNotEqualTo
+import assertk.assertions.isNotNull
 import assertk.assertions.isNull
 import assertk.assertions.isTrue
 import assertk.assertions.messageContains
 import assertk.assertions.prop
 import assertk.assertions.single
 import fi.hel.haitaton.hanke.DatabaseTest
+import fi.hel.haitaton.hanke.HankeService
 import fi.hel.haitaton.hanke.allu.ApplicationStatus
+import fi.hel.haitaton.hanke.domain.Hanke
+import fi.hel.haitaton.hanke.domain.HankeYhteystieto
+import fi.hel.haitaton.hanke.domain.Yhteyshenkilo
 import fi.hel.haitaton.hanke.factory.HakemusFactory
 import fi.hel.haitaton.hanke.factory.HankeFactory
 import fi.hel.haitaton.hanke.permissions.HankeKayttajaNotFoundException
 import fi.hel.haitaton.hanke.permissions.HankeKayttajaService
 import fi.hel.haitaton.hanke.permissions.HankekayttajaDeleteService
 import fi.hel.haitaton.hanke.permissions.HankekayttajaDeleteService.DeleteInfo
-import fi.hel.haitaton.hanke.permissions.HankekayttajaEntity
+import fi.hel.haitaton.hanke.permissions.HasActiveApplicationsException
+import fi.hel.haitaton.hanke.permissions.Kayttooikeustaso
+import fi.hel.haitaton.hanke.permissions.NoAdminRemainingException
+import fi.hel.haitaton.hanke.permissions.OnlyOmistajaContactException
 import fi.hel.haitaton.hanke.test.USERNAME
 import java.util.UUID
 import org.junit.jupiter.api.Nested
@@ -34,6 +43,8 @@ import org.springframework.beans.factory.annotation.Autowired
 class HankekayttajaDeleteServiceITest(
     @Autowired val deleteService: HankekayttajaDeleteService,
     @Autowired val hankeKayttajaService: HankeKayttajaService,
+    @Autowired val hankeService: HankeService,
+    @Autowired val hakemusService: HakemusService,
     @Autowired val hankeFactory: HankeFactory,
     @Autowired val hakemusFactory: HakemusFactory,
 ) : DatabaseTest() {
@@ -55,13 +66,11 @@ class HankekayttajaDeleteServiceITest(
 
         @Test
         fun `returns true for onlyOmistajanYhteyshenkilo when the user is only contact for omistaja`() {
-            lateinit var perustaja: HankekayttajaEntity
-            hankeFactory.builder().saveWithYhteystiedot {
-                perustaja = hankeKayttajaService.getKayttajaByUserId(hankeEntity.id, USERNAME)!!
-                omistaja(perustaja)
-            }
+            val hanke = hankeFactory.builder().saveEntity()
+            val founder = hankeKayttajaService.getKayttajaByUserId(hanke.id, USERNAME)!!
+            hankeFactory.addYhteystiedotTo(hanke) { omistaja(founder) }
 
-            val response: DeleteInfo = deleteService.checkForDelete(perustaja.id)
+            val response: DeleteInfo = deleteService.checkForDelete(founder.id)
 
             assertThat(response).all {
                 prop(DeleteInfo::onlyOmistajanYhteyshenkilo).isTrue()
@@ -72,14 +81,14 @@ class HankekayttajaDeleteServiceITest(
 
         @Test
         fun `returns true for onlyOmistajanYhteyshenkilo when the user is only contact for one omistaja`() {
-            lateinit var perustaja: HankekayttajaEntity
-            hankeFactory.builder().saveWithYhteystiedot {
-                perustaja = hankeKayttajaService.getKayttajaByUserId(hankeEntity.id, USERNAME)!!
-                omistaja(perustaja)
-                omistaja(perustaja, kayttaja())
+            val hanke = hankeFactory.builder().saveEntity()
+            val founder = hankeKayttajaService.getKayttajaByUserId(hanke.id, USERNAME)!!
+            hankeFactory.addYhteystiedotTo(hanke) {
+                omistaja(founder)
+                omistaja(founder, kayttaja())
             }
 
-            val response: DeleteInfo = deleteService.checkForDelete(perustaja.id)
+            val response: DeleteInfo = deleteService.checkForDelete(founder.id)
 
             assertThat(response).all {
                 prop(DeleteInfo::onlyOmistajanYhteyshenkilo).isTrue()
@@ -91,9 +100,9 @@ class HankekayttajaDeleteServiceITest(
         @Test
         fun `returns false for onlyOmistajanYhteyshenkilo when there are no contacts`() {
             val hanke = hankeFactory.builder().save()
-            val perustaja = hankeKayttajaService.getKayttajaByUserId(hanke.id, USERNAME)!!
+            val founder = hankeKayttajaService.getKayttajaByUserId(hanke.id, USERNAME)!!
 
-            val response: DeleteInfo = deleteService.checkForDelete(perustaja.id)
+            val response: DeleteInfo = deleteService.checkForDelete(founder.id)
 
             assertThat(response).all {
                 prop(DeleteInfo::onlyOmistajanYhteyshenkilo).isFalse()
@@ -105,9 +114,9 @@ class HankekayttajaDeleteServiceITest(
         @Test
         fun `returns false for onlyOmistajanYhteyshenkilo when someone else is the contact`() {
             val hanke = hankeFactory.builder().saveWithYhteystiedot { omistaja() }
-            val perustaja = hankeKayttajaService.getKayttajaByUserId(hanke.id, USERNAME)!!
+            val founder = hankeKayttajaService.getKayttajaByUserId(hanke.id, USERNAME)!!
 
-            val response: DeleteInfo = deleteService.checkForDelete(perustaja.id)
+            val response: DeleteInfo = deleteService.checkForDelete(founder.id)
 
             assertThat(response).all {
                 prop(DeleteInfo::onlyOmistajanYhteyshenkilo).isFalse()
@@ -118,13 +127,10 @@ class HankekayttajaDeleteServiceITest(
 
         @Test
         fun `returns false for onlyOmistajanYhteyshenkilo when there is another contact as well`() {
-            lateinit var perustaja: HankekayttajaEntity
-            hankeFactory.builder().saveWithYhteystiedot {
-                perustaja = hankeKayttajaService.getKayttajaByUserId(hankeEntity.id, USERNAME)!!
-                omistaja()
-            }
+            val hanke = hankeFactory.builder().saveWithYhteystiedot { omistaja() }
+            val founder = hankeKayttajaService.getKayttajaByUserId(hanke.id, USERNAME)!!
 
-            val response: DeleteInfo = deleteService.checkForDelete(perustaja.id)
+            val response: DeleteInfo = deleteService.checkForDelete(founder.id)
 
             assertThat(response).all {
                 prop(DeleteInfo::onlyOmistajanYhteyshenkilo).isFalse()
@@ -136,22 +142,22 @@ class HankekayttajaDeleteServiceITest(
         @Test
         fun `divides active and draft applications correctly`() {
             val hanke = hankeFactory.saveWithAlue()
-            val perustaja = hankeKayttajaService.getKayttajaByUserId(hanke.id, USERNAME)!!
+            val founder = hankeKayttajaService.getKayttajaByUserId(hanke.id, USERNAME)!!
             hakemusFactory.builder(hankeEntity = hanke).withName("Draft").saveWithYhteystiedot {
-                hakija { addYhteyshenkilo(it, perustaja) }
+                hakija { addYhteyshenkilo(it, founder) }
             }
             hakemusFactory
                 .builder(hankeEntity = hanke)
                 .withName("Pending")
                 .withStatus(ApplicationStatus.PENDING, alluId = 1, identifier = "JS230001")
-                .saveWithYhteystiedot { hakija { addYhteyshenkilo(it, perustaja) } }
+                .saveWithYhteystiedot { hakija { addYhteyshenkilo(it, founder) } }
             hakemusFactory
                 .builder(hankeEntity = hanke)
                 .withName("Decision")
                 .withStatus(ApplicationStatus.DECISION, alluId = 2, identifier = "JS230002")
-                .saveWithYhteystiedot { hakija { addYhteyshenkilo(it, perustaja) } }
+                .saveWithYhteystiedot { hakija { addYhteyshenkilo(it, founder) } }
 
-            val response: DeleteInfo = deleteService.checkForDelete(perustaja.id)
+            val response: DeleteInfo = deleteService.checkForDelete(founder.id)
 
             assertThat(response).prop(DeleteInfo::draftHakemukset).single().all {
                 prop(DeleteInfo.HakemusDetails::nimi).isEqualTo("Draft")
@@ -170,6 +176,121 @@ class HankekayttajaDeleteServiceITest(
                     .containsExactlyInAnyOrder("JS230001", "JS230002")
             }
             assertThat(response).prop(DeleteInfo::onlyOmistajanYhteyshenkilo).isFalse()
+        }
+    }
+
+    @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    inner class Delete {
+        @Test
+        fun `throws an exception when hankekayttaja does not exist`() {
+            val kayttajaId = UUID.fromString("750b4207-2c5f-49a0-9b80-4829c807abeb")
+
+            val failure = assertFailure { deleteService.delete(kayttajaId) }
+
+            failure.all {
+                hasClass(HankeKayttajaNotFoundException::class)
+                messageContains(kayttajaId.toString())
+            }
+        }
+
+        @Test
+        fun `throws an exception if the user is the only user with Kaikki Oikeudet privileges`() {
+            val hanke = hankeFactory.builder().save()
+            val founder = hankeKayttajaService.getKayttajaByUserId(hanke.id, USERNAME)!!
+
+            val failure = assertFailure { deleteService.delete(founder.id) }
+
+            failure.all {
+                hasClass(NoAdminRemainingException::class)
+                messageContains(hanke.hankeTunnus)
+            }
+        }
+
+        @Test
+        fun `throws an exception if the user is the only yhteyshenkilo for an omistaja`() {
+            val hanke = hankeFactory.builder().saveEntity()
+            val founder = hankeKayttajaService.getKayttajaByUserId(hanke.id, USERNAME)!!
+            val builder = hankeFactory.yhteystietoBuilderFrom(hanke)
+            builder.omistaja(founder, builder.kayttaja())
+            val offendingOmistaja = builder.omistaja(founder)
+            builder.toteuttaja(kayttooikeustaso = Kayttooikeustaso.KAIKKI_OIKEUDET)
+
+            val failure = assertFailure { deleteService.delete(founder.id) }
+
+            failure.all {
+                hasClass(OnlyOmistajaContactException::class)
+                messageContains(founder.id.toString())
+                messageContains("yhteystietoIds=${offendingOmistaja.id}")
+            }
+        }
+
+        @Test
+        fun `throws an exception if the user is a contact in an active hakemus`() {
+            val hanke =
+                hankeFactory.builder().withHankealue().saveWithYhteystiedot {
+                    toteuttaja(kayttooikeustaso = Kayttooikeustaso.KAIKKI_OIKEUDET)
+                }
+            val founder = hankeKayttajaService.getKayttajaByUserId(hanke.id, USERNAME)!!
+            val pending =
+                hakemusFactory
+                    .builder(hankeEntity = hanke)
+                    .withName("Pending")
+                    .withStatus(ApplicationStatus.PENDING, alluId = 1, identifier = "JS230001")
+                    .saveWithYhteystiedot { hakija { addYhteyshenkilo(it, founder) } }
+            val decision =
+                hakemusFactory
+                    .builder(hankeEntity = hanke)
+                    .withName("Decision")
+                    .withStatus(ApplicationStatus.DECISION, alluId = 2, identifier = "JS230002")
+                    .saveWithYhteystiedot { tyonSuorittaja { addYhteyshenkilo(it, founder) } }
+
+            val failure = assertFailure { deleteService.delete(founder.id) }
+
+            failure.all {
+                hasClass(HasActiveApplicationsException::class)
+                messageContains(founder.id.toString())
+                messageContains(pending.id.toString())
+                messageContains(decision.id.toString())
+            }
+        }
+
+        @Test
+        fun `delete the user when there are no violations`() {
+            val hanke = hankeFactory.builder().withHankealue().saveEntity()
+            val founder = hankeKayttajaService.getKayttajaByUserId(hanke.id, USERNAME)!!
+            hankeFactory.addYhteystiedotTo(hanke) {
+                omistaja(founder, kayttaja())
+                toteuttaja(kayttooikeustaso = Kayttooikeustaso.KAIKKI_OIKEUDET)
+            }
+            val draftHakemus =
+                hakemusFactory.builder(hankeEntity = hanke).withName("Draft").saveWithYhteystiedot {
+                    hakija {
+                        addYhteyshenkilo(it, founder)
+                        addYhteyshenkilo(it, kayttaja(sahkoposti = "Something else"))
+                    }
+                }
+
+            deleteService.delete(founder.id)
+
+            assertThat(hankeKayttajaService.getKayttajaByUserId(hanke.id, USERNAME)).isNull()
+            assertThat(hankeService.loadHankeById(hanke.id))
+                .isNotNull()
+                .prop(Hanke::omistajat)
+                .single()
+                .prop(HankeYhteystieto::yhteyshenkilot)
+                .single()
+                .prop(Yhteyshenkilo::id)
+                .isNotEqualTo(founder.id)
+            assertThat(hakemusService.hakemusResponse(draftHakemus.id!!))
+                .isNotNull()
+                .prop(HakemusResponse::applicationData)
+                .prop(HakemusDataResponse::customerWithContacts)
+                .isNotNull()
+                .prop(CustomerWithContactsResponse::contacts)
+                .single()
+                .prop(ContactResponse::hankekayttajaId)
+                .isNotEqualTo(founder.id)
         }
     }
 

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaServiceITest.kt
@@ -221,11 +221,11 @@ class HankeKayttajaServiceITest : DatabaseTest() {
                     .withPerustaja(KAYTTAJA_INPUT_PERUSTAJA)
                     .saveWithYhteystiedot {
                         omistaja()
-                            .rakennuttaja()
-                            .toteuttaja()
-                            .toteuttaja(toteuttaja = KAYTTAJA_INPUT_RAKENNUTTAJA)
-                            .muuYhteystieto(KAYTTAJA_INPUT_ASIANHOITAJA)
-                            .muuYhteystieto(KAYTTAJA_INPUT_MUU)
+                        rakennuttaja()
+                        toteuttaja()
+                        toteuttaja(toteuttaja = KAYTTAJA_INPUT_RAKENNUTTAJA)
+                        muuYhteystieto(KAYTTAJA_INPUT_ASIANHOITAJA)
+                        muuYhteystieto(KAYTTAJA_INPUT_MUU)
                     }
             val expectedRoles =
                 mapOf(

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeBuilder.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeBuilder.kt
@@ -238,14 +238,17 @@ data class HankeYhteystietoBuilder(
         yhteystieto: HankeYhteystieto = HankeYhteystietoFactory.create(id = null),
         vararg yhteyshenkilot: HankekayttajaEntity =
             arrayOf(kayttaja(HankeKayttajaFactory.KAYTTAJA_INPUT_OMISTAJA))
-    ): HankeYhteystietoBuilder {
+    ): HankeYhteystietoEntity {
         val saved = saveYhteystieto(ContactType.OMISTAJA, yhteystieto)
         addYhteyshenkilot(saved, yhteyshenkilot.toList())
-        return this
+        return saved
     }
 
-    fun omistaja(first: HankekayttajaEntity, vararg yhteyshenkilot: HankekayttajaEntity) {
-        omistaja(yhteyshenkilot = arrayOf(first) + yhteyshenkilot)
+    fun omistaja(
+        first: HankekayttajaEntity,
+        vararg yhteyshenkilot: HankekayttajaEntity
+    ): HankeYhteystietoEntity {
+        return omistaja(yhteyshenkilot = arrayOf(first) + yhteyshenkilot)
     }
 
     fun rakennuttaja(
@@ -253,9 +256,8 @@ data class HankeYhteystietoBuilder(
         kayttooikeustaso: Kayttooikeustaso = Kayttooikeustaso.KATSELUOIKEUS,
         yhteystieto: HankeYhteystieto = HankeYhteystietoFactory.create(id = null),
         f: (HankeYhteystietoEntity) -> Unit = defaultYhteyshenkilo(rakennuttaja, kayttooikeustaso),
-    ): HankeYhteystietoBuilder {
+    ) {
         f(saveYhteystieto(ContactType.RAKENNUTTAJA, yhteystieto))
-        return this
     }
 
     fun toteuttaja(
@@ -263,9 +265,8 @@ data class HankeYhteystietoBuilder(
         kayttooikeustaso: Kayttooikeustaso = Kayttooikeustaso.KATSELUOIKEUS,
         yhteystieto: HankeYhteystieto = HankeYhteystietoFactory.create(id = null),
         f: (HankeYhteystietoEntity) -> Unit = defaultYhteyshenkilo(toteuttaja, kayttooikeustaso),
-    ): HankeYhteystietoBuilder {
+    ) {
         f(saveYhteystieto(ContactType.TOTEUTTAJA, yhteystieto))
-        return this
     }
 
     fun muuYhteystieto(
@@ -273,9 +274,8 @@ data class HankeYhteystietoBuilder(
         kayttooikeustaso: Kayttooikeustaso = Kayttooikeustaso.KATSELUOIKEUS,
         yhteystieto: HankeYhteystieto = HankeYhteystietoFactory.create(id = null),
         f: (HankeYhteystietoEntity) -> Unit = defaultYhteyshenkilo(muu, kayttooikeustaso),
-    ): HankeYhteystietoBuilder {
+    ) {
         f(saveYhteystieto(ContactType.MUU, yhteystieto))
-        return this
     }
 
     private fun addYhteyshenkilo(
@@ -300,9 +300,9 @@ data class HankeYhteystietoBuilder(
 
     private fun addYhteyshenkilot(
         yhteystietoEntity: HankeYhteystietoEntity,
-        yhteystiedot: Iterable<HankekayttajaEntity>
+        yhteyshenkilot: Iterable<HankekayttajaEntity>
     ) {
-        yhteystiedot.forEach { addYhteyshenkilo(yhteystietoEntity, it) }
+        yhteyshenkilot.forEach { addYhteyshenkilo(yhteystietoEntity, it) }
     }
 
     private fun saveYhteystieto(

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeFactory.kt
@@ -90,6 +90,19 @@ class HankeFactory(
         )
     }
 
+    fun yhteystietoBuilderFrom(hanke: HankeEntity): HankeYhteystietoBuilder =
+        HankeYhteystietoBuilder(
+            hanke,
+            hanke.createdByUserId!!,
+            hankeKayttajaFactory,
+            hankeYhteystietoRepository,
+            hankeYhteyshenkiloRepository
+        )
+
+    fun addYhteystiedotTo(hanke: HankeEntity, f: HankeYhteystietoBuilder.() -> Unit) {
+        yhteystietoBuilderFrom(hanke).f()
+    }
+
     companion object {
 
         const val defaultHankeTunnus = "HAI21-1"


### PR DESCRIPTION
# Description

The delete endpoint will check the same things as the `checkForDelete` endpoint and that there will be an admin user left on the hanke after the delete (a user with Kaikki Oikeudet privileges). If any of the checks fail, 409 will be returned.

In test data factories, add new methods for getting a yhteystieto builder for a hanke. Hanke creation can be split between creating the hanke and creating the yhteystiedot, so there's no need to save entities from inside the builder function call anymore.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2393

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 