### PR TITLE
HAI-2393 Refactor DatabaseTest to IntegrationTest

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
@@ -38,7 +38,6 @@ import fi.hel.haitaton.hanke.application.Contact
 import fi.hel.haitaton.hanke.attachment.azure.Container.HANKE_LIITTEET
 import fi.hel.haitaton.hanke.attachment.common.HankeAttachmentRepository
 import fi.hel.haitaton.hanke.attachment.common.MockFileClient
-import fi.hel.haitaton.hanke.attachment.common.MockFileClientExtension
 import fi.hel.haitaton.hanke.domain.CreateHankeRequest
 import fi.hel.haitaton.hanke.domain.Hanke
 import fi.hel.haitaton.hanke.domain.HankeStatus
@@ -123,17 +122,13 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.RegisterExtension
 import org.skyscreamer.jsonassert.JSONAssert
 import org.skyscreamer.jsonassert.JSONCompareMode
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.security.core.context.SecurityContext
-import org.springframework.security.test.context.support.WithMockUser
-import org.springframework.test.context.ActiveProfiles
 import org.springframework.transaction.annotation.Transactional
 
 private const val NAME_1 = "etu1 suku1"
@@ -141,9 +136,6 @@ private const val NAME_2 = "etu2 suku2"
 private const val NAME_3 = "etu3 suku3"
 private const val NAME_SOMETHING = "Som Et Hing"
 
-@SpringBootTest
-@ActiveProfiles("test")
-@WithMockUser(USERNAME)
 class HankeServiceITests(
     @Autowired private val hankeService: HankeService,
     @Autowired private val permissionService: PermissionService,
@@ -162,7 +154,7 @@ class HankeServiceITests(
     @Autowired private val hankeKayttajaFactory: HankeKayttajaFactory,
     @Autowired private val hakemusFactory: HakemusFactory,
     @Autowired private val cableReportService: CableReportService,
-) : DatabaseTest() {
+) : IntegrationTest() {
 
     companion object {
         @JvmField
@@ -1339,7 +1331,6 @@ class HankeServiceITests(
     }
 
     @Nested
-    @ExtendWith(MockFileClientExtension::class)
     inner class DeleteHanke {
         @Test
         fun `creates audit log entry for deleted hanke`() {

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HanketunnusServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HanketunnusServiceITest.kt
@@ -4,12 +4,8 @@ import assertk.assertThat
 import assertk.assertions.isLessThan
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.ActiveProfiles
 
-@SpringBootTest
-@ActiveProfiles("test")
-internal class HanketunnusServiceITest : DatabaseTest() {
+internal class HanketunnusServiceITest : IntegrationTest() {
 
     @Autowired lateinit var hanketunnusService: HanketunnusService
 

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/IntegrationTest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/IntegrationTest.kt
@@ -1,6 +1,8 @@
 package fi.hel.haitaton.hanke
 
+import fi.hel.haitaton.hanke.attachment.common.MockFileClientExtension
 import fi.hel.haitaton.hanke.test.USERNAME
+import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection
 import org.springframework.security.test.context.support.WithMockUser
@@ -26,7 +28,8 @@ import org.testcontainers.utility.MountableFile
 @SpringBootTest
 @ActiveProfiles("test")
 @WithMockUser(USERNAME)
-abstract class DatabaseTest {
+@ExtendWith(MockFileClientExtension::class)
+abstract class IntegrationTest {
     companion object {
         @ServiceConnection
         private val postgresContainer: PostgreSQLContainer<*> =

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/SpringDocITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/SpringDocITest.kt
@@ -4,17 +4,13 @@ import org.hamcrest.CoreMatchers.containsString
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
-import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.MediaType
-import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
-@SpringBootTest
-@ActiveProfiles("test")
 @AutoConfigureMockMvc
-class SpringdocITest(@Autowired override val mockMvc: MockMvc) : ControllerTest, DatabaseTest() {
+class SpringdocITest(@Autowired override val mockMvc: MockMvc) : ControllerTest, IntegrationTest() {
 
     @Test
     fun `Should display Swagger UI page`() {

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationAuthorizerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationAuthorizerITest.kt
@@ -6,8 +6,8 @@ import assertk.assertThat
 import assertk.assertions.hasClass
 import assertk.assertions.isTrue
 import assertk.assertions.messageContains
-import fi.hel.haitaton.hanke.DatabaseTest
 import fi.hel.haitaton.hanke.HankeNotFoundException
+import fi.hel.haitaton.hanke.IntegrationTest
 import fi.hel.haitaton.hanke.attachment.common.AttachmentNotFoundException
 import fi.hel.haitaton.hanke.factory.ApplicationAttachmentFactory
 import fi.hel.haitaton.hanke.factory.ApplicationFactory
@@ -22,20 +22,14 @@ import java.util.UUID
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.security.test.context.support.WithMockUser
-import org.springframework.test.context.ActiveProfiles
 
-@SpringBootTest
-@ActiveProfiles("test")
-@WithMockUser(USERNAME)
 class ApplicationAuthorizerITest(
     @Autowired private val authorizer: ApplicationAuthorizer,
     @Autowired private val applicationFactory: ApplicationFactory,
     @Autowired private val hankeFactory: HankeFactory,
     @Autowired private val permissionService: PermissionService,
     @Autowired private val applicationAttachmentFactory: ApplicationAttachmentFactory,
-) : DatabaseTest() {
+) : IntegrationTest() {
 
     val applicationId = 987654321L
 

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceITest.kt
@@ -24,11 +24,11 @@ import assertk.assertions.single
 import com.icegreen.greenmail.configuration.GreenMailConfiguration
 import com.icegreen.greenmail.junit5.GreenMailExtension
 import com.icegreen.greenmail.util.ServerSetupTest
-import fi.hel.haitaton.hanke.DatabaseTest
 import fi.hel.haitaton.hanke.HankeEntity
 import fi.hel.haitaton.hanke.HankeNotFoundException
 import fi.hel.haitaton.hanke.HankeRepository
 import fi.hel.haitaton.hanke.HankeService
+import fi.hel.haitaton.hanke.IntegrationTest
 import fi.hel.haitaton.hanke.allu.AlluCableReportApplicationData
 import fi.hel.haitaton.hanke.allu.AlluException
 import fi.hel.haitaton.hanke.allu.AlluStatusRepository
@@ -46,7 +46,6 @@ import fi.hel.haitaton.hanke.attachment.application.ApplicationAttachmentContent
 import fi.hel.haitaton.hanke.attachment.azure.Container
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentRepository
 import fi.hel.haitaton.hanke.attachment.common.MockFileClient
-import fi.hel.haitaton.hanke.attachment.common.MockFileClientExtension
 import fi.hel.haitaton.hanke.domain.Hankealue
 import fi.hel.haitaton.hanke.email.EmailSenderService.Companion.translations
 import fi.hel.haitaton.hanke.email.textBody
@@ -122,27 +121,19 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.RegisterExtension
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
 import org.skyscreamer.jsonassert.JSONAssert
 import org.skyscreamer.jsonassert.JSONCompareMode
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.security.test.context.support.WithMockUser
-import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.jdbc.Sql
 
 private const val HANKE_TUNNUS = "HAI23-5"
 
 private val dataWithoutAreas = createCableReportApplicationData(areas = listOf())
 
-@SpringBootTest
-@ActiveProfiles("test")
-@WithMockUser(USERNAME)
-@ExtendWith(MockFileClientExtension::class)
-class ApplicationServiceITest : DatabaseTest() {
+class ApplicationServiceITest : IntegrationTest() {
 
     @Autowired private lateinit var applicationService: ApplicationService
     @Autowired private lateinit var hankeService: HankeService

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentContentServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentContentServiceITest.kt
@@ -8,35 +8,25 @@ import assertk.assertions.hasClass
 import assertk.assertions.hasMessage
 import assertk.assertions.isEmpty
 import assertk.assertions.isEqualTo
-import fi.hel.haitaton.hanke.DatabaseTest
+import fi.hel.haitaton.hanke.IntegrationTest
 import fi.hel.haitaton.hanke.attachment.DEFAULT_DATA
 import fi.hel.haitaton.hanke.attachment.FILE_NAME_PDF
 import fi.hel.haitaton.hanke.attachment.azure.Container
 import fi.hel.haitaton.hanke.attachment.common.AttachmentNotFoundException
 import fi.hel.haitaton.hanke.attachment.common.MockFileClient
-import fi.hel.haitaton.hanke.attachment.common.MockFileClientExtension
 import fi.hel.haitaton.hanke.factory.ApplicationAttachmentFactory
 import fi.hel.haitaton.hanke.test.Asserts.isValidBlobLocation
-import fi.hel.haitaton.hanke.test.USERNAME
 import java.util.UUID
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.MediaType
-import org.springframework.security.test.context.support.WithMockUser
-import org.springframework.test.context.ActiveProfiles
 
-@SpringBootTest
-@ActiveProfiles("test")
-@WithMockUser(USERNAME)
-@ExtendWith(MockFileClientExtension::class)
 class ApplicationAttachmentContentServiceITest(
     @Autowired private val attachmentContentService: ApplicationAttachmentContentService,
     @Autowired private val attachmentFactory: ApplicationAttachmentFactory,
     @Autowired private val fileClient: MockFileClient,
-) : DatabaseTest() {
+) : IntegrationTest() {
 
     private val applicationId = 1L
     private val attachmentId = UUID.fromString("b820121e-ad54-4ab8-926a-c4a8193010b5")

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentServiceITest.kt
@@ -18,7 +18,7 @@ import assertk.assertions.prop
 import assertk.assertions.single
 import assertk.assertions.startsWith
 import fi.hel.haitaton.hanke.ALLOWED_ATTACHMENT_COUNT
-import fi.hel.haitaton.hanke.DatabaseTest
+import fi.hel.haitaton.hanke.IntegrationTest
 import fi.hel.haitaton.hanke.allu.CableReportService
 import fi.hel.haitaton.hanke.application.ApplicationNotFoundException
 import fi.hel.haitaton.hanke.attachment.DEFAULT_DATA
@@ -37,7 +37,6 @@ import fi.hel.haitaton.hanke.attachment.common.AttachmentLimitReachedException
 import fi.hel.haitaton.hanke.attachment.common.AttachmentNotFoundException
 import fi.hel.haitaton.hanke.attachment.common.DownloadResponse
 import fi.hel.haitaton.hanke.attachment.common.MockFileClient
-import fi.hel.haitaton.hanke.attachment.common.MockFileClientExtension
 import fi.hel.haitaton.hanke.attachment.failResult
 import fi.hel.haitaton.hanke.attachment.response
 import fi.hel.haitaton.hanke.attachment.successResult
@@ -58,20 +57,13 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.MediaType.APPLICATION_PDF_VALUE
-import org.springframework.security.test.context.support.WithMockUser
-import org.springframework.test.context.ActiveProfiles
 
 private const val ALLU_ID = 42
 
-@SpringBootTest
-@ActiveProfiles("test")
-@WithMockUser(USERNAME)
 class ApplicationAttachmentServiceITest(
     @Autowired private val cableReportService: CableReportService,
     @Autowired private val attachmentService: ApplicationAttachmentService,
@@ -79,7 +71,7 @@ class ApplicationAttachmentServiceITest(
     @Autowired private val applicationFactory: ApplicationFactory,
     @Autowired private val attachmentFactory: ApplicationAttachmentFactory,
     @Autowired private val fileClient: MockFileClient,
-) : DatabaseTest() {
+) : IntegrationTest() {
     private lateinit var mockClamAv: MockWebServer
 
     @BeforeEach
@@ -170,7 +162,6 @@ class ApplicationAttachmentServiceITest(
         }
 
         @Nested
-        @ExtendWith(MockFileClientExtension::class)
         inner class FromCloud {
             @Test
             fun `Returns the attachment content, filename and type`() {

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/common/FileScanClientITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/common/FileScanClientITest.kt
@@ -3,7 +3,7 @@ package fi.hel.haitaton.hanke.attachment.common
 import assertk.assertThat
 import assertk.assertions.isFalse
 import assertk.assertions.isTrue
-import fi.hel.haitaton.hanke.DatabaseTest
+import fi.hel.haitaton.hanke.IntegrationTest
 import fi.hel.haitaton.hanke.attachment.body
 import fi.hel.haitaton.hanke.attachment.failResult
 import fi.hel.haitaton.hanke.attachment.response
@@ -18,13 +18,9 @@ import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.ActiveProfiles
 import org.springframework.web.reactive.function.client.WebClientResponseException
 
-@SpringBootTest
-@ActiveProfiles("test")
-class FileScanClientITest : DatabaseTest() {
+class FileScanClientITest : IntegrationTest() {
 
     @Autowired private lateinit var scanClient: FileScanClient
 

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentAuthorizerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentAuthorizerITest.kt
@@ -6,8 +6,8 @@ import assertk.assertThat
 import assertk.assertions.hasClass
 import assertk.assertions.isTrue
 import assertk.assertions.messageContains
-import fi.hel.haitaton.hanke.DatabaseTest
 import fi.hel.haitaton.hanke.HankeNotFoundException
+import fi.hel.haitaton.hanke.IntegrationTest
 import fi.hel.haitaton.hanke.attachment.common.AttachmentNotFoundException
 import fi.hel.haitaton.hanke.factory.HankeAttachmentFactory
 import fi.hel.haitaton.hanke.factory.HankeFactory
@@ -20,19 +20,13 @@ import java.util.UUID
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.security.test.context.support.WithMockUser
-import org.springframework.test.context.ActiveProfiles
 
-@SpringBootTest
-@ActiveProfiles("test")
-@WithMockUser(USERNAME)
 class HankeAttachmentAuthorizerITest(
     @Autowired private val authorizer: HankeAttachmentAuthorizer,
     @Autowired private val permissionService: PermissionService,
     @Autowired private val hankeFactory: HankeFactory,
     @Autowired private val hankeAttachmentFactory: HankeAttachmentFactory,
-) : DatabaseTest() {
+) : IntegrationTest() {
     private val hankeTunnus = "HAI24-14"
     private val attachmentId = UUID.fromString("3b0e3149-37a2-4393-af03-6a34b946fef1")
 

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentContentServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentContentServiceITest.kt
@@ -8,35 +8,25 @@ import assertk.assertions.hasClass
 import assertk.assertions.hasMessage
 import assertk.assertions.isEmpty
 import assertk.assertions.isEqualTo
-import fi.hel.haitaton.hanke.DatabaseTest
+import fi.hel.haitaton.hanke.IntegrationTest
 import fi.hel.haitaton.hanke.attachment.DEFAULT_DATA
 import fi.hel.haitaton.hanke.attachment.FILE_NAME_PDF
 import fi.hel.haitaton.hanke.attachment.azure.Container.HANKE_LIITTEET
 import fi.hel.haitaton.hanke.attachment.common.AttachmentNotFoundException
 import fi.hel.haitaton.hanke.attachment.common.MockFileClient
-import fi.hel.haitaton.hanke.attachment.common.MockFileClientExtension
 import fi.hel.haitaton.hanke.factory.HankeAttachmentFactory
 import fi.hel.haitaton.hanke.test.Asserts.isValidBlobLocation
-import fi.hel.haitaton.hanke.test.USERNAME
 import java.util.UUID
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.MediaType.APPLICATION_PDF
-import org.springframework.security.test.context.support.WithMockUser
-import org.springframework.test.context.ActiveProfiles
 
-@SpringBootTest
-@ActiveProfiles("test")
-@WithMockUser(USERNAME)
-@ExtendWith(MockFileClientExtension::class)
 class HankeAttachmentContentServiceITest(
     @Autowired private val attachmentContentService: HankeAttachmentContentService,
     @Autowired private val fileClient: MockFileClient,
     @Autowired private val attachmentFactory: HankeAttachmentFactory,
-) : DatabaseTest() {
+) : IntegrationTest() {
     private val hankeId = 1
     private val attachmentId = UUID.fromString("b820121e-ad54-4ab8-926a-c4a8193010b5")
     private val bytes = "Test content. Sisältää myös skandeja.".toByteArray()

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentMetadataServiceITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentMetadataServiceITests.kt
@@ -14,9 +14,9 @@ import assertk.assertions.isNotNull
 import assertk.assertions.prop
 import assertk.assertions.single
 import fi.hel.haitaton.hanke.ALLOWED_ATTACHMENT_COUNT
-import fi.hel.haitaton.hanke.DatabaseTest
 import fi.hel.haitaton.hanke.HankeIdentifier
 import fi.hel.haitaton.hanke.HankeNotFoundException
+import fi.hel.haitaton.hanke.IntegrationTest
 import fi.hel.haitaton.hanke.attachment.DEFAULT_SIZE
 import fi.hel.haitaton.hanke.attachment.FILE_NAME_PDF
 import fi.hel.haitaton.hanke.attachment.common.AttachmentInvalidException
@@ -32,19 +32,13 @@ import java.util.UUID
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.MediaType.APPLICATION_PDF_VALUE
-import org.springframework.security.test.context.support.WithMockUser
-import org.springframework.test.context.ActiveProfiles
 
-@SpringBootTest
-@ActiveProfiles("test")
-@WithMockUser(USERNAME)
 class HankeAttachmentMetadataServiceITests(
     @Autowired private val hankeAttachmentMetadataService: HankeAttachmentMetadataService,
     @Autowired private val hankeAttachmentRepository: HankeAttachmentRepository,
     @Autowired private val hankeFactory: HankeFactory,
-) : DatabaseTest() {
+) : IntegrationTest() {
 
     @Nested
     inner class GetMetadataList {

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentRepositoryITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentRepositoryITests.kt
@@ -6,8 +6,8 @@ import assertk.assertions.isEqualTo
 import assertk.assertions.isNotNull
 import assertk.assertions.prop
 import assertk.assertions.single
-import fi.hel.haitaton.hanke.DatabaseTest
 import fi.hel.haitaton.hanke.HankeEntity
+import fi.hel.haitaton.hanke.IntegrationTest
 import fi.hel.haitaton.hanke.attachment.DEFAULT_SIZE
 import fi.hel.haitaton.hanke.attachment.common.HankeAttachmentEntity
 import fi.hel.haitaton.hanke.attachment.common.HankeAttachmentRepository
@@ -18,13 +18,9 @@ import fi.hel.haitaton.hanke.test.Asserts.isSameInstantAs
 import fi.hel.haitaton.hanke.test.USERNAME
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.MediaType.APPLICATION_PDF_VALUE
-import org.springframework.test.context.ActiveProfiles
 
-@ActiveProfiles("test")
-@SpringBootTest
-class HankeAttachmentRepositoryITests : DatabaseTest() {
+class HankeAttachmentRepositoryITests : IntegrationTest() {
 
     @Autowired private lateinit var hankeFactory: HankeFactory
     @Autowired private lateinit var hankeAttachmentRepository: HankeAttachmentRepository

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentServiceITest.kt
@@ -14,7 +14,7 @@ import assertk.assertions.isEqualTo
 import assertk.assertions.isNotNull
 import assertk.assertions.messageContains
 import assertk.assertions.prop
-import fi.hel.haitaton.hanke.DatabaseTest
+import fi.hel.haitaton.hanke.IntegrationTest
 import fi.hel.haitaton.hanke.attachment.DEFAULT_DATA
 import fi.hel.haitaton.hanke.attachment.DEFAULT_SIZE
 import fi.hel.haitaton.hanke.attachment.FILE_NAME_PDF
@@ -25,7 +25,6 @@ import fi.hel.haitaton.hanke.attachment.common.AttachmentNotFoundException
 import fi.hel.haitaton.hanke.attachment.common.HankeAttachmentMetadataDto
 import fi.hel.haitaton.hanke.attachment.common.HankeAttachmentRepository
 import fi.hel.haitaton.hanke.attachment.common.MockFileClient
-import fi.hel.haitaton.hanke.attachment.common.MockFileClientExtension
 import fi.hel.haitaton.hanke.attachment.failResult
 import fi.hel.haitaton.hanke.attachment.response
 import fi.hel.haitaton.hanke.attachment.successResult
@@ -41,25 +40,17 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.http.MediaType.APPLICATION_PDF_VALUE
-import org.springframework.security.test.context.support.WithMockUser
-import org.springframework.test.context.ActiveProfiles
 
-@SpringBootTest
-@ActiveProfiles("test")
-@WithMockUser(USERNAME)
-@ExtendWith(MockFileClientExtension::class)
 class HankeAttachmentServiceITest(
     @Autowired private val hankeAttachmentService: HankeAttachmentService,
     @Autowired private val attachmentRepository: HankeAttachmentRepository,
     @Autowired private val hankeFactory: HankeFactory,
     @Autowired private val hankeAttachmentFactory: HankeAttachmentFactory,
     @Autowired private val fileClient: MockFileClient
-) : DatabaseTest() {
+) : IntegrationTest() {
 
     private lateinit var mockClamAv: MockWebServer
 

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/email/EmailSenderServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/email/EmailSenderServiceITest.kt
@@ -8,24 +8,20 @@ import assertk.assertions.isEqualTo
 import com.icegreen.greenmail.configuration.GreenMailConfiguration
 import com.icegreen.greenmail.junit5.GreenMailExtension
 import com.icegreen.greenmail.util.ServerSetupTest
-import fi.hel.haitaton.hanke.DatabaseTest
+import fi.hel.haitaton.hanke.IntegrationTest
 import fi.hel.haitaton.hanke.application.ApplicationType
 import fi.hel.haitaton.hanke.firstReceivedMessage
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.ActiveProfiles
 
 private const val TEST_EMAIL = "test@test.test"
 private const val HAITATON_NO_REPLY = "no-reply@hel.fi"
 private const val APPLICATION_IDENTIFIER = "JS2300001"
 private const val INVITER_NAME = "Matti Meikäläinen"
 
-@SpringBootTest
-@ActiveProfiles("test")
-class EmailSenderServiceITest : DatabaseTest() {
+class EmailSenderServiceITest : IntegrationTest() {
 
     companion object {
         @JvmField

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/email/FilteredEmailSenderServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/email/FilteredEmailSenderServiceITest.kt
@@ -6,14 +6,13 @@ import assertk.assertions.isEqualTo
 import com.icegreen.greenmail.configuration.GreenMailConfiguration
 import com.icegreen.greenmail.junit5.GreenMailExtension
 import com.icegreen.greenmail.util.ServerSetupTest
-import fi.hel.haitaton.hanke.DatabaseTest
+import fi.hel.haitaton.hanke.IntegrationTest
 import fi.hel.haitaton.hanke.application.ApplicationType.CABLE_REPORT
 import fi.hel.haitaton.hanke.firstReceivedMessage
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.ActiveProfiles
 
 @SpringBootTest(
     properties =
@@ -23,8 +22,7 @@ import org.springframework.test.context.ActiveProfiles
             "haitaton.features.user-management=false"
         ]
 )
-@ActiveProfiles("test")
-class FilteredEmailSenderServiceITest : DatabaseTest() {
+class FilteredEmailSenderServiceITest : IntegrationTest() {
 
     companion object {
         @JvmField

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/gdpr/KortistoGdprServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/gdpr/KortistoGdprServiceITest.kt
@@ -20,12 +20,11 @@ import assertk.assertions.isNull
 import assertk.assertions.isTrue
 import assertk.assertions.prop
 import assertk.assertions.single
-import fi.hel.haitaton.hanke.DatabaseTest
 import fi.hel.haitaton.hanke.HankeEntity
 import fi.hel.haitaton.hanke.HankeRepository
+import fi.hel.haitaton.hanke.IntegrationTest
 import fi.hel.haitaton.hanke.application.ApplicationEntity
 import fi.hel.haitaton.hanke.application.ApplicationRepository
-import fi.hel.haitaton.hanke.attachment.common.MockFileClientExtension
 import fi.hel.haitaton.hanke.factory.HakemusFactory
 import fi.hel.haitaton.hanke.factory.HakemusyhteystietoFactory
 import fi.hel.haitaton.hanke.factory.HankeFactory
@@ -43,15 +42,10 @@ import fi.hel.haitaton.hanke.permissions.PermissionRepository
 import fi.hel.haitaton.hanke.test.USERNAME
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.security.test.context.support.WithMockUser
-import org.springframework.test.context.ActiveProfiles
 
 @SpringBootTest(properties = ["haitaton.features.user-management=true"])
-@ActiveProfiles("test")
-@WithMockUser(USERNAME)
 class KortistoGdprServiceITest(
     @Autowired val gdprService: GdprService,
     @Autowired val hankeKayttajaService: HankeKayttajaService,
@@ -62,7 +56,7 @@ class KortistoGdprServiceITest(
     @Autowired val hakemusFactory: HakemusFactory,
     @Autowired val hankeFactory: HankeFactory,
     @Autowired val hankekayttajaFactory: HankeKayttajaFactory,
-) : DatabaseTest() {
+) : IntegrationTest() {
     val OTHER_USER_ID = "Other user"
 
     @Test
@@ -335,7 +329,6 @@ class KortistoGdprServiceITest(
     }
 
     @Nested
-    @ExtendWith(MockFileClientExtension::class)
     inner class DeleteInfo {
         @Test
         fun `doesn't throw an exception when there's no data for the user`() {

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/gdpr/OldGdprServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/gdpr/OldGdprServiceITest.kt
@@ -10,12 +10,11 @@ import assertk.assertions.isEmpty
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNull
 import assertk.assertions.prop
-import fi.hel.haitaton.hanke.DatabaseTest
+import fi.hel.haitaton.hanke.IntegrationTest
 import fi.hel.haitaton.hanke.allu.ApplicationStatus
 import fi.hel.haitaton.hanke.application.Application
 import fi.hel.haitaton.hanke.application.ApplicationEntity
 import fi.hel.haitaton.hanke.application.ApplicationRepository
-import fi.hel.haitaton.hanke.attachment.common.MockFileClientExtension
 import fi.hel.haitaton.hanke.factory.ApplicationFactory
 import fi.hel.haitaton.hanke.factory.ApplicationFactory.Companion.TEPPO
 import fi.hel.haitaton.hanke.factory.ApplicationFactory.Companion.TEPPO_EMAIL
@@ -29,16 +28,11 @@ import fi.hel.haitaton.hanke.test.USERNAME
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.security.test.context.support.WithMockUser
-import org.springframework.test.context.ActiveProfiles
 
 @SpringBootTest(properties = ["haitaton.features.user-management=false"])
-@ActiveProfiles("test")
-@WithMockUser(USERNAME)
-class OldGdprServiceITest : DatabaseTest() {
+class OldGdprServiceITest : IntegrationTest() {
 
     @Autowired lateinit var gdprService: OldGdprService
     @Autowired lateinit var applicationFactory: ApplicationFactory
@@ -178,7 +172,6 @@ class OldGdprServiceITest : DatabaseTest() {
     }
 
     @Nested
-    @ExtendWith(MockFileClientExtension::class)
     inner class DeleteApplications {
         @Test
         fun `Deletes all given applications of the given user`() {

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/geometria/GeometriatDaoITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/geometria/GeometriatDaoITest.kt
@@ -8,21 +8,17 @@ import assertk.assertions.isFalse
 import assertk.assertions.isNotNull
 import assertk.assertions.isNull
 import assertk.assertions.isTrue
-import fi.hel.haitaton.hanke.DatabaseTest
+import fi.hel.haitaton.hanke.IntegrationTest
 import fi.hel.haitaton.hanke.asJsonResource
 import fi.hel.haitaton.hanke.factory.GeometriaFactory
 import java.time.ZonedDateTime
 import org.geojson.Polygon
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.jdbc.core.JdbcTemplate
-import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.jdbc.Sql
 
-@SpringBootTest
-@ActiveProfiles("test")
-internal class GeometriatDaoITest : DatabaseTest() {
+internal class GeometriatDaoITest : IntegrationTest() {
 
     private val expectedPolygonArea = 1707f
 

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/geometria/GeometriatServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/geometria/GeometriatServiceITest.kt
@@ -11,28 +11,23 @@ import assertk.assertions.isNotSameInstanceAs
 import assertk.assertions.isNull
 import assertk.assertions.prop
 import fi.hel.haitaton.hanke.DATABASE_TIMESTAMP_FORMAT
-import fi.hel.haitaton.hanke.DatabaseTest
 import fi.hel.haitaton.hanke.HankeService
+import fi.hel.haitaton.hanke.IntegrationTest
 import fi.hel.haitaton.hanke.domain.geometriat
 import fi.hel.haitaton.hanke.factory.GeometriaFactory
 import fi.hel.haitaton.hanke.factory.HankeFactory
 import fi.hel.haitaton.hanke.factory.HankealueFactory
 import fi.hel.haitaton.hanke.test.Asserts.isRecentZDT
+import fi.hel.haitaton.hanke.test.USERNAME
 import org.geojson.Polygon
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.security.core.context.SecurityContextHolder
-import org.springframework.security.test.context.support.WithMockUser
-import org.springframework.test.context.ActiveProfiles
 
-@SpringBootTest
-@ActiveProfiles("test")
-@WithMockUser(username = "test")
-internal class GeometriatServiceITest : DatabaseTest() {
+internal class GeometriatServiceITest : IntegrationTest() {
 
     @Autowired private lateinit var hankeService: HankeService
 
@@ -53,7 +48,7 @@ internal class GeometriatServiceITest : DatabaseTest() {
         // they must be picked from the created hanke-instance.
         val hankeTunnus =
             hankeFactory
-                .builder("test")
+                .builder(USERNAME)
                 .withHankealue(HankealueFactory.createMinimal(geometriat = geometriat))
                 .save()
                 .hankeTunnus
@@ -156,7 +151,7 @@ internal class GeometriatServiceITest : DatabaseTest() {
             assertThat(savedGeometriat).isNotNull().all {
                 prop(Geometriat::version).isEqualTo(0)
                 prop(Geometriat::createdAt).isRecentZDT()
-                prop(Geometriat::createdByUserId).isEqualTo("test")
+                prop(Geometriat::createdByUserId).isEqualTo(USERNAME)
                 prop(Geometriat::modifiedAt).isNull()
                 prop(Geometriat::modifiedByUserId).isNull()
                 prop(Geometriat::featureCollection).isNotNull().all {

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceITest.kt
@@ -13,8 +13,8 @@ import assertk.assertions.isNotNull
 import assertk.assertions.messageContains
 import assertk.assertions.prop
 import assertk.assertions.single
-import fi.hel.haitaton.hanke.DatabaseTest
 import fi.hel.haitaton.hanke.HankeNotFoundException
+import fi.hel.haitaton.hanke.IntegrationTest
 import fi.hel.haitaton.hanke.allu.CustomerType
 import fi.hel.haitaton.hanke.application.ApplicationAlreadySentException
 import fi.hel.haitaton.hanke.application.ApplicationContactType
@@ -46,13 +46,7 @@ import java.util.UUID
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.security.test.context.support.WithMockUser
-import org.springframework.test.context.ActiveProfiles
 
-@SpringBootTest
-@ActiveProfiles("test")
-@WithMockUser(USERNAME)
 class HakemusServiceITest(
     @Autowired private val hakemusService: HakemusService,
     @Autowired private val applicationRepository: ApplicationRepository,
@@ -62,7 +56,7 @@ class HakemusServiceITest(
     @Autowired private val hakemusFactory: HakemusFactory,
     @Autowired private val hankeFactory: HankeFactory,
     @Autowired private val hankeKayttajaFactory: HankeKayttajaFactory
-) : DatabaseTest() {
+) : IntegrationTest() {
 
     @Nested
     inner class HakemusResponse {

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HankekayttajaDeleteServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HankekayttajaDeleteServiceITest.kt
@@ -17,8 +17,8 @@ import assertk.assertions.isTrue
 import assertk.assertions.messageContains
 import assertk.assertions.prop
 import assertk.assertions.single
-import fi.hel.haitaton.hanke.DatabaseTest
 import fi.hel.haitaton.hanke.HankeService
+import fi.hel.haitaton.hanke.IntegrationTest
 import fi.hel.haitaton.hanke.allu.ApplicationStatus
 import fi.hel.haitaton.hanke.domain.Hanke
 import fi.hel.haitaton.hanke.domain.HankeYhteystieto
@@ -47,7 +47,7 @@ class HankekayttajaDeleteServiceITest(
     @Autowired val hakemusService: HakemusService,
     @Autowired val hankeFactory: HankeFactory,
     @Autowired val hakemusFactory: HakemusFactory,
-) : DatabaseTest() {
+) : IntegrationTest() {
 
     @Nested
     @TestInstance(TestInstance.Lifecycle.PER_CLASS)

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/logging/AuditLogServiceITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/logging/AuditLogServiceITests.kt
@@ -5,23 +5,19 @@ import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
 import assertk.assertions.isNotNull
 import assertk.assertions.isNull
-import fi.hel.haitaton.hanke.DatabaseTest
+import fi.hel.haitaton.hanke.IntegrationTest
 import fi.hel.haitaton.hanke.test.Asserts.isRecent
 import fi.hel.haitaton.hanke.test.TestUtils
 import jakarta.persistence.EntityManager
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.ActiveProfiles
 
 /**
  * Testing the configurations and database setup for AuditLogRepository class with a database. The
  * repositories have no additional code over the base JPARepository, so only the configs/setups get
  * indirectly tested.
  */
-@SpringBootTest
-@ActiveProfiles("test")
-class AuditLogServiceITests : DatabaseTest() {
+class AuditLogServiceITests : IntegrationTest() {
 
     @Autowired private lateinit var entityManager: EntityManager
     @Autowired private lateinit var auditLogService: AuditLogService

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeAuthorizerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeAuthorizerITest.kt
@@ -6,26 +6,20 @@ import assertk.assertThat
 import assertk.assertions.hasClass
 import assertk.assertions.isTrue
 import assertk.assertions.messageContains
-import fi.hel.haitaton.hanke.DatabaseTest
 import fi.hel.haitaton.hanke.HankeAuthorizer
 import fi.hel.haitaton.hanke.HankeNotFoundException
+import fi.hel.haitaton.hanke.IntegrationTest
 import fi.hel.haitaton.hanke.factory.HankeFactory
 import fi.hel.haitaton.hanke.test.USERNAME
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.security.test.context.support.WithMockUser
-import org.springframework.test.context.ActiveProfiles
 
-@SpringBootTest
-@ActiveProfiles("test")
-@WithMockUser(USERNAME)
 class HankeAuthorizerITest(
     @Autowired private val authorizer: HankeAuthorizer,
     @Autowired private val hankeFactory: HankeFactory,
     @Autowired private val permissionService: PermissionService,
-) : DatabaseTest() {
+) : IntegrationTest() {
 
     val hankeTunnus = "HAI24-14"
 

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaAuthorizerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaAuthorizerITest.kt
@@ -6,7 +6,7 @@ import assertk.assertThat
 import assertk.assertions.hasClass
 import assertk.assertions.isTrue
 import assertk.assertions.messageContains
-import fi.hel.haitaton.hanke.DatabaseTest
+import fi.hel.haitaton.hanke.IntegrationTest
 import fi.hel.haitaton.hanke.factory.HankeFactory
 import fi.hel.haitaton.hanke.factory.HankeKayttajaFactory
 import fi.hel.haitaton.hanke.test.USERNAME
@@ -14,19 +14,13 @@ import java.util.UUID
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.security.test.context.support.WithMockUser
-import org.springframework.test.context.ActiveProfiles
 
-@SpringBootTest
-@ActiveProfiles("test")
-@WithMockUser(USERNAME)
 class HankeKayttajaAuthorizerITest(
     @Autowired private val authorizer: HankeKayttajaAuthorizer,
     @Autowired private val hankeFactory: HankeFactory,
     @Autowired private val hankeKayttajaFactory: HankeKayttajaFactory,
     @Autowired private val permissionService: PermissionService,
-) : DatabaseTest() {
+) : IntegrationTest() {
 
     @Nested
     inner class AuthorizeKayttajaId {

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaServiceITest.kt
@@ -26,8 +26,8 @@ import com.icegreen.greenmail.configuration.GreenMailConfiguration
 import com.icegreen.greenmail.junit5.GreenMailExtension
 import com.icegreen.greenmail.util.ServerSetupTest
 import fi.hel.haitaton.hanke.ContactType
-import fi.hel.haitaton.hanke.DatabaseTest
 import fi.hel.haitaton.hanke.HankeNotFoundException
+import fi.hel.haitaton.hanke.IntegrationTest
 import fi.hel.haitaton.hanke.application.ApplicationRepository
 import fi.hel.haitaton.hanke.domain.Hanke
 import fi.hel.haitaton.hanke.email.textBody
@@ -86,17 +86,11 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.security.core.context.SecurityContext
-import org.springframework.security.test.context.support.WithMockUser
-import org.springframework.test.context.ActiveProfiles
 
 const val kayttajaTunnistePattern = "[a-zA-z0-9]{24}"
 
-@SpringBootTest
-@ActiveProfiles("test")
-@WithMockUser(USERNAME)
-class HankeKayttajaServiceITest : DatabaseTest() {
+class HankeKayttajaServiceITest : IntegrationTest() {
 
     @Autowired private lateinit var hankeKayttajaService: HankeKayttajaService
     @Autowired private lateinit var permissionService: PermissionService

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/KayttooikeustasoEntityITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/KayttooikeustasoEntityITest.kt
@@ -3,18 +3,14 @@ package fi.hel.haitaton.hanke.permissions
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.key
-import fi.hel.haitaton.hanke.DatabaseTest
+import fi.hel.haitaton.hanke.IntegrationTest
 import fi.hel.haitaton.hanke.hasSameElementsAs
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.ActiveProfiles
 
-@SpringBootTest
-@ActiveProfiles("test")
-class KayttooikeustasoEntityITest : DatabaseTest() {
+class KayttooikeustasoEntityITest : IntegrationTest() {
 
     @Autowired lateinit var kayttooikeustasoRepository: KayttooikeustasoRepository
 

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/PermissionServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/PermissionServiceITest.kt
@@ -10,9 +10,9 @@ import assertk.assertions.isNotNull
 import assertk.assertions.isNull
 import assertk.assertions.prop
 import assertk.assertions.single
-import fi.hel.haitaton.hanke.DatabaseTest
 import fi.hel.haitaton.hanke.HankeEntity
 import fi.hel.haitaton.hanke.HankeService
+import fi.hel.haitaton.hanke.IntegrationTest
 import fi.hel.haitaton.hanke.factory.HankeFactory
 import fi.hel.haitaton.hanke.hasSameElementsAs
 import fi.hel.haitaton.hanke.logging.AuditLogEvent
@@ -27,22 +27,15 @@ import fi.hel.haitaton.hanke.test.AuditLogEntryEntityAsserts.hasObjectBefore
 import fi.hel.haitaton.hanke.test.AuditLogEntryEntityAsserts.hasUserActor
 import fi.hel.haitaton.hanke.test.AuditLogEntryEntityAsserts.isSuccess
 import fi.hel.haitaton.hanke.test.AuditLogEntryEntityAsserts.withTarget
+import fi.hel.haitaton.hanke.test.USERNAME
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.security.test.context.support.WithMockUser
-import org.springframework.test.context.ActiveProfiles
 
-private const val CURRENT_USER: String = "test7358"
-
-@SpringBootTest
-@ActiveProfiles("test")
-@WithMockUser(username = CURRENT_USER)
-class PermissionServiceITest : DatabaseTest() {
+class PermissionServiceITest : IntegrationTest() {
 
     val username = "user"
 
@@ -102,19 +95,19 @@ class PermissionServiceITest : DatabaseTest() {
     inner class PermissionsByHanke {
         @Test
         fun `Should return empty if no permissions`() {
-            val result = permissionService.permissionsByHanke(CURRENT_USER)
+            val result = permissionService.permissionsByHanke(USERNAME)
 
             assertThat(result).isEmpty()
         }
 
         @Test
         fun `Should find all users permissions`() {
-            val firstHanke = hankeFactory.builder(CURRENT_USER).save()
+            val firstHanke = hankeFactory.builder(USERNAME).save()
             val secondHanke =
                 hankeFactory.saveMinimal().permit(privilege = Kayttooikeustaso.KATSELUOIKEUS)
             hankeFactory.saveMinimal().permit(username) // someone else
 
-            val result = permissionService.permissionsByHanke(CURRENT_USER)
+            val result = permissionService.permissionsByHanke(USERNAME)
 
             assertThat(result).hasSize(2)
             assertThat(result.find { it.hankeTunnus == firstHanke.hankeTunnus }).isNotNull().all {
@@ -132,7 +125,7 @@ class PermissionServiceITest : DatabaseTest() {
         }
 
         private fun HankeEntity.permit(
-            userId: String = CURRENT_USER,
+            userId: String = USERNAME,
             privilege: Kayttooikeustaso = Kayttooikeustaso.KAIKKI_OIKEUDET,
         ) = also { permissionService.create(id, userId, privilege) }
     }
@@ -201,7 +194,7 @@ class PermissionServiceITest : DatabaseTest() {
                     hasObjectAfter(expectedObject)
                 }
                 prop(AuditLogEvent::operation).isEqualTo(Operation.CREATE)
-                hasUserActor(CURRENT_USER)
+                hasUserActor(USERNAME)
             }
         }
     }
@@ -239,7 +232,7 @@ class PermissionServiceITest : DatabaseTest() {
             permissionService.updateKayttooikeustaso(
                 permission,
                 Kayttooikeustaso.HAKEMUSASIOINTI,
-                CURRENT_USER,
+                USERNAME,
             )
 
             val expectedObject =
@@ -258,7 +251,7 @@ class PermissionServiceITest : DatabaseTest() {
                         expectedObject.copy(kayttooikeustaso = Kayttooikeustaso.HAKEMUSASIOINTI)
                     )
                 }
-                hasUserActor(CURRENT_USER)
+                hasUserActor(USERNAME)
             }
         }
     }

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/testdata/TestDataServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/testdata/TestDataServiceITest.kt
@@ -5,7 +5,7 @@ import assertk.assertions.each
 import assertk.assertions.hasSize
 import assertk.assertions.isNull
 import assertk.assertions.isTrue
-import fi.hel.haitaton.hanke.DatabaseTest
+import fi.hel.haitaton.hanke.IntegrationTest
 import fi.hel.haitaton.hanke.allu.ApplicationStatus
 import fi.hel.haitaton.hanke.application.ApplicationRepository
 import fi.hel.haitaton.hanke.factory.ApplicationFactory
@@ -14,14 +14,8 @@ import fi.hel.haitaton.hanke.test.USERNAME
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.security.test.context.support.WithMockUser
-import org.springframework.test.context.ActiveProfiles
 
-@SpringBootTest
-@ActiveProfiles("test")
-@WithMockUser(USERNAME)
-class TestDataServiceITest : DatabaseTest() {
+class TestDataServiceITest : IntegrationTest() {
 
     @Autowired private lateinit var testDataService: TestDataService
     @Autowired private lateinit var applicationRepository: ApplicationRepository

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluTormaysServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluTormaysServiceITest.kt
@@ -4,19 +4,15 @@ import assertk.assertThat
 import assertk.assertions.containsExactlyInAnyOrder
 import assertk.assertions.isEmpty
 import assertk.assertions.isEqualTo
-import fi.hel.haitaton.hanke.DatabaseTest
+import fi.hel.haitaton.hanke.IntegrationTest
 import fi.hel.haitaton.hanke.asJsonResource
 import fi.hel.haitaton.hanke.geometria.Geometriat
 import fi.hel.haitaton.hanke.geometria.GeometriatDao
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.ActiveProfiles
 
-@SpringBootTest
-@ActiveProfiles("test")
-internal class TormaystarkasteluTormaysServiceITest : DatabaseTest() {
+internal class TormaystarkasteluTormaysServiceITest : IntegrationTest() {
 
     @Autowired private lateinit var geometriatDao: GeometriatDao
 


### PR DESCRIPTION
# Description

Add the annotations shared by integration tests to DatabaseTest and rename it to IntegrationTest. The annotations can be removed from the test classes since IntegrationTest adds them. Leave the `@SpringBootTest` annotation to the class, if it modifies system properties. The class-specific annotation overrides the one from the abstract class.

Also, add MockFileClientExtension to IntegrationTest, so the file client is always available. Remove the extension annotation from other places.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2393

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [X] Other