### PR TITLE
HAI-2275 Make customer and contractor optional in applications

### DIFF
--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/ApplicationPdfService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/ApplicationPdfService.kt
@@ -148,8 +148,12 @@ object ApplicationPdfService {
         document.newPage()
 
         document.section("Yhteystiedot") { table ->
-            table.row("Työstä vastaavat", data.customerWithContacts.format())
-            table.row("Työn suorittajat", data.contractorWithContacts.format())
+            if (data.customerWithContacts != null) {
+                table.row("Työstä vastaavat", data.customerWithContacts.format())
+            }
+            if (data.contractorWithContacts != null) {
+                table.row("Työn suorittajat", data.contractorWithContacts.format())
+            }
             if (data.propertyDeveloperWithContacts != null) {
                 table.row("Rakennuttajat", data.propertyDeveloperWithContacts.format())
             }
@@ -173,8 +177,8 @@ object ApplicationPdfService {
     }
 
     private fun getOrderer(data: CableReportApplicationData): Contact? =
-        data.customerWithContacts.contacts.find { it.orderer }
-            ?: data.contractorWithContacts.contacts.find { it.orderer }
+        data.customerWithContacts?.contacts?.find { it.orderer }
+            ?: data.contractorWithContacts?.contacts?.find { it.orderer }
             ?: data.representativeWithContacts?.contacts?.find { it.orderer }
             ?: data.propertyDeveloperWithContacts?.contacts?.find { it.orderer }
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationData.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationData.kt
@@ -62,7 +62,7 @@ data class CableReportApplicationData(
 
     // Common, required
     override val name: String,
-    val customerWithContacts: CustomerWithContacts,
+    val customerWithContacts: CustomerWithContacts?,
     override val areas: List<ApplicationArea>?,
     val startTime: ZonedDateTime?,
     val endTime: ZonedDateTime?,
@@ -70,7 +70,7 @@ data class CableReportApplicationData(
 
     // CableReport specific, required
     val workDescription: String,
-    val contractorWithContacts: CustomerWithContacts, // työn suorittaja
+    val contractorWithContacts: CustomerWithContacts?, // työn suorittaja
     val rockExcavation: Boolean?,
 
     // Common, not required
@@ -104,8 +104,8 @@ data class CableReportApplicationData(
 
     fun customersByRole(): List<Pair<ApplicationContactType, CustomerWithContacts>> =
         listOfNotNull(
-            ApplicationContactType.HAKIJA to customerWithContacts,
-            ApplicationContactType.TYON_SUORITTAJA to contractorWithContacts,
+            customerWithContacts?.let { ApplicationContactType.HAKIJA to it },
+            contractorWithContacts?.let { ApplicationContactType.TYON_SUORITTAJA to it },
             representativeWithContacts?.let { ApplicationContactType.ASIANHOITAJA to it },
             propertyDeveloperWithContacts?.let { ApplicationContactType.RAKENNUTTAJA to it },
         )

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationDataMapper.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationDataMapper.kt
@@ -19,7 +19,9 @@ object ApplicationDataMapper {
             AlluCableReportApplicationData(
                 name = name,
                 customerWithContacts =
-                    customerWithContacts.toAlluData(path("customerWithContacts")),
+                    customerWithContacts
+                        .orThrow(path("customerWithContacts"))
+                        .toAlluData(path("customerWithContacts")),
                 geometry = getGeometry(applicationData = this),
                 startTime = startTime.orThrow(path("startTime")),
                 endTime = endTime.orThrow(path("endTime")),
@@ -28,7 +30,9 @@ object ApplicationDataMapper {
                 clientApplicationKind = description, // intentional
                 workDescription = description,
                 contractorWithContacts =
-                    contractorWithContacts.toAlluData(path("contractorWithContacts")),
+                    contractorWithContacts
+                        .orThrow(path("contractorWithContacts"))
+                        .toAlluData(path("contractorWithContacts")),
                 postalAddress = postalAddress?.toAlluData(),
                 representativeWithContacts =
                     representativeWithContacts?.toAlluData(path("representativeWithContacts")),

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/validation/CableReportErrorValidation.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/validation/CableReportErrorValidation.kt
@@ -25,8 +25,8 @@ fun CableReportApplicationData.validateForErrors(): ValidationResult =
             isBeforeOrEqual(startTime!!, endTime!!, "endTime")
         }
         .whenNotNull(postalAddress) { it.validateForErrors("postalAddress") }
-        .and { customerWithContacts.validateForErrors("customerWithContacts") }
-        .and { contractorWithContacts.validateForErrors("contractorWithContacts") }
+        .whenNotNull(customerWithContacts) { it.validateForErrors("customerWithContacts") }
+        .whenNotNull(contractorWithContacts) { it.validateForErrors("contractorWithContacts") }
         .whenNotNull(representativeWithContacts) {
             it.validateForErrors("representativeWithContacts")
         }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/validation/CableReportMissingValidation.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/validation/CableReportMissingValidation.kt
@@ -24,8 +24,8 @@ fun CableReportApplicationData.validateForMissing(): ValidationResult =
         .and { notNull(areas, "areas") }
         .and { notNull(rockExcavation, "rockExcavation") }
         .and { exactlyOneOrderer(customersWithContacts()) }
-        .and { customerWithContacts.validateForMissing("customerWithContacts") }
-        .and { contractorWithContacts.validateForMissing("contractorWithContacts") }
+        .andWithNotNull(customerWithContacts, "customerWithContacts") { validateForMissing(it) }
+        .andWithNotNull(contractorWithContacts, "contractorWithContacts") { validateForMissing(it) }
         .whenNotNull(representativeWithContacts) {
             it.validateForMissing("representativeWithContacts")
         }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
@@ -427,7 +427,7 @@ class IncompatibleHakemusUpdateRequestException(
     requestClass: KClass<out HakemusUpdateRequest>,
 ) :
     RuntimeException(
-        "Invalid update reeuqest for application id=$applicationId type=$oldApplicationClass requestType=$requestClass"
+        "Invalid update request for application id=$applicationId type=$oldApplicationClass requestType=$requestClass"
     )
 
 class InvalidHakemusyhteystietoException(

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/validation/HankeValidator.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/validation/HankeValidator.kt
@@ -1,6 +1,5 @@
 package fi.hel.haitaton.hanke.validation
 
-import fi.hel.haitaton.hanke.ContactType
 import fi.hel.haitaton.hanke.HankeError
 import fi.hel.haitaton.hanke.MAXIMUM_DATE
 import fi.hel.haitaton.hanke.MAXIMUM_HANKE_ALUE_NIMI_LENGTH
@@ -70,20 +69,6 @@ private fun Hankealue.validate(path: String) =
         .andWhen(haittaAlkuPvm != null && haittaLoppuPvm != null) {
             isBeforeOrEqual(haittaAlkuPvm!!, haittaLoppuPvm!!, "$path.haittaLoppuPvm")
         }
-
-private fun validateYhteystiedot(
-    yhteystiedot: Map<ContactType, List<Yhteystieto>>
-): ValidationResult =
-    whenNotNull(yhteystiedot[ContactType.OMISTAJA]) {
-            allIn(it, "omistajat", ::validateYhteystieto)
-        }
-        .whenNotNull(yhteystiedot[ContactType.TOTEUTTAJA]) {
-            allIn(it, "toteuttajat", ::validateYhteystieto)
-        }
-        .whenNotNull(yhteystiedot[ContactType.RAKENNUTTAJA]) {
-            allIn(it, "rakennuttajat", ::validateYhteystieto)
-        }
-        .whenNotNull(yhteystiedot[ContactType.MUU]) { allIn(it, "muut", ::validateYhteystieto) }
 
 private fun validateYhteystieto(yhteystieto: Yhteystieto, path: String): ValidationResult =
     yhteystieto.validate(path)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/validation/Validators.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/validation/Validators.kt
@@ -99,6 +99,13 @@ private constructor(private val errorPaths: MutableList<String> = mutableListOf(
     fun <T> whenNotNull(value: T?, f: (T) -> ValidationResult): ValidationResult =
         if (value != null) this.and { f(value) } else this
 
+    /** Fail if the value is null. Run the validation when it is not. */
+    fun <T> andWithNotNull(
+        value: T?,
+        path: String,
+        f: (T).(String) -> ValidationResult
+    ): ValidationResult = if (value != null) this.and { value.f(path) } else and { failure(path) }
+
     /** Check run the validation lambda only if the pre-condition is true. */
     fun andWhen(condition: Boolean, f: () -> ValidationResult): ValidationResult =
         if (condition) this.and(f) else this

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/application/ApplicationDataMapperTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/application/ApplicationDataMapperTest.kt
@@ -42,7 +42,7 @@ internal class ApplicationDataMapperTest {
             val result = ApplicationDataMapper.toAlluData(HANKE_TUNNUS, input)
 
             assertThat(result.name).isEqualTo(input.name)
-            assertThat(result.customerWithContacts).isValid(input.customerWithContacts)
+            assertThat(result.customerWithContacts).isValid(input.customerWithContacts!!)
             assertThat(result.geometry).isEqualTo(ApplicationDataMapper.getGeometry(input))
             assertThat(result.startTime).isEqualTo(input.startTime)
             assertThat(result.endTime).isEqualTo(input.endTime)
@@ -50,7 +50,7 @@ internal class ApplicationDataMapperTest {
             assertThat(result.identificationNumber).isEqualTo(HANKE_TUNNUS)
             assertThat(result.clientApplicationKind).isEqualTo(toDescription(input.workDescription))
             assertThat(result.workDescription).isEqualTo(toDescription(input.workDescription))
-            assertThat(result.contractorWithContacts).isValid(input.contractorWithContacts)
+            assertThat(result.contractorWithContacts).isValid(input.contractorWithContacts!!)
             assertThat(result.postalAddress).isEqualTo(input.postalAddress)
             assertThat(result.representativeWithContacts).isNull()
             assertThat(result.invoicingCustomer).isNull()

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceTest.kt
@@ -114,9 +114,11 @@ class ApplicationServiceTest {
                 Arguments.of(
                     applicationData.copy(
                         customerWithContacts =
-                            applicationData.customerWithContacts.copy(
+                            applicationData.customerWithContacts!!.copy(
                                 customer =
-                                    applicationData.customerWithContacts.customer.copy(type = null)
+                                    applicationData.customerWithContacts!!
+                                        .customer
+                                        .copy(type = null)
                             )
                     ),
                     "applicationData.customerWithContacts.customer.type",

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/ApplicationFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/ApplicationFactory.kt
@@ -247,7 +247,7 @@ class ApplicationFactory(
                 hankeTunnus = hankeTunnus
             )
 
-        fun Application.withCustomer(customer: CustomerWithContacts): Application =
+        fun Application.withCustomer(customer: CustomerWithContacts?): Application =
             this.copy(
                 applicationData =
                     (applicationData as CableReportApplicationData).copy(
@@ -258,7 +258,7 @@ class ApplicationFactory(
         fun Application.withCustomerContacts(vararg contacts: Contact): Application =
             this.withCustomer(
                 (applicationData as CableReportApplicationData)
-                    .customerWithContacts
+                    .customerWithContacts!!
                     .copy(contacts = contacts.asList())
             )
 

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/logging/DisclosureLogServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/logging/DisclosureLogServiceTest.kt
@@ -316,8 +316,8 @@ internal class DisclosureLogServiceTest {
     fun `saveDisclosureLogsForApplication with contacts logs contacts`() {
         val applicationId = 41L
         val cableReportApplication = ApplicationFactory.createCableReportApplicationData()
-        val firstContact = cableReportApplication.customerWithContacts.contacts[0]
-        val secondContact = cableReportApplication.contractorWithContacts.contacts[0]
+        val firstContact = cableReportApplication.customerWithContacts!!.contacts[0]
+        val secondContact = cableReportApplication.contractorWithContacts!!.contacts[0]
         val application =
             ApplicationFactory.createApplication(
                 id = applicationId,
@@ -346,8 +346,8 @@ internal class DisclosureLogServiceTest {
     fun `saveDisclosureLogsForAllu saves logs with the given status`(expectedStatus: Status) {
         val applicationId = 41L
         val cableReportApplication = ApplicationFactory.createCableReportApplicationData()
-        val firstContact = cableReportApplication.customerWithContacts.contacts[0]
-        val secondContact = cableReportApplication.contractorWithContacts.contacts[0]
+        val firstContact = cableReportApplication.customerWithContacts!!.contacts[0]
+        val secondContact = cableReportApplication.contractorWithContacts!!.contacts[0]
         val expectedLogs =
             listOf(HAKIJA to firstContact, TYON_SUORITTAJA to secondContact).map { (role, contact)
                 ->
@@ -511,8 +511,8 @@ internal class DisclosureLogServiceTest {
         fun `saves logs with the given status`(expectedStatus: Status) {
             val applicationId = 41L
             val cableReportApplication = ApplicationFactory.createCableReportApplicationData()
-            val firstContact = cableReportApplication.customerWithContacts.contacts[0]
-            val secondContact = cableReportApplication.contractorWithContacts.contacts[0]
+            val firstContact = cableReportApplication.customerWithContacts!!.contacts[0]
+            val secondContact = cableReportApplication.contractorWithContacts!!.contacts[0]
             val expectedLogs =
                 listOf(HAKIJA to firstContact, TYON_SUORITTAJA to secondContact).map {
                     (role, contact) ->

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/validation/ApplicationDataValidatorTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/validation/ApplicationDataValidatorTest.kt
@@ -186,7 +186,15 @@ class ApplicationDataValidatorTest {
                 of(
                     "Null rock excavation",
                     createCableReportApplicationData().copy(rockExcavation = null)
-                )
+                ),
+                of(
+                    "Null customer",
+                    createCableReportApplicationData().copy(customerWithContacts = null)
+                ),
+                of(
+                    "Null contractor",
+                    createCableReportApplicationData().copy(contractorWithContacts = null)
+                ),
             )
 
         @JvmStatic


### PR DESCRIPTION
# Description

Customer and contractor have been mandatory in applications. However, they have not been added until the 4th page of the johtoselvityshakemus form. The frontend is using a customer with nothing but nulls and empty strings as a placeholder. This doesn't make much sense, when the two other roles have been nullable.

Change the `customerWithContacts` and `contractorWithContacts` to be nullable in `ApplicationData`. Add validation so they can't be null when sending the data to Allu.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2275

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [X] Other

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 