### PR TITLE
HAI-2275 Add a new API for creating a stand-alone johtoselvityshakemus

### DIFF
--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationData.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationData.kt
@@ -8,7 +8,6 @@ import fi.hel.haitaton.hanke.ChangeLogView
 import fi.hel.haitaton.hanke.NotInChangeLogView
 import fi.hel.haitaton.hanke.allu.AlluApplicationData
 import fi.hel.haitaton.hanke.allu.AlluCableReportApplicationData
-import fi.hel.haitaton.hanke.hakemus.HakemusData
 import fi.hel.haitaton.hanke.hakemus.Hakemusyhteystieto
 import fi.hel.haitaton.hanke.hakemus.JohtoselvityshakemusData
 import java.time.ZonedDateTime
@@ -113,7 +112,9 @@ data class CableReportApplicationData(
     fun findOrderer(): Contact? =
         customersWithContacts().flatMap { it.contacts }.find { it.orderer }
 
-    fun toHakemusData(yhteystiedot: Map<ApplicationContactType, Hakemusyhteystieto>): HakemusData =
+    fun toHakemusData(
+        yhteystiedot: Map<ApplicationContactType, Hakemusyhteystieto>
+    ): JohtoselvityshakemusData =
         JohtoselvityshakemusData(
             name = name,
             postalAddress = postalAddress,
@@ -125,6 +126,7 @@ data class CableReportApplicationData(
             workDescription = workDescription,
             startTime = startTime,
             endTime = endTime,
+            pendingOnClient = pendingOnClient,
             areas = areas,
             customerWithContacts = yhteystiedot[ApplicationContactType.HAKIJA],
             contractorWithContacts = yhteystiedot[ApplicationContactType.TYON_SUORITTAJA],

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationEntity.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationEntity.kt
@@ -54,19 +54,22 @@ data class ApplicationEntity(
 
     fun toHakemus(): Hakemus {
         val yhteystiedot = yhteystiedot.mapValues { it.value.toDomain() }
-        val applicationData =
-            when (applicationData) {
-                is CableReportApplicationData ->
+
+        return when (applicationData) {
+            is CableReportApplicationData -> {
+                val applicationData =
                     (this.applicationData as CableReportApplicationData).toHakemusData(yhteystiedot)
+                Hakemus(
+                    id = id!!,
+                    alluid = alluid,
+                    alluStatus = alluStatus,
+                    applicationIdentifier = applicationIdentifier,
+                    applicationType = applicationType,
+                    applicationData = applicationData,
+                    hankeTunnus = hanke.hankeTunnus,
+                    hankeId = hanke.id,
+                )
             }
-        return Hakemus(
-            id = id!!,
-            alluid = alluid,
-            alluStatus = alluStatus,
-            applicationIdentifier = applicationIdentifier,
-            applicationType = applicationType,
-            applicationData = applicationData,
-            hankeTunnus = hanke.hankeTunnus
-        )
+        }
     }
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusResponse.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusResponse.kt
@@ -27,7 +27,7 @@ sealed interface HakemusDataResponse {
     val postalAddress: PostalAddress?
     val startTime: ZonedDateTime?
     val endTime: ZonedDateTime?
-    val areas: List<ApplicationArea>?
+    val areas: List<ApplicationArea>
     val customerWithContacts: CustomerWithContactsResponse?
 }
 
@@ -60,7 +60,7 @@ data class JohtoselvitysHakemusDataResponse(
     /** Työn arvioitu loppupäivä */
     override val endTime: ZonedDateTime?,
     /** Työalueet */
-    override val areas: List<ApplicationArea>?,
+    override val areas: List<ApplicationArea>,
     // 3. sivu Yhteystiedot
     /** Hakijan tiedot */
     override val customerWithContacts: CustomerWithContactsResponse?,

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/Hakemusyhteystieto.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/Hakemusyhteystieto.kt
@@ -13,7 +13,21 @@ data class Hakemusyhteystieto(
     val puhelinnumero: String,
     val ytunnus: String?,
     val yhteyshenkilot: List<Hakemusyhteyshenkilo>,
-)
+) {
+    fun toResponse(): CustomerWithContactsResponse =
+        CustomerWithContactsResponse(
+            customer =
+                CustomerResponse(
+                    yhteystietoId = id,
+                    type = tyyppi,
+                    name = nimi,
+                    email = sahkoposti,
+                    phone = puhelinnumero,
+                    registryKey = ytunnus,
+                ),
+            contacts = yhteyshenkilot.map { it.toResponse() }
+        )
+}
 
 data class Hakemusyhteyshenkilo(
     val id: UUID,
@@ -23,4 +37,7 @@ data class Hakemusyhteyshenkilo(
     val sahkoposti: String,
     val puhelin: String,
     val tilaaja: Boolean,
-)
+) {
+    fun toResponse(): ContactResponse =
+        ContactResponse(hankekayttajaId, etunimi, sukunimi, sahkoposti, puhelin, tilaaja)
+}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankekayttajaDeleteService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankekayttajaDeleteService.kt
@@ -44,7 +44,7 @@ class HankekayttajaDeleteService(
 
         val activeHakemukset = getHakemuksetForKayttaja(kayttajaId).filter { it.alluStatus != null }
         if (activeHakemukset.isNotEmpty()) {
-            throw HasActiveApplicationsException(kayttajaId, activeHakemukset.map { it.id!! })
+            throw HasActiveApplicationsException(kayttajaId, activeHakemukset.map { it.id })
         }
 
         hankekayttajaRepository.delete(kayttaja)

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusFactory.kt
@@ -50,13 +50,14 @@ class HakemusFactory(
 
     companion object {
         fun create(
-            id: Long? = 1,
+            id: Long = 1,
             alluid: Int? = null,
             alluStatus: ApplicationStatus? = null,
             applicationIdentifier: String? = null,
             applicationType: ApplicationType = ApplicationType.CABLE_REPORT,
             applicationData: HakemusData = createJohtoselvityshakemusData(),
             hankeTunnus: String = "HAI-1234",
+            hankeId: Int = 1,
         ): Hakemus =
             Hakemus(
                 id = id,
@@ -65,7 +66,8 @@ class HakemusFactory(
                 applicationIdentifier = applicationIdentifier,
                 applicationType = applicationType,
                 applicationData = applicationData,
-                hankeTunnus = hankeTunnus
+                hankeTunnus = hankeTunnus,
+                hankeId = hankeId,
             )
 
         fun createJohtoselvityshakemusData(
@@ -75,6 +77,7 @@ class HakemusFactory(
             workDescription: String = "Work description.",
             startTime: ZonedDateTime? = DateFactory.getStartDatetime(),
             endTime: ZonedDateTime? = DateFactory.getEndDatetime(),
+            pendingOnClient: Boolean = false,
             areas: List<ApplicationArea>? = listOf(ApplicationFactory.createApplicationArea()),
             customerWithContacts: Hakemusyhteystieto? = null,
             contractorWithContacts: Hakemusyhteystieto? = null,
@@ -92,6 +95,7 @@ class HakemusFactory(
                 workDescription = workDescription,
                 startTime = startTime,
                 endTime = endTime,
+                pendingOnClient = pendingOnClient,
                 areas = areas,
                 customerWithContacts = customerWithContacts,
                 contractorWithContacts = contractorWithContacts,

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusResponseFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusResponseFactory.kt
@@ -44,7 +44,7 @@ object HakemusResponseFactory {
         workDescription: String = "Work description.",
         startTime: ZonedDateTime? = DateFactory.getStartDatetime(),
         endTime: ZonedDateTime? = DateFactory.getEndDatetime(),
-        areas: List<ApplicationArea>? = listOf(ApplicationFactory.createApplicationArea()),
+        areas: List<ApplicationArea> = listOf(ApplicationFactory.createApplicationArea()),
         customerWithContacts: CustomerWithContactsResponse? =
             CustomerWithContactsResponse(
                 createCompanyCustomerResponse(),


### PR DESCRIPTION
# Description

The API takes in a name for the hakemus (and the generated hanke) and the founders contact info (email and phone number). It creates a hanke with the given name, adds the founder as a Kaikki Oikeudet level hankekayttaja and creates a new johtoselvityshakemus for the hanke with the same name as the hanke.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2275

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
It should be possible to create a johtoselvityshakemus from the Swagger UI now.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 

# Other relevant info
Audit logging is added in the next PR (#656).