### PR TITLE
HAI-2275 Add audit logging for hakemus creation

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
@@ -1204,6 +1204,22 @@ class HankeServiceITests(
 
             assertThat(exception).hasMessage("Orderer not found.")
         }
+
+        @Test
+        fun `writes to audit logs`() {
+            val inputApplication = ApplicationFactory.cableReportWithoutHanke()
+
+            hankeService.generateHankeWithApplication(inputApplication, setUpProfiiliMocks())
+
+            assertThat(auditLogRepository.findAll())
+                .extracting { it.message.auditEvent.target.type }
+                .containsExactlyInAnyOrder(
+                    ObjectType.APPLICATION,
+                    ObjectType.HANKE,
+                    ObjectType.HANKE_KAYTTAJA,
+                    ObjectType.PERMISSION,
+                )
+        }
     }
 
     @Nested
@@ -1287,6 +1303,22 @@ class HankeServiceITests(
 
             val hanke = hankeRepository.findByHankeTunnus(hakemus.hankeTunnus)!!
             assertThat(hanke.nimi).isEqualTo(expectedName)
+        }
+
+        @Test
+        fun `writes to audit logs`() {
+            val request = CreateHankeRequest(hakemusNimi, DEFAULT_HANKE_PERUSTAJA)
+
+            hankeService.generateHankeWithJohtoselvityshakemus(request, setUpProfiiliMocks())
+
+            assertThat(auditLogRepository.findAll())
+                .extracting { it.message.auditEvent.target.type }
+                .containsExactlyInAnyOrder(
+                    ObjectType.HAKEMUS,
+                    ObjectType.HANKE,
+                    ObjectType.HANKE_KAYTTAJA,
+                    ObjectType.PERMISSION,
+                )
         }
     }
 

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/IntegrationTest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/IntegrationTest.kt
@@ -1,6 +1,7 @@
 package fi.hel.haitaton.hanke
 
 import fi.hel.haitaton.hanke.attachment.common.MockFileClientExtension
+import fi.hel.haitaton.hanke.test.JacksonTestExtension
 import fi.hel.haitaton.hanke.test.USERNAME
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.boot.test.context.SpringBootTest
@@ -29,6 +30,7 @@ import org.testcontainers.utility.MountableFile
 @ActiveProfiles("test")
 @WithMockUser(USERNAME)
 @ExtendWith(MockFileClientExtension::class)
+@ExtendWith(JacksonTestExtension::class)
 abstract class IntegrationTest {
     companion object {
         @ServiceConnection

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/AuditLogEntry.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/AuditLogEntry.kt
@@ -43,19 +43,20 @@ enum class Status {
 }
 
 enum class ObjectType {
-    APPLICATION,
     ALLU_CONTACT,
     ALLU_CUSTOMER,
+    APPLICATION,
     APPLICATION_CONTACT,
     APPLICATION_CUSTOMER,
     CABLE_REPORT,
     GDPR_RESPONSE,
+    HAKEMUS,
     HANKE,
     HANKE_KAYTTAJA,
     KAYTTAJA_TUNNISTE,
     PERMISSION,
-    YHTEYSTIETO,
     PROFIILI_NIMI,
+    YHTEYSTIETO,
 }
 
 enum class UserRole {

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/HakemusLoggingService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/HakemusLoggingService.kt
@@ -1,0 +1,31 @@
+package fi.hel.haitaton.hanke.logging
+
+import fi.hel.haitaton.hanke.hakemus.Hakemus
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class HakemusLoggingService(private val auditLogService: AuditLogService) {
+
+    @Transactional(propagation = Propagation.MANDATORY)
+    fun logCreate(savedHakemus: Hakemus, userId: String) {
+        auditLogService.create(
+            AuditLogService.createEntry(userId, ObjectType.HAKEMUS, savedHakemus)
+        )
+    }
+
+    @Transactional(propagation = Propagation.MANDATORY)
+    fun logUpdate(hakemusBefore: Hakemus, hakemusAfter: Hakemus, userId: String) {
+        AuditLogService.updateEntry(userId, ObjectType.HAKEMUS, hakemusBefore, hakemusAfter)?.let {
+            auditLogService.create(it)
+        }
+    }
+
+    @Transactional(propagation = Propagation.MANDATORY)
+    fun logDelete(hakemusBefore: Hakemus, userId: String) {
+        auditLogService.create(
+            AuditLogService.deleteEntry(userId, ObjectType.HAKEMUS, hakemusBefore)
+        )
+    }
+}

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/ControllerTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/ControllerTest.kt
@@ -1,5 +1,7 @@
 package fi.hel.haitaton.hanke
 
+import fi.hel.haitaton.hanke.test.JacksonTestExtension
+import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.http.MediaType
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors
 import org.springframework.test.web.servlet.MockMvc
@@ -8,6 +10,7 @@ import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilde
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
 
+@ExtendWith(JacksonTestExtension::class)
 interface ControllerTest {
     val mockMvc: MockMvc
 

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusDeserializer.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusDeserializer.kt
@@ -1,0 +1,62 @@
+package fi.hel.haitaton.hanke.hakemus
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.JsonDeserializer
+import com.fasterxml.jackson.databind.node.ObjectNode
+import fi.hel.haitaton.hanke.OBJECT_MAPPER
+import fi.hel.haitaton.hanke.allu.ApplicationStatus
+import fi.hel.haitaton.hanke.application.ApplicationType
+import java.io.IOException
+
+/**
+ * Custom deserializer for Hakemus. Because applicationData is polymorphic, this can't be
+ * deserialized without some sort of customization. The easy way would be to use JsonSubTypes like
+ * in [HakemusUpdateRequest]. But that would be in use always, even in production code.
+ *
+ * We don't need to deserialize Hakemus data in production code, just in tests. That's easiest to do
+ * with a custom serializer we register when the tests start.
+ */
+class HakemusDeserializer : JsonDeserializer<Hakemus>() {
+    @Throws(IOException::class)
+    override fun deserialize(
+        jsonParser: JsonParser,
+        deserializationContext: DeserializationContext
+    ): Hakemus {
+        val root = jsonParser.readValueAsTree<ObjectNode>()
+        val basicHakemus = OBJECT_MAPPER.treeToValue(root, BasicHakemus::class.java)
+
+        val dataClass =
+            when (basicHakemus.applicationType) {
+                ApplicationType.CABLE_REPORT -> JohtoselvityshakemusData::class.java
+            }
+
+        val dataNode = root.path("applicationData") as ObjectNode
+        val hakemusData = OBJECT_MAPPER.treeToValue(dataNode, dataClass)
+        return basicHakemus.toHakemus(hakemusData)
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    data class BasicHakemus(
+        val id: Long,
+        val alluid: Int?,
+        val alluStatus: ApplicationStatus?,
+        val applicationIdentifier: String?,
+        val applicationType: ApplicationType,
+        val hankeTunnus: String,
+        val hankeId: Int,
+    ) {
+        fun toHakemus(hakemusData: HakemusData) =
+            Hakemus(
+                id,
+                alluid,
+                alluStatus,
+                applicationIdentifier,
+                applicationType,
+                hakemusData,
+                hankeTunnus,
+                hankeId,
+            )
+    }
+}

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/test/JacksonTestExtension.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/test/JacksonTestExtension.kt
@@ -1,0 +1,34 @@
+package fi.hel.haitaton.hanke.test
+
+import com.fasterxml.jackson.databind.module.SimpleModule
+import fi.hel.haitaton.hanke.OBJECT_MAPPER
+import fi.hel.haitaton.hanke.hakemus.Hakemus
+import fi.hel.haitaton.hanke.hakemus.HakemusDeserializer
+import org.junit.jupiter.api.extension.BeforeAllCallback
+import org.junit.jupiter.api.extension.ExtensionContext
+
+/**
+ * Extension for customizing Jackson for test use. E.g. deserializing abstract classes we don't want
+ * to deserialize in production code.
+ *
+ * Tests that extend [fi.hel.haitaton.hanke.IntegrationTest] or
+ * [fi.hel.haitaton.hanke.ControllerTest] have this extension enabled by default. Others can use it
+ * by annotating the test class with:
+ * ```
+ * @ExtendWith(JacksonTestExtension::class)
+ * ```
+ */
+class JacksonTestExtension : BeforeAllCallback {
+
+    override fun beforeAll(context: ExtensionContext) {
+        if (started) return
+
+        val module = SimpleModule()
+        module.addDeserializer(Hakemus::class.java, HakemusDeserializer())
+        OBJECT_MAPPER.registerModule(module)
+    }
+
+    companion object {
+        private var started = false
+    }
+}


### PR DESCRIPTION
# Description

Add audit logging for hakemus creation.

Also, make hakemus updates use the Hakemus type for audit logging updates.

Add a custom deserializer for Hakemus for test use. This allows Jackson to deserialize Hakemus correctly, by using the `applicationType` field to deduce which kind of `applicationData` field it should have. Deserializing wouldn't be very useful for production code, but in tests, we will encounter situations where we want to deserialize a response for inspections.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2275

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
After creating a new johtoselvityshakemus, the audit log table should have a HAKEMUS type log entry.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 