### PR TITLE
HAI-2301 Add a missing exception handler

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HankekayttajaDeleteServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HankekayttajaDeleteServiceITest.kt
@@ -287,7 +287,7 @@ class HankekayttajaDeleteServiceITest(
                 .single()
                 .prop(Yhteyshenkilo::id)
                 .isNotEqualTo(founder.id)
-            assertThat(hakemusService.hakemusResponse(draftHakemus.id!!))
+            assertThat(hakemusService.hakemusResponse(draftHakemus.id))
                 .isNotNull()
                 .prop(HakemusResponse::applicationData)
                 .prop(HakemusDataResponse::customerWithContacts)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusController.kt
@@ -5,6 +5,7 @@ import fi.hel.haitaton.hanke.HankeErrorDetail
 import fi.hel.haitaton.hanke.HankeService
 import fi.hel.haitaton.hanke.application.ApplicationAlreadySentException
 import fi.hel.haitaton.hanke.application.ApplicationGeometryException
+import fi.hel.haitaton.hanke.application.ApplicationGeometryNotInsideHankeException
 import fi.hel.haitaton.hanke.currentUserId
 import fi.hel.haitaton.hanke.domain.CreateHankeRequest
 import fi.hel.haitaton.hanke.logging.DisclosureLogService
@@ -227,6 +228,16 @@ class HakemusController(
     fun applicationGeometryException(ex: ApplicationGeometryException): HankeError {
         logger.warn(ex) { ex.message }
         return HankeError.HAI2005
+    }
+
+    @ExceptionHandler(ApplicationGeometryNotInsideHankeException::class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @Hidden
+    fun applicationGeometryNotInsideHankeException(
+        ex: ApplicationGeometryNotInsideHankeException
+    ): HankeError {
+        logger.warn(ex) { ex.message }
+        return HankeError.HAI2007
     }
 
     @ExceptionHandler(InvalidHakemusyhteystietoException::class)

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusBuilder.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusBuilder.kt
@@ -8,6 +8,8 @@ import fi.hel.haitaton.hanke.application.ApplicationRepository
 import fi.hel.haitaton.hanke.application.ApplicationType
 import fi.hel.haitaton.hanke.application.CableReportApplicationData
 import fi.hel.haitaton.hanke.application.ExcavationNotificationApplicationData
+import fi.hel.haitaton.hanke.hakemus.Hakemus
+import fi.hel.haitaton.hanke.hakemus.HakemusService
 import fi.hel.haitaton.hanke.hakemus.HakemusyhteyshenkiloEntity
 import fi.hel.haitaton.hanke.hakemus.HakemusyhteyshenkiloRepository
 import fi.hel.haitaton.hanke.hakemus.Hakemusyhteystieto
@@ -22,6 +24,7 @@ data class HakemusBuilder(
     private var applicationEntity: ApplicationEntity,
     private val userId: String,
     private val hakemusFactory: HakemusFactory,
+    private val hakemusService: HakemusService,
     private val hankeKayttajaService: HankeKayttajaService,
     private val applicationRepository: ApplicationRepository,
     private val hankeRepository: HankeRepository,
@@ -29,7 +32,9 @@ data class HakemusBuilder(
     private val hakemusyhteystietoRepository: HakemusyhteystietoRepository,
     private val hakemusyhteyshenkiloRepository: HakemusyhteyshenkiloRepository,
 ) {
-    fun save(): ApplicationEntity {
+    fun save(): Hakemus = hakemusService.getById(saveEntity().id!!)
+
+    fun saveEntity(): ApplicationEntity {
         val savedApplication = applicationRepository.save(applicationEntity)
         savedApplication.yhteystiedot.forEach { (_, yhteystieto) ->
             yhteystieto.yhteyshenkilot.forEach { yhteyshenkilo ->

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusFactory.kt
@@ -11,6 +11,7 @@ import fi.hel.haitaton.hanke.application.ApplicationType
 import fi.hel.haitaton.hanke.application.PostalAddress
 import fi.hel.haitaton.hanke.hakemus.Hakemus
 import fi.hel.haitaton.hanke.hakemus.HakemusData
+import fi.hel.haitaton.hanke.hakemus.HakemusService
 import fi.hel.haitaton.hanke.hakemus.HakemusyhteyshenkiloRepository
 import fi.hel.haitaton.hanke.hakemus.Hakemusyhteystieto
 import fi.hel.haitaton.hanke.hakemus.HakemusyhteystietoRepository
@@ -23,6 +24,7 @@ import org.springframework.stereotype.Component
 @Component
 class HakemusFactory(
     private val hankeKayttajaService: HankeKayttajaService,
+    private val hakemusService: HakemusService,
     private val applicationRepository: ApplicationRepository,
     private val hankeRepository: HankeRepository,
     private val hakemusyhteystietoRepository: HakemusyhteystietoRepository,
@@ -39,6 +41,7 @@ class HakemusFactory(
             applicationEntity,
             userId,
             this,
+            hakemusService,
             hankeKayttajaService,
             applicationRepository,
             hankeRepository,


### PR DESCRIPTION
# Description

HakemusController is missing an exception handler for `ApplicationGeometryNotInsideHankeException`. Add the missing handler.

Clean up HakemusControllerITest a bit while adding a test for the new exception handler.

Rename `save()` to `saveEntity()` in HankeBuilder to match the naming conventions elsewhere. Add a new `save()` that returns Hakemus instead of the entity. Use the new `save()` wherever it doesn't cause problems.

Add `getById()` to HakemusService, which returns a Hakemus domain object. Use it in the `HakemusResponse` method. Replace the `hakemusResponseWithYhteystiedot()` by converting the entity to Hakemus first and then calling `Hakemus.toResponse()`.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2301

## Type of change

- [X] Bug fix 
- [ ] New feature 
- [ ] Other

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 