### PR TITLE
HAI-2301 API for sending hakemus to Allu

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationControllerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationControllerITest.kt
@@ -11,7 +11,9 @@ import fi.hel.haitaton.hanke.HankeNotFoundException
 import fi.hel.haitaton.hanke.HankeService
 import fi.hel.haitaton.hanke.IntegrationTestConfiguration
 import fi.hel.haitaton.hanke.OBJECT_MAPPER
+import fi.hel.haitaton.hanke.allu.ApplicationStatus
 import fi.hel.haitaton.hanke.andReturnBody
+import fi.hel.haitaton.hanke.andReturnContent
 import fi.hel.haitaton.hanke.factory.ApplicationFactory
 import fi.hel.haitaton.hanke.factory.ApplicationFactory.Companion.withContacts
 import fi.hel.haitaton.hanke.factory.ApplicationFactory.Companion.withCustomerContacts
@@ -393,12 +395,12 @@ class ApplicationControllerITest(@Autowired override val mockMvc: MockMvc) : Con
                     )
                     .toCableReportWithoutHanke()
 
-            val result =
+            val response =
                 post("$BASE_URL/johtoselvitys", applicationInput)
                     .andExpect(status().isBadRequest)
-                    .andReturn()
+                    .andReturnContent()
 
-            assertThat(result.response.contentAsString)
+            assertThat(response)
                 .isEqualTo(
                     HankeErrorDetail(
                             HankeError.HAI2008,
@@ -441,10 +443,12 @@ class ApplicationControllerITest(@Autowired override val mockMvc: MockMvc) : Con
                 )
             every { authorizer.authorizeApplicationId(id, EDIT_APPLICATIONS.name) } returns true
 
-            val result =
-                put("$BASE_URL/$id", application).andExpect(status().isBadRequest).andReturn()
+            val response =
+                put("$BASE_URL/$id", application)
+                    .andExpect(status().isBadRequest)
+                    .andReturnContent()
 
-            assertThat(result.response.contentAsString)
+            assertThat(response)
                 .isEqualTo(HankeErrorDetail(HankeError.HAI2008, listOf("endTime")).toJsonString())
             verify {
                 authorizer.authorizeApplicationId(id, EDIT_APPLICATIONS.name)
@@ -524,9 +528,11 @@ class ApplicationControllerITest(@Autowired override val mockMvc: MockMvc) : Con
             } throws InvalidApplicationDataException(mockErrorPaths)
 
             val response =
-                put("$BASE_URL/$id", application).andExpect(status().isBadRequest).andReturn()
+                put("$BASE_URL/$id", application)
+                    .andExpect(status().isBadRequest)
+                    .andReturnContent()
 
-            assertThat(response.response.contentAsString)
+            assertThat(response)
                 .isEqualTo(HankeErrorDetail(HankeError.HAI2008, mockErrorPaths).toJsonString())
             verifySequence {
                 authorizer.authorizeApplicationId(id, EDIT_APPLICATIONS.name)
@@ -551,7 +557,7 @@ class ApplicationControllerITest(@Autowired override val mockMvc: MockMvc) : Con
             every { authorizer.authorizeApplicationId(id, EDIT_APPLICATIONS.name) } returns true
             every {
                 applicationService.updateApplicationData(id, application.applicationData, USERNAME)
-            } throws ApplicationAlreadySentException(id, 21)
+            } throws ApplicationAlreadySentException(id, 21, ApplicationStatus.HANDLING)
 
             put("$BASE_URL/$id", application)
                 .andExpect(status().isConflict)
@@ -674,9 +680,11 @@ class ApplicationControllerITest(@Autowired override val mockMvc: MockMvc) : Con
                 InvalidApplicationDataException(mockErrorPaths)
 
             val response =
-                post("$BASE_URL/$id/send-application").andExpect(status().isBadRequest).andReturn()
+                post("$BASE_URL/$id/send-application")
+                    .andExpect(status().isBadRequest)
+                    .andReturnContent()
 
-            assertThat(response.response.contentAsString)
+            assertThat(response)
                 .isEqualTo(HankeErrorDetail(HankeError.HAI2008, mockErrorPaths).toJsonString())
             verifySequence {
                 authorizer.authorizeApplicationId(id, EDIT_APPLICATIONS.name)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeError.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeError.kt
@@ -42,6 +42,7 @@ enum class HankeError(val errorMessage: String) {
     HAI2009("Application is already sent to Allu, operation prohibited."),
     HAI2010("Application contains invalid customer"),
     HAI2011("Application contains invalid contact"),
+    HAI2012("User is not a contact on the application, operation forbidden"),
     HAI3001("Attachment upload failed"),
     HAI3002("Loading attachment failed"),
     HAI3003("Attachment limit reached"),

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationService.kt
@@ -136,7 +136,11 @@ class ApplicationService(
         val previousApplication = application.toApplication()
 
         application.alluid?.let {
-            throw ApplicationAlreadySentException(application.id, application.alluid)
+            throw ApplicationAlreadySentException(
+                application.id,
+                application.alluid,
+                application.alluStatus
+            )
         } ?: logger.info("Updating application id=$id")
 
         if (previousApplication.applicationData == newApplicationData) {
@@ -445,7 +449,7 @@ class ApplicationService(
         }
     }
 
-    private fun checkApplicationAreasInsideHankealue(
+    fun checkApplicationAreasInsideHankealue(
         hankeId: Int,
         areas: List<ApplicationArea>,
         customMessageOnFailure: (ApplicationArea) -> String
@@ -737,11 +741,11 @@ class IncompatibleApplicationException(
 class ApplicationNotFoundException(id: Long) :
     RuntimeException("Application not found with id $id")
 
-class ApplicationAlreadySentException(id: Long?, alluid: Int?) :
-    RuntimeException("Application is already sent to Allu, id=$id, alluid=$alluid")
+class ApplicationAlreadySentException(id: Long?, alluid: Int?, status: ApplicationStatus?) :
+    RuntimeException("Application is already sent to Allu, id=$id, alluId=$alluid, status=$status")
 
 class ApplicationAlreadyProcessingException(id: Long?, alluid: Int?) :
-    RuntimeException("Application is no longer pending in Allu, id=$id, alluid=$alluid")
+    RuntimeException("Application is no longer pending in Allu, id=$id, alluId=$alluid")
 
 class ApplicationGeometryException(message: String) : RuntimeException(message)
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusDataMapper.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusDataMapper.kt
@@ -1,0 +1,103 @@
+package fi.hel.haitaton.hanke.hakemus
+
+import fi.hel.haitaton.hanke.COORDINATE_SYSTEM_URN
+import fi.hel.haitaton.hanke.allu.AlluCableReportApplicationData
+import fi.hel.haitaton.hanke.allu.Contact
+import fi.hel.haitaton.hanke.allu.Customer
+import fi.hel.haitaton.hanke.allu.CustomerWithContacts
+import fi.hel.haitaton.hanke.application.AlluDataError.EMPTY_OR_NULL
+import fi.hel.haitaton.hanke.application.AlluDataError.NULL
+import fi.hel.haitaton.hanke.application.AlluDataException
+import fi.hel.haitaton.hanke.geometria.UnsupportedCoordinateSystemException
+import org.geojson.GeometryCollection
+import org.geojson.Polygon
+
+object HakemusDataMapper {
+
+    fun JohtoselvityshakemusData.toAlluData(hankeTunnus: String): AlluCableReportApplicationData {
+        val description = workDescription()
+        return AlluCableReportApplicationData(
+            name = name,
+            customerWithContacts =
+                customerWithContacts.orThrow(path("customerWithContacts")).toAlluData(),
+            geometry = this.getGeometries(),
+            startTime = startTime.orThrow(path("startTime")),
+            endTime = endTime.orThrow(path("endTime")),
+            pendingOnClient = pendingOnClient,
+            identificationNumber = hankeTunnus,
+            clientApplicationKind = description, // intentionally copied here
+            workDescription = description,
+            contractorWithContacts =
+                contractorWithContacts.orThrow(path("contractorWithContacts")).toAlluData(),
+            postalAddress = postalAddress?.toAlluData(),
+            representativeWithContacts = representativeWithContacts?.toAlluData(),
+            invoicingCustomer = null,
+            customerReference = null,
+            area = null,
+            propertyDeveloperWithContacts = propertyDeveloperWithContacts?.toAlluData(),
+            constructionWork = constructionWork,
+            maintenanceWork = maintenanceWork,
+            emergencyWork = emergencyWork,
+            propertyConnectivity = propertyConnectivity
+        )
+    }
+
+    /** If areas are missing, throw an exception. */
+    private fun HakemusData.getGeometries(): GeometryCollection {
+        if (areas.isNullOrEmpty()) {
+            throw AlluDataException(path("areas"), EMPTY_OR_NULL)
+        } else {
+            // Check that all polygons have the coordinate reference system Haitaton understands
+            areas!!
+                .map { it.geometry.crs?.properties?.get("name") }
+                .find { it.toString() != COORDINATE_SYSTEM_URN }
+                ?.let { throw UnsupportedCoordinateSystemException(it.toString()) }
+
+            return GeometryCollection().apply {
+                // Read coordinate reference system from the first polygon. Remove the CRS from
+                // all polygons and add it to the GeometryCollection.
+                this.crs = areas!!.first().geometry.crs!!
+                this.geometries =
+                    areas!!.map { area ->
+                        Polygon(area.geometry.exteriorRing).apply {
+                            this.crs = null
+                            area.geometry.interiorRings.forEach { this.addInteriorRing(it) }
+                        }
+                    }
+            }
+        }
+    }
+
+    private fun Hakemusyhteystieto.toAlluData(): CustomerWithContacts =
+        CustomerWithContacts(
+            Customer(
+                type = tyyppi,
+                name = nimi,
+                postalAddress = null,
+                country = "FI",
+                email = sahkoposti,
+                phone = puhelinnumero,
+                registryKey = ytunnus,
+                ovt = null,
+                invoicingOperator = null,
+                sapCustomerNumber = null,
+            ),
+            yhteyshenkilot.map { it.toAlluData() }
+        )
+
+    private fun Hakemusyhteyshenkilo.toAlluData() =
+        Contact("$etunimi $sukunimi".trim(), sahkoposti, puhelin, tilaaja)
+
+    private fun path(vararg field: String) =
+        field.joinToString(separator = ".", prefix = "applicationData.")
+
+    private fun <T> T?.orThrow(path: String) = this ?: throw AlluDataException(path, NULL)
+
+    private fun JohtoselvityshakemusData.workDescription(): String {
+        val excavation = rockExcavation.orThrow(path("rockExcavation"))
+        return workDescription + excavationText(excavation)
+    }
+
+    private fun excavationText(excavation: Boolean): String =
+        if (excavation) "\nLouhitaan" else "\nEi louhita"
+}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusDataValidator.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusDataValidator.kt
@@ -1,0 +1,24 @@
+package fi.hel.haitaton.hanke.hakemus
+
+import fi.hel.haitaton.hanke.validation.ValidationResult
+import fi.hel.haitaton.hanke.validation.Validators.validate
+
+object HakemusDataValidator {
+
+    fun ensureValidForSend(data: HakemusData): Boolean {
+        val result =
+            when (data) {
+                is JohtoselvityshakemusData ->
+                    validate { data.validateForErrors() }.and { data.validateForMissing() }
+            }
+
+        return result.okOrThrow()
+    }
+}
+
+private fun ValidationResult.okOrThrow(): Boolean {
+    if (isOk()) {
+        return true
+    }
+    throw InvalidHakemusDataException(errorPaths())
+}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusUpdateRequest.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusUpdateRequest.kt
@@ -57,7 +57,7 @@ data class JohtoselvityshakemusUpdateRequest(
     /** Työn nimi */
     override val name: String,
     /** Katuosoite */
-    val postalAddress: PostalAddressRequest,
+    val postalAddress: PostalAddressRequest?,
     /** Työssä on kyse: Uuden rakenteen tai johdon rakentamisesta */
     val constructionWork: Boolean,
     /** Työssä on kyse: Olemassaolevan rakenteen kunnossapitotyöstä */
@@ -96,7 +96,7 @@ data class JohtoselvityshakemusUpdateRequest(
     override fun hasChanges(applicationEntity: ApplicationEntity): Boolean {
         val applicationData = applicationEntity.applicationData as CableReportApplicationData
         return name != applicationData.name ||
-            (postalAddress.streetAddress.streetName ?: "") !=
+            (postalAddress?.streetAddress?.streetName ?: "") !=
                 (applicationData.postalAddress?.streetAddress?.streetName ?: "") ||
             constructionWork != applicationData.constructionWork ||
             maintenanceWork != applicationData.maintenanceWork ||
@@ -125,7 +125,7 @@ data class JohtoselvityshakemusUpdateRequest(
         (baseData as CableReportApplicationData).copy(
             name = this.name,
             postalAddress =
-                PostalAddress(StreetAddress(this.postalAddress.streetAddress.streetName), "", ""),
+                PostalAddress(StreetAddress(this.postalAddress?.streetAddress?.streetName), "", ""),
             constructionWork = this.constructionWork,
             maintenanceWork = this.maintenanceWork,
             propertyConnectivity = this.propertyConnectivity,

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/Hakemusyhteystieto.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/Hakemusyhteystieto.kt
@@ -40,4 +40,6 @@ data class Hakemusyhteyshenkilo(
 ) {
     fun toResponse(): ContactResponse =
         ContactResponse(hankekayttajaId, etunimi, sukunimi, sahkoposti, puhelin, tilaaja)
+
+    fun kokoNimi() = "$etunimi $sukunimi".trim()
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/JohtoselvityshakemusErrorValidation.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/JohtoselvityshakemusErrorValidation.kt
@@ -1,0 +1,53 @@
+package fi.hel.haitaton.hanke.hakemus
+
+import fi.hel.haitaton.hanke.application.PostalAddress
+import fi.hel.haitaton.hanke.isValidBusinessId
+import fi.hel.haitaton.hanke.validation.ValidationResult
+import fi.hel.haitaton.hanke.validation.Validators.isBeforeOrEqual
+import fi.hel.haitaton.hanke.validation.Validators.notJustWhitespace
+import fi.hel.haitaton.hanke.validation.Validators.validate
+import fi.hel.haitaton.hanke.validation.Validators.validateFalse
+import fi.hel.haitaton.hanke.validation.Validators.validateTrue
+
+/** Validate draft application. Checks only fields that have some actual data. */
+fun JohtoselvityshakemusData.validateForErrors(): ValidationResult =
+    validate { notJustWhitespace(name, "name") }
+        .and { notJustWhitespace(workDescription, "workDescription") }
+        .and { atMostOneOrderer(yhteystiedot()) }
+        .andWhen(startTime != null && endTime != null) {
+            isBeforeOrEqual(startTime!!, endTime!!, "endTime")
+        }
+        .whenNotNull(postalAddress) { it.validateForErrors("postalAddress") }
+        .whenNotNull(customerWithContacts) { it.validateForErrors("customerWithContacts") }
+        .whenNotNull(contractorWithContacts) { it.validateForErrors("contractorWithContacts") }
+        .whenNotNull(representativeWithContacts) {
+            it.validateForErrors("representativeWithContacts")
+        }
+        .whenNotNull(propertyDeveloperWithContacts) {
+            it.validateForErrors("propertyDeveloperWithContacts")
+        }
+
+private fun Hakemusyhteystieto.validateForErrors(path: String): ValidationResult =
+    validate { notJustWhitespace(nimi, "$path.nimi") }
+        .and { notJustWhitespace(sahkoposti, "$path.sahkoposti") }
+        .and { notJustWhitespace(puhelinnumero, "$path.puhelinnumero") }
+        .whenNotNull(ytunnus) { validateTrue(it.isValidBusinessId(), "$path.ytunnus") }
+        .andAllIn(yhteyshenkilot, "$path.yhteyshenkilot", ::validateContactForErrors)
+
+private fun validateContactForErrors(yhteyshenkilo: Hakemusyhteyshenkilo, path: String) =
+    with(yhteyshenkilo) {
+        validate { notJustWhitespace(etunimi, "$path.etunimi") }
+            .and { notJustWhitespace(sukunimi, "$path.sukunimi") }
+            .and { notJustWhitespace(sahkoposti, "$path.sahkoposti") }
+            .and { notJustWhitespace(puhelin, "$path.puhelin") }
+    }
+
+private fun PostalAddress.validateForErrors(path: String) =
+    validate { notJustWhitespace(postalCode, "$path.postalCode") }
+        .and { notJustWhitespace(city, "$path.city") }
+        .and { notJustWhitespace(streetAddress.streetName, "$path.streetAddress.streetName") }
+
+private fun atMostOneOrderer(yhteystiedot: List<Hakemusyhteystieto>): ValidationResult =
+    validateFalse(yhteystiedot.tilaajaCount() > 1, "customersWithContacts[].contacts[].orderer")
+
+fun List<Hakemusyhteystieto>.tilaajaCount() = flatMap { it.yhteyshenkilot }.count { it.tilaaja }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/JohtoselvityshakemusMissingValidation.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/JohtoselvityshakemusMissingValidation.kt
@@ -1,0 +1,36 @@
+package fi.hel.haitaton.hanke.hakemus
+
+import fi.hel.haitaton.hanke.validation.ValidationResult
+import fi.hel.haitaton.hanke.validation.Validators.notBlank
+import fi.hel.haitaton.hanke.validation.Validators.notNull
+import fi.hel.haitaton.hanke.validation.Validators.notNullOrBlank
+import fi.hel.haitaton.hanke.validation.Validators.validate
+
+/**
+ * Validate required field are set. When application is a draft, it is ok to have fields that are
+ * not yet defined. But e.g. when sending, they must be present.
+ */
+fun JohtoselvityshakemusData.validateForMissing(): ValidationResult =
+    validate { notBlank(name, "name") }
+        .and { notNullOrBlank(workDescription, "workDescription") }
+        .and { notNull(startTime, "startTime") }
+        .and { notNull(endTime, "endTime") }
+        .and { notNull(areas, "areas") }
+        .and { notNull(rockExcavation, "rockExcavation") }
+        .andWithNotNull(customerWithContacts, "customerWithContacts") { validateForMissing(it) }
+        .andWithNotNull(contractorWithContacts, "contractorWithContacts") { validateForMissing(it) }
+        .whenNotNull(representativeWithContacts) {
+            it.validateForMissing("representativeWithContacts")
+        }
+        .whenNotNull(propertyDeveloperWithContacts) {
+            it.validateForMissing("propertyDeveloperWithContacts")
+        }
+
+private fun Hakemusyhteystieto.validateForMissing(path: String): ValidationResult =
+    validate { notNull(tyyppi, "$path.tyyppi") }
+        .and { notBlank(nimi, "$path.nimi") }
+        .andAllIn(yhteyshenkilot, "$path.yhteyshenkilot", ::validateForMissing)
+
+private fun validateForMissing(contact: Hakemusyhteyshenkilo, path: String) = validate {
+    notBlank(contact.kokoNimi(), "$path.firstName")
+}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/validation/Validators.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/validation/Validators.kt
@@ -106,6 +106,12 @@ private constructor(private val errorPaths: MutableList<String> = mutableListOf(
         f: (T).(String) -> ValidationResult
     ): ValidationResult = if (value != null) this.and { value.f(path) } else and { failure(path) }
 
+    fun <T> andNotNull(
+        value: T?,
+        path: String,
+        f: (T, String) -> ValidationResult
+    ): ValidationResult = if (value != null) this.and { f(value, path) } else and { failure(path) }
+
     /** Check run the validation lambda only if the pre-condition is true. */
     fun andWhen(condition: Boolean, f: () -> ValidationResult): ValidationResult =
         if (condition) this.and(f) else this

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/TestExtensions.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/TestExtensions.kt
@@ -22,7 +22,10 @@ inline fun <reified T : Any> String.asJsonResource(): T =
 
 /** Read the response body from a MockMvc result and deserialize from JSON. */
 inline fun <reified T> ResultActions.andReturnBody(): T =
-    OBJECT_MAPPER.readValue(andReturn().response.getContentAsString(StandardCharsets.UTF_8))
+    OBJECT_MAPPER.readValue(andReturnContent())
+
+fun ResultActions.andReturnContent(): String =
+    andReturn().response.getContentAsString(StandardCharsets.UTF_8)
 
 fun String.getResourceAsBytes(): ByteArray = this.getResource().readBytes()
 

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceTest.kt
@@ -254,7 +254,8 @@ class ApplicationServiceTest {
                     applicationService.updateApplicationData(3, updatedData, USERNAME)
                 }
 
-            assertThat(exception).hasMessage("Application is already sent to Allu, id=3, alluid=42")
+            assertThat(exception)
+                .hasMessage("Application is already sent to Allu, id=3, alluId=42, status=null")
             verifySequence { applicationRepository.findOneById(3) }
             verifyAll {
                 disclosureLogService wasNot Called

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/ApplicationFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/ApplicationFactory.kt
@@ -37,6 +37,7 @@ class ApplicationFactory(
         const val DEFAULT_APPLICATION_ID: Long = 1
         const val DEFAULT_APPLICATION_NAME: String = "Hakemuksen oletusnimi"
         const val DEFAULT_APPLICATION_IDENTIFIER: String = "JS230014"
+        const val DEFAULT_WORK_DESCRIPTION: String = "Työn kuvaus."
         const val TEPPO = "Teppo"
         const val TESTIHENKILO = "Testihenkilö"
         const val TEPPO_EMAIL = "teppo@example.test"
@@ -143,7 +144,7 @@ class ApplicationFactory(
             startTime: ZonedDateTime? = DateFactory.getStartDatetime(),
             endTime: ZonedDateTime? = DateFactory.getEndDatetime(),
             pendingOnClient: Boolean = false,
-            workDescription: String = "Työn kuvaus.",
+            workDescription: String = DEFAULT_WORK_DESCRIPTION,
             customerWithContacts: CustomerWithContacts =
                 createCompanyCustomer().withContacts(createContact(orderer = true)),
             contractorWithContacts: CustomerWithContacts =
@@ -206,16 +207,23 @@ class ApplicationFactory(
                     createExcavationNotificationApplicationData()
             }
 
+        fun createBlankApplicationData(applicationType: ApplicationType): ApplicationData =
+            when (applicationType) {
+                ApplicationType.CABLE_REPORT -> createBlankCableReportApplicationData()
+                ApplicationType.EXCAVATION_NOTIFICATION ->
+                    createBlankExcavationNotificationApplicationData()
+            }
+
         fun createCableReportApplicationData(
             name: String = DEFAULT_APPLICATION_NAME,
             areas: List<ApplicationArea>? = listOf(createApplicationArea()),
             startTime: ZonedDateTime? = DateFactory.getStartDatetime(),
             endTime: ZonedDateTime? = DateFactory.getEndDatetime(),
             pendingOnClient: Boolean = false,
-            workDescription: String = "Työn kuvaus.",
-            customerWithContacts: CustomerWithContacts =
+            workDescription: String = DEFAULT_WORK_DESCRIPTION,
+            customerWithContacts: CustomerWithContacts? =
                 createCompanyCustomer().withContacts(createContact(orderer = true)),
-            contractorWithContacts: CustomerWithContacts =
+            contractorWithContacts: CustomerWithContacts? =
                 createCompanyCustomer().withContacts(createContact()),
             representativeWithContacts: CustomerWithContacts? = null,
             propertyDeveloperWithContacts: CustomerWithContacts? = null,
@@ -236,6 +244,22 @@ class ApplicationFactory(
                 propertyDeveloperWithContacts = propertyDeveloperWithContacts,
                 rockExcavation = rockExcavation,
                 postalAddress = postalAddress,
+            )
+
+        internal fun createBlankCableReportApplicationData() =
+            createCableReportApplicationData(
+                name = "",
+                areas = null,
+                startTime = null,
+                endTime = null,
+                pendingOnClient = false,
+                workDescription = "",
+                customerWithContacts = null,
+                contractorWithContacts = null,
+                representativeWithContacts = null,
+                propertyDeveloperWithContacts = null,
+                rockExcavation = false,
+                postalAddress = PostalAddress(StreetAddress(""), "", "")
             )
 
         fun createExcavationNotificationApplicationData(
@@ -284,27 +308,6 @@ class ApplicationFactory(
                 invoicingCustomer = invoicingCustomer,
                 customerReference = customerReference,
                 additionalInfo = additionalInfo,
-            )
-
-        fun createBlankApplicationData(applicationType: ApplicationType): ApplicationData =
-            when (applicationType) {
-                ApplicationType.CABLE_REPORT -> createBlankCableReportApplicationData()
-                ApplicationType.EXCAVATION_NOTIFICATION ->
-                    createBlankExcavationNotificationApplicationData()
-            }
-
-        internal fun createBlankCableReportApplicationData() =
-            createCableReportApplicationData(
-                name = "",
-                workDescription = "",
-                startTime = null,
-                endTime = null,
-                areas = null,
-                customerWithContacts =
-                    CustomerWithContacts(Customer(null, "", null, null, null), listOf()),
-                contractorWithContacts =
-                    CustomerWithContacts(Customer(null, "", null, null, null), listOf()),
-                postalAddress = PostalAddress(StreetAddress(""), "", "")
             )
 
         internal fun createBlankExcavationNotificationApplicationData() =

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusResponseFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusResponseFactory.kt
@@ -41,7 +41,7 @@ object HakemusResponseFactory {
         name: String = ApplicationFactory.DEFAULT_APPLICATION_NAME,
         postalAddress: PostalAddress = PostalAddress(StreetAddress(DEFAULT_STREET_NAME), "", ""),
         rockExcavation: Boolean = false,
-        workDescription: String = "Work description.",
+        workDescription: String = ApplicationFactory.DEFAULT_WORK_DESCRIPTION,
         startTime: ZonedDateTime? = DateFactory.getStartDatetime(),
         endTime: ZonedDateTime? = DateFactory.getEndDatetime(),
         areas: List<ApplicationArea> = listOf(ApplicationFactory.createApplicationArea()),

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusUpdateRequestFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusUpdateRequestFactory.kt
@@ -7,6 +7,7 @@ import fi.hel.haitaton.hanke.application.StreetAddress
 import fi.hel.haitaton.hanke.hakemus.ContactRequest
 import fi.hel.haitaton.hanke.hakemus.CustomerRequest
 import fi.hel.haitaton.hanke.hakemus.CustomerWithContactsRequest
+import fi.hel.haitaton.hanke.hakemus.Hakemus
 import fi.hel.haitaton.hanke.hakemus.HakemusResponse
 import fi.hel.haitaton.hanke.hakemus.JohtoselvityshakemusUpdateRequest
 import fi.hel.haitaton.hanke.hakemus.PostalAddressRequest
@@ -154,8 +155,8 @@ object HakemusUpdateRequestFactory {
     fun JohtoselvityshakemusUpdateRequest.withWorkDescription(workDescription: String) =
         this.copy(workDescription = workDescription)
 
-    fun JohtoselvityshakemusUpdateRequest.withAreas(areas: List<ApplicationArea>) =
-        this.copy(areas = areas)
+    fun JohtoselvityshakemusUpdateRequest.withArea(area: ApplicationArea) =
+        this.copy(areas = (areas ?: listOf()) + area)
 
     fun JohtoselvityshakemusUpdateRequest.withTimes(
         startTime: ZonedDateTime?,
@@ -171,5 +172,8 @@ object HakemusUpdateRequestFactory {
         )
 
     fun HakemusResponse.toUpdateRequest(): JohtoselvityshakemusUpdateRequest =
+        this.applicationData.toJsonString().parseJson()
+
+    fun Hakemus.toUpdateRequest(): JohtoselvityshakemusUpdateRequest =
         this.applicationData.toJsonString().parseJson()
 }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeBuilder.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeBuilder.kt
@@ -92,6 +92,21 @@ data class HankeBuilder(
         return Pair(application, hanke)
     }
 
+    /**
+     * Save a hanke that has the generated field set. The hanke is created like it would be created
+     * for a stand-alone johtoselvityshakemus.
+     *
+     * This is the best way to create a hanke with generated = true, since [save] overwrites the
+     * generated tag during the update. Call through [HankeFactory.saveGenerated].
+     */
+    internal fun saveGenerated(
+        createRequest: CreateHankeRequest = HankeFactory.createRequest()
+    ): HankeEntity {
+        val hanke = hankeService.createHanke(createRequest, setUpProfiiliMocks())
+        val entity = hankeRepository.getReferenceById(hanke.id)
+        return hankeRepository.save(entity.apply { generated = true })
+    }
+
     fun saveWithYhteystiedot(f: HankeYhteystietoBuilder.() -> Unit): HankeEntity {
         val entity = saveEntity()
         val builder =

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeFactory.kt
@@ -69,6 +69,15 @@ class HankeFactory(
     fun saveWithAlue(userId: String = USERNAME): HankeEntity =
         builder(userId).withHankealue().saveEntity()
 
+    /**
+     * Save a hanke that has the generated field set. The hanke is created like it would be created
+     * for a stand-alone johtoselvityshakemus.
+     */
+    fun saveGenerated(
+        createRequest: CreateHankeRequest = createRequest(),
+        userId: String = USERNAME,
+    ): HankeEntity = builder(userId).saveGenerated(createRequest)
+
     fun builder(userId: String = USERNAME): HankeBuilder {
         val hanke =
             create(


### PR DESCRIPTION
# Description

Send the hakemus to Allu like before, except use Kortisto to get the customers and contacts. Also, set the orderer to be the user who does the sending. This means they have to be a contact on the application.

Disclosure logging and sending the form data PDF will be added in later PRs.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2301

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 