### PR TITLE
HAI-2301 Add disclosure logging to sending a hakemus to Allu

### DIFF
--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/AlluApplicationData.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/AlluApplicationData.kt
@@ -2,6 +2,7 @@ package fi.hel.haitaton.hanke.allu
 
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonInclude.Include
+import fi.hel.haitaton.hanke.application.ApplicationContactType
 import java.time.ZonedDateTime
 import org.geojson.GeometryCollection
 
@@ -21,6 +22,8 @@ sealed interface AlluApplicationData {
     val customerReference: String?
     val trafficArrangementImages: List<Int>?
     val clientApplicationKind: String
+
+    fun customersByRole(): Map<ApplicationContactType, CustomerWithContacts>
 }
 
 data class AlluCableReportApplicationData(
@@ -45,7 +48,16 @@ data class AlluCableReportApplicationData(
     override val invoicingCustomer: Customer? = null,
     override val customerReference: String? = null,
     override val trafficArrangementImages: List<Int>? = null,
-) : AlluApplicationData
+) : AlluApplicationData {
+    override fun customersByRole(): Map<ApplicationContactType, CustomerWithContacts> =
+        listOfNotNull(
+                customerWithContacts.let { ApplicationContactType.HAKIJA to it },
+                contractorWithContacts.let { ApplicationContactType.TYON_SUORITTAJA to it },
+                representativeWithContacts?.let { ApplicationContactType.ASIANHOITAJA to it },
+                propertyDeveloperWithContacts?.let { ApplicationContactType.RAKENNUTTAJA to it },
+            )
+            .toMap()
+}
 
 data class CableReportInformationRequestResponse(
     val applicationData: AlluCableReportApplicationData,
@@ -81,7 +93,16 @@ data class AlluExcavationNotificationData(
     override val trafficArrangementImages: List<Int>? = null,
     val trafficArrangements: String? = null,
     val trafficArrangementImpediment: TrafficArrangementImpediment? = null,
-) : AlluApplicationData
+) : AlluApplicationData {
+    override fun customersByRole(): Map<ApplicationContactType, CustomerWithContacts> =
+        listOfNotNull(
+                customerWithContacts.let { ApplicationContactType.HAKIJA to it },
+                contractorWithContacts.let { ApplicationContactType.TYON_SUORITTAJA to it },
+                representativeWithContacts?.let { ApplicationContactType.ASIANHOITAJA to it },
+                propertyDeveloperWithContacts?.let { ApplicationContactType.RAKENNUTTAJA to it },
+            )
+            .toMap()
+}
 
 enum class TrafficArrangementImpediment {
     NO_IMPEDIMENT,

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/AlluCommonDomain.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/AlluCommonDomain.kt
@@ -1,5 +1,6 @@
 package fi.hel.haitaton.hanke.allu
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonView
 import fi.hel.haitaton.hanke.ChangeLogView
@@ -13,7 +14,12 @@ data class Contact(
     val email: String?,
     val phone: String?,
     val orderer: Boolean = false
-)
+) {
+    /** Check if this contact is blank, i.e. it doesn't contain any actual contact information. */
+    @JsonIgnore fun isBlank() = listOf(name, email, phone).all { it.isNullOrBlank() }
+
+    fun hasInformation() = !isBlank()
+}
 
 /** Non-null fields are not mandatory in Allu. */
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -28,7 +34,22 @@ data class Customer(
     val invoicingOperator: String?, // e-invoicing operator code
     val country: String, // ISO 3166-1 alpha-2 country code
     val sapCustomerNumber: String? // customer's sap number
-)
+) {
+    /**
+     * Check if this customer contains any actual personal information.
+     *
+     * Country alone isn't considered personal information when it's dissociated from other
+     * information, so it's not checked here.
+     */
+    fun hasPersonalInformation() =
+        !(name.isBlank() &&
+            email.isNullOrBlank() &&
+            phone.isNullOrBlank() &&
+            registryKey.isNullOrBlank() &&
+            ovt.isNullOrBlank() &&
+            invoicingOperator.isNullOrBlank() &&
+            sapCustomerNumber.isNullOrBlank())
+}
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class PostalAddress(

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationService.kt
@@ -6,6 +6,7 @@ import fi.hel.haitaton.hanke.HankeNotFoundException
 import fi.hel.haitaton.hanke.HankeRepository
 import fi.hel.haitaton.hanke.HankealueService
 import fi.hel.haitaton.hanke.allu.AlluApplicationResponse
+import fi.hel.haitaton.hanke.allu.AlluCableReportApplicationData
 import fi.hel.haitaton.hanke.allu.AlluLoginException
 import fi.hel.haitaton.hanke.allu.AlluStatusRepository
 import fi.hel.haitaton.hanke.allu.ApplicationHistory
@@ -616,9 +617,7 @@ class ApplicationService(
         val alluData = cableReport.toAlluData(hankeTunnus)
 
         return withFormDataPdfUploading(cableReport) {
-            withDisclosureLogging(applicationId, cableReport) {
-                cableReportService.create(alluData)
-            }
+            withDisclosureLogging(applicationId, alluData) { cableReportService.create(alluData) }
         }
     }
 
@@ -631,7 +630,7 @@ class ApplicationService(
         val alluData = cableReport.toAlluData(hankeTunnus)
 
         withFormDataPdfUploading(cableReport) {
-            withDisclosureLogging(applicationId, cableReport) {
+            withDisclosureLogging(applicationId, alluData) {
                 cableReportService.update(alluId, alluData)
             }
             alluId
@@ -694,7 +693,7 @@ class ApplicationService(
      */
     private fun <T> withDisclosureLogging(
         applicationId: Long,
-        cableReportApplicationData: CableReportApplicationData,
+        cableReportApplicationData: AlluCableReportApplicationData,
         f: () -> T,
     ): T {
         try {
@@ -709,7 +708,7 @@ class ApplicationService(
             // Since the login failed we didn't send the application itself, so logging not needed.
             throw e
         } catch (e: Throwable) {
-            // There was an exception outside logging, so there was at least an attempt to send the
+            // There was an exception outside login, so there was at least an attempt to send the
             // application to Allu. Allu might have read it and rejected it, so we should log this
             // as a disclosure event.
             disclosureLogService.saveDisclosureLogsForAllu(

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusyhteystietoValidation.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusyhteystietoValidation.kt
@@ -35,9 +35,8 @@ internal fun exactlyOneOrderer(yhteystiedot: List<Hakemusyhteystieto>): Validati
     )
 
 internal fun Hakemusyhteystieto.validateForMissing(path: String): ValidationResult =
-    Validators.validate { Validators.notNull(tyyppi, "$path.tyyppi") }
-        .and { Validators.notBlank(nimi, "$path.nimi") }
+    Validators.validate { Validators.notBlank(nimi, "$path.nimi") }
         .andAllIn(yhteyshenkilot, "$path.yhteyshenkilot", ::validateForMissing)
 
 internal fun validateForMissing(contact: Hakemusyhteyshenkilo, path: String) =
-    Validators.validate { Validators.notBlank(contact.kokoNimi(), "$path.firstName") }
+    Validators.validate { Validators.notBlank(contact.kokoNimi(), "$path.etunimi") }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceTest.kt
@@ -313,7 +313,8 @@ class ApplicationServiceTest {
 
             applicationService.sendApplication(3, USERNAME)
 
-            val expectedApplication = applicationData.copy(pendingOnClient = false)
+            val expectedApplication =
+                applicationData.copy(pendingOnClient = false).toAlluData(hankeEntity.hankeTunnus)
             verifySequence {
                 applicationRepository.findOneById(3)
                 geometriatDao.isInsideHankeAlueet(1, any())
@@ -355,7 +356,8 @@ class ApplicationServiceTest {
 
             assertThrows<AlluException> { applicationService.sendApplication(3, USERNAME) }
 
-            val expectedApplication = applicationData.copy(pendingOnClient = false)
+            val expectedApplication =
+                applicationData.copy(pendingOnClient = false).toAlluData(hankeEntity.hankeTunnus)
             verifySequence {
                 applicationRepository.findOneById(3)
                 geometriatDao.isInsideHankeAlueet(1, any())
@@ -435,11 +437,7 @@ class ApplicationServiceTest {
                 geometriatDao.calculateCombinedArea(any())
                 geometriatDao.calculateArea(any())
                 cableReportService.create(expectedAlluData)
-                disclosureLogService.saveDisclosureLogsForAllu(
-                    3,
-                    expectedApplicationData,
-                    Status.SUCCESS
-                )
+                disclosureLogService.saveDisclosureLogsForAllu(3, any(), Status.SUCCESS)
                 cableReportService.addAttachment(852, any())
                 cableReportService.getApplicationInformation(852)
                 hankeKayttajaService.getKayttajaByUserId(1, USERNAME)
@@ -457,7 +455,7 @@ class ApplicationServiceTest {
             }
         }
 
-        @ParameterizedTest(name = "{1} {2}")
+        @ParameterizedTest(name = "{1}")
         @MethodSource("fi.hel.haitaton.hanke.application.ApplicationServiceTest#invalidData")
         fun `when invalid data should not send application`(
             applicationData: ApplicationData,

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/AuditLogEntryFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/AuditLogEntryFactory.kt
@@ -1,11 +1,13 @@
 package fi.hel.haitaton.hanke.factory
 
+import fi.hel.haitaton.hanke.allu.Contact as AlluContact
 import fi.hel.haitaton.hanke.application.ApplicationContactType
 import fi.hel.haitaton.hanke.application.Contact
 import fi.hel.haitaton.hanke.application.Customer
 import fi.hel.haitaton.hanke.domain.Hanke
 import fi.hel.haitaton.hanke.hakemus.ContactResponse
 import fi.hel.haitaton.hanke.hakemus.CustomerResponse
+import fi.hel.haitaton.hanke.logging.AlluContactWithRole
 import fi.hel.haitaton.hanke.logging.AuditLogEntry
 import fi.hel.haitaton.hanke.logging.ContactResponseWithRole
 import fi.hel.haitaton.hanke.logging.ContactWithRole
@@ -53,6 +55,17 @@ object AuditLogEntryFactory {
             objectId = applicationId,
             objectType = ObjectType.APPLICATION_CONTACT,
             objectBefore = ContactWithRole(role, contact).toJsonString()
+        )
+
+    fun createReadEntryForContact(
+        applicationId: Long,
+        contact: AlluContact,
+        role: ApplicationContactType = ApplicationContactType.HAKIJA,
+    ): AuditLogEntry =
+        createReadEntry(
+            objectId = applicationId,
+            objectType = ObjectType.ALLU_CONTACT,
+            objectBefore = AlluContactWithRole(role, contact).toJsonString()
         )
 
     fun createReadEntryForContactResponse(

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusyhteyshenkiloFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusyhteyshenkiloFactory.kt
@@ -52,4 +52,11 @@ object HakemusyhteyshenkiloFactory {
             hankekayttaja = hankekayttaja,
             tilaaja = tilaaja
         )
+
+    fun HakemusyhteystietoEntity.withYhteyshenkilo(
+        permission: PermissionEntity = PermissionFactory.createEntity()
+    ): HakemusyhteystietoEntity {
+        yhteyshenkilot.add(createEntity(permission = permission, hakemusyhteystieto = this))
+        return this
+    }
 }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceTest.kt
@@ -1,0 +1,470 @@
+package fi.hel.haitaton.hanke.hakemus
+
+import assertk.all
+import assertk.assertFailure
+import assertk.assertThat
+import assertk.assertions.hasClass
+import assertk.assertions.hasMessage
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isNull
+import assertk.assertions.isTrue
+import assertk.assertions.prop
+import assertk.assertions.single
+import fi.hel.haitaton.hanke.HankeRepository
+import fi.hel.haitaton.hanke.HankealueService
+import fi.hel.haitaton.hanke.allu.AlluCableReportApplicationData
+import fi.hel.haitaton.hanke.allu.AlluException
+import fi.hel.haitaton.hanke.allu.AlluLoginException
+import fi.hel.haitaton.hanke.allu.CableReportService
+import fi.hel.haitaton.hanke.allu.Contact
+import fi.hel.haitaton.hanke.allu.Customer
+import fi.hel.haitaton.hanke.allu.CustomerWithContacts
+import fi.hel.haitaton.hanke.application.ALLU_APPLICATION_ERROR_MSG
+import fi.hel.haitaton.hanke.application.ApplicationContactType
+import fi.hel.haitaton.hanke.application.ApplicationData
+import fi.hel.haitaton.hanke.application.ApplicationEntity
+import fi.hel.haitaton.hanke.application.ApplicationRepository
+import fi.hel.haitaton.hanke.application.CableReportApplicationData
+import fi.hel.haitaton.hanke.attachment.application.ApplicationAttachmentService
+import fi.hel.haitaton.hanke.factory.AlluFactory
+import fi.hel.haitaton.hanke.factory.ApplicationFactory
+import fi.hel.haitaton.hanke.factory.HakemusyhteyshenkiloFactory.withYhteyshenkilo
+import fi.hel.haitaton.hanke.factory.HakemusyhteystietoFactory
+import fi.hel.haitaton.hanke.factory.HankeFactory
+import fi.hel.haitaton.hanke.factory.PermissionFactory
+import fi.hel.haitaton.hanke.geometria.GeometriatDao
+import fi.hel.haitaton.hanke.logging.DisclosureLogService
+import fi.hel.haitaton.hanke.logging.HakemusLoggingService
+import fi.hel.haitaton.hanke.logging.Status
+import fi.hel.haitaton.hanke.permissions.HankeKayttajaService
+import fi.hel.haitaton.hanke.test.USERNAME
+import io.mockk.called
+import io.mockk.checkUnnecessaryStub
+import io.mockk.clearAllMocks
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import io.mockk.verifySequence
+import java.util.stream.Stream
+import org.geojson.Polygon
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.CsvSource
+import org.junit.jupiter.params.provider.MethodSource
+
+class HakemusServiceTest {
+    private val applicationRepository: ApplicationRepository = mockk()
+    private val hankeRepository: HankeRepository = mockk()
+    private val geometriatDao: GeometriatDao = mockk()
+    private val hankealueService: HankealueService = mockk()
+    private val loggingService: HakemusLoggingService = mockk(relaxUnitFun = true)
+    private val disclosureLogService: DisclosureLogService = mockk(relaxUnitFun = true)
+    private val hankeKayttajaService: HankeKayttajaService = mockk(relaxUnitFun = true)
+    private val attachmentService: ApplicationAttachmentService = mockk()
+    private val alluClient: CableReportService = mockk()
+
+    private val hakemusService =
+        HakemusService(
+            applicationRepository,
+            hankeRepository,
+            geometriatDao,
+            hankealueService,
+            loggingService,
+            disclosureLogService,
+            hankeKayttajaService,
+            attachmentService,
+            alluClient,
+        )
+
+    @BeforeEach
+    fun clearMocks() {
+        clearAllMocks()
+    }
+
+    @AfterEach
+    fun checkMocks() {
+        checkUnnecessaryStub()
+        confirmVerified(
+            applicationRepository,
+            hankeRepository,
+            geometriatDao,
+            hankealueService,
+            loggingService,
+            disclosureLogService,
+            hankeKayttajaService,
+            attachmentService,
+            alluClient,
+        )
+    }
+
+    @Nested
+    inner class SendApplication {
+        private val hankeTunnus = HankeFactory.defaultHankeTunnus
+        private val alluId = 42
+
+        @Test
+        fun `save disclosure logs when sending succeeds`() {
+            val applicationEntity = applicationEntity()
+            val hakija = applicationEntity.yhteystiedot[ApplicationContactType.HAKIJA]!!
+            val suorittaja =
+                applicationEntity.yhteystiedot[ApplicationContactType.TYON_SUORITTAJA]!!
+            every { applicationRepository.findOneById(3) } returns applicationEntity
+            every { applicationRepository.save(any()) } answers { firstArg() }
+            every { alluClient.create(any()) } returns alluId
+            every { alluClient.getApplicationInformation(alluId) } returns
+                AlluFactory.createAlluApplicationResponse()
+            every { geometriatDao.isInsideHankeAlueet(1, any()) } returns true
+            justRun { attachmentService.sendInitialAttachments(alluId, any()) }
+            val applicationCapturingSlot = slot<AlluCableReportApplicationData>()
+            justRun {
+                disclosureLogService.saveDisclosureLogsForAllu(
+                    3,
+                    capture(applicationCapturingSlot),
+                    Status.SUCCESS
+                )
+            }
+
+            hakemusService.sendHakemus(3, USERNAME)
+
+            val sent = applicationCapturingSlot.captured
+            assertThat(sent.identificationNumber).isEqualTo(hankeTunnus)
+            assertThat(sent.pendingOnClient).isFalse()
+            assertThat(sent.name).isEqualTo(applicationData.name)
+            assertThat(sent.postalAddress).isNull()
+            assertThat(sent.constructionWork).isFalse()
+            assertThat(sent.maintenanceWork).isFalse()
+            assertThat(sent.propertyConnectivity).isFalse()
+            assertThat(sent.emergencyWork).isFalse()
+            val expectedDescription = applicationData.workDescription + "\nEi louhita"
+            assertThat(sent.workDescription).isEqualTo(expectedDescription)
+            assertThat(sent.clientApplicationKind).isEqualTo(expectedDescription)
+            assertThat(sent.startTime).isEqualTo(applicationData.startTime)
+            assertThat(sent.endTime).isEqualTo(applicationData.endTime)
+            assertThat(sent.pendingOnClient).isFalse()
+            val expectedGeometry =
+                Polygon().apply {
+                    crs = null
+                    coordinates = applicationData.areas!![0].geometry.coordinates
+                }
+            assertThat(sent.geometry.geometries).single().isEqualTo(expectedGeometry)
+            assertThat(sent.area).isNull()
+            val hakijaYhteyshenkilo = hakija.yhteyshenkilot.single().hankekayttaja
+            assertThat(sent.customerWithContacts).all {
+                prop(CustomerWithContacts::customer).all {
+                    prop(Customer::type).isEqualTo(hakija.tyyppi)
+                    prop(Customer::name).isEqualTo(hakija.nimi)
+                    prop(Customer::postalAddress).isNull()
+                    prop(Customer::email).isEqualTo(hakija.sahkoposti)
+                    prop(Customer::phone).isEqualTo(hakija.puhelinnumero)
+                    prop(Customer::registryKey).isEqualTo(hakija.ytunnus)
+                    prop(Customer::ovt).isNull()
+                    prop(Customer::invoicingOperator).isNull()
+                    prop(Customer::country).isEqualTo("FI")
+                    prop(Customer::sapCustomerNumber).isNull()
+                }
+                prop(CustomerWithContacts::contacts).single().all {
+                    prop(Contact::name).isEqualTo(hakijaYhteyshenkilo.fullName())
+                    prop(Contact::email).isEqualTo(hakijaYhteyshenkilo.sahkoposti)
+                    prop(Contact::phone).isEqualTo(hakijaYhteyshenkilo.puhelin)
+                    prop(Contact::orderer).isTrue()
+                }
+            }
+            val suorittajaYhteyshenkilo = suorittaja.yhteyshenkilot.single().hankekayttaja
+            assertThat(sent.contractorWithContacts).all {
+                prop(CustomerWithContacts::customer).all {
+                    prop(Customer::type).isEqualTo(suorittaja.tyyppi)
+                    prop(Customer::name).isEqualTo(suorittaja.nimi)
+                    prop(Customer::postalAddress).isNull()
+                    prop(Customer::email).isEqualTo(suorittaja.sahkoposti)
+                    prop(Customer::phone).isEqualTo(suorittaja.puhelinnumero)
+                    prop(Customer::registryKey).isEqualTo(suorittaja.ytunnus)
+                    prop(Customer::ovt).isNull()
+                    prop(Customer::invoicingOperator).isNull()
+                    prop(Customer::country).isEqualTo("FI")
+                    prop(Customer::sapCustomerNumber).isNull()
+                }
+                prop(CustomerWithContacts::contacts).single().all {
+                    prop(Contact::name).isEqualTo(suorittajaYhteyshenkilo.fullName())
+                    prop(Contact::email).isEqualTo(suorittajaYhteyshenkilo.sahkoposti)
+                    prop(Contact::phone).isEqualTo(suorittajaYhteyshenkilo.puhelin)
+                    prop(Contact::orderer).isFalse()
+                }
+            }
+            assertThat(sent.propertyDeveloperWithContacts).isNull()
+            assertThat(sent.representativeWithContacts).isNull()
+            assertThat(sent.invoicingCustomer).isNull()
+            assertThat(sent.customerReference).isNull()
+            assertThat(sent.trafficArrangementImages).isNull()
+
+            verifySequence {
+                applicationRepository.findOneById(3)
+                geometriatDao.isInsideHankeAlueet(1, any())
+                alluClient.create(any())
+                disclosureLogService.saveDisclosureLogsForAllu(3, any(), Status.SUCCESS)
+                attachmentService.sendInitialAttachments(alluId, any())
+                alluClient.getApplicationInformation(alluId)
+                applicationRepository.save(any())
+            }
+        }
+
+        @Test
+        fun `saves disclosure logs when sending fails`() {
+            val applicationEntity = applicationEntity()
+            every { applicationRepository.findOneById(3) } returns applicationEntity
+            every { alluClient.create(any()) } throws AlluException(listOf())
+            every { geometriatDao.isInsideHankeAlueet(1, any()) } returns true
+
+            assertThrows<AlluException> { hakemusService.sendHakemus(3, USERNAME) }
+
+            verifySequence {
+                applicationRepository.findOneById(3)
+                geometriatDao.isInsideHankeAlueet(1, any())
+                alluClient.create(any())
+                disclosureLogService.saveDisclosureLogsForAllu(
+                    3,
+                    any(),
+                    Status.FAILED,
+                    ALLU_APPLICATION_ERROR_MSG
+                )
+            }
+        }
+
+        @Test
+        fun `does not save disclosure logs when allu login fails`() {
+            val applicationEntity = applicationEntity()
+            every { applicationRepository.findOneById(3) } returns applicationEntity
+            every { geometriatDao.isInsideHankeAlueet(any(), any()) } returns true
+            every { alluClient.create(any()) } throws AlluLoginException(RuntimeException())
+
+            assertThrows<AlluLoginException> { hakemusService.sendHakemus(3, USERNAME) }
+
+            verifySequence {
+                applicationRepository.findOneById(3)
+                geometriatDao.isInsideHankeAlueet(any(), any())
+                alluClient.create(any())
+            }
+            verify { disclosureLogService wasNot called }
+        }
+
+        @ParameterizedTest
+        @CsvSource("true,Louhitaan", "false,Ei louhita")
+        fun `adds rock excavation information to work description`(
+            rockExcavation: Boolean,
+            expectedSuffix: String
+        ) {
+            val applicationEntity = applicationEntity()
+            applicationEntity.applicationData =
+                (applicationEntity.applicationData as CableReportApplicationData).copy(
+                    rockExcavation = rockExcavation
+                )
+            every { applicationRepository.findOneById(3) } returns applicationEntity
+            every { applicationRepository.save(any()) } answers { firstArg() }
+            every { geometriatDao.isInsideHankeAlueet(1, any()) } returns true
+            val applicationCapturingSlot = slot<AlluCableReportApplicationData>()
+            every { alluClient.create(capture(applicationCapturingSlot)) } returns alluId
+            every { alluClient.getApplicationInformation(alluId) } returns
+                AlluFactory.createAlluApplicationResponse(alluId)
+            justRun { attachmentService.sendInitialAttachments(alluId, any()) }
+
+            hakemusService.sendHakemus(3, USERNAME)
+
+            val sent = applicationCapturingSlot.captured
+            val expectedDescription = applicationData.workDescription + "\n" + expectedSuffix
+            assertThat(sent.workDescription).isEqualTo(expectedDescription)
+            assertThat(sent.clientApplicationKind).isEqualTo(expectedDescription)
+            verifySequence {
+                applicationRepository.findOneById(3)
+                geometriatDao.isInsideHankeAlueet(1, any())
+                alluClient.create(any())
+                disclosureLogService.saveDisclosureLogsForAllu(3, any(), Status.SUCCESS)
+                attachmentService.sendInitialAttachments(alluId, any())
+                alluClient.getApplicationInformation(alluId)
+                applicationRepository.save(any())
+            }
+        }
+
+        @ParameterizedTest(name = "{1}")
+        @MethodSource("fi.hel.haitaton.hanke.hakemus.HakemusServiceTest#invalidData")
+        fun `throws exception when application has invalid data`(
+            applicationData: ApplicationData,
+            path: String,
+        ) {
+            val applicationEntity = applicationEntity()
+            applicationEntity.applicationData = applicationData
+            every { applicationRepository.findOneById(3) } returns applicationEntity
+            every { geometriatDao.isInsideHankeAlueet(1, any()) } returns true
+
+            assertFailure { hakemusService.sendHakemus(3, USERNAME) }
+                .all {
+                    hasClass(InvalidHakemusDataException::class)
+                    hasMessage("Application contains invalid data. Errors at paths: $path")
+                }
+
+            verifySequence {
+                applicationRepository.findOneById(3)
+                geometriatDao.isInsideHankeAlueet(1, any())
+            }
+        }
+
+        @Test
+        fun `throws exception when application has invalid customer`() {
+            val applicationEntity = applicationEntity()
+            applicationEntity.yhteystiedot[ApplicationContactType.HAKIJA]!!.nimi = ""
+            every { applicationRepository.findOneById(3) } returns applicationEntity
+            every { geometriatDao.isInsideHankeAlueet(1, any()) } returns true
+
+            assertFailure { hakemusService.sendHakemus(3, USERNAME) }
+                .all {
+                    hasClass(InvalidHakemusDataException::class)
+                    hasMessage(
+                        "Application contains invalid data. Errors at paths: applicationData.customerWithContacts.nimi"
+                    )
+                }
+
+            verifySequence {
+                applicationRepository.findOneById(3)
+                geometriatDao.isInsideHankeAlueet(1, any())
+            }
+        }
+
+        @Test
+        fun `throws exception when application has invalid contractor`() {
+            val applicationEntity = applicationEntity()
+            val yhteystieto = applicationEntity.yhteystiedot[ApplicationContactType.TYON_SUORITTAJA]
+            val hankekayttaja = yhteystieto!!.yhteyshenkilot[0].hankekayttaja
+            hankekayttaja.etunimi = ""
+            hankekayttaja.sukunimi = ""
+            every { applicationRepository.findOneById(3) } returns applicationEntity
+            every { geometriatDao.isInsideHankeAlueet(1, any()) } returns true
+
+            assertFailure { hakemusService.sendHakemus(3, USERNAME) }
+                .all {
+                    hasClass(InvalidHakemusDataException::class)
+                    hasMessage(
+                        "Application contains invalid data. Errors at paths: " +
+                            "applicationData.contractorWithContacts.yhteyshenkilot[0].etunimi"
+                    )
+                }
+
+            verifySequence {
+                applicationRepository.findOneById(3)
+                geometriatDao.isInsideHankeAlueet(1, any())
+            }
+        }
+
+        @Test
+        fun `throws exception when application has invalid property developer`() {
+            val applicationEntity = applicationEntity()
+            applicationEntity.yhteystiedot[ApplicationContactType.RAKENNUTTAJA] =
+                HakemusyhteystietoFactory.createEntity(
+                        application = applicationEntity,
+                        sahkoposti = "  "
+                    )
+                    .withYhteyshenkilo(
+                        permission = PermissionFactory.createEntity(userId = USERNAME)
+                    )
+            every { applicationRepository.findOneById(3) } returns applicationEntity
+            every { geometriatDao.isInsideHankeAlueet(1, any()) } returns true
+
+            assertFailure { hakemusService.sendHakemus(3, USERNAME) }
+                .all {
+                    hasClass(InvalidHakemusDataException::class)
+                    hasMessage(
+                        "Application contains invalid data. Errors at paths: " +
+                            "applicationData.propertyDeveloperWithContacts.sahkoposti"
+                    )
+                }
+
+            verifySequence {
+                applicationRepository.findOneById(3)
+                geometriatDao.isInsideHankeAlueet(1, any())
+            }
+        }
+
+        @Test
+        fun `throws exception when application has invalid representative`() {
+            val applicationEntity = applicationEntity()
+            applicationEntity.yhteystiedot[ApplicationContactType.ASIANHOITAJA] =
+                HakemusyhteystietoFactory.createEntity(
+                        application = applicationEntity,
+                        puhelinnumero = "  "
+                    )
+                    .withYhteyshenkilo(
+                        permission = PermissionFactory.createEntity(userId = USERNAME)
+                    )
+            every { applicationRepository.findOneById(3) } returns applicationEntity
+            every { geometriatDao.isInsideHankeAlueet(1, any()) } returns true
+
+            assertFailure { hakemusService.sendHakemus(3, USERNAME) }
+                .all {
+                    hasClass(InvalidHakemusDataException::class)
+                    hasMessage(
+                        "Application contains invalid data. Errors at paths: " +
+                            "applicationData.representativeWithContacts.puhelinnumero"
+                    )
+                }
+
+            verifySequence {
+                applicationRepository.findOneById(3)
+                geometriatDao.isInsideHankeAlueet(1, any())
+            }
+        }
+
+        private fun applicationEntity(): ApplicationEntity {
+            val hankeEntity = HankeFactory.createMinimalEntity(id = 1)
+            val applicationEntity =
+                ApplicationFactory.createApplicationEntity(
+                    userId = USERNAME,
+                    applicationData = applicationData,
+                    hanke = hankeEntity,
+                )
+            applicationEntity.yhteystiedot[ApplicationContactType.HAKIJA] =
+                HakemusyhteystietoFactory.createEntity(application = applicationEntity)
+                    .withYhteyshenkilo(
+                        permission = PermissionFactory.createEntity(userId = USERNAME)
+                    )
+            applicationEntity.yhteystiedot[ApplicationContactType.TYON_SUORITTAJA] =
+                HakemusyhteystietoFactory.createEntity(application = applicationEntity)
+                    .withYhteyshenkilo(
+                        permission = PermissionFactory.createEntity(userId = USERNAME)
+                    )
+            return applicationEntity
+        }
+    }
+
+    companion object {
+        private val applicationData: CableReportApplicationData =
+            ApplicationFactory.createCableReportApplicationData(
+                customerWithContacts = null,
+                contractorWithContacts = null,
+                propertyDeveloperWithContacts = null,
+                representativeWithContacts = null,
+            )
+
+        @JvmStatic
+        private fun invalidData(): Stream<Arguments> =
+            Stream.of(
+                Arguments.of(
+                    applicationData.copy(endTime = null),
+                    "applicationData.endTime",
+                ),
+                Arguments.of(
+                    applicationData.copy(startTime = null),
+                    "applicationData.startTime",
+                ),
+                Arguments.of(
+                    applicationData.copy(rockExcavation = null),
+                    "applicationData.rockExcavation",
+                ),
+            )
+    }
+}

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/test/AuditLogEntryAsserts.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/test/AuditLogEntryAsserts.kt
@@ -6,6 +6,7 @@ import assertk.assertions.isEqualTo
 import assertk.assertions.isNotNull
 import assertk.assertions.isNull
 import assertk.assertions.prop
+import fi.hel.haitaton.hanke.logging.ALLU_AUDIT_LOG_USERID
 import fi.hel.haitaton.hanke.logging.AuditLogEntry
 import fi.hel.haitaton.hanke.logging.ObjectType
 import fi.hel.haitaton.hanke.logging.Operation
@@ -24,6 +25,11 @@ object AuditLogEntryAsserts {
         prop(AuditLogEntry::userId).isEqualTo(userId)
     }
 
+    fun Assert<AuditLogEntry>.hasAlluActor() = all {
+        prop(AuditLogEntry::userRole).isEqualTo(UserRole.SERVICE)
+        prop(AuditLogEntry::userId).isEqualTo(ALLU_AUDIT_LOG_USERID)
+    }
+
     inline fun <reified T> Assert<AuditLogEntry>.hasObjectAfter(after: T) = hasObjectAfter {
         isEqualTo(after)
     }
@@ -36,8 +42,8 @@ object AuditLogEntryAsserts {
             .transform { it.parseJson<T>() }
             .all { body(this) }
 
-    inline fun <reified T> Assert<AuditLogEntry>.hasObjectBefore(after: T) = hasObjectBefore {
-        isEqualTo(after)
+    inline fun <reified T> Assert<AuditLogEntry>.hasObjectBefore(before: T) = hasObjectBefore {
+        isEqualTo(before)
     }
 
     inline fun <reified T> Assert<AuditLogEntry>.hasObjectBefore(


### PR DESCRIPTION
# Description

Use the Allu types when logging data sent to Allu, so we log the actual data being sent, not any Haitaton data representation.

There's a lot of duplication in DisclosureLogService in sending AlluApplicationData instead of ApplicationData. The methods handling ApplicationData can be removed soon when we remove ApplicationController.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2301

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 