### PR TITLE
HAI-2301 Add PDF generation

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceITest.kt
@@ -34,7 +34,6 @@ import fi.hel.haitaton.hanke.HankeRepository
 import fi.hel.haitaton.hanke.HankeService
 import fi.hel.haitaton.hanke.IntegrationTest
 import fi.hel.haitaton.hanke.allu.AlluCableReportApplicationData
-import fi.hel.haitaton.hanke.allu.AlluException
 import fi.hel.haitaton.hanke.allu.AlluStatusRepository
 import fi.hel.haitaton.hanke.allu.ApplicationStatus
 import fi.hel.haitaton.hanke.allu.ApplicationStatus.APPROVED
@@ -94,6 +93,7 @@ import fi.hel.haitaton.hanke.permissions.Kayttooikeustaso.HAKEMUSASIOINTI
 import fi.hel.haitaton.hanke.permissions.Kayttooikeustaso.KATSELUOIKEUS
 import fi.hel.haitaton.hanke.permissions.PermissionService
 import fi.hel.haitaton.hanke.permissions.kayttajaTunnistePattern
+import fi.hel.haitaton.hanke.test.AlluException
 import fi.hel.haitaton.hanke.test.Asserts.hasSingleGeometryWithCoordinates
 import fi.hel.haitaton.hanke.test.Asserts.isRecent
 import fi.hel.haitaton.hanke.test.AuditLogEntryEntityAsserts.hasUserActor
@@ -889,8 +889,7 @@ class ApplicationServiceITest : IntegrationTest() {
                 cableReportServiceAllu.create(pendingApplicationData.toAlluData(HANKE_TUNNUS))
             } returns 26
             justRun { cableReportServiceAllu.addAttachment(26, any()) }
-            every { cableReportServiceAllu.getApplicationInformation(26) } throws
-                AlluException(listOf())
+            every { cableReportServiceAllu.getApplicationInformation(26) } throws AlluException()
 
             val response = applicationService.sendApplication(application.id!!, USERNAME)
 
@@ -944,7 +943,7 @@ class ApplicationServiceITest : IntegrationTest() {
             every { cableReportServiceAllu.create(expectedAlluRequest) } returns alluId
             justRun { cableReportServiceAllu.addAttachment(alluId, any()) }
             every { cableReportServiceAllu.addAttachments(alluId, any(), any()) } throws
-                AlluException(listOf())
+                AlluException()
             justRun { cableReportServiceAllu.cancel(alluId) }
             every { cableReportServiceAllu.sendSystemComment(alluId, any()) } returns 4141
 
@@ -978,8 +977,7 @@ class ApplicationServiceITest : IntegrationTest() {
             val expectedAlluRequest = pendingApplicationData.toAlluData(HANKE_TUNNUS)
             val alluId = 467
             every { cableReportServiceAllu.create(expectedAlluRequest) } returns alluId
-            every { cableReportServiceAllu.addAttachment(alluId, any()) } throws
-                AlluException(listOf())
+            every { cableReportServiceAllu.addAttachment(alluId, any()) } throws AlluException()
             every { cableReportServiceAllu.getApplicationInformation(alluId) } returns
                 createAlluApplicationResponse(alluId)
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/CableReportService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/CableReportService.kt
@@ -114,10 +114,9 @@ class CableReportService(
 
     fun create(application: AlluApplicationData): Int =
         when (application) {
-            is AlluCableReportApplicationData ->
-                create(application, "/cablereports", "cable report")
+            is AlluCableReportApplicationData -> create(application, "cablereports", "cable report")
             is AlluExcavationNotificationData ->
-                create(application, "/excavationannouncements", "excavation announcement")
+                create(application, "excavationannouncements", "excavation announcement")
         }
 
     fun create(cableReport: AlluApplicationData, path: String, name: String): Int {
@@ -143,12 +142,12 @@ class CableReportService(
     fun update(alluApplicationId: Int, application: AlluApplicationData) {
         when (application) {
             is AlluCableReportApplicationData ->
-                update(alluApplicationId, application, "/cablereports", "cable report")
+                update(alluApplicationId, application, "cablereports", "cable report")
             is AlluExcavationNotificationData ->
                 update(
                     alluApplicationId,
                     application,
-                    "/excavationannouncements",
+                    "excavationannouncements",
                     "excavation announcement"
                 )
         }
@@ -434,12 +433,8 @@ data class Attachment(
     )
 }
 
-class AlluException(val errors: List<ErrorInfo>) : RuntimeException()
-
 class AlluLoginException(cause: Throwable) : RuntimeException(cause)
 
 /** Exception to use when Allu doesn't follow their API descriptions. */
 class AlluApiException(requestUri: String, message: String) :
     RuntimeException("$message, request URI: $requestUri")
-
-data class ErrorInfo(val errorMessage: String, val additionalInfo: String)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusPdfService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusPdfService.kt
@@ -1,0 +1,185 @@
+package fi.hel.haitaton.hanke.hakemus
+
+import com.lowagie.text.Chunk
+import com.lowagie.text.Document
+import com.lowagie.text.Element
+import com.lowagie.text.Font
+import com.lowagie.text.PageSize
+import com.lowagie.text.Paragraph
+import com.lowagie.text.Phrase
+import com.lowagie.text.Rectangle
+import com.lowagie.text.pdf.PdfPTable
+import com.lowagie.text.pdf.PdfWriter
+import fi.hel.haitaton.hanke.application.PostalAddress
+import java.io.ByteArrayOutputStream
+import java.time.ZoneId
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+
+/**
+ * Transform an application to a PDF. The PDF is added as an attachment when sending the application
+ * to Allu. It will be archived along the application and decision to show how the user inputted the
+ * application in Haitaton, as the data models of Haitaton and Allu differ slightly.
+ */
+object HakemusPdfService {
+    private val titleFont = Font(Font.HELVETICA, 18f, Font.BOLD)
+    private val sectionFont = Font(Font.HELVETICA, 15f, Font.BOLD)
+
+    private val headerFont = Font(Font.HELVETICA, 10f, Font.BOLD)
+    private val textFont = Font(Font.HELVETICA, 10f, Font.NORMAL)
+
+    private val finnishDateFormat: DateTimeFormatter = DateTimeFormatter.ofPattern("d.M.uuuu")
+
+    private fun Document.newline() {
+        this.add(Paragraph(Chunk.NEWLINE))
+    }
+
+    private fun Document.title(title: String) {
+        val paragraph = Paragraph(title, titleFont)
+        paragraph.alignment = Element.ALIGN_CENTER
+        this.add(paragraph)
+        this.newline()
+    }
+
+    private fun Document.sectionTitle(sectionTitle: String) {
+        val paragraph = Paragraph(sectionTitle, sectionFont)
+        this.add(paragraph)
+        this.newline()
+    }
+
+    fun PdfPTable.row(key: String, value: Any?) {
+        this.addCell(Phrase("$key ", headerFont))
+        this.addCell(Phrase(value?.toString() ?: "<Tyhjä>", textFont))
+    }
+
+    private fun Document.section(sectionTitle: String, addRows: (table: PdfPTable) -> Unit) {
+        this.sectionTitle(sectionTitle)
+
+        val table = PdfPTable(2)
+        table.widthPercentage = 100f
+        table.setWidths(floatArrayOf(1.5f, 3.5f))
+        table.setSpacingBefore(10f)
+        table.defaultCell.border = Rectangle.NO_BORDER
+        table.defaultCell.paddingBottom = 15f
+
+        addRows(table)
+
+        this.add(table)
+    }
+
+    private fun PostalAddress.format(): String =
+        "${this.streetAddress.streetName}\n${this.postalCode} ${this.city}"
+
+    private fun Hakemusyhteyshenkilo.format(): String =
+        listOfNotNull(kokoNimi(), sahkoposti, puhelin).filter { it.isNotBlank() }.joinToString("\n")
+
+    private fun Hakemusyhteystieto.format(): String =
+        listOfNotNull(
+                nimi + "\n",
+                ytunnus,
+                sahkoposti,
+                puhelinnumero,
+                "\nYhteyshenkilöt\n",
+            )
+            .filter { it.isNotBlank() }
+            .joinToString("\n") + this.yhteyshenkilot.joinToString("\n") { "\n" + it.format() }
+
+    private fun ZonedDateTime?.format(): String? =
+        this?.withZoneSameInstant(ZoneId.of("Europe/Helsinki"))?.format(finnishDateFormat)
+
+    fun createPdf(
+        data: JohtoselvityshakemusData,
+        totalArea: Float?,
+        areas: List<Float?>,
+    ): ByteArray {
+        val outputStream = ByteArrayOutputStream()
+        val document = Document(PageSize.A4)
+        PdfWriter.getInstance(document, outputStream)
+        formatPdf(
+            document,
+            data,
+            totalArea,
+            areas,
+        )
+        return outputStream.toByteArray()
+    }
+
+    private fun formatPdf(
+        document: Document,
+        data: JohtoselvityshakemusData,
+        totalArea: Float?,
+        areas: List<Float?>,
+    ) {
+        document.open()
+
+        document.title("Johtoselvityshakemus")
+
+        document.section("Perustiedot") { table ->
+            table.row("Työn nimi", data.name)
+            table.row("Osoitetiedot", data.postalAddress?.format())
+            table.row("Työssä on kyse", data.getWorkTargets())
+            table.row("Työn kuvaus", data.workDescription)
+            table.row("Omat tiedot", data.getOrderer()?.format())
+        }
+
+        document.newPage()
+
+        document.section("Alueet") { table ->
+            val areaNames =
+                data.areas?.mapIndexed { i, area -> area.name.ifBlank { "Työalue ${i+1}" } }
+                    ?: listOf()
+
+            table.row("Työn arvioitu alkupäivä", data.startTime.format())
+            table.row("Työn arvioitu loppupäivä", data.endTime.format())
+            table.row("Alueiden kokonaispinta-ala", totalArea.toString() + " m²")
+            table.row(
+                "Alueet",
+                areas
+                    .mapIndexed { i, area -> "${areaNames[i]}\n\nPinta-ala: $area m²" }
+                    .joinToString("\n\n")
+            )
+        }
+
+        document.newPage()
+
+        document.section("Yhteystiedot") { table ->
+            if (data.customerWithContacts != null) {
+                table.row("Työstä vastaavat", data.customerWithContacts.format())
+            }
+            if (data.contractorWithContacts != null) {
+                table.row("Työn suorittajat", data.contractorWithContacts.format())
+            }
+            if (data.propertyDeveloperWithContacts != null) {
+                table.row("Rakennuttajat", data.propertyDeveloperWithContacts.format())
+            }
+            if (data.representativeWithContacts != null) {
+                table.row("Asianhoitajat", data.representativeWithContacts.format())
+            }
+        }
+
+        document.newPage()
+
+        document.section("Liitteet") { table ->
+            // TODO: Attachments
+        }
+
+        document.close()
+    }
+
+    private fun JohtoselvityshakemusData.getOrderer(): Hakemusyhteyshenkilo? =
+        customerWithContacts?.yhteyshenkilot?.find { it.tilaaja }
+            ?: contractorWithContacts?.yhteyshenkilot?.find { it.tilaaja }
+            ?: representativeWithContacts?.yhteyshenkilot?.find { it.tilaaja }
+            ?: propertyDeveloperWithContacts?.yhteyshenkilot?.find { it.tilaaja }
+
+    private fun JohtoselvityshakemusData.getWorkTargets(): String =
+        listOf(
+                constructionWork to "Uuden rakenteen tai johdon rakentamisesta",
+                maintenanceWork to "Olemassaolevan rakenteen kunnossapitotyöstä",
+                emergencyWork to
+                    "Kaivutyö on aloitettu ennen johtoselvityksen tilaamista merkittävien vahinkojen välttämiseksi",
+                propertyConnectivity to "Kiinteistöliittymien rakentamisesta"
+            )
+            .filter { (active, _) -> active }
+            .joinToString("\n") { (_, description) -> description }
+}

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceTest.kt
@@ -12,7 +12,6 @@ import assertk.assertions.isNotNull
 import fi.hel.haitaton.hanke.HankeEntity
 import fi.hel.haitaton.hanke.HankeRepository
 import fi.hel.haitaton.hanke.HankealueService
-import fi.hel.haitaton.hanke.allu.AlluException
 import fi.hel.haitaton.hanke.allu.AlluLoginException
 import fi.hel.haitaton.hanke.allu.AlluStatus
 import fi.hel.haitaton.hanke.allu.AlluStatusRepository
@@ -37,6 +36,7 @@ import fi.hel.haitaton.hanke.logging.HankeLoggingService
 import fi.hel.haitaton.hanke.logging.Status
 import fi.hel.haitaton.hanke.permissions.HankeKayttajaService
 import fi.hel.haitaton.hanke.permissions.PermissionService
+import fi.hel.haitaton.hanke.test.AlluException
 import fi.hel.haitaton.hanke.test.USERNAME
 import fi.hel.haitaton.hanke.validation.InvalidApplicationDataException
 import io.mockk.Called
@@ -351,7 +351,7 @@ class ApplicationServiceTest {
             every { applicationRepository.findOneById(3) } returns applicationEntity
             every { geometriatDao.calculateCombinedArea(any()) } returns 100f
             every { geometriatDao.calculateArea(any()) } returns 100f
-            every { cableReportService.create(any()) } throws AlluException(listOf())
+            every { cableReportService.create(any()) } throws AlluException()
             every { geometriatDao.isInsideHankeAlueet(1, any()) } returns true
 
             assertThrows<AlluException> { applicationService.sendApplication(3, USERNAME) }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusFactory.kt
@@ -108,7 +108,7 @@ class HakemusFactory(
                 ApplicationType.EXCAVATION_NOTIFICATION -> createKaivuilmoitusData()
             }
 
-        private fun createJohtoselvityshakemusData(
+        fun createJohtoselvityshakemusData(
             name: String = ApplicationFactory.DEFAULT_APPLICATION_NAME,
             postalAddress: PostalAddress? = null,
             rockExcavation: Boolean = false,
@@ -121,14 +121,18 @@ class HakemusFactory(
             contractorWithContacts: Hakemusyhteystieto? = null,
             representativeWithContacts: Hakemusyhteystieto? = null,
             propertyDeveloperWithContacts: Hakemusyhteystieto? = null,
+            constructionWork: Boolean = false,
+            maintenanceWork: Boolean = false,
+            propertyConnectivity: Boolean = false,
+            emergencyWork: Boolean = false,
         ): JohtoselvityshakemusData =
             JohtoselvityshakemusData(
                 name = name,
                 postalAddress = postalAddress,
-                constructionWork = false,
-                maintenanceWork = false,
-                propertyConnectivity = false,
-                emergencyWork = false,
+                constructionWork = constructionWork,
+                maintenanceWork = maintenanceWork,
+                propertyConnectivity = propertyConnectivity,
+                emergencyWork = emergencyWork,
                 rockExcavation = rockExcavation,
                 workDescription = workDescription,
                 startTime = startTime,

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusyhteyshenkiloFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusyhteyshenkiloFactory.kt
@@ -1,5 +1,6 @@
 package fi.hel.haitaton.hanke.factory
 
+import fi.hel.haitaton.hanke.hakemus.Hakemusyhteyshenkilo
 import fi.hel.haitaton.hanke.hakemus.HakemusyhteyshenkiloEntity
 import fi.hel.haitaton.hanke.hakemus.HakemusyhteystietoEntity
 import fi.hel.haitaton.hanke.permissions.HankekayttajaEntity
@@ -10,11 +11,30 @@ import org.springframework.stereotype.Component
 @Component
 object HakemusyhteyshenkiloFactory {
 
-    private const val DEFAULT_ETUNIMI = "Tauno"
-    private const val DEFAULT_SUKUNIMI = "Testaaja"
-    private const val DEFAULT_SAHKOPOSTI = "tauno.testaaja@gmail.com"
-    private const val DEFAULT_PUHELIN = "0401234567"
-    private const val DEFAULT_TILAAJA = false
+    const val DEFAULT_ETUNIMI = "Tauno"
+    const val DEFAULT_SUKUNIMI = "Testaaja"
+    const val DEFAULT_SAHKOPOSTI = "tauno.testaaja@gmail.com"
+    const val DEFAULT_PUHELIN = "0401234567"
+    const val DEFAULT_TILAAJA = false
+    val DEFAULT_ID = UUID.fromString("650fbf8b-e4f2-495b-9bc4-efd1ccf1c2a7")
+    val DEFAULT_HANKEKAYTTAJA_ID = UUID.fromString("db92aa0e-5a32-4ffd-83b3-9bff28700cfc")
+
+    fun create(
+        etunimi: String = DEFAULT_ETUNIMI,
+        sukunimi: String = DEFAULT_SUKUNIMI,
+        sahkoposti: String = DEFAULT_SAHKOPOSTI,
+        puhelin: String = DEFAULT_PUHELIN,
+        tilaaja: Boolean = DEFAULT_TILAAJA,
+    ) =
+        Hakemusyhteyshenkilo(
+            DEFAULT_ID,
+            DEFAULT_HANKEKAYTTAJA_ID,
+            etunimi,
+            sukunimi,
+            sahkoposti,
+            puhelin,
+            tilaaja
+        )
 
     fun createEntity(
         id: UUID = UUID.randomUUID(),

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusyhteystietoFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusyhteystietoFactory.kt
@@ -18,6 +18,10 @@ object HakemusyhteystietoFactory {
     private const val DEFAULT_PUHELINNUMERO = "0401234567"
     private const val DEFAULT_YTUNNUS = "1817548-2"
 
+    private const val DEFAULT_PERSON_NIMI = "Pertti Perushenkilö"
+    private const val DEFAULT_PERSON_SAHKOPOSTI = "pertti@perus.fi"
+    private const val DEFAULT_PERSON_PUHELINNUMERO = "554466546"
+
     fun createEntity(
         tyyppi: CustomerType = CustomerType.COMPANY,
         rooli: ApplicationContactType = ApplicationContactType.HAKIJA,
@@ -57,4 +61,37 @@ object HakemusyhteystietoFactory {
             ytunnus,
             yhteyshenkilot,
         )
+
+    fun createPerson(
+        id: UUID = DEFAULT_ID,
+        tyyppi: CustomerType = CustomerType.PERSON,
+        rooli: ApplicationContactType = ApplicationContactType.HAKIJA,
+        nimi: String = DEFAULT_PERSON_NIMI,
+        sahkoposti: String = DEFAULT_PERSON_SAHKOPOSTI,
+        puhelinnumero: String = DEFAULT_PERSON_PUHELINNUMERO,
+        ytunnus: String? = null,
+        yhteyshenkilot: List<Hakemusyhteyshenkilo> = listOf()
+    ) =
+        Hakemusyhteystieto(
+            id,
+            tyyppi,
+            rooli,
+            nimi,
+            sahkoposti,
+            puhelinnumero,
+            ytunnus,
+            yhteyshenkilot,
+        )
+
+    fun Hakemusyhteystieto.withYhteyshenkilo(
+        etunimi: String = HakemusyhteyshenkiloFactory.DEFAULT_ETUNIMI,
+        sukunimi: String = HakemusyhteyshenkiloFactory.DEFAULT_SUKUNIMI,
+        sahkoposti: String = HakemusyhteyshenkiloFactory.DEFAULT_SAHKOPOSTI,
+        puhelin: String = HakemusyhteyshenkiloFactory.DEFAULT_PUHELIN,
+        tilaaja: Boolean = HakemusyhteyshenkiloFactory.DEFAULT_TILAAJA,
+    ): Hakemusyhteystieto {
+        val yhteyshenkilo =
+            HakemusyhteyshenkiloFactory.create(etunimi, sukunimi, sahkoposti, puhelin, tilaaja)
+        return copy(yhteyshenkilot = yhteyshenkilot + yhteyshenkilo)
+    }
 }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusPdfServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusPdfServiceTest.kt
@@ -1,0 +1,306 @@
+package fi.hel.haitaton.hanke.hakemus
+
+import assertk.all
+import assertk.assertThat
+import assertk.assertions.contains
+import assertk.assertions.doesNotContain
+import com.lowagie.text.pdf.PdfReader
+import com.lowagie.text.pdf.parser.PdfTextExtractor
+import fi.hel.haitaton.hanke.application.ApplicationArea
+import fi.hel.haitaton.hanke.factory.ApplicationFactory
+import fi.hel.haitaton.hanke.factory.ApplicationFactory.Companion.createPostalAddress
+import fi.hel.haitaton.hanke.factory.HakemusFactory
+import fi.hel.haitaton.hanke.factory.HakemusyhteyshenkiloFactory
+import fi.hel.haitaton.hanke.factory.HakemusyhteystietoFactory
+import fi.hel.haitaton.hanke.factory.HakemusyhteystietoFactory.withYhteyshenkilo
+import java.time.ZonedDateTime
+import org.geojson.Polygon
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class HakemusPdfServiceTest {
+
+    @Nested
+    inner class CreatePdf {
+        @Test
+        fun `created PDF contains title and section headers`() {
+            val hakemusData = HakemusFactory.createJohtoselvityshakemusData()
+
+            val pdfData = HakemusPdfService.createPdf(hakemusData, 1f, listOf())
+
+            assertThat(getPdfAsText(pdfData))
+                .contains("Johtoselvityshakemus", "Perustiedot", "Alueet", "Yhteystiedot")
+        }
+
+        @Test
+        fun `created PDF contains headers for basic information`() {
+            val hakemusData = HakemusFactory.createJohtoselvityshakemusData()
+
+            val pdfData = HakemusPdfService.createPdf(hakemusData, 614f, listOf())
+
+            assertThat(getPdfAsText(pdfData)).all {
+                contains("Työn nimi")
+                contains("Osoitetiedot")
+                contains("Työssä on kyse")
+                contains("Työn kuvaus")
+                contains("Omat tiedot")
+            }
+        }
+
+        @Test
+        fun `created PDF contains basic information`() {
+            val applicationData =
+                HakemusFactory.createJohtoselvityshakemusData(
+                    postalAddress = createPostalAddress(),
+                    customerWithContacts = HakemusyhteystietoFactory.create().withYhteyshenkilo(),
+                    constructionWork = true,
+                    maintenanceWork = true,
+                    emergencyWork = true,
+                    propertyConnectivity = true,
+                )
+
+            val pdfData = HakemusPdfService.createPdf(applicationData, 1f, listOf())
+
+            val pdfText = getPdfAsText(pdfData)
+            assertThat(pdfText).all {
+                contains(ApplicationFactory.DEFAULT_APPLICATION_NAME)
+                contains("Katu 1")
+                contains("00100")
+                contains("Helsinki")
+                contains("Uuden rakenteen tai johdon rakentamisesta")
+                contains("Olemassaolevan rakenteen kunnossapitotyöstä")
+                // This is too long to fit on one line in the PDF. It's not found as a continuous
+                // String. Check for each word instead.
+                contains(
+                    "Kaivutyö",
+                    "on",
+                    "aloitettu",
+                    "ennen",
+                    "johtoselvityksen",
+                    "tilaamista",
+                    "merkittävien",
+                    "vahinkojen",
+                    "välttämiseksi",
+                )
+                contains("Kiinteistöliittymien rakentamisesta")
+                contains(ApplicationFactory.DEFAULT_WORK_DESCRIPTION)
+                contains(
+                    "${HakemusyhteyshenkiloFactory.DEFAULT_ETUNIMI} ${HakemusyhteyshenkiloFactory.DEFAULT_SUKUNIMI}"
+                )
+                contains(HakemusyhteyshenkiloFactory.DEFAULT_SAHKOPOSTI)
+                contains(HakemusyhteyshenkiloFactory.DEFAULT_PUHELIN)
+            }
+        }
+
+        @Test
+        fun `created PDF doesn't have this work involves fields if none are selected`() {
+            val hakemusData =
+                HakemusFactory.createJohtoselvityshakemusData(
+                    constructionWork = false,
+                    maintenanceWork = false,
+                    emergencyWork = false,
+                    propertyConnectivity = false,
+                )
+
+            val pdfData = HakemusPdfService.createPdf(hakemusData, 1f, listOf())
+
+            assertThat(getPdfAsText(pdfData)).all {
+                doesNotContain("Uuden rakenteen tai johdon rakentamisesta")
+                doesNotContain("Olemassaolevan rakenteen kunnossapitotyöstä")
+                doesNotContain("välttämiseksi")
+                doesNotContain("Kiinteistöliittymien rakentamisesta")
+            }
+        }
+
+        @Test
+        fun `created PDF contains headers for area information`() {
+            val hakemusData = HakemusFactory.createJohtoselvityshakemusData()
+
+            val pdfData = HakemusPdfService.createPdf(hakemusData, 614f, listOf())
+
+            assertThat(getPdfAsText(pdfData)).all {
+                contains("Työn arvioitu alkupäivä")
+                contains("Työn arvioitu loppupäivä")
+                contains("Alueiden kokonaispinta-ala")
+                contains("Alueet")
+            }
+        }
+
+        @Test
+        fun `created PDF contains area information`() {
+            val hakemusData =
+                HakemusFactory.createJohtoselvityshakemusData(
+                    startTime = ZonedDateTime.parse("2022-11-17T22:00:00.000Z"),
+                    endTime = ZonedDateTime.parse("2022-11-28T21:59:59.999Z"),
+                    areas =
+                        listOf(
+                            ApplicationArea("Ensimmäinen työalue", Polygon()),
+                            ApplicationArea("Toinen alue", Polygon()),
+                            ApplicationArea("", Polygon()),
+                        )
+                )
+
+            val pdfData = HakemusPdfService.createPdf(hakemusData, 614f, listOf(185f, 231f, 198f))
+
+            assertThat(getPdfAsText(pdfData)).all {
+                contains("18.11.2022")
+                contains("28.11.2022")
+                contains("614.0 m²")
+                contains("Ensimmäinen työalue")
+                contains("185.0 m²")
+                contains("Toinen alue")
+                contains("231.0 m²")
+                contains("Työalue 3")
+                contains("198.0 m²")
+            }
+        }
+
+        @Test
+        fun `contains headers for contact information`() {
+            val hakemusData =
+                HakemusFactory.createJohtoselvityshakemusData(
+                    customerWithContacts = HakemusyhteystietoFactory.create().withYhteyshenkilo(),
+                    contractorWithContacts = HakemusyhteystietoFactory.create().withYhteyshenkilo(),
+                    representativeWithContacts =
+                        HakemusyhteystietoFactory.createPerson().withYhteyshenkilo(),
+                    propertyDeveloperWithContacts =
+                        HakemusyhteystietoFactory.create().withYhteyshenkilo()
+                )
+
+            val pdfData = HakemusPdfService.createPdf(hakemusData, 1f, listOf())
+
+            assertThat(getPdfAsText(pdfData)).all {
+                contains("Työstä vastaavat")
+                contains("Työn suorittajat")
+                contains("Rakennuttajat")
+                contains("Asianhoitajat")
+                contains("Yhteyshenkilöt")
+            }
+        }
+
+        @Test
+        fun `doesn't contain headers for missing optional contacts`() {
+            val hakemusData =
+                HakemusFactory.createJohtoselvityshakemusData(
+                    customerWithContacts = HakemusyhteystietoFactory.create().withYhteyshenkilo(),
+                    contractorWithContacts = HakemusyhteystietoFactory.create().withYhteyshenkilo(),
+                    representativeWithContacts = null,
+                    propertyDeveloperWithContacts = null,
+                )
+
+            val pdfData = HakemusPdfService.createPdf(hakemusData, 614f, listOf())
+
+            assertThat(getPdfAsText(pdfData)).all {
+                contains("Työstä vastaavat")
+                contains("Työn suorittajat")
+                doesNotContain("Rakennuttajat")
+                doesNotContain("Asianhoitajat")
+            }
+        }
+
+        @Test
+        fun `created PDF contains contact information`() {
+            val hakija =
+                HakemusyhteystietoFactory.create(
+                        nimi = "Company Ltd",
+                        ytunnus = "1054713-0",
+                        sahkoposti = "info@company.test",
+                        puhelinnumero = "050123456789",
+                    )
+                    .withYhteyshenkilo(
+                        etunimi = "Cole",
+                        sukunimi = "Contact",
+                        sahkoposti = "cole@company.test",
+                        puhelin = "050987654321",
+                    )
+                    .withYhteyshenkilo(
+                        etunimi = "Seth",
+                        sukunimi = "Secondary",
+                        sahkoposti = "seth@company.test",
+                        puhelin = "0505556666",
+                    )
+            val tyonSuorittaja =
+                HakemusyhteystietoFactory.create(
+                        nimi = "Contractor Inc.",
+                        ytunnus = "0156555-6",
+                        sahkoposti = "info@contractor.test",
+                        puhelinnumero = "0509999999",
+                    )
+                    .withYhteyshenkilo(
+                        etunimi = "Cody",
+                        sukunimi = "Contractor",
+                        sahkoposti = "cody@contractor.test",
+                        puhelin = "0501111111",
+                        tilaaja = true
+                    )
+            val asianhoitaja =
+                HakemusyhteystietoFactory.create(
+                    nimi = "Reynold Representative",
+                    ytunnus = "281192-937W",
+                    sahkoposti = "reynold@company.test",
+                    puhelinnumero = "0509990000",
+                )
+            val rakennuttaja =
+                HakemusyhteystietoFactory.create(
+                        nimi = "Developer Inc.",
+                        ytunnus = "8545758-6",
+                        sahkoposti = "info@developer.test",
+                        puhelinnumero = "0508888888",
+                    )
+                    .withYhteyshenkilo(
+                        etunimi = "Denise",
+                        sukunimi = "Developer",
+                        sahkoposti = "denise@developer.test",
+                        puhelin = "0502222222"
+                    )
+
+            val hakemusData =
+                HakemusFactory.createJohtoselvityshakemusData(
+                    customerWithContacts = hakija,
+                    contractorWithContacts = tyonSuorittaja,
+                    representativeWithContacts = asianhoitaja,
+                    propertyDeveloperWithContacts = rakennuttaja,
+                )
+
+            val pdfData = HakemusPdfService.createPdf(hakemusData, 614f, listOf())
+
+            assertThat(getPdfAsText(pdfData)).all {
+                contains("Company Ltd")
+                contains("1054713-0")
+                contains("info@company.test")
+                contains("050123456789")
+                contains("Cole Contact")
+                contains("cole@company.test")
+                contains("050987654321")
+                contains("Seth Secondary")
+                contains("seth@company.test")
+                contains("0505556666")
+                contains("Contractor Inc.")
+                contains("0156555-6")
+                contains("info@contractor.test")
+                contains("0509999999")
+                contains("Cody Contractor")
+                contains("cody@contractor.test")
+                contains("0501111111")
+                contains("Reynold Representative")
+                contains("281192-937W")
+                contains("reynold@company.test")
+                contains("0509990000")
+                contains("Developer Inc.")
+                contains("8545758-6")
+                contains("info@developer.test")
+                contains("0508888888")
+                contains("Denise Developer")
+                contains("denise@developer.test")
+                contains("0502222222")
+            }
+        }
+    }
+
+    private fun getPdfAsText(pdfData: ByteArray): String {
+        val reader = PdfReader(pdfData)
+        val pages = reader.numberOfPages
+        val textExtractor = PdfTextExtractor(reader)
+        return (1..pages).joinToString("\n") { textExtractor.getTextFromPage(it) }
+    }
+}

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceTest.kt
@@ -14,7 +14,6 @@ import assertk.assertions.single
 import fi.hel.haitaton.hanke.HankeRepository
 import fi.hel.haitaton.hanke.HankealueService
 import fi.hel.haitaton.hanke.allu.AlluCableReportApplicationData
-import fi.hel.haitaton.hanke.allu.AlluException
 import fi.hel.haitaton.hanke.allu.AlluLoginException
 import fi.hel.haitaton.hanke.allu.CableReportService
 import fi.hel.haitaton.hanke.allu.Contact
@@ -38,6 +37,7 @@ import fi.hel.haitaton.hanke.logging.DisclosureLogService
 import fi.hel.haitaton.hanke.logging.HakemusLoggingService
 import fi.hel.haitaton.hanke.logging.Status
 import fi.hel.haitaton.hanke.permissions.HankeKayttajaService
+import fi.hel.haitaton.hanke.test.AlluException
 import fi.hel.haitaton.hanke.test.USERNAME
 import io.mockk.called
 import io.mockk.checkUnnecessaryStub
@@ -123,6 +123,9 @@ class HakemusServiceTest {
             every { alluClient.getApplicationInformation(alluId) } returns
                 AlluFactory.createAlluApplicationResponse()
             every { geometriatDao.isInsideHankeAlueet(1, any()) } returns true
+            every { geometriatDao.calculateCombinedArea(any()) } returns 11.0f
+            every { geometriatDao.calculateArea(any()) } returns 11.0f
+            justRun { alluClient.addAttachment(alluId, any()) }
             justRun { attachmentService.sendInitialAttachments(alluId, any()) }
             val applicationCapturingSlot = slot<AlluCableReportApplicationData>()
             justRun {
@@ -208,8 +211,11 @@ class HakemusServiceTest {
             verifySequence {
                 applicationRepository.findOneById(3)
                 geometriatDao.isInsideHankeAlueet(1, any())
+                geometriatDao.calculateCombinedArea(any())
+                geometriatDao.calculateArea(any())
                 alluClient.create(any())
                 disclosureLogService.saveDisclosureLogsForAllu(3, any(), Status.SUCCESS)
+                alluClient.addAttachment(alluId, any())
                 attachmentService.sendInitialAttachments(alluId, any())
                 alluClient.getApplicationInformation(alluId)
                 applicationRepository.save(any())
@@ -220,7 +226,9 @@ class HakemusServiceTest {
         fun `saves disclosure logs when sending fails`() {
             val applicationEntity = applicationEntity()
             every { applicationRepository.findOneById(3) } returns applicationEntity
-            every { alluClient.create(any()) } throws AlluException(listOf())
+            every { geometriatDao.calculateCombinedArea(any()) } returns 11.0f
+            every { geometriatDao.calculateArea(any()) } returns 11.0f
+            every { alluClient.create(any()) } throws AlluException()
             every { geometriatDao.isInsideHankeAlueet(1, any()) } returns true
 
             assertThrows<AlluException> { hakemusService.sendHakemus(3, USERNAME) }
@@ -228,6 +236,8 @@ class HakemusServiceTest {
             verifySequence {
                 applicationRepository.findOneById(3)
                 geometriatDao.isInsideHankeAlueet(1, any())
+                geometriatDao.calculateCombinedArea(any())
+                geometriatDao.calculateArea(any())
                 alluClient.create(any())
                 disclosureLogService.saveDisclosureLogsForAllu(
                     3,
@@ -243,6 +253,8 @@ class HakemusServiceTest {
             val applicationEntity = applicationEntity()
             every { applicationRepository.findOneById(3) } returns applicationEntity
             every { geometriatDao.isInsideHankeAlueet(any(), any()) } returns true
+            every { geometriatDao.calculateCombinedArea(any()) } returns 11.0f
+            every { geometriatDao.calculateArea(any()) } returns 11.0f
             every { alluClient.create(any()) } throws AlluLoginException(RuntimeException())
 
             assertThrows<AlluLoginException> { hakemusService.sendHakemus(3, USERNAME) }
@@ -250,6 +262,8 @@ class HakemusServiceTest {
             verifySequence {
                 applicationRepository.findOneById(3)
                 geometriatDao.isInsideHankeAlueet(any(), any())
+                geometriatDao.calculateCombinedArea(any())
+                geometriatDao.calculateArea(any())
                 alluClient.create(any())
             }
             verify { disclosureLogService wasNot called }
@@ -269,8 +283,11 @@ class HakemusServiceTest {
             every { applicationRepository.findOneById(3) } returns applicationEntity
             every { applicationRepository.save(any()) } answers { firstArg() }
             every { geometriatDao.isInsideHankeAlueet(1, any()) } returns true
+            every { geometriatDao.calculateCombinedArea(any()) } returns 11.0f
+            every { geometriatDao.calculateArea(any()) } returns 11.0f
             val applicationCapturingSlot = slot<AlluCableReportApplicationData>()
             every { alluClient.create(capture(applicationCapturingSlot)) } returns alluId
+            justRun { alluClient.addAttachment(alluId, any()) }
             every { alluClient.getApplicationInformation(alluId) } returns
                 AlluFactory.createAlluApplicationResponse(alluId)
             justRun { attachmentService.sendInitialAttachments(alluId, any()) }
@@ -284,8 +301,11 @@ class HakemusServiceTest {
             verifySequence {
                 applicationRepository.findOneById(3)
                 geometriatDao.isInsideHankeAlueet(1, any())
+                geometriatDao.calculateCombinedArea(any())
+                geometriatDao.calculateArea(any())
                 alluClient.create(any())
                 disclosureLogService.saveDisclosureLogsForAllu(3, any(), Status.SUCCESS)
+                alluClient.addAttachment(alluId, any())
                 attachmentService.sendInitialAttachments(alluId, any())
                 alluClient.getApplicationInformation(alluId)
                 applicationRepository.save(any())

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/test/TestUtils.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/test/TestUtils.kt
@@ -16,3 +16,10 @@ object TestUtils {
 
     fun nextYear(): Int = getCurrentTimeUTC().year + 1
 }
+
+/**
+ * Exception to use as a stand-in for communication errors etc. that can occur when calling the Allu
+ * API. This needs to be a specific exception and not RuntimeException, because things like Mockk
+ * errors are inherit RuntimeException, which can cause unexpected behaviour in tests.
+ */
+class AlluException : RuntimeException()


### PR DESCRIPTION
# Description

Add creating a PDF from the hakemus form data. The created PDF is identical to how it looked before Kortisto.

Create a separate HakemusPdfService for generating the PDF. It's very similar to ApplicationPdfService, but it can be removed soon when purging the old Application package.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2301

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 