### PR TITLE
HAI-2411 Send an email notification when the user is removed from Hanke

### DIFF
--- a/email/kayttaja-poistettu-hanke.mjml
+++ b/email/kayttaja-poistettu-hanke.mjml
@@ -1,0 +1,37 @@
+<mjml>
+    <mj-head>
+        <mj-include path="common/attributes.partial"/>
+    </mj-head>
+    <mj-body>
+        <mj-include path="common/header-content.partial"/>
+        <mj-section>
+            <mj-column>
+                <mj-text mj-class="header-txt">
+                    Sinut on poistettu hankkeelta ({{hankeTunnus}}) / Sinut on poistettu hankkeelta ({{hankeTunnus}}) / Sinut on poistettu hankkeelta ({{hankeTunnus}})
+                </mj-text>
+                <mj-text mj-class="basic-txt">
+                    {{deletedByName}} ({{deletedByEmail}}) on poistanut sinut hankkeelta <b>{{hankeNimi}} ({{hankeTunnus}})</b>,
+                    eikä sinulla ole enää pääsyä hankkeelle.
+                </mj-text>
+                <mj-include path="common/signature-fi.partial"/>
+
+                <mj-divider mj-class="language-separator" />
+
+                <mj-text mj-class="basic-txt">
+                    {{deletedByName}} ({{deletedByEmail}}) on poistanut sinut hankkeelta <b>{{hankeNimi}} ({{hankeTunnus}})</b>.
+                    eikä sinulla ole enää pääsyä hankkeelle.
+                </mj-text>
+                <mj-include path="common/signature-sv.partial"/>
+
+                <mj-divider mj-class="language-separator" />
+
+                <mj-text mj-class="basic-txt">
+                    {{deletedByName}} ({{deletedByEmail}}) on poistanut sinut hankkeelta <b>{{hankeNimi}} ({{hankeTunnus}})</b>.
+                    eikä sinulla ole enää pääsyä hankkeelle.
+                </mj-text>
+                <mj-include path="common/signature-en.partial"/>
+            </mj-column>
+        </mj-section>
+        <mj-include path="common/footer-content.partial"/>
+    </mj-body>
+</mjml>

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaControllerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaControllerITest.kt
@@ -1034,69 +1034,69 @@ class HankeKayttajaControllerITest(
         @Test
         fun `Returns not found when hankekayttaja is not found`() {
             every { authorizer.authorizeKayttajaId(kayttajaId, DELETE_USER.name) } returns true
-            every { deleteService.delete(kayttajaId) } throws
+            every { deleteService.delete(kayttajaId, USERNAME) } throws
                 HankeKayttajaNotFoundException(kayttajaId)
 
             delete(url).andExpect(status().isNotFound).andExpect(hankeError(HankeError.HAI4001))
 
             verifySequence {
                 authorizer.authorizeKayttajaId(kayttajaId, DELETE_USER.name)
-                deleteService.delete(kayttajaId)
+                deleteService.delete(kayttajaId, USERNAME)
             }
         }
 
         @Test
         fun `Returns 409 when hankekayttaja is the only one with Kaikki Oikeudet`() {
             every { authorizer.authorizeKayttajaId(kayttajaId, DELETE_USER.name) } returns true
-            every { deleteService.delete(kayttajaId) } throws
+            every { deleteService.delete(kayttajaId, USERNAME) } throws
                 NoAdminRemainingException(TestHankeIdentifier(132, "JS44-11"))
 
             delete(url).andExpect(status().isConflict).andExpect(hankeError(HankeError.HAI4003))
 
             verifySequence {
                 authorizer.authorizeKayttajaId(kayttajaId, DELETE_USER.name)
-                deleteService.delete(kayttajaId)
+                deleteService.delete(kayttajaId, USERNAME)
             }
         }
 
         @Test
         fun `Returns 409 when hankekayttaja is the only contact for an omistaja`() {
             every { authorizer.authorizeKayttajaId(kayttajaId, DELETE_USER.name) } returns true
-            every { deleteService.delete(kayttajaId) } throws
+            every { deleteService.delete(kayttajaId, USERNAME) } throws
                 OnlyOmistajaContactException(kayttajaId, listOf(13, 15))
 
             delete(url).andExpect(status().isConflict).andExpect(hankeError(HankeError.HAI4003))
 
             verifySequence {
                 authorizer.authorizeKayttajaId(kayttajaId, DELETE_USER.name)
-                deleteService.delete(kayttajaId)
+                deleteService.delete(kayttajaId, USERNAME)
             }
         }
 
         @Test
         fun `Returns 409 when hankekayttaja is an yhteyshenkilo on an active hakemus`() {
             every { authorizer.authorizeKayttajaId(kayttajaId, DELETE_USER.name) } returns true
-            every { deleteService.delete(kayttajaId) } throws
+            every { deleteService.delete(kayttajaId, USERNAME) } throws
                 HasActiveApplicationsException(kayttajaId, listOf(13, 15))
 
             delete(url).andExpect(status().isConflict).andExpect(hankeError(HankeError.HAI4003))
 
             verifySequence {
                 authorizer.authorizeKayttajaId(kayttajaId, DELETE_USER.name)
-                deleteService.delete(kayttajaId)
+                deleteService.delete(kayttajaId, USERNAME)
             }
         }
 
         @Test
         fun `Returns 204 when hankekayttaja was deleted`() {
             every { authorizer.authorizeKayttajaId(kayttajaId, DELETE_USER.name) } returns true
-            justRun { deleteService.delete(kayttajaId) }
+            justRun { deleteService.delete(kayttajaId, USERNAME) }
 
             delete(url).andExpect(status().isNoContent).andExpect(content().string(""))
 
             verifySequence {
                 authorizer.authorizeKayttajaId(kayttajaId, DELETE_USER.name)
-                deleteService.delete(kayttajaId)
+                deleteService.delete(kayttajaId, USERNAME)
             }
         }
     }

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankekayttajaDeleteServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankekayttajaDeleteServiceITest.kt
@@ -1,6 +1,5 @@
 package fi.hel.haitaton.hanke.permissions
 
-import assertk.Assert
 import assertk.all
 import assertk.assertFailure
 import assertk.assertThat
@@ -313,7 +312,7 @@ class HankekayttajaDeleteServiceITest(
         }
 
         @Test
-        fun `send email notification when user is deleted`() {
+        fun `send an email notification when the user is deleted`() {
             val hanke = hankeFactory.builder().withHankealue().saveEntity()
             val founder = hankeKayttajaService.getKayttajaByUserId(hanke.id, USERNAME)!!
             hankeFactory.addYhteystiedotTo(hanke) {
@@ -325,24 +324,9 @@ class HankekayttajaDeleteServiceITest(
 
             val capturedEmails = greenMail.receivedMessages
             assertThat(capturedEmails).hasSize(1)
-            assertThat(capturedEmails.first())
-                .isValidRemovalFromHankeNotification(
-                    hanke.hankeTunnus,
-                    hanke.nimi,
-                    founder.fullName(),
-                    founder.sahkoposti,
-                )
-        }
-
-        private fun Assert<MimeMessage>.isValidRemovalFromHankeNotification(
-            hankeTunnus: String,
-            hankeNimi: String,
-            updatedByName: String,
-            updatedByEmail: String,
-        ) {
-            prop(MimeMessage::textBody).all {
-                contains("$updatedByName ($updatedByEmail) on poistanut sinut")
-                contains("hankkeelta \"$hankeNimi\" ($hankeTunnus)")
+            assertThat(capturedEmails.first()).prop(MimeMessage::textBody).all {
+                contains("${founder.fullName()} (${founder.sahkoposti}) on poistanut sinut")
+                contains("hankkeelta \"${hanke.nimi}\" (${hanke.hankeTunnus})")
             }
         }
     }

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankekayttajaDeleteServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankekayttajaDeleteServiceITest.kt
@@ -1,8 +1,10 @@
-package fi.hel.haitaton.hanke.hakemus
+package fi.hel.haitaton.hanke.permissions
 
+import assertk.Assert
 import assertk.all
 import assertk.assertFailure
 import assertk.assertThat
+import assertk.assertions.contains
 import assertk.assertions.containsExactlyInAnyOrder
 import assertk.assertions.extracting
 import assertk.assertions.hasClass
@@ -17,28 +19,32 @@ import assertk.assertions.isTrue
 import assertk.assertions.messageContains
 import assertk.assertions.prop
 import assertk.assertions.single
+import com.icegreen.greenmail.configuration.GreenMailConfiguration
+import com.icegreen.greenmail.junit5.GreenMailExtension
+import com.icegreen.greenmail.util.ServerSetupTest
 import fi.hel.haitaton.hanke.HankeService
 import fi.hel.haitaton.hanke.IntegrationTest
 import fi.hel.haitaton.hanke.allu.ApplicationStatus
 import fi.hel.haitaton.hanke.domain.Hanke
 import fi.hel.haitaton.hanke.domain.HankeYhteystieto
 import fi.hel.haitaton.hanke.domain.Yhteyshenkilo
+import fi.hel.haitaton.hanke.email.textBody
 import fi.hel.haitaton.hanke.factory.HakemusFactory
 import fi.hel.haitaton.hanke.factory.HankeFactory
 import fi.hel.haitaton.hanke.factory.HankeKayttajaFactory
-import fi.hel.haitaton.hanke.permissions.HankeKayttajaNotFoundException
-import fi.hel.haitaton.hanke.permissions.HankeKayttajaService
-import fi.hel.haitaton.hanke.permissions.HankekayttajaDeleteService
+import fi.hel.haitaton.hanke.hakemus.ContactResponse
+import fi.hel.haitaton.hanke.hakemus.CustomerWithContactsResponse
+import fi.hel.haitaton.hanke.hakemus.HakemusDataResponse
+import fi.hel.haitaton.hanke.hakemus.HakemusResponse
+import fi.hel.haitaton.hanke.hakemus.HakemusService
 import fi.hel.haitaton.hanke.permissions.HankekayttajaDeleteService.DeleteInfo
-import fi.hel.haitaton.hanke.permissions.HasActiveApplicationsException
-import fi.hel.haitaton.hanke.permissions.Kayttooikeustaso
-import fi.hel.haitaton.hanke.permissions.NoAdminRemainingException
-import fi.hel.haitaton.hanke.permissions.OnlyOmistajaContactException
 import fi.hel.haitaton.hanke.test.USERNAME
+import jakarta.mail.internet.MimeMessage
 import java.util.UUID
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.extension.RegisterExtension
 import org.springframework.beans.factory.annotation.Autowired
 
 class HankekayttajaDeleteServiceITest(
@@ -50,6 +56,14 @@ class HankekayttajaDeleteServiceITest(
     @Autowired val hankeKayttajaFactory: HankeKayttajaFactory,
     @Autowired val hakemusFactory: HakemusFactory,
 ) : IntegrationTest() {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val greenMail: GreenMailExtension =
+            GreenMailExtension(ServerSetupTest.SMTP)
+                .withConfiguration(GreenMailConfiguration.aConfig().withDisabledAuthentication())
+    }
 
     @Nested
     @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -188,7 +202,7 @@ class HankekayttajaDeleteServiceITest(
         fun `throws an exception when hankekayttaja does not exist`() {
             val kayttajaId = UUID.fromString("750b4207-2c5f-49a0-9b80-4829c807abeb")
 
-            val failure = assertFailure { deleteService.delete(kayttajaId) }
+            val failure = assertFailure { deleteService.delete(kayttajaId, USERNAME) }
 
             failure.all {
                 hasClass(HankeKayttajaNotFoundException::class)
@@ -201,7 +215,7 @@ class HankekayttajaDeleteServiceITest(
             val hanke = hankeFactory.builder().save()
             val founder = hankeKayttajaService.getKayttajaByUserId(hanke.id, USERNAME)!!
 
-            val failure = assertFailure { deleteService.delete(founder.id) }
+            val failure = assertFailure { deleteService.delete(founder.id, USERNAME) }
 
             failure.all {
                 hasClass(NoAdminRemainingException::class)
@@ -218,7 +232,7 @@ class HankekayttajaDeleteServiceITest(
             val offendingOmistaja = builder.omistaja(founder)
             builder.toteuttaja(Kayttooikeustaso.KAIKKI_OIKEUDET)
 
-            val failure = assertFailure { deleteService.delete(founder.id) }
+            val failure = assertFailure { deleteService.delete(founder.id, USERNAME) }
 
             failure.all {
                 hasClass(OnlyOmistajaContactException::class)
@@ -249,7 +263,7 @@ class HankekayttajaDeleteServiceITest(
                     .tyonSuorittaja(founder)
                     .save()
 
-            val failure = assertFailure { deleteService.delete(founder.id) }
+            val failure = assertFailure { deleteService.delete(founder.id, USERNAME) }
 
             failure.all {
                 hasClass(HasActiveApplicationsException::class)
@@ -276,7 +290,7 @@ class HankekayttajaDeleteServiceITest(
                     .hakija(founder, otherKayttaja)
                     .save()
 
-            deleteService.delete(founder.id)
+            deleteService.delete(founder.id, USERNAME)
 
             assertThat(hankeKayttajaService.getKayttajaByUserId(hanke.id, USERNAME)).isNull()
             assertThat(hankeService.loadHankeById(hanke.id))
@@ -296,6 +310,40 @@ class HankekayttajaDeleteServiceITest(
                 .single()
                 .prop(ContactResponse::hankekayttajaId)
                 .isNotEqualTo(founder.id)
+        }
+
+        @Test
+        fun `send email notification when user is deleted`() {
+            val hanke = hankeFactory.builder().withHankealue().saveEntity()
+            val founder = hankeKayttajaService.getKayttajaByUserId(hanke.id, USERNAME)!!
+            hankeFactory.addYhteystiedotTo(hanke) {
+                omistaja(founder, kayttaja())
+                toteuttaja(Kayttooikeustaso.KAIKKI_OIKEUDET)
+            }
+
+            deleteService.delete(founder.id, USERNAME)
+
+            val capturedEmails = greenMail.receivedMessages
+            assertThat(capturedEmails).hasSize(1)
+            assertThat(capturedEmails.first())
+                .isValidRemovalFromHankeNotification(
+                    hanke.hankeTunnus,
+                    hanke.nimi,
+                    founder.fullName(),
+                    founder.sahkoposti,
+                )
+        }
+
+        private fun Assert<MimeMessage>.isValidRemovalFromHankeNotification(
+            hankeTunnus: String,
+            hankeNimi: String,
+            updatedByName: String,
+            updatedByEmail: String,
+        ) {
+            prop(MimeMessage::textBody).all {
+                contains("$updatedByName ($updatedByEmail) on poistanut sinut")
+                contains("hankkeelta \"$hankeNimi\" ($hankeTunnus)")
+            }
         }
     }
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/email/EmailSenderService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/email/EmailSenderService.kt
@@ -60,6 +60,14 @@ data class AccessRightsUpdateNotificationData(
     val newAccessRights: Kayttooikeustaso,
 )
 
+data class RemovalFromHankeNotificationData(
+    val recipientEmail: String,
+    val hankeTunnus: String,
+    val hankeNimi: String,
+    val deletedByName: String,
+    val deletedByEmail: String,
+)
+
 data class Translations(val fi: String, val sv: String, val en: String)
 
 enum class EmailTemplate(val value: String) {
@@ -67,6 +75,7 @@ enum class EmailTemplate(val value: String) {
     INVITATION_HANKE("kayttaja-lisatty-hanke"),
     APPLICATION_NOTIFICATION("kayttaja-lisatty-hakemus"),
     ACCESS_RIGHTS_UPDATE_NOTIFICATION("kayttooikeustason-muutos"),
+    REMOVAL_FROM_HANKE_NOTIFICATION("kayttaja-poistettu-hanke"),
 }
 
 @Service
@@ -154,6 +163,31 @@ class EmailSenderService(
         sendHybridEmail(
             data.recipientEmail,
             EmailTemplate.ACCESS_RIGHTS_UPDATE_NOTIFICATION,
+            templateData
+        )
+    }
+
+    fun sendRemovalFromHankeNotificationEmail(data: RemovalFromHankeNotificationData) {
+        if (featureFlags.isDisabled(Feature.USER_MANAGEMENT)) {
+            return
+        }
+
+        logger.info { "Sending notification email for removal from hanke" }
+
+        val templateData =
+            mapOf(
+                "baseUrl" to emailConfig.baseUrl,
+                "recipientEmail" to data.recipientEmail,
+                "hankeTunnus" to data.hankeTunnus,
+                "hankeNimi" to data.hankeNimi,
+                "deletedByName" to data.deletedByName,
+                "deletedByEmail" to data.deletedByEmail,
+                "signatures" to signatures(),
+            )
+
+        sendHybridEmail(
+            data.recipientEmail,
+            EmailTemplate.REMOVAL_FROM_HANKE_NOTIFICATION,
             templateData
         )
     }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaController.kt
@@ -518,7 +518,7 @@ contact in the applicant customer role. If either is true, refuse to delete the 
     )
     fun delete(@PathVariable kayttajaId: UUID) {
         logger.info { "Deleting kayttaja $kayttajaId" }
-        hankekayttajaDeleteService.delete(kayttajaId)
+        hankekayttajaDeleteService.delete(kayttajaId, currentUserId())
         logger.info { "Deleted kayttaja $kayttajaId" }
     }
 

--- a/services/hanke-service/src/main/resources/email/template/kayttaja-poistettu-hanke.html.mustache
+++ b/services/hanke-service/src/main/resources/email/template/kayttaja-poistettu-hanke.html.mustache
@@ -1,0 +1,215 @@
+<!doctype html>
+<html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
+
+<head>
+  <title></title>
+  <!--[if !mso]><!-->
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <!--<![endif]-->
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <style type="text/css">#outlook a{padding:0}body{margin:0;padding:0;-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%}table,td{border-collapse:collapse;mso-table-lspace:0;mso-table-rspace:0}img{border:0;height:auto;line-height:100%;outline:0;text-decoration:none;-ms-interpolation-mode:bicubic}p{display:block;margin:13px 0}</style>
+  <!--[if mso]>
+    <noscript>
+    <xml>
+    <o:OfficeDocumentSettings>
+      <o:AllowPNG/>
+      <o:PixelsPerInch>96</o:PixelsPerInch>
+    </o:OfficeDocumentSettings>
+    </xml>
+    </noscript>
+    <![endif]-->
+  <!--[if lte mso 11]>
+    <style type="text/css">
+      .mj-outlook-group-fix { width:100% !important; }
+    </style>
+    <![endif]-->
+  <style type="text/css">@media only screen and (min-width:480px){.mj-column-per-100{width:100%!important;max-width:100%}}</style>
+  <style media="screen and (min-width:480px)">.moz-text-html .mj-column-per-100{width:100%!important;max-width:100%}</style>
+</head>
+
+<body style="word-spacing:normal">
+  <div lang="und" dir="auto">
+    <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    <div style="margin:0 auto;max-width:600px">
+      <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%">
+        <tbody>
+          <tr>
+            <td style="direction:ltr;font-size:0;padding:20px 0;text-align:center">
+              <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
+              <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%">
+                <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top" width="100%">
+                  <tbody>
+                    <div style="display:flex;align-items:center">
+                      <div style="padding-left:24px;padding-top:16px">
+                        <img src="{{baseUrl}}/helsinki.png" alt="Helsingin logo" width="131" height="65">
+                      </div>
+                      <div style="padding-left:16px;padding-top:12px;font-family:Arial;font-size:24px"> Haitaton </div>
+                    </div>
+                  </tbody>
+                </table>
+              </div>
+              <!--[if mso | IE]></td></tr></table><![endif]-->
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    <div style="margin:0 auto;max-width:600px">
+      <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%">
+        <tbody>
+          <tr>
+            <td style="direction:ltr;font-size:0;padding:20px 0;text-align:center">
+              <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
+              <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%">
+                <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top" width="100%">
+                  <tbody>
+                    <tr>
+                      <td align="left" style="font-size:0;padding:16px 24px 16px 24px;word-break:break-word">
+                        <div style="font-family:Arial;font-size:36px;line-height:43px;text-align:left;color:#000">Sinut on poistettu hankkeelta ({{hankeTunnus}}) / Sinut on poistettu hankkeelta ({{hankeTunnus}}) / Sinut on poistettu hankkeelta ({{hankeTunnus}})</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="left" style="font-size:0;padding:16px 24px 0 24px;word-break:break-word">
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">{{deletedByName}} ({{deletedByEmail}}) on poistanut sinut hankkeelta <b>{{hankeNimi}} ({{hankeTunnus}})</b>, eikä sinulla ole enää pääsyä hankkeelle.</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="left" style="font-size:0;padding:16px 24px 0 24px;word-break:break-word">
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">Haitaton on Helsingin kaupungin asiointijärjestelmä yleisille alueille sijoittuvien hankkeiden edistämiseen ja haittojen hallintaan.</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="left" style="font-size:0;padding:16px 24px 0 24px;word-break:break-word">
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">Tämä on automaattinen sähköposti – älä vastaa tähän viestiin.</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="left" style="font-size:0;padding:16px 24px 0 24px;word-break:break-word">
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">Ystävällisin terveisin,</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="left" style="font-size:0;padding:16px 24px 16px 24px;word-break:break-word">
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">Helsingin kaupungin kaupunkiympäristön toimiala <br> Haitaton-asiointi <br> haitaton@hel.fi</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="center" style="font-size:0;padding:10px 25px;word-break:break-word">
+                        <p style="border-top:solid 1px #999898;font-size:1px;margin:0 auto;width:100%">
+                        </p>
+                        <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" style="border-top:solid 1px #999898;font-size:1px;margin:0px auto;width:550px;" role="presentation" width="550px" ><tr><td style="height:0;line-height:0;"> &nbsp;
+</td></tr></table><![endif]-->
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="left" style="font-size:0;padding:16px 24px 0 24px;word-break:break-word">
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">{{deletedByName}} ({{deletedByEmail}}) on poistanut sinut hankkeelta <b>{{hankeNimi}} ({{hankeTunnus}})</b>. eikä sinulla ole enää pääsyä hankkeelle.</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="left" style="font-size:0;padding:16px 24px 0 24px;word-break:break-word">
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">Haitaton är Helsingfors stads hanteringssystem för att främja projekt i allmänna områden och att hantera olägenheter</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="left" style="font-size:0;padding:16px 24px 0 24px;word-break:break-word">
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">Det här är ett automatiskt e-postmeddelande – svara inte på det.</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="left" style="font-size:0;padding:16px 24px 0 24px;word-break:break-word">
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">Med vänlig hälsning,</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="left" style="font-size:0;padding:16px 24px 16px 24px;word-break:break-word">
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">Helsingfors stads stadsmiljösektor <br> Haitaton-ärenden <br> haitaton@hel.fi</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="center" style="font-size:0;padding:10px 25px;word-break:break-word">
+                        <p style="border-top:solid 1px #999898;font-size:1px;margin:0 auto;width:100%">
+                        </p>
+                        <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" style="border-top:solid 1px #999898;font-size:1px;margin:0px auto;width:550px;" role="presentation" width="550px" ><tr><td style="height:0;line-height:0;"> &nbsp;
+</td></tr></table><![endif]-->
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="left" style="font-size:0;padding:16px 24px 0 24px;word-break:break-word">
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">{{deletedByName}} ({{deletedByEmail}}) on poistanut sinut hankkeelta <b>{{hankeNimi}} ({{hankeTunnus}})</b>. eikä sinulla ole enää pääsyä hankkeelle.</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="left" style="font-size:0;padding:16px 24px 0 24px;word-break:break-word">
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">Haitaton is the City of Helsinki’s service system intended for advancing projects taking place in public areas and managing the disturbances caused by them.</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="left" style="font-size:0;padding:16px 24px 0 24px;word-break:break-word">
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">This email was generated automatically – please do not reply to this message.</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="left" style="font-size:0;padding:16px 24px 0 24px;word-break:break-word">
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">Kind regards,</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="left" style="font-size:0;padding:16px 24px 16px 24px;word-break:break-word">
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">City of Helsinki Urban Environment Division <br> Haitaton services <br> haitaton@hel.fi</div>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+              <!--[if mso | IE]></td></tr></table><![endif]-->
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#FFC61E" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    <div style="background:#ffc61e;background-color:#ffc61e;margin:0 auto;max-width:600px">
+      <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#ffc61e;background-color:#ffc61e;width:100%">
+        <tbody>
+          <tr>
+            <td style="direction:ltr;font-size:0;padding:20px 0;text-align:center">
+              <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
+              <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%">
+                <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top" width="100%">
+                  <tbody>
+                    <div style="display:flex;align-items:center">
+                      <div style="padding-left:24px;padding-top:5px;padding-bottom:16px">
+                        <img src="{{baseUrl}}/helsinki.png" alt="Helsingin logo" width="87" height="43">
+                      </div>
+                      <div style="padding-left:16px;padding-top:12px;padding-bottom:26px;font-family:Arial;font-size:16px"> Haitaton </div>
+                    </div>
+                    <tr>
+                      <td align="center" style="font-size:0;padding:0 24px 16px 24px;word-break:break-word">
+                        <p style="border-top:solid 1px #999898;font-size:1px;margin:0 auto;width:100%">
+                        </p>
+                        <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" style="border-top:solid 1px #999898;font-size:1px;margin:0px auto;width:552px;" role="presentation" width="552px" ><tr><td style="height:0;line-height:0;"> &nbsp;
+</td></tr></table><![endif]-->
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="left" style="font-size:0;padding:0 24px 0 24px;word-break:break-word">
+                        <div style="font-family:Arial;font-size:16px;line-height:1;text-align:left;color:#000">© Helsingin kaupunki 2023</div>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+              <!--[if mso | IE]></td></tr></table><![endif]-->
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <!--[if mso | IE]></td></tr></table><![endif]-->
+  </div>
+</body>
+
+</html>

--- a/services/hanke-service/src/main/resources/email/template/kayttaja-poistettu-hanke.subject.mustache
+++ b/services/hanke-service/src/main/resources/email/template/kayttaja-poistettu-hanke.subject.mustache
@@ -1,0 +1,1 @@
+Haitaton: Sinut on poistettu hankkeelta ({{hankeTunnus}}) / Sinut on poistettu hankkeelta ({{hankeTunnus}}) / Sinut on poistettu hankkeelta ({{hankeTunnus}})

--- a/services/hanke-service/src/main/resources/email/template/kayttaja-poistettu-hanke.text.mustache
+++ b/services/hanke-service/src/main/resources/email/template/kayttaja-poistettu-hanke.text.mustache
@@ -1,0 +1,15 @@
+Sinut on poistettu hankkeelta ({{hankeTunnus}}) / Sinut on poistettu hankkeelta ({{hankeTunnus}}) / Sinut on poistettu hankkeelta ({{hankeTunnus}})
+
+{{{deletedByName}}} ({{{deletedByEmail}}}) on poistanut sinut hankkeelta "{{{hankeNimi}}}" ({{hankeTunnus}}), eikä sinulla ole enää pääsyä hankkeelle.
+
+{{{signatures.fi}}}
+
+
+{{{deletedByName}}} ({{{deletedByEmail}}}) on poistanut sinut hankkeelta "{{{hankeNimi}}}" ({{hankeTunnus}}), eikä sinulla ole enää pääsyä hankkeelle.
+
+{{{signatures.sv}}}
+
+
+{{{deletedByName}}} ({{{deletedByEmail}}}) on poistanut sinut hankkeelta "{{{hankeNimi}}}" ({{hankeTunnus}}), eikä sinulla ole enää pääsyä hankkeelle.
+
+{{{signatures.en}}}


### PR DESCRIPTION
# Description

Send an email notification when the user is removed from Hanke.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2411

## Type of change

- [ ] Bug fix 
- [x] New feature 
- [ ] Other

# Instructions for testing
Create a new Hanke or add some (deletable) user on existing Hanke. Use Swagger UI or Haitaton UI (in branch of this PR: https://github.com/City-of-Helsinki/haitaton-ui/pull/605). When deleting a user it should receive an email notification about deletion.

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 

# Other relevant info
Please describe here if there is e.g. some requirements for this change or
 other info that the tester/user needs to know.