### PR TITLE
HAI-2301 Add disclosure logging for invoicing customer

### DIFF
--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/ApplicationFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/ApplicationFactory.kt
@@ -110,14 +110,14 @@ class ApplicationFactory(
             )
 
         fun createPersonInvoicingCustomer(
-            name: String = "Liisa Laskuttaja",
+            name: String = "Liisa Laskutettava",
         ): InvoicingCustomer =
             InvoicingCustomer(
                 type = CustomerType.PERSON,
                 name = name,
                 postalAddress = createPostalAddress(),
-                email = "info@dna.test",
-                phone = "+3581012345678",
+                email = "liisa@laskutus.info",
+                phone = "963852741",
                 registryKey = null,
                 ovt = null,
                 invoicingOperator = null,


### PR DESCRIPTION
# Description

If the invoicing customer is a person, their information should be logged in disclosure logs when the application information is sent to Allu.

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 

# Other relevant info
I'm afraid we'll forget to add this later, so I'm adding it now.