### PR TITLE
HAI-2301 Fix sending johtoselvityshakemus to Allu

### DIFF
--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/AlluApplicationData.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/AlluApplicationData.kt
@@ -1,8 +1,11 @@
 package fi.hel.haitaton.hanke.allu
 
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonInclude.Include
 import java.time.ZonedDateTime
 import org.geojson.GeometryCollection
 
+@JsonInclude(Include.NON_NULL)
 sealed interface AlluApplicationData {
     val identificationNumber: String
     val pendingOnClient: Boolean


### PR DESCRIPTION
# Description

Allu send fails when `trafficArrangementImages` is null, which it always is. Allu returns with 500 Internal Server Error. I'm guessing it's because it's expecting an array in that field, if the field is present. Our Jackson seems to be configured to include null values as explicit nulls.

Add an annotation to `AlluApplicationData` to make it ignore the null values when serializing the data to be sent. It will remove fields that are nulls, so `trafficArrangementImages` will not be sent unless it's a list.

## Type of change

- [X] Bug fix 
- [ ] New feature 
- [ ] Other

# Instructions for testing
Create a johtoselvityshakemus and send it to Allu.

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 