### PR TITLE
HAI-2376 Copy decision download functionality to hakemus side

### DIFF
--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/Hakemus.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/Hakemus.kt
@@ -2,6 +2,7 @@ package fi.hel.haitaton.hanke.hakemus
 
 import fi.hel.haitaton.hanke.allu.ApplicationStatus
 import fi.hel.haitaton.hanke.application.ApplicationArea
+import fi.hel.haitaton.hanke.application.ApplicationMetaData
 import fi.hel.haitaton.hanke.application.ApplicationType
 import fi.hel.haitaton.hanke.application.PostalAddress
 import fi.hel.haitaton.hanke.domain.HasId
@@ -26,6 +27,16 @@ data class Hakemus(
             applicationType = applicationType,
             applicationData = applicationData.toResponse(),
             hankeTunnus = hankeTunnus,
+        )
+
+    fun toMetadata(): ApplicationMetaData =
+        ApplicationMetaData(
+            id = id,
+            alluid = alluid,
+            alluStatus = alluStatus,
+            applicationIdentifier = applicationIdentifier,
+            applicationType = applicationType,
+            hankeTunnus = hankeTunnus
         )
 }
 

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusBuilder.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusBuilder.kt
@@ -48,9 +48,9 @@ data class HakemusBuilder(
     }
 
     fun withStatus(
-        status: ApplicationStatus = ApplicationStatus.PENDING,
-        alluId: Int = 1,
-        identifier: String = "JS000$alluId",
+        status: ApplicationStatus? = ApplicationStatus.PENDING,
+        alluId: Int? = 1,
+        identifier: String? = "JS000$alluId",
     ): HakemusBuilder {
         applicationEntity.apply {
             alluid = alluId
@@ -59,6 +59,9 @@ data class HakemusBuilder(
         }
         return this
     }
+
+    fun withNoAlluFields(): HakemusBuilder =
+        withStatus(status = null, alluId = null, identifier = null)
 
     fun inHandling(alluId: Int = 1) = withStatus(ApplicationStatus.HANDLING, alluId)
 


### PR DESCRIPTION
# Description

Copy the decision endpoint from ApplicationController to HakemusController, along with the service implementation. There are no changes in how downloading the decision from Allu works with kortisto, so only some factory calls and such needed to be modified.

Rename `cableReportService` to `alluClient` in `HakemusServiceITest` to match the naming in the service itself.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2376

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
Make a decision in Allu for an application. Download it from Haitaton.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 