### PR TITLE
HAI-2375 Copy application cancellation / deletion endpoint to hakemus

### DIFF
--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationService.kt
@@ -23,6 +23,7 @@ import fi.hel.haitaton.hanke.configuration.Feature
 import fi.hel.haitaton.hanke.configuration.FeatureFlags
 import fi.hel.haitaton.hanke.email.ApplicationNotificationData
 import fi.hel.haitaton.hanke.email.EmailSenderService
+import fi.hel.haitaton.hanke.geometria.Geometriat
 import fi.hel.haitaton.hanke.geometria.GeometriatDao
 import fi.hel.haitaton.hanke.logging.ApplicationLoggingService
 import fi.hel.haitaton.hanke.logging.DisclosureLogService
@@ -341,7 +342,7 @@ class ApplicationService(
 
             logger.info { "Deleting application, id=$id, alluid=$alluid userid=$userId" }
             val application = toApplication()
-            attachmentService.deleteAllAttachments(application)
+            attachmentService.deleteAllAttachments(id!!)
             applicationRepository.delete(this)
             applicationLoggingService.logDelete(application, userId)
             logger.info { "Application deleted, id=$id, alluid=$alluid userid=$userId" }
@@ -722,7 +723,7 @@ class ApplicationService(
     }
 
     /** Map by area geometry id to area geometry data. */
-    private fun geometryMapFrom(hanke: HankeEntity) =
+    private fun geometryMapFrom(hanke: HankeEntity): Map<Int, Geometriat?> =
         hanke.alueet
             .mapNotNull { it.geometriat }
             .associateWith { geometriatDao.retrieveGeometriat(it) }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentService.kt
@@ -115,11 +115,11 @@ class ApplicationAttachmentService(
         logger.info { "Deleted attachment $attachmentId from application ${application.id}" }
     }
 
-    fun deleteAllAttachments(application: Application) {
-        logger.info { "Deleting all attachments from application ${application.id}" }
-        metadataService.deleteAllAttachments(application.id!!)
-        attachmentContentService.deleteAllForApplication(application.id)
-        logger.info { "Deleted all attachments from application ${application.id}" }
+    fun deleteAllAttachments(applicationId: Long) {
+        logger.info { "Deleting all attachments from application $applicationId" }
+        metadataService.deleteAllAttachments(applicationId)
+        attachmentContentService.deleteAllForApplication(applicationId)
+        logger.info { "Deleted all attachments from application $applicationId" }
     }
 
     fun sendInitialAttachments(alluId: Int, applicationId: Long) {

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceTest.kt
@@ -35,6 +35,7 @@ import fi.hel.haitaton.hanke.factory.PermissionFactory
 import fi.hel.haitaton.hanke.geometria.GeometriatDao
 import fi.hel.haitaton.hanke.logging.DisclosureLogService
 import fi.hel.haitaton.hanke.logging.HakemusLoggingService
+import fi.hel.haitaton.hanke.logging.HankeLoggingService
 import fi.hel.haitaton.hanke.logging.Status
 import fi.hel.haitaton.hanke.permissions.HankeKayttajaService
 import fi.hel.haitaton.hanke.test.AlluException
@@ -67,6 +68,7 @@ class HakemusServiceTest {
     private val geometriatDao: GeometriatDao = mockk()
     private val hankealueService: HankealueService = mockk()
     private val loggingService: HakemusLoggingService = mockk(relaxUnitFun = true)
+    private val hankeLoggingService: HankeLoggingService = mockk(relaxUnitFun = true)
     private val disclosureLogService: DisclosureLogService = mockk(relaxUnitFun = true)
     private val hankeKayttajaService: HankeKayttajaService = mockk(relaxUnitFun = true)
     private val attachmentService: ApplicationAttachmentService = mockk()
@@ -79,6 +81,7 @@ class HakemusServiceTest {
             geometriatDao,
             hankealueService,
             loggingService,
+            hankeLoggingService,
             disclosureLogService,
             hankeKayttajaService,
             attachmentService,


### PR DESCRIPTION
# Description

Copy the application cancellation and deletion endpoint from ApplicationController to HakemusController, along with the service implementation. Modify some method boundaries to make the code easier to test.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2375

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
Create a johtoselvityshakemus and then cancel it.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 