### PR TITLE
HAI-2375 Improve logging of hakemus ID's

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationAuthorizerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationAuthorizerITest.kt
@@ -49,7 +49,7 @@ class ApplicationAuthorizerITest(
             val hanke = hankeFactory.saveMinimal()
             val application = applicationFactory.saveApplicationEntity(USERNAME, hanke)
 
-            assertFailure { authorizer.authorizeApplicationId(application.id!!, VIEW.name) }
+            assertFailure { authorizer.authorizeApplicationId(application.id, VIEW.name) }
                 .all {
                     hasClass(ApplicationNotFoundException::class)
                     messageContains(application.id.toString())
@@ -63,7 +63,7 @@ class ApplicationAuthorizerITest(
             permissionService.create(hanke.id, USERNAME, Kayttooikeustaso.HANKEMUOKKAUS)
 
             assertFailure {
-                    authorizer.authorizeApplicationId(application.id!!, PermissionCode.DELETE.name)
+                    authorizer.authorizeApplicationId(application.id, PermissionCode.DELETE.name)
                 }
                 .all {
                     hasClass(ApplicationNotFoundException::class)
@@ -77,7 +77,7 @@ class ApplicationAuthorizerITest(
             val application = applicationFactory.saveApplicationEntity(USERNAME, hanke)
             permissionService.create(hanke.id, USERNAME, Kayttooikeustaso.HANKEMUOKKAUS)
 
-            assertThat(authorizer.authorizeApplicationId(application.id!!, VIEW.name)).isTrue()
+            assertThat(authorizer.authorizeApplicationId(application.id, VIEW.name)).isTrue()
         }
     }
 
@@ -138,11 +138,11 @@ class ApplicationAuthorizerITest(
             val application = applicationFactory.saveApplicationEntity(USERNAME, hanke)
 
             assertFailure {
-                    authorizer.authorizeAttachment(application.id!!, attachmentId, VIEW.name)
+                    authorizer.authorizeAttachment(application.id, attachmentId, VIEW.name)
                 }
                 .all {
                     hasClass(ApplicationNotFoundException::class)
-                    messageContains(application.id!!.toString())
+                    messageContains(application.id.toString())
                 }
         }
 
@@ -153,11 +153,11 @@ class ApplicationAuthorizerITest(
             val application = applicationFactory.saveApplicationEntity(USERNAME, hanke)
 
             assertFailure {
-                    authorizer.authorizeAttachment(application.id!!, attachmentId, EDIT.name)
+                    authorizer.authorizeAttachment(application.id, attachmentId, EDIT.name)
                 }
                 .all {
                     hasClass(ApplicationNotFoundException::class)
-                    messageContains(application.id!!.toString())
+                    messageContains(application.id.toString())
                 }
         }
 
@@ -168,7 +168,7 @@ class ApplicationAuthorizerITest(
             val application = applicationFactory.saveApplicationEntity(USERNAME, hanke)
 
             assertFailure {
-                    authorizer.authorizeAttachment(application.id!!, attachmentId, VIEW.name)
+                    authorizer.authorizeAttachment(application.id, attachmentId, VIEW.name)
                 }
                 .all {
                     hasClass(AttachmentNotFoundException::class)
@@ -187,7 +187,7 @@ class ApplicationAuthorizerITest(
             permissionService.create(hanke.id, USERNAME, Kayttooikeustaso.KATSELUOIKEUS)
 
             assertFailure {
-                    authorizer.authorizeAttachment(application.id!!, attachment.id!!, VIEW.name)
+                    authorizer.authorizeAttachment(application.id, attachment.id!!, VIEW.name)
                 }
                 .all {
                     hasClass(AttachmentNotFoundException::class)
@@ -203,7 +203,7 @@ class ApplicationAuthorizerITest(
                 applicationAttachmentFactory.save(application = application).withContent().value
             permissionService.create(hanke.id, USERNAME, Kayttooikeustaso.KATSELUOIKEUS)
 
-            assertThat(authorizer.authorizeAttachment(application.id!!, attachment.id!!, VIEW.name))
+            assertThat(authorizer.authorizeAttachment(application.id, attachment.id!!, VIEW.name))
                 .isTrue()
         }
 

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationControllerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationControllerITest.kt
@@ -248,7 +248,7 @@ class ApplicationControllerITest(@Autowired override val mockMvc: MockMvc) : Con
         @Test
         @WithAnonymousUser
         fun `when unknown user should return 401`() {
-            post(BASE_URL, ApplicationFactory.createApplication(id = null))
+            post(BASE_URL, ApplicationFactory.createApplication(id = 0))
                 .andExpect(status().isUnauthorized)
 
             verify { applicationService wasNot Called }
@@ -264,7 +264,7 @@ class ApplicationControllerITest(@Autowired override val mockMvc: MockMvc) : Con
         @Test
         fun `when valid application should create application`() {
             val newApplication =
-                ApplicationFactory.createApplication(id = null, hankeTunnus = HANKE_TUNNUS)
+                ApplicationFactory.createApplication(id = 0, hankeTunnus = HANKE_TUNNUS)
             val createdApplication = newApplication.copy(id = 1234)
             every { authorizer.authorizeCreate(newApplication) } returns true
             every { applicationService.create(newApplication, USERNAME) } returns createdApplication
@@ -281,7 +281,7 @@ class ApplicationControllerITest(@Autowired override val mockMvc: MockMvc) : Con
 
         @Test
         fun `when missing application data type should return 400`() {
-            val application = ApplicationFactory.createApplication(id = null)
+            val application = ApplicationFactory.createApplication(id = 0)
             val content: ObjectNode = OBJECT_MAPPER.valueToTree(application)
             (content.get("applicationData") as ObjectNode).remove("applicationType")
 
@@ -294,7 +294,7 @@ class ApplicationControllerITest(@Autowired override val mockMvc: MockMvc) : Con
         fun `when end before start should return 400`() {
             val application =
                 ApplicationFactory.createApplication(
-                    id = null,
+                    id = 0,
                     applicationData =
                         ApplicationFactory.createCableReportApplicationData(
                             startTime = ZonedDateTime.now(),
@@ -313,7 +313,7 @@ class ApplicationControllerITest(@Autowired override val mockMvc: MockMvc) : Con
 
         @Test
         fun `when missing application type should return 400`() {
-            val application = ApplicationFactory.createApplication(id = null)
+            val application = ApplicationFactory.createApplication(id = 0)
             val content: ObjectNode = OBJECT_MAPPER.valueToTree(application)
             content.remove("applicationType")
 
@@ -333,7 +333,7 @@ class ApplicationControllerITest(@Autowired override val mockMvc: MockMvc) : Con
                             .withContacts()
                 )
             val application =
-                ApplicationFactory.createApplication(id = null, applicationData = applicationData)
+                ApplicationFactory.createApplication(id = 0, applicationData = applicationData)
             every { authorizer.authorizeCreate(application) } returns true
 
             post(BASE_URL, application).andExpect(status().isBadRequest)
@@ -347,7 +347,7 @@ class ApplicationControllerITest(@Autowired override val mockMvc: MockMvc) : Con
         @Test
         fun `when application without hankeTunnus should return 400`() {
             val newApplication =
-                ApplicationFactory.createApplication(id = null, hankeTunnus = HANKE_TUNNUS)
+                ApplicationFactory.createApplication(id = 0, hankeTunnus = HANKE_TUNNUS)
             val json = objectMapper.valueToTree<ObjectNode>(newApplication)
             json.remove("hankeTunnus")
             val text = json.asText()
@@ -357,7 +357,7 @@ class ApplicationControllerITest(@Autowired override val mockMvc: MockMvc) : Con
         @Test
         fun `when no hanke permission should return hanke not found 404`() {
             val newApplication =
-                ApplicationFactory.createApplication(id = null, hankeTunnus = HANKE_TUNNUS)
+                ApplicationFactory.createApplication(id = 0, hankeTunnus = HANKE_TUNNUS)
             every { authorizer.authorizeCreate(newApplication) } throws
                 HankeNotFoundException(HANKE_TUNNUS)
 
@@ -434,7 +434,7 @@ class ApplicationControllerITest(@Autowired override val mockMvc: MockMvc) : Con
         fun `when end before start should return 400`() {
             val application =
                 ApplicationFactory.createApplication(
-                    id = null,
+                    id = 0,
                     applicationData =
                         ApplicationFactory.createCableReportApplicationData(
                             startTime = ZonedDateTime.now(),
@@ -465,7 +465,7 @@ class ApplicationControllerITest(@Autowired override val mockMvc: MockMvc) : Con
                             .withContacts()
                 )
             val application =
-                ApplicationFactory.createApplication(id = null, applicationData = applicationData)
+                ApplicationFactory.createApplication(id = 0, applicationData = applicationData)
             every { authorizer.authorizeApplicationId(id, EDIT_APPLICATIONS.name) } returns true
 
             put("$BASE_URL/$id", application).andExpect(status().isBadRequest)

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceITest.kt
@@ -189,7 +189,7 @@ class ApplicationServiceITest : IntegrationTest() {
             val application =
                 applicationService.create(
                     createApplication(
-                        id = null,
+                        id = 0,
                         hankeTunnus = hanke.hankeTunnus,
                         applicationData = dataWithoutAreas
                     ),
@@ -202,7 +202,7 @@ class ApplicationServiceITest : IntegrationTest() {
             assertThat(applicationLogs).single().isSuccess(Operation.CREATE) {
                 hasUserActor(USERNAME, TestUtils.mockedIp)
                 withTarget {
-                    prop(AuditLogTarget::id).isEqualTo(application.id?.toString())
+                    prop(AuditLogTarget::id).isEqualTo(application.id.toString())
                     prop(AuditLogTarget::type).isEqualTo(ObjectType.APPLICATION)
                     prop(AuditLogTarget::objectBefore).isNull()
                     prop(AuditLogTarget::objectAfter).given {
@@ -272,7 +272,7 @@ class ApplicationServiceITest : IntegrationTest() {
             val response = applicationService.create(newApplication, USERNAME)
 
             assertTrue(response.applicationData.pendingOnClient)
-            val savedApplication = applicationRepository.findById(response.id!!).get()
+            val savedApplication = applicationRepository.findById(response.id).get()
             assertTrue(savedApplication.applicationData.pendingOnClient)
             verify { cableReportServiceAllu wasNot Called }
         }
@@ -280,7 +280,7 @@ class ApplicationServiceITest : IntegrationTest() {
         @Test
         fun `when invalid geometry in areas should throw`() {
             val cableReportData = createCableReportApplicationData(areas = listOf(intersectingArea))
-            val newApplication = createApplication(id = null, applicationData = cableReportData)
+            val newApplication = createApplication(id = 0, applicationData = cableReportData)
 
             val exception =
                 assertThrows<ApplicationGeometryException> {
@@ -304,7 +304,7 @@ class ApplicationServiceITest : IntegrationTest() {
                 createCableReportApplicationData(areas = listOf(havisAmanda))
             val newApplication =
                 createApplication(
-                    id = null,
+                    id = 0,
                     hankeTunnus = hanke.hankeTunnus,
                     applicationData = cableReportApplicationData
                 )
@@ -317,7 +317,7 @@ class ApplicationServiceITest : IntegrationTest() {
         @Test
         fun `when application without hankeTunnus should throw`() {
             assertThrows<HankeNotFoundException> {
-                applicationService.create(createApplication(id = null, hankeTunnus = ""), USERNAME)
+                applicationService.create(createApplication(id = 0, hankeTunnus = ""), USERNAME)
             }
         }
     }
@@ -332,7 +332,7 @@ class ApplicationServiceITest : IntegrationTest() {
                 applicationService.create(
                     createApplication(
                         applicationType = ApplicationType.CABLE_REPORT,
-                        id = null,
+                        id = 0,
                         hankeTunnus = hanke.hankeTunnus,
                         applicationData = dataWithoutAreas
                     ),
@@ -342,7 +342,7 @@ class ApplicationServiceITest : IntegrationTest() {
             assertThat(auditLogRepository.findAll()).isEmpty()
 
             applicationService.updateApplicationData(
-                application.id!!,
+                application.id,
                 dataWithoutAreas.copy(name = "Modified application"),
                 USERNAME
             )
@@ -355,7 +355,7 @@ class ApplicationServiceITest : IntegrationTest() {
             assertThat(applicationLogs).single().isSuccess(Operation.UPDATE) {
                 hasUserActor(USERNAME, TestUtils.mockedIp)
                 withTarget {
-                    prop(AuditLogTarget::id).isEqualTo(application.id?.toString())
+                    prop(AuditLogTarget::id).isEqualTo(application.id.toString())
                     prop(AuditLogTarget::type).isEqualTo(ObjectType.APPLICATION)
                     prop(AuditLogTarget::objectBefore).given {
                         JSONAssert.assertEquals(expectedBefore, it, JSONCompareMode.NON_EXTENSIBLE)
@@ -386,7 +386,7 @@ class ApplicationServiceITest : IntegrationTest() {
 
             val exception = assertFailure {
                 applicationService.updateApplicationData(
-                    application.id!!,
+                    application.id,
                     newApplicationData,
                     USERNAME
                 )
@@ -409,7 +409,7 @@ class ApplicationServiceITest : IntegrationTest() {
             assertThat(auditLogRepository.findAll()).isEmpty()
 
             applicationService.updateApplicationData(
-                application.id!!,
+                application.id,
                 application.applicationData,
                 USERNAME
             )
@@ -447,7 +447,7 @@ class ApplicationServiceITest : IntegrationTest() {
 
             val response =
                 applicationService.updateApplicationData(
-                    initialApplication.id!!,
+                    initialApplication.id,
                     newApplicationData,
                     USERNAME
                 )
@@ -469,7 +469,7 @@ class ApplicationServiceITest : IntegrationTest() {
 
             val response =
                 applicationService.updateApplicationData(
-                    initialApplication.id!!,
+                    initialApplication.id,
                     newApplicationData,
                     USERNAME
                 )
@@ -498,7 +498,7 @@ class ApplicationServiceITest : IntegrationTest() {
 
             val response =
                 applicationService.updateApplicationData(
-                    application.id!!,
+                    application.id,
                     newApplicationData,
                     USERNAME
                 )
@@ -533,13 +533,13 @@ class ApplicationServiceITest : IntegrationTest() {
 
             val response =
                 applicationService.updateApplicationData(
-                    application.id!!,
+                    application.id,
                     newApplicationData,
                     USERNAME
                 )
 
             assertFalse(response.applicationData.pendingOnClient)
-            val savedApplication = applicationRepository.findById(application.id!!).get()
+            val savedApplication = applicationRepository.findById(application.id).get()
             assertFalse(savedApplication.applicationData.pendingOnClient)
         }
 
@@ -553,7 +553,7 @@ class ApplicationServiceITest : IntegrationTest() {
             val exception =
                 assertThrows<ApplicationGeometryException> {
                     applicationService.updateApplicationData(
-                        application.id!!,
+                        application.id,
                         cableReportApplicationData,
                         USERNAME
                     )
@@ -582,7 +582,7 @@ class ApplicationServiceITest : IntegrationTest() {
             val exception =
                 assertThrows<ApplicationGeometryNotInsideHankeException> {
                     applicationService.updateApplicationData(
-                        application.id!!,
+                        application.id,
                         cableReportApplicationData,
                         USERNAME
                     )
@@ -678,7 +678,7 @@ class ApplicationServiceITest : IntegrationTest() {
             val hanke = hankeFactory.saveMinimal()
             val applications =
                 applicationFactory.saveApplicationEntities(3, USERNAME, hanke = hanke)
-            val selectedId = applications[1].id!!
+            val selectedId = applications[1].id
             assertThat(applicationRepository.findAll()).hasSize(3)
 
             val response = applicationService.getApplicationById(selectedId)
@@ -713,7 +713,7 @@ class ApplicationServiceITest : IntegrationTest() {
                 createAlluApplicationResponse(alluIdMock)
             justRun { cableReportServiceAllu.addAttachment(any(), any()) }
 
-            applicationService.sendApplication(initialApplication.id!!, USERNAME)
+            applicationService.sendApplication(initialApplication.id, USERNAME)
 
             verify { cableReportServiceAllu.create(any()) }
             verify { cableReportServiceAllu.addAttachment(any(), any()) }
@@ -745,11 +745,11 @@ class ApplicationServiceITest : IntegrationTest() {
             every { cableReportServiceAllu.getApplicationInformation(21) } returns
                 createAlluApplicationResponse(21, PENDING)
 
-            val response = applicationService.sendApplication(application.id!!, USERNAME)
+            val response = applicationService.sendApplication(application.id, USERNAME)
 
             val responseApplicationData = response.applicationData as CableReportApplicationData
             assertFalse(responseApplicationData.pendingOnClient)
-            val savedApplication = applicationRepository.findById(application.id!!).get()
+            val savedApplication = applicationRepository.findById(application.id).get()
             val savedApplicationData =
                 savedApplication.applicationData as CableReportApplicationData
             assertFalse(savedApplicationData.pendingOnClient)
@@ -774,7 +774,7 @@ class ApplicationServiceITest : IntegrationTest() {
             every { cableReportServiceAllu.getApplicationInformation(26) } returns
                 createAlluApplicationResponse(26)
 
-            applicationService.sendApplication(application.id!!, USERNAME)
+            applicationService.sendApplication(application.id, USERNAME)
 
             val kutsut = kayttajakutsuRepository.findAll()
             assertThat(kutsut).single().all {
@@ -822,7 +822,7 @@ class ApplicationServiceITest : IntegrationTest() {
                 createAlluApplicationResponse(26)
             justRun { cableReportServiceAllu.addAttachment(26, any()) }
 
-            applicationService.sendApplication(application.id!!, USERNAME)
+            applicationService.sendApplication(application.id, USERNAME)
 
             val capturedEmails = getApplicationNotifications()
             assertThat(capturedEmails).hasSize(3) // 4 contacts, but one is the sender
@@ -847,7 +847,7 @@ class ApplicationServiceITest : IntegrationTest() {
             every { cableReportServiceAllu.getApplicationInformation(21) } returns
                 createAlluApplicationResponse(21, PENDING)
 
-            applicationService.sendApplication(application.id!!, USERNAME)
+            applicationService.sendApplication(application.id, USERNAME)
 
             verify { cableReportServiceAllu.getApplicationInformation(21) }
             verify(exactly = 0) { cableReportServiceAllu.update(any(), any()) }
@@ -867,7 +867,7 @@ class ApplicationServiceITest : IntegrationTest() {
                 createAlluApplicationResponse(21, DECISIONMAKING)
 
             assertThrows<ApplicationAlreadyProcessingException> {
-                applicationService.sendApplication(application.id!!, USERNAME)
+                applicationService.sendApplication(application.id, USERNAME)
             }
 
             verify { cableReportServiceAllu.getApplicationInformation(21) }
@@ -891,13 +891,13 @@ class ApplicationServiceITest : IntegrationTest() {
             justRun { cableReportServiceAllu.addAttachment(26, any()) }
             every { cableReportServiceAllu.getApplicationInformation(26) } throws AlluException()
 
-            val response = applicationService.sendApplication(application.id!!, USERNAME)
+            val response = applicationService.sendApplication(application.id, USERNAME)
 
             assertEquals(26, response.alluid)
             assertEquals(pendingApplicationData, response.applicationData)
             assertNull(response.applicationIdentifier)
             assertNull(response.alluStatus)
-            val savedApplication = applicationRepository.findById(application.id!!).get()
+            val savedApplication = applicationRepository.findById(application.id).get()
             assertEquals(26, savedApplication.alluid)
             assertEquals(pendingApplicationData, savedApplication.applicationData)
             assertNull(savedApplication.applicationIdentifier)
@@ -922,7 +922,7 @@ class ApplicationServiceITest : IntegrationTest() {
                 )
 
             assertThrows<ApplicationGeometryNotInsideHankeException> {
-                applicationService.sendApplication(application.id!!, USERNAME)
+                applicationService.sendApplication(application.id, USERNAME)
             }
         }
 
@@ -948,7 +948,7 @@ class ApplicationServiceITest : IntegrationTest() {
             every { cableReportServiceAllu.sendSystemComment(alluId, any()) } returns 4141
 
             assertThrows<AlluException> {
-                applicationService.sendApplication(application.id!!, USERNAME)
+                applicationService.sendApplication(application.id, USERNAME)
             }
 
             verifyOrder {
@@ -981,11 +981,11 @@ class ApplicationServiceITest : IntegrationTest() {
             every { cableReportServiceAllu.getApplicationInformation(alluId) } returns
                 createAlluApplicationResponse(alluId)
 
-            val response = applicationService.sendApplication(application.id!!, USERNAME)
+            val response = applicationService.sendApplication(application.id, USERNAME)
 
             assertThat(response.alluid).isEqualTo(alluId)
             assertThat(response.alluStatus).isEqualTo(PENDING)
-            val savedApplication = applicationRepository.findById(application.id!!).get()
+            val savedApplication = applicationRepository.findById(application.id).get()
             assertThat(savedApplication.alluid).isEqualTo(alluId)
             assertThat(savedApplication.alluStatus).isEqualTo(PENDING)
             verifyOrder {
@@ -1014,7 +1014,7 @@ class ApplicationServiceITest : IntegrationTest() {
             every { cableReportServiceAllu.getApplicationInformation(26) } returns
                 createAlluApplicationResponse(26)
 
-            val response = applicationService.sendApplication(application.id!!, USERNAME)
+            val response = applicationService.sendApplication(application.id, USERNAME)
 
             assertEquals(26, response.alluid)
             assertEquals(pendingApplicationData, response.applicationData)
@@ -1023,7 +1023,7 @@ class ApplicationServiceITest : IntegrationTest() {
                 response.applicationIdentifier
             )
             assertEquals(PENDING, response.alluStatus)
-            val savedApplication = applicationRepository.findById(application.id!!).get()
+            val savedApplication = applicationRepository.findById(application.id).get()
             assertEquals(26, savedApplication.alluid)
             assertEquals(pendingApplicationData, savedApplication.applicationData)
             assertEquals(
@@ -1060,18 +1060,18 @@ class ApplicationServiceITest : IntegrationTest() {
             assertThat(applicationRepository.findAll()).hasSize(1)
             attachmentFactory.save(application = application).withContent()
             attachmentFactory.save(application = application).withContent()
-            assertThat(fileClient.list(Container.HAKEMUS_LIITTEET, prefix(application.id!!)))
+            assertThat(fileClient.list(Container.HAKEMUS_LIITTEET, prefix(application.id)))
                 .hasSize(2)
-            assertThat(applicationAttachmentRepository.findByApplicationId(application.id!!))
+            assertThat(applicationAttachmentRepository.findByApplicationId(application.id))
                 .hasSize(2)
 
-            applicationService.delete(application.id!!, USERNAME)
+            applicationService.delete(application.id, USERNAME)
 
             assertThat(applicationRepository.findAll()).isEmpty()
             verify { cableReportServiceAllu wasNot Called }
-            assertThat(fileClient.list(Container.HAKEMUS_LIITTEET, prefix(application.id!!)))
+            assertThat(fileClient.list(Container.HAKEMUS_LIITTEET, prefix(application.id)))
                 .isEmpty()
-            assertThat(applicationAttachmentRepository.findByApplicationId(application.id!!))
+            assertThat(applicationAttachmentRepository.findByApplicationId(application.id))
                 .isEmpty()
         }
 
@@ -1083,7 +1083,7 @@ class ApplicationServiceITest : IntegrationTest() {
                 applicationService.create(
                     createApplication(
                         applicationType = ApplicationType.CABLE_REPORT,
-                        id = null,
+                        id = 0,
                         hankeTunnus = hanke.hankeTunnus,
                         applicationData = dataWithoutAreas
                     ),
@@ -1092,7 +1092,7 @@ class ApplicationServiceITest : IntegrationTest() {
             auditLogRepository.deleteAll()
             assertThat(auditLogRepository.findAll()).isEmpty()
 
-            applicationService.delete(application.id!!, USERNAME)
+            applicationService.delete(application.id, USERNAME)
 
             val applicationLogs = auditLogRepository.findByType(ObjectType.APPLICATION)
             val expectedObject =
@@ -1100,7 +1100,7 @@ class ApplicationServiceITest : IntegrationTest() {
             assertThat(applicationLogs).single().isSuccess(Operation.DELETE) {
                 hasUserActor(USERNAME, TestUtils.mockedIp)
                 withTarget {
-                    prop(AuditLogTarget::id).isEqualTo(application.id?.toString())
+                    prop(AuditLogTarget::id).isEqualTo(application.id.toString())
                     prop(AuditLogTarget::type).isEqualTo(ObjectType.APPLICATION)
                     prop(AuditLogTarget::objectBefore).given {
                         JSONAssert.assertEquals(expectedObject, it, JSONCompareMode.NON_EXTENSIBLE)
@@ -1122,7 +1122,7 @@ class ApplicationServiceITest : IntegrationTest() {
             justRun { cableReportServiceAllu.cancel(73) }
             every { cableReportServiceAllu.sendSystemComment(73, any()) } returns 1324
 
-            applicationService.delete(application.id!!, USERNAME)
+            applicationService.delete(application.id, USERNAME)
 
             assertThat(applicationRepository.findAll()).hasSize(0)
             verifyOrder {
@@ -1142,7 +1142,7 @@ class ApplicationServiceITest : IntegrationTest() {
                 createAlluApplicationResponse(73, APPROVED)
 
             assertThrows<ApplicationAlreadyProcessingException> {
-                applicationService.delete(application.id!!, USERNAME)
+                applicationService.delete(application.id, USERNAME)
             }
 
             assertThat(applicationRepository.findAll()).hasSize(1)
@@ -1160,7 +1160,7 @@ class ApplicationServiceITest : IntegrationTest() {
             assertThat(applicationRepository.findAll()).hasSize(1)
 
             val result =
-                applicationService.deleteWithOrphanGeneratedHankeRemoval(application.id!!, USERNAME)
+                applicationService.deleteWithOrphanGeneratedHankeRemoval(application.id, USERNAME)
 
             assertThat(result).isEqualTo(ApplicationDeletionResultDto(hankeDeleted = true))
             assertThat(applicationRepository.findAll()).isEmpty()
@@ -1178,20 +1178,20 @@ class ApplicationServiceITest : IntegrationTest() {
             assertThat(applicationRepository.findAll()).hasSize(1)
             attachmentFactory.save(application = application).withContent()
             attachmentFactory.save(application = application).withContent()
-            assertThat(applicationAttachmentRepository.findByApplicationId(application.id!!))
+            assertThat(applicationAttachmentRepository.findByApplicationId(application.id))
                 .hasSize(2)
-            assertThat(fileClient.list(Container.HAKEMUS_LIITTEET, prefix(application.id!!)))
+            assertThat(fileClient.list(Container.HAKEMUS_LIITTEET, prefix(application.id)))
                 .hasSize(2)
 
             val result =
-                applicationService.deleteWithOrphanGeneratedHankeRemoval(application.id!!, USERNAME)
+                applicationService.deleteWithOrphanGeneratedHankeRemoval(application.id, USERNAME)
 
             assertThat(result).isEqualTo(ApplicationDeletionResultDto(hankeDeleted = true))
             assertThat(applicationRepository.findAll()).isEmpty()
             assertThat(hankeRepository.findAll()).isEmpty()
-            assertThat(fileClient.list(Container.HAKEMUS_LIITTEET, prefix(application.id!!)))
+            assertThat(fileClient.list(Container.HAKEMUS_LIITTEET, prefix(application.id)))
                 .isEmpty()
-            assertThat(applicationAttachmentRepository.findByApplicationId(application.id!!))
+            assertThat(applicationAttachmentRepository.findByApplicationId(application.id))
                 .isEmpty()
         }
 
@@ -1203,7 +1203,7 @@ class ApplicationServiceITest : IntegrationTest() {
             assertThat(applicationRepository.findAll()).hasSize(1)
 
             val result =
-                applicationService.deleteWithOrphanGeneratedHankeRemoval(application.id!!, USERNAME)
+                applicationService.deleteWithOrphanGeneratedHankeRemoval(application.id, USERNAME)
 
             assertThat(result).isEqualTo(ApplicationDeletionResultDto(hankeDeleted = false))
             assertThat(applicationRepository.findAll()).isEmpty()
@@ -1220,14 +1220,11 @@ class ApplicationServiceITest : IntegrationTest() {
             assertThat(applicationRepository.findAll()).hasSize(2)
 
             val result =
-                applicationService.deleteWithOrphanGeneratedHankeRemoval(
-                    application1.id!!,
-                    USERNAME
-                )
+                applicationService.deleteWithOrphanGeneratedHankeRemoval(application1.id, USERNAME)
 
             assertThat(result).isEqualTo(ApplicationDeletionResultDto(hankeDeleted = false))
             assertThat(applicationRepository.findAll()).hasSize(1)
-            assertThat(applicationRepository.findById(application2.id!!)).isPresent()
+            assertThat(applicationRepository.findById(application2.id)).isPresent()
             assertThat(hankeRepository.findByHankeTunnus(hanke.hankeTunnus)).isNotNull()
             verify { cableReportServiceAllu wasNot Called }
         }
@@ -1253,7 +1250,7 @@ class ApplicationServiceITest : IntegrationTest() {
                 applicationFactory.saveApplicationEntity(USERNAME, hanke = hanke, alluId = null)
 
             assertThrows<ApplicationDecisionNotFoundException> {
-                applicationService.downloadDecision(application.id!!, USERNAME)
+                applicationService.downloadDecision(application.id, USERNAME)
             }
 
             verify { cableReportServiceAllu wasNot Called }
@@ -1268,7 +1265,7 @@ class ApplicationServiceITest : IntegrationTest() {
                 .throws(ApplicationDecisionNotFoundException(""))
 
             assertThrows<ApplicationDecisionNotFoundException> {
-                applicationService.downloadDecision(application.id!!, USERNAME)
+                applicationService.downloadDecision(application.id, USERNAME)
             }
 
             verify { cableReportServiceAllu.getDecisionPdf(alluId) }
@@ -1286,7 +1283,7 @@ class ApplicationServiceITest : IntegrationTest() {
                 )
             every { cableReportServiceAllu.getDecisionPdf(alluId) }.returns(decisionPdf)
 
-            val (filename, bytes) = applicationService.downloadDecision(application.id!!, USERNAME)
+            val (filename, bytes) = applicationService.downloadDecision(application.id, USERNAME)
 
             assertThat(filename).isNotNull().isEqualTo("JS230001")
             assertThat(bytes).isEqualTo(decisionPdf)
@@ -1305,7 +1302,7 @@ class ApplicationServiceITest : IntegrationTest() {
                 )
             every { cableReportServiceAllu.getDecisionPdf(alluId) }.returns(decisionPdf)
 
-            val (filename, bytes) = applicationService.downloadDecision(application.id!!, USERNAME)
+            val (filename, bytes) = applicationService.downloadDecision(application.id, USERNAME)
 
             assertThat(filename).isNotNull().isEqualTo("paatos")
             assertThat(bytes).isEqualTo(decisionPdf)
@@ -1439,7 +1436,7 @@ class ApplicationServiceITest : IntegrationTest() {
 
             assertThat(result).hasSize(3)
             val userids =
-                result.map { applicationRepository.getReferenceById(it.id!!) }.map { it.userId }
+                result.map { applicationRepository.getReferenceById(it.id) }.map { it.userId }
             assertThat(userids).containsExactly(USERNAME, USERNAME, USERNAME)
         }
     }

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentServiceITest.kt
@@ -104,7 +104,7 @@ class ApplicationAttachmentServiceITest(
         fun `Returns empty when application doesn't have attachments`() {
             val application = applicationFactory.saveApplicationEntity(USERNAME)
 
-            val result = attachmentService.getMetadataList(application.id!!)
+            val result = attachmentService.getMetadataList(application.id)
 
             assertThat(result).isEmpty()
         }
@@ -115,7 +115,7 @@ class ApplicationAttachmentServiceITest(
             attachmentFactory.save(application = application).withContent()
             attachmentFactory.save(application = application).withContent()
 
-            val result = attachmentService.getMetadataList(application.id!!)
+            val result = attachmentService.getMetadataList(application.id)
 
             assertThat(result).hasSize(2)
             assertThat(result).each {
@@ -188,7 +188,7 @@ class ApplicationAttachmentServiceITest(
 
             val result =
                 attachmentService.addAttachment(
-                    applicationId = application.id!!,
+                    applicationId = application.id,
                     attachmentType = typeInput,
                     attachment = testFile(),
                 )
@@ -214,7 +214,7 @@ class ApplicationAttachmentServiceITest(
                 prop(ApplicationAttachmentEntity::attachmentType).isEqualTo(typeInput)
                 prop(ApplicationAttachmentEntity::blobLocation)
                     .isNotNull()
-                    .startsWith("${application.id!!}/")
+                    .startsWith("${application.id}/")
             }
 
             val content = fileClient.download(HAKEMUS_LIITTEET, attachments.first().blobLocation)
@@ -235,7 +235,7 @@ class ApplicationAttachmentServiceITest(
 
             val result =
                 attachmentService.addAttachment(
-                    applicationId = application.id!!,
+                    applicationId = application.id,
                     attachmentType = MUU,
                     attachment = testFile(fileName = "exa*mple.pdf"),
                 )
@@ -250,14 +250,14 @@ class ApplicationAttachmentServiceITest(
             val application = applicationFactory.saveApplicationEntity(USERNAME)
             val attachments =
                 (1..ALLOWED_ATTACHMENT_COUNT).map {
-                    ApplicationAttachmentFactory.createEntity(applicationId = application.id!!)
+                    ApplicationAttachmentFactory.createEntity(applicationId = application.id)
                 }
             attachmentRepository.saveAll(attachments)
             mockClamAv.enqueue(response(body(results = successResult())))
 
             val failure = assertFailure {
                 attachmentService.addAttachment(
-                    applicationId = application.id!!,
+                    applicationId = application.id,
                     attachmentType = VALTAKIRJA,
                     attachment = testFile()
                 )
@@ -277,7 +277,7 @@ class ApplicationAttachmentServiceITest(
 
             val failure = assertFailure {
                 attachmentService.addAttachment(
-                    applicationId = application.id!!,
+                    applicationId = application.id,
                     attachmentType = VALTAKIRJA,
                     attachment = testFile(contentType = null)
                 )
@@ -296,7 +296,7 @@ class ApplicationAttachmentServiceITest(
 
             val failure = assertFailure {
                 attachmentService.addAttachment(
-                    applicationId = application.id!!,
+                    applicationId = application.id,
                     attachmentType = MUU,
                     attachment = testFile(),
                 )
@@ -308,7 +308,7 @@ class ApplicationAttachmentServiceITest(
                     "Application is already sent to Allu, applicationId=${application.id}, alluId=${application.alluid}"
                 )
             }
-            assertThat(attachmentRepository.countByApplicationId(application.id!!)).isEqualTo(0)
+            assertThat(attachmentRepository.countByApplicationId(application.id)).isEqualTo(0)
         }
 
         @Test
@@ -332,7 +332,7 @@ class ApplicationAttachmentServiceITest(
 
             val failure = assertFailure {
                 attachmentService.addAttachment(
-                    applicationId = application.id!!,
+                    applicationId = application.id,
                     attachmentType = VALTAKIRJA,
                     attachment = testFile(fileName = invalidFilename)
                 )
@@ -352,7 +352,7 @@ class ApplicationAttachmentServiceITest(
 
             val failure = assertFailure {
                 attachmentService.addAttachment(
-                    applicationId = application.id!!,
+                    applicationId = application.id,
                     attachmentType = VALTAKIRJA,
                     attachment = testFile()
                 )

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusControllerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusControllerITest.kt
@@ -421,7 +421,7 @@ class HakemusControllerITest(@Autowired override val mockMvc: MockMvc) : Control
             } returns true
             every { hakemusService.updateHakemus(id, request, USERNAME) } throws
                 IncompatibleHakemusUpdateRequestException(
-                    id,
+                    HakemusFactory.create(id = id),
                     CableReportApplicationData::class,
                     JohtoselvityshakemusUpdateRequest::class
                 ) // these types are actually compatible but since there are no other application
@@ -486,7 +486,7 @@ class HakemusControllerITest(@Autowired override val mockMvc: MockMvc) : Control
             } returns true
             every { hakemusService.updateHakemus(id, request, USERNAME) } throws
                 InvalidHakemusyhteystietoException(
-                    id,
+                    HakemusFactory.create(id = id),
                     ApplicationContactType.HAKIJA,
                     null,
                     UUID.randomUUID()
@@ -594,7 +594,7 @@ class HakemusControllerITest(@Autowired override val mockMvc: MockMvc) : Control
                 authorizer.authorizeApplicationId(id, PermissionCode.EDIT_APPLICATIONS.name)
             } returns true
             every { hakemusService.sendHakemus(id, USERNAME) } throws
-                UserNotInContactsException(id, USERNAME)
+                UserNotInContactsException(HakemusFactory.create(id = id))
 
             post(url).andExpect(status().isForbidden).andExpect(hankeError(HankeError.HAI2012))
 

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceITest.kt
@@ -1361,8 +1361,9 @@ class HakemusServiceITest(
 
             failure.all {
                 hasClass(UserNotInContactsException::class)
-                messageContains("applicationId=${hakemus.id}")
-                messageContains("userId=$USERNAME")
+                messageContains("id=${hakemus.id}")
+                messageContains("alluId=null")
+                messageContains("identifier=null")
             }
         }
 

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceITest.kt
@@ -443,7 +443,7 @@ class HakemusServiceITest(
             @Test
             fun `throws exception when the application has been sent to Allu`() {
                 val entity = hakemusFactory.builder().withStatus(alluId = 21).saveEntity()
-                val hakemus = hakemusService.hakemusResponse(entity.id!!)
+                val hakemus = hakemusService.hakemusResponse(entity.id)
                 val request = hakemus.toUpdateRequest()
 
                 val exception = assertFailure {
@@ -460,7 +460,7 @@ class HakemusServiceITest(
             @Test
             fun `does not create a new audit log entry when the application has not changed`() {
                 val entity = hakemusFactory.builder().saveEntity()
-                val hakemus = hakemusService.hakemusResponse(entity.id!!)
+                val hakemus = hakemusService.hakemusResponse(entity.id)
                 val originalAuditLogSize =
                     auditLogRepository.findByType(ObjectType.APPLICATION).size
                 // The saved hakemus has null in areas, but the response replaces it with an empty
@@ -477,7 +477,7 @@ class HakemusServiceITest(
             @Test
             fun `throws exception when there are invalid geometry in areas`() {
                 val entity = hakemusFactory.builder().saveEntity()
-                val hakemus = hakemusService.hakemusResponse(entity.id!!)
+                val hakemus = hakemusService.hakemusResponse(entity.id)
                 val request = hakemus.toUpdateRequest().withArea(intersectingArea)
 
                 val exception = assertFailure {
@@ -497,7 +497,7 @@ class HakemusServiceITest(
             @Test
             fun `throws exception when the request has a persisted contact but the application does not`() {
                 val entity = hakemusFactory.builder().saveEntity()
-                val hakemus = hakemusService.hakemusResponse(entity.id!!)
+                val hakemus = hakemusService.hakemusResponse(entity.id)
                 val requestYhteystietoId = UUID.randomUUID()
                 val request =
                     hakemus
@@ -520,7 +520,7 @@ class HakemusServiceITest(
             @Test
             fun `throws exception when the request has different persisted contact than the application`() {
                 val entity = hakemusFactory.builder().hakija().saveEntity()
-                val hakemus = hakemusService.hakemusResponse(entity.id!!)
+                val hakemus = hakemusService.hakemusResponse(entity.id)
                 val originalYhteystietoId = hakemusyhteystietoRepository.findAll().first().id
                 val requestYhteystietoId = UUID.randomUUID()
                 val request =
@@ -544,7 +544,7 @@ class HakemusServiceITest(
             @Test
             fun `throws exception when the request has a contact that is not a user on hanke`() {
                 val entity = hakemusFactory.builder().hakija().saveEntity()
-                val hakemus = hakemusService.hakemusResponse(entity.id!!)
+                val hakemus = hakemusService.hakemusResponse(entity.id)
                 val yhteystieto = hakemusyhteystietoRepository.findAll().first()
                 val requestHankekayttajaId = UUID.randomUUID()
                 val request =
@@ -567,7 +567,7 @@ class HakemusServiceITest(
             fun `throws exception when area is not inside hanke area`() {
                 val hanke = hankeFactory.builder().withHankealue().saveEntity()
                 val entity = hakemusFactory.builder(hanke).saveEntity()
-                val hakemus = hakemusService.hakemusResponse(entity.id!!)
+                val hakemus = hakemusService.hakemusResponse(entity.id)
                 val request = hakemus.toUpdateRequest().withArea(notInHankeArea)
 
                 val exception = assertFailure {
@@ -577,7 +577,7 @@ class HakemusServiceITest(
                 exception.all {
                     hasClass(ApplicationGeometryNotInsideHankeException::class)
                     messageContains("id=${hakemus.id}")
-                    messageContains("hankeId=${hanke.id}")
+                    messageContains(hanke.logString())
                     messageContains("geometry=${notInHankeArea.geometry.toJsonString()}")
                 }
             }
@@ -591,7 +591,7 @@ class HakemusServiceITest(
                         .withWorkDescription("Old work description")
                         .hakija()
                         .saveEntity()
-                val hakemus = hakemusService.hakemusResponse(entity.id!!)
+                val hakemus = hakemusService.hakemusResponse(entity.id)
                 val yhteystieto = hakemusyhteystietoRepository.findAll().first()
                 val kayttaja = hankeKayttajaFactory.getFounderFromHakemus(hakemus.id)
                 val newKayttaja = hankeKayttajaFactory.saveUser(hanke.id)
@@ -744,7 +744,7 @@ class HakemusServiceITest(
                         )
                         .withStatus(alluId = 21)
                         .saveEntity()
-                val hakemus = hakemusService.hakemusResponse(entity.id!!)
+                val hakemus = hakemusService.hakemusResponse(entity.id)
                 val request = hakemus.toUpdateRequest()
 
                 val exception = assertFailure {
@@ -767,7 +767,7 @@ class HakemusServiceITest(
                             applicationType = ApplicationType.EXCAVATION_NOTIFICATION
                         )
                         .saveEntity()
-                val hakemus = hakemusService.hakemusResponse(entity.id!!)
+                val hakemus = hakemusService.hakemusResponse(entity.id)
                 val originalAuditLogSize =
                     auditLogRepository.findByType(ObjectType.APPLICATION).size
                 // The saved hakemus has null in areas, but the response replaces it with an empty
@@ -790,7 +790,7 @@ class HakemusServiceITest(
                             applicationType = ApplicationType.EXCAVATION_NOTIFICATION
                         )
                         .saveEntity()
-                val hakemus = hakemusService.hakemusResponse(entity.id!!)
+                val hakemus = hakemusService.hakemusResponse(entity.id)
                 val request = hakemus.toUpdateRequest().withAreas(listOf(intersectingArea))
 
                 val exception = assertFailure {
@@ -816,7 +816,7 @@ class HakemusServiceITest(
                             applicationType = ApplicationType.EXCAVATION_NOTIFICATION
                         )
                         .saveEntity()
-                val hakemus = hakemusService.hakemusResponse(entity.id!!)
+                val hakemus = hakemusService.hakemusResponse(entity.id)
                 val requestYhteystietoId = UUID.randomUUID()
                 val request =
                     hakemus
@@ -846,7 +846,7 @@ class HakemusServiceITest(
                         )
                         .hakija()
                         .saveEntity()
-                val hakemus = hakemusService.hakemusResponse(entity.id!!)
+                val hakemus = hakemusService.hakemusResponse(entity.id)
                 val originalYhteystietoId = hakemusyhteystietoRepository.findAll().first().id
                 val requestYhteystietoId = UUID.randomUUID()
                 val request =
@@ -877,7 +877,7 @@ class HakemusServiceITest(
                         )
                         .hakija()
                         .saveEntity()
-                val hakemus = hakemusService.hakemusResponse(entity.id!!)
+                val hakemus = hakemusService.hakemusResponse(entity.id)
                 val yhteystieto = hakemusyhteystietoRepository.findAll().first()
                 val requestHankekayttajaId = UUID.randomUUID()
                 val request =
@@ -907,7 +907,7 @@ class HakemusServiceITest(
                     hakemusFactory
                         .builder(USERNAME, hanke, ApplicationType.EXCAVATION_NOTIFICATION)
                         .saveEntity()
-                val hakemus = hakemusService.hakemusResponse(entity.id!!)
+                val hakemus = hakemusService.hakemusResponse(entity.id)
                 val request = hakemus.toUpdateRequest().withAreas(listOf(notInHankeArea))
 
                 val exception = assertFailure {
@@ -917,7 +917,7 @@ class HakemusServiceITest(
                 exception.all {
                     hasClass(ApplicationGeometryNotInsideHankeException::class)
                     messageContains("id=${hakemus.id}")
-                    messageContains("hankeId=${hanke.id}")
+                    messageContains(hanke.logString())
                     messageContains("geometry=${notInHankeArea.geometry.toJsonString()}")
                 }
             }
@@ -931,7 +931,7 @@ class HakemusServiceITest(
                         .withWorkDescription("Old work description")
                         .hakija()
                         .saveEntity()
-                val hakemus = hakemusService.hakemusResponse(entity.id!!)
+                val hakemus = hakemusService.hakemusResponse(entity.id)
                 val yhteystieto = hakemusyhteystietoRepository.findAll().first()
                 val kayttaja = hankeKayttajaFactory.getFounderFromHakemus(hakemus.id)
                 val newKayttaja = hankeKayttajaFactory.saveUser(hanke.id)
@@ -989,7 +989,7 @@ class HakemusServiceITest(
                         .hakija()
                         .tyonSuorittaja(kayttaja1, kayttaja2)
                         .saveEntity()
-                val hakemus = hakemusService.hakemusResponse(entity.id!!)
+                val hakemus = hakemusService.hakemusResponse(entity.id)
                 val tyonSuorittaja =
                     hakemusyhteystietoRepository.findAll().single { it.rooli == TYON_SUORITTAJA }
                 val request =
@@ -1020,7 +1020,7 @@ class HakemusServiceITest(
                         .builder(USERNAME, hanke)
                         .withWorkDescription("Old work description")
                         .saveEntity()
-                val hakemus = hakemusService.hakemusResponse(entity.id!!)
+                val hakemus = hakemusService.hakemusResponse(entity.id)
                 assertThat(hakemus.applicationData.customerWithContacts).isNull()
                 val request =
                     hakemus
@@ -1164,7 +1164,7 @@ class HakemusServiceITest(
                     .inHandling(alluId = alluId)
                     .saveEntity()
 
-            val failure = assertFailure { hakemusService.sendHakemus(application.id!!, USERNAME) }
+            val failure = assertFailure { hakemusService.sendHakemus(application.id, USERNAME) }
 
             failure.all {
                 hasClass(ApplicationAlreadySentException::class)
@@ -1185,14 +1185,14 @@ class HakemusServiceITest(
             justRun { alluClient.addAttachment(alluId, any()) }
             every { alluClient.getApplicationInformation(alluId) } throws AlluException()
 
-            val response = hakemusService.sendHakemus(application.id!!, USERNAME)
+            val response = hakemusService.sendHakemus(application.id, USERNAME)
 
             assertThat(response).all {
                 prop(Hakemus::alluid).isEqualTo(alluId)
                 prop(Hakemus::applicationIdentifier).isNull()
                 prop(Hakemus::alluStatus).isNull()
             }
-            assertThat(applicationRepository.getReferenceById(application.id!!)).all {
+            assertThat(applicationRepository.getReferenceById(application.id)).all {
                 prop(ApplicationEntity::alluid).isEqualTo(alluId)
                 prop(ApplicationEntity::applicationData).isEqualTo(expectedDataAfterSend)
                 prop(ApplicationEntity::applicationIdentifier).isNull()
@@ -1220,10 +1220,10 @@ class HakemusServiceITest(
 
             failure.all {
                 hasClass(ApplicationGeometryNotInsideHankeException::class)
-                messageContains("hakemusId=${hakemus.id}")
+                messageContains(hakemus.logString())
                 messageContains(hanke.logString())
                 messageContains(
-                    "application geometry=${areaOutsideDefaultHanke.geometry.toJsonString()}"
+                    "hakemus geometry=${areaOutsideDefaultHanke.geometry.toJsonString()}"
                 )
             }
         }
@@ -1492,17 +1492,16 @@ class HakemusServiceITest(
             val hakemus = hakemusFactory.builderWithGeneratedHanke().withNoAlluFields().saveEntity()
             attachmentFactory.save(application = hakemus).withContent()
             attachmentFactory.save(application = hakemus).withContent()
-            assertThat(applicationAttachmentRepository.findByApplicationId(hakemus.id!!)).hasSize(2)
+            assertThat(applicationAttachmentRepository.findByApplicationId(hakemus.id)).hasSize(2)
             assertThat(
                     fileClient.list(
                         Container.HAKEMUS_LIITTEET,
-                        ApplicationAttachmentContentService.prefix(hakemus.id!!)
+                        ApplicationAttachmentContentService.prefix(hakemus.id)
                     )
                 )
                 .hasSize(2)
 
-            val result =
-                hakemusService.deleteWithOrphanGeneratedHankeRemoval(hakemus.id!!, USERNAME)
+            val result = hakemusService.deleteWithOrphanGeneratedHankeRemoval(hakemus.id, USERNAME)
 
             assertThat(result).isEqualTo(ApplicationDeletionResultDto(hankeDeleted = true))
             assertThat(applicationRepository.findAll()).isEmpty()
@@ -1510,11 +1509,11 @@ class HakemusServiceITest(
             assertThat(
                     fileClient.list(
                         Container.HAKEMUS_LIITTEET,
-                        ApplicationAttachmentContentService.prefix(hakemus.id!!)
+                        ApplicationAttachmentContentService.prefix(hakemus.id)
                     )
                 )
                 .isEmpty()
-            assertThat(applicationAttachmentRepository.findByApplicationId(hakemus.id!!)).isEmpty()
+            assertThat(applicationAttachmentRepository.findByApplicationId(hakemus.id)).isEmpty()
         }
 
         @Test
@@ -1535,8 +1534,7 @@ class HakemusServiceITest(
             val hakemus2 = hakemusFactory.builder(hanke).withNoAlluFields().saveEntity()
             assertThat(applicationRepository.findAll()).hasSize(2)
 
-            val result =
-                hakemusService.deleteWithOrphanGeneratedHankeRemoval(hakemus1.id!!, USERNAME)
+            val result = hakemusService.deleteWithOrphanGeneratedHankeRemoval(hakemus1.id, USERNAME)
 
             assertThat(result).isEqualTo(ApplicationDeletionResultDto(hankeDeleted = false))
             assertThat(applicationRepository.findAll())
@@ -1558,7 +1556,7 @@ class HakemusServiceITest(
                     .asianhoitaja()
                     .saveEntity()
 
-            hakemusService.deleteWithOrphanGeneratedHankeRemoval(application.id!!, USERNAME)
+            hakemusService.deleteWithOrphanGeneratedHankeRemoval(application.id, USERNAME)
 
             assertThat(applicationRepository.findAll()).isEmpty()
             assertThat(hankeRepository.findAll()).isEmpty()
@@ -1644,15 +1642,15 @@ class HakemusServiceITest(
             val application = hakemusFactory.builder().withNoAlluFields().saveEntity()
             attachmentFactory.save(application = application).withContent()
             attachmentFactory.save(application = application).withContent()
-            val hakemus = hakemusService.getById(application.id!!)
+            val hakemus = hakemusService.getById(application.id)
             assertThat(
                     fileClient.list(
                         Container.HAKEMUS_LIITTEET,
-                        ApplicationAttachmentContentService.prefix(application.id!!)
+                        ApplicationAttachmentContentService.prefix(application.id)
                     )
                 )
                 .hasSize(2)
-            assertThat(applicationAttachmentRepository.findByApplicationId(application.id!!))
+            assertThat(applicationAttachmentRepository.findByApplicationId(application.id))
                 .hasSize(2)
 
             hakemusService.cancelAndDelete(hakemus, USERNAME)
@@ -1661,11 +1659,11 @@ class HakemusServiceITest(
             assertThat(
                     fileClient.list(
                         Container.HAKEMUS_LIITTEET,
-                        ApplicationAttachmentContentService.prefix(application.id!!)
+                        ApplicationAttachmentContentService.prefix(application.id)
                     )
                 )
                 .isEmpty()
-            assertThat(applicationAttachmentRepository.findByApplicationId(application.id!!))
+            assertThat(applicationAttachmentRepository.findByApplicationId(application.id))
                 .isEmpty()
         }
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeService.kt
@@ -169,9 +169,7 @@ class HankeService(
             )
         }
 
-        hakemukset.forEach { hakemus ->
-            hakemus.id?.let { id -> applicationService.delete(id, userId) }
-        }
+        hakemukset.forEach { hakemus -> applicationService.delete(hakemus.id, userId) }
 
         hankeAttachmentService.deleteAllAttachments(hanke)
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/Application.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/Application.kt
@@ -15,17 +15,17 @@ sealed interface BaseApplication {
 }
 
 data class Application(
-    override val id: Long?,
+    override val id: Long,
     val alluid: Int?,
     val alluStatus: ApplicationStatus?,
     val applicationIdentifier: String?,
     override val applicationType: ApplicationType,
     override val applicationData: ApplicationData,
     val hankeTunnus: String,
-) : HasId<Long?>, BaseApplication {
+) : HasId<Long>, BaseApplication {
     fun toMetadata() =
         ApplicationMetaData(
-            id!!,
+            id,
             alluid,
             alluStatus,
             applicationIdentifier,
@@ -41,7 +41,7 @@ data class CableReportWithoutHanke(
 ) : BaseApplication {
     fun toNewApplication(hankeTunnus: String) =
         Application(
-            id = null,
+            id = 0,
             alluid = null,
             alluStatus = null,
             applicationIdentifier = null,

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationEntity.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationEntity.kt
@@ -3,6 +3,7 @@ package fi.hel.haitaton.hanke.application
 import fi.hel.haitaton.hanke.HankeEntity
 import fi.hel.haitaton.hanke.allu.ApplicationStatus
 import fi.hel.haitaton.hanke.hakemus.Hakemus
+import fi.hel.haitaton.hanke.hakemus.HakemusIdentifier
 import fi.hel.haitaton.hanke.hakemus.HakemusyhteystietoEntity
 import io.hypersistence.utils.hibernate.type.json.JsonType
 import jakarta.persistence.CascadeType
@@ -24,10 +25,10 @@ import org.hibernate.annotations.Type
 @Entity
 @Table(name = "applications")
 data class ApplicationEntity(
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY) val id: Long?,
-    var alluid: Int?,
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY) override val id: Long,
+    override var alluid: Int?,
     @Enumerated(EnumType.STRING) var alluStatus: ApplicationStatus?,
-    var applicationIdentifier: String?,
+    override var applicationIdentifier: String?,
     var userId: String?,
     @Enumerated(EnumType.STRING) val applicationType: ApplicationType,
     @Type(JsonType::class) @Column(columnDefinition = "jsonb") var applicationData: ApplicationData,
@@ -40,7 +41,7 @@ data class ApplicationEntity(
     )
     @MapKey(name = "rooli")
     var yhteystiedot: MutableMap<ApplicationContactType, HakemusyhteystietoEntity> = mutableMapOf(),
-) {
+) : HakemusIdentifier {
     fun toApplication() =
         Application(
             id,
@@ -62,7 +63,7 @@ data class ApplicationEntity(
                     (this.applicationData as ExcavationNotificationData).toHakemusData(yhteystiedot)
             }
         return Hakemus(
-            id = id!!,
+            id = id,
             alluid = alluid,
             alluStatus = alluStatus,
             applicationIdentifier = applicationIdentifier,

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationService.kt
@@ -108,7 +108,7 @@ class ApplicationService(
 
         val applicationEntity =
             ApplicationEntity(
-                id = null,
+                id = 0,
                 alluid = null,
                 alluStatus = null,
                 applicationIdentifier = null,
@@ -342,7 +342,7 @@ class ApplicationService(
 
             logger.info { "Deleting application, id=$id, alluid=$alluid userid=$userId" }
             val application = toApplication()
-            attachmentService.deleteAllAttachments(id!!)
+            attachmentService.deleteAllAttachments(applicationEntity)
             applicationRepository.delete(this)
             applicationLoggingService.logDelete(application, userId)
             logger.info { "Application deleted, id=$id, alluid=$alluid userid=$userId" }
@@ -516,8 +516,7 @@ class ApplicationService(
 
         if (receivers.isEmpty()) {
             logger.error {
-                "No receivers found for decision ready email, not sending any." +
-                    "applicationId=${application.id}, applicationIdentifier=${applicationIdentifier}"
+                "No receivers found for decision ready email, not sending any. ${application.logString()}"
             }
             return
         }
@@ -577,7 +576,7 @@ class ApplicationService(
 
         when (val data = entity.applicationData) {
             is CableReportApplicationData ->
-                updateCableReportInAllu(entity.id!!, alluId, entity.hanke.hankeTunnus, data)
+                updateCableReportInAllu(entity.id, alluId, entity.hanke.hankeTunnus, data)
             is ExcavationNotificationData ->
                 TODO("Sending excavation notification to Allu not implemented.")
         }
@@ -591,7 +590,7 @@ class ApplicationService(
         val alluId =
             when (val data = entity.applicationData) {
                 is CableReportApplicationData ->
-                    createCableReportToAllu(entity.id!!, entity.hanke.hankeTunnus, data)
+                    createCableReportToAllu(entity.id, entity.hanke.hankeTunnus, data)
                 is ExcavationNotificationData ->
                     TODO("Sending excavation notification to Allu not implemented.")
             }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentContentService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentContentService.kt
@@ -5,6 +5,7 @@ import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentMetadata
 import fi.hel.haitaton.hanke.attachment.common.AttachmentNotFoundException
 import fi.hel.haitaton.hanke.attachment.common.DownloadNotFoundException
 import fi.hel.haitaton.hanke.attachment.common.FileClient
+import fi.hel.haitaton.hanke.hakemus.HakemusIdentifier
 import java.util.UUID
 import mu.KotlinLogging
 import org.springframework.http.MediaType
@@ -37,9 +38,9 @@ class ApplicationAttachmentContentService(
             }
         }
 
-    fun deleteAllForApplication(applicationId: Long) {
-        fileClient.deleteAllByPrefix(Container.HAKEMUS_LIITTEET, prefix(applicationId))
-        logger.info { "Deleted all attachment content from application $applicationId" }
+    fun deleteAllForApplication(hakemus: HakemusIdentifier) {
+        fileClient.deleteAllByPrefix(Container.HAKEMUS_LIITTEET, prefix(hakemus.id))
+        logger.info { "Deleted all attachment content from application. ${hakemus.logString()}" }
     }
 
     fun find(attachment: ApplicationAttachmentMetadata): ByteArray =

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentMetadataService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentMetadataService.kt
@@ -9,9 +9,11 @@ import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType
 import fi.hel.haitaton.hanke.attachment.common.AttachmentLimitReachedException
 import fi.hel.haitaton.hanke.attachment.common.AttachmentNotFoundException
 import fi.hel.haitaton.hanke.currentUserId
+import fi.hel.haitaton.hanke.hakemus.HakemusIdentifier
 import java.time.OffsetDateTime
 import java.util.UUID
 import mu.KotlinLogging
+import org.springframework.data.jpa.domain.AbstractPersistable_.id
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -67,9 +69,9 @@ class ApplicationAttachmentMetadataService(
     }
 
     @Transactional
-    fun deleteAllAttachments(id: Long) {
-        attachmentRepository.deleteByApplicationId(id)
-        logger.info { "Deleted all attachment metadata for application $id" }
+    fun deleteAllAttachments(hakemus: HakemusIdentifier) {
+        attachmentRepository.deleteByApplicationId(hakemus.id)
+        logger.info { "Deleted all attachment metadata for application ${hakemus.logString()}" }
     }
 
     @Transactional(readOnly = true)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentService.kt
@@ -12,6 +12,7 @@ import fi.hel.haitaton.hanke.attachment.common.AttachmentValidator
 import fi.hel.haitaton.hanke.attachment.common.FileScanClient
 import fi.hel.haitaton.hanke.attachment.common.FileScanInput
 import fi.hel.haitaton.hanke.attachment.common.hasInfected
+import fi.hel.haitaton.hanke.hakemus.HakemusIdentifier
 import java.util.UUID
 import mu.KotlinLogging
 import org.springframework.data.repository.findByIdOrNull
@@ -115,11 +116,11 @@ class ApplicationAttachmentService(
         logger.info { "Deleted attachment $attachmentId from application ${application.id}" }
     }
 
-    fun deleteAllAttachments(applicationId: Long) {
-        logger.info { "Deleting all attachments from application $applicationId" }
-        metadataService.deleteAllAttachments(applicationId)
-        attachmentContentService.deleteAllForApplication(applicationId)
-        logger.info { "Deleted all attachments from application $applicationId" }
+    fun deleteAllAttachments(hakemus: HakemusIdentifier) {
+        logger.info { "Deleting all attachments from application. ${hakemus.logString()}" }
+        metadataService.deleteAllAttachments(hakemus)
+        attachmentContentService.deleteAllForApplication(hakemus)
+        logger.info { "Deleted all attachments from application. ${hakemus.logString()}" }
     }
 
     fun sendInitialAttachments(alluId: Int, applicationId: Long) {

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/gdpr/GdprService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/gdpr/GdprService.kt
@@ -273,7 +273,7 @@ class OldGdprService(private val applicationService: ApplicationService) : GdprS
         applicationsToDelete.forEach {
             // Application service will check the status of every application again.
             // This is not optimal, but this is so rarely used, we can live with it.
-            applicationService.deleteWithOrphanGeneratedHankeRemoval(it.id!!, userId)
+            applicationService.deleteWithOrphanGeneratedHankeRemoval(it.id, userId)
         }
     }
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/Hakemus.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/Hakemus.kt
@@ -10,14 +10,14 @@ import java.time.ZonedDateTime
 
 data class Hakemus(
     override val id: Long,
-    val alluid: Int?,
+    override val alluid: Int?,
     val alluStatus: ApplicationStatus?,
-    val applicationIdentifier: String?,
+    override val applicationIdentifier: String?,
     val applicationType: ApplicationType,
     val applicationData: HakemusData,
     val hankeTunnus: String,
     val hankeId: Int,
-) : HasId<Long> {
+) : HakemusIdentifier {
     fun toResponse(): HakemusResponse =
         HakemusResponse(
             id = id,
@@ -158,4 +158,12 @@ data class KaivuilmoitusData(
             propertyDeveloperWithContacts,
             representativeWithContacts,
         )
+}
+
+interface HakemusIdentifier : HasId<Long> {
+    override val id: Long
+    val alluid: Int?
+    val applicationIdentifier: String?
+
+    fun logString() = "Hakemus: (id=$id, alluId=$alluid, identifier=$applicationIdentifier)"
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
@@ -119,7 +119,7 @@ class HakemusService(
         request: HakemusUpdateRequest,
         userId: String
     ): HakemusResponse {
-        logger.info("Updating application id=$applicationId")
+        logger.info("Updating hakemus id=$applicationId")
 
         val applicationEntity = getEntityById(applicationId)
         val hakemus = applicationEntity.toHakemus() // the original state for audit logging
@@ -128,14 +128,12 @@ class HakemusService(
         assertCompatibility(applicationEntity, request)
 
         if (!request.hasChanges(applicationEntity)) {
-            logger.info(
-                "Not updating unchanged application data. id=$applicationId, identifier=${applicationEntity.applicationIdentifier}"
-            )
+            logger.info("Not updating unchanged hakemus data. ${applicationEntity.logString()}")
             return hakemus.toResponse()
         }
 
         assertGeometryValidity(request.areas) { validationError ->
-            "Invalid geometry received when updating application ${applicationEntity.logString()}, reason=${validationError.reason}, location=${validationError.location}"
+            "Invalid geometry received when updating hakemus. ${applicationEntity.logString()}, reason=${validationError.reason}, location=${validationError.location}"
         }
 
         assertYhteystiedotValidity(applicationEntity, request)
@@ -144,8 +142,9 @@ class HakemusService(
         if (!hankeEntity.generated) {
             request.areas?.let { areas ->
                 assertGeometryCompatibility(hankeEntity.id, areas) { area ->
-                    "Application geometry doesn't match any hankealue when updating application ${applicationEntity.logString()}, " +
-                        "${hankeEntity.logString()}, application geometry=${area.geometry.toJsonString()}"
+                    "Hakemus geometry doesn't match any hankealue when updating hakemus. " +
+                        "${applicationEntity.logString()}, ${hankeEntity.logString()}, " +
+                        "hakemus geometry=${area.geometry.toJsonString()}"
                 }
             }
         } else {
@@ -154,7 +153,7 @@ class HakemusService(
 
         val updatedHakemus = saveWithUpdate(applicationEntity, request).toHakemus()
 
-        logger.info("Updated application id=${applicationId}")
+        logger.info("Updated hakemus. ${updatedHakemus.logString()}")
         hakemusLoggingService.logUpdate(hakemus, updatedHakemus, userId)
 
         return updatedHakemus.toResponse()
@@ -185,17 +184,13 @@ class HakemusService(
         logger.info("Sending hakemus id=$id")
         hakemus.alluid = createApplicationInAllu(hakemus.toHakemus())
 
-        logger.info {
-            "Application sent, fetching application identifier and status. id=$id, alluid=${hakemus.alluid}."
-        }
+        logger.info { "Hakemus sent, fetching identifier and status. ${hakemus.logString()}" }
         getApplicationInformationFromAllu(hakemus.alluid!!)?.let { response ->
             hakemus.applicationIdentifier = response.applicationId
             hakemus.alluStatus = response.status
         }
 
-        logger.info(
-            "Sent application id=$id, alluid=${hakemus.alluid}, alluStatus = ${hakemus.alluStatus}"
-        )
+        logger.info("Sent hakemus. ${hakemus.logString()}, alluStatus = ${hakemus.alluStatus}")
         // Save only if sendApplicationToAllu didn't throw an exception
         return applicationRepository.save(hakemus).toHakemus()
     }
@@ -219,7 +214,7 @@ class HakemusService(
 
         if (hanke.generated && hanke.hakemukset.size == 1) {
             logger.info {
-                "Application was the only one of a generated Hanke, removing Hanke. ${hanke.logString()}, ${application.logString()}"
+                "Hakemus was the only one of a generated Hanke, removing Hanke. ${hanke.logString()}, ${application.logString()}"
             }
             hankeRepository.delete(hanke)
             val hankeDomain =
@@ -238,7 +233,7 @@ class HakemusService(
         val alluid =
             hakemus.alluid
                 ?: throw ApplicationDecisionNotFoundException(
-                    "Application not in Allu, so it doesn't have a decision. id=${hakemus.id}"
+                    "Hakemus not in Allu, so it doesn't have a decision. ${hakemus.logString()}"
                 )
         val filename = hakemus.applicationIdentifier ?: "paatos"
         val pdfBytes = alluClient.getDecisionPdf(alluid)
@@ -261,7 +256,7 @@ class HakemusService(
                 .mapNotNull { hakemus.yhteystiedot[it] }
                 .flatMap { it.yhteyshenkilot }
                 .find { it.hankekayttaja.permission?.userId == currentUserId }
-                ?: throw UserNotInContactsException(hakemus.id, currentUserId)
+                ?: throw UserNotInContactsException(hakemus)
         yhteyshenkilo.tilaaja = true
     }
 
@@ -280,7 +275,7 @@ class HakemusService(
         return try {
             alluClient.getApplicationInformation(alluid)
         } catch (e: Exception) {
-            logger.error(e) { "Exception while getting application information." }
+            logger.error(e) { "Exception while getting hakemus information." }
             null
         }
     }
@@ -294,7 +289,7 @@ class HakemusService(
             attachmentService.sendInitialAttachments(alluId, hakemus.id)
         } catch (e: Exception) {
             logger.error(e) {
-                "Error while sending the initial attachments. Canceling the application. ${hakemus.logString()}"
+                "Error while sending the initial attachments. Canceling the hakemus. ${hakemus.logString()}"
             }
             alluClient.cancel(alluId)
             alluClient.sendSystemComment(alluId, ALLU_INITIAL_ATTACHMENT_CANCELLATION_MSG)
@@ -335,7 +330,7 @@ class HakemusService(
                 is JohtoselvityshakemusData -> getApplicationDataAsPdf(cableReport)
                 else -> {
                     logger.warn(
-                        "No PDF created for application with type ${cableReport.applicationType}."
+                        "No PDF created for hakemus with type ${cableReport.applicationType}."
                     )
                     return alluAction()
                 }
@@ -355,7 +350,7 @@ class HakemusService(
     }
 
     private fun getApplicationDataAsPdf(data: JohtoselvityshakemusData): Attachment {
-        logger.info { "Creating a PDF from the application data for data attachment." }
+        logger.info { "Creating a PDF from the hakemus data for data attachment." }
         val totalArea =
             geometriatDao.calculateCombinedArea(data.areas?.map { it.geometry } ?: listOf())
         val areas = data.areas?.map { geometriatDao.calculateArea(it.geometry) } ?: listOf()
@@ -418,7 +413,7 @@ class HakemusService(
             }
         if (!expected) {
             throw IncompatibleHakemusUpdateRequestException(
-                applicationEntity.id,
+                applicationEntity,
                 applicationEntity.applicationData::class,
                 request::class
             )
@@ -448,7 +443,7 @@ class HakemusService(
         val customersWithContacts = updateRequest.customersByRole()
         ApplicationContactType.entries.forEach {
             assertYhteystietoValidity(
-                applicationEntity.id,
+                applicationEntity,
                 it,
                 applicationEntity.yhteystiedot[it],
                 customersWithContacts[it]
@@ -462,7 +457,7 @@ class HakemusService(
                 .flatMap { it.contacts.map { contact -> contact.hankekayttajaId } }
                 .toSet()
         ) {
-            "Invalid hanke user/users received when updating application ${applicationEntity.logString()}, invalidHankeKayttajaIds=$it"
+            "Invalid hanke user/users received when updating hakemus ${applicationEntity.logString()}, invalidHankeKayttajaIds=$it"
         }
     }
 
@@ -474,7 +469,7 @@ class HakemusService(
      * Otherwise, the request is invalid.
      */
     private fun assertYhteystietoValidity(
-        applicationId: Long,
+        application: HakemusIdentifier,
         rooli: ApplicationContactType,
         hakemusyhteystietoEntity: HakemusyhteystietoEntity?,
         customerWithContacts: CustomerWithContactsRequest?
@@ -487,7 +482,7 @@ class HakemusService(
             return
         }
         throw InvalidHakemusyhteystietoException(
-            applicationId,
+            application,
             rooli,
             hakemusyhteystietoEntity?.id,
             customerWithContacts.customer.yhteystietoId
@@ -713,27 +708,25 @@ class HakemusService(
 }
 
 class IncompatibleHakemusUpdateRequestException(
-    applicationId: Long,
+    application: HakemusIdentifier,
     oldApplicationClass: KClass<out ApplicationData>,
     requestClass: KClass<out HakemusUpdateRequest>,
 ) :
     RuntimeException(
-        "Invalid update request for application id=$applicationId type=$oldApplicationClass requestType=$requestClass"
+        "Invalid update request for hakemus. ${application.logString()}, type=$oldApplicationClass, requestType=$requestClass"
     )
 
 class InvalidHakemusyhteystietoException(
-    applicationId: Long,
+    application: HakemusIdentifier,
     rooli: ApplicationContactType,
     yhteystietoId: UUID?,
     newId: UUID?,
 ) :
     RuntimeException(
-        "Invalid hakemusyhteystieto received when updating application id=$applicationId, role=$rooli, yhteystietoId=$yhteystietoId, newId=$newId"
+        "Invalid hakemusyhteystieto received when updating hakemus. ${application.logString()}, role=$rooli, yhteystietoId=$yhteystietoId, newId=$newId"
     )
 
 class InvalidHakemusyhteyshenkiloException(message: String) : RuntimeException(message)
 
-class UserNotInContactsException(applicationId: Long, userId: String) :
-    RuntimeException(
-        "Sending user is not a contact on the application applicationId=$applicationId, userId=$userId"
-    )
+class UserNotInContactsException(application: HakemusIdentifier) :
+    RuntimeException("Sending user is not a contact on the hakemus. ${application.logString()}")

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HankkeenHakemuksetResponse.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HankkeenHakemuksetResponse.kt
@@ -20,7 +20,7 @@ data class HankkeenHakemusResponse(
     constructor(
         application: ApplicationEntity
     ) : this(
-        application.id!!,
+        application.id,
         application.alluid,
         application.alluStatus,
         application.applicationIdentifier,

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/DisclosureLogService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/DisclosureLogService.kt
@@ -244,7 +244,7 @@ class DisclosureLogService(private val auditLogService: AuditLogService) {
     private fun auditLogEntriesForCustomers(
         applications: List<Application>,
     ): Set<AuditLogEntry> =
-        applications.flatMap { auditLogEntriesForCustomers(it.id!!, it.applicationData) }.toSet()
+        applications.flatMap { auditLogEntriesForCustomers(it.id, it.applicationData) }.toSet()
 
     private fun auditLogEntriesForHakemusResponseCustomers(
         hakemusResponses: List<HakemusResponse>,
@@ -293,7 +293,7 @@ class DisclosureLogService(private val auditLogService: AuditLogService) {
         }
 
     private fun auditLogEntriesForContacts(applications: List<Application>): Set<AuditLogEntry> =
-        applications.flatMap { auditLogEntriesForContacts(it.id!!, it.applicationData) }.toSet()
+        applications.flatMap { auditLogEntriesForContacts(it.id, it.applicationData) }.toSet()
 
     private fun auditLogEntriesForHakemusDataResponseContacts(
         applicationId: Long,

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaService.kt
@@ -110,9 +110,7 @@ class HankeKayttajaService(
         currentUserId: String,
         currentKayttaja: HankekayttajaEntity? = null,
     ) {
-        logger.info {
-            "Creating users and user tokens for application ${application.id}, alluid=${application.alluid}}"
-        }
+        logger.info { "Creating users and user tokens for application. ${application.logString()}" }
 
         val kayttajaInput =
             application.applicationData

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/testdata/TestDataService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/testdata/TestDataService.kt
@@ -17,10 +17,7 @@ class TestDataService(
     fun unlinkApplicationsFromAllu() {
         logger.warn { "Unlinking all applications from Allu." }
         applicationRepository.findAll().forEach {
-            logger.warn {
-                "Unlinking application from Allu id=${it.id} alluid=${it.alluid} " +
-                    "applicationIdentifier=${it.applicationIdentifier}."
-            }
+            logger.warn { "Unlinking application from Allu. ${it.logString()}" }
             it.alluid = null
             it.alluStatus = null
             it.applicationIdentifier = null

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/application/ApplicationControllerTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/application/ApplicationControllerTest.kt
@@ -88,7 +88,7 @@ class ApplicationControllerTest {
     fun `create saves disclosure logs`() {
         val hankeTunnus = "HAI-1234"
         val requestApplication =
-            ApplicationFactory.createApplication(id = null, hankeTunnus = hankeTunnus)
+            ApplicationFactory.createApplication(id = 0, hankeTunnus = hankeTunnus)
         val createdApplication = requestApplication.copy(id = 1)
         every { applicationService.create(requestApplication, USERNAME) } returns createdApplication
 

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceTest.kt
@@ -661,7 +661,7 @@ class ApplicationServiceTest {
             )
     }
 
-    private fun application(id: Long? = null) =
+    private fun application(id: Long = 0) =
         ApplicationFactory.createApplication(
             id = id,
             applicationData = applicationData,
@@ -669,7 +669,7 @@ class ApplicationServiceTest {
         )
 
     private fun applicationEntity(
-        id: Long? = 3,
+        id: Long = 3,
         alluId: Int? = null,
         data: ApplicationData = applicationData,
         hanke: HankeEntity

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/ApplicationAttachmentFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/ApplicationAttachmentFactory.kt
@@ -48,7 +48,7 @@ class ApplicationAttachmentFactory(
                     createdByUser,
                     createdAt,
                     attachmentType,
-                    application.id!!,
+                    application.id,
                 )
             )
         return ApplicationAttachmentBuilder(entity, attachmentRepository, this)

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/ApplicationFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/ApplicationFactory.kt
@@ -416,7 +416,7 @@ class ApplicationFactory(
             )
 
         fun createApplication(
-            id: Long? = 1,
+            id: Long = 1,
             alluid: Int? = null,
             alluStatus: ApplicationStatus? = null,
             applicationIdentifier: String? = null,
@@ -503,10 +503,10 @@ class ApplicationFactory(
                             )
                     )
                 }
-                .map { application -> mapper(application.id!!, application) }
+                .map { application -> mapper(application.id, application) }
 
         fun createApplicationEntity(
-            id: Long? = 3,
+            id: Long = 3,
             alluid: Int? = null,
             alluStatus: ApplicationStatus? = null,
             applicationIdentifier: String? = null,
@@ -600,7 +600,7 @@ class ApplicationFactory(
     ): ApplicationEntity {
         val applicationEntity =
             ApplicationEntity(
-                id = null,
+                id = 0,
                 alluid = alluId,
                 alluStatus = alluStatus,
                 applicationIdentifier = applicationIdentifier,
@@ -625,7 +625,7 @@ class ApplicationFactory(
         val entities =
             createApplications(n).map { application ->
                 ApplicationEntity(
-                    id = null,
+                    id = 0,
                     alluid = application.alluid,
                     alluStatus = null,
                     applicationIdentifier = null,

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusBuilder.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusBuilder.kt
@@ -35,7 +35,7 @@ data class HakemusBuilder(
     private val hakemusyhteystietoRepository: HakemusyhteystietoRepository,
     private val hakemusyhteyshenkiloRepository: HakemusyhteyshenkiloRepository,
 ) {
-    fun save(): Hakemus = hakemusService.getById(saveEntity().id!!)
+    fun save(): Hakemus = hakemusService.getById(saveEntity().id)
 
     fun saveEntity(): ApplicationEntity {
         val savedApplication = applicationRepository.save(applicationEntity)

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusFactory.kt
@@ -181,7 +181,7 @@ class HakemusFactory(
             hanke: HankeEntity,
         ): ApplicationEntity =
             ApplicationEntity(
-                id = null,
+                id = 0,
                 alluid = alluid,
                 alluStatus = alluStatus,
                 applicationIdentifier = applicationIdentifier,

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/logging/DisclosureLogServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/logging/DisclosureLogServiceTest.kt
@@ -312,7 +312,7 @@ internal class DisclosureLogServiceTest {
         val expectedLogs =
             listOf(HAKIJA, TYON_SUORITTAJA).map {
                 AuditLogEntryFactory.createReadEntryForCustomer(
-                    application.id!!,
+                    application.id,
                     customerWithoutContacts.customer,
                     it
                 )
@@ -726,7 +726,7 @@ internal class DisclosureLogServiceTest {
                 AuditLogEntryFactory.createReadEntry(
                     userId,
                     objectType = ObjectType.CABLE_REPORT,
-                    objectId = application.id!!,
+                    objectId = application.id,
                     objectBefore = expectedObject
                 )
 


### PR DESCRIPTION
# Description

We have three different IDs for a hakemus: there's our database ID (`id`), Allu's ID (`alluid`) and the official identifier of the hakemus (`applicationIdentifier`). When logging application events, different combinations of these have been arbitrarily added to log rows. There has also been some variance in the formatting of the ID fields.

Add a new interface that groups these three values, and different views of applications can implement that. The interface provides a way to log all three IDs uniformly. It also provides a simple way of passing all the values needed for logging them in a single value.

Implement the interface for Hakemus and ApplicationEntity. Change all the logging where the logging parameter was calling the `id` field directly to use the new identifier. Just the ID is still logged in some places where e.g. the ID is passed as a method parameter. Also, in some places, logging all three IDs made no sense, since `alluid` and `applicationIdentifier` are always null.

Make the ApplicationEntity `id` field to be non-nullable. It's already `NOT NULL` in the database, so this only affects creating new applications. The `id` field is a primitive value, so the default value of `0` is considered to be empty, which is used as a placeholder before the application has been saved.

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [X] Other