### PR TITLE
HAI-2370 Make kayttaja/deleteInfo return every hakemus just once

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankekayttajaDeleteServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankekayttajaDeleteServiceITest.kt
@@ -192,6 +192,28 @@ class HankekayttajaDeleteServiceITest(
             }
             assertThat(response).prop(DeleteInfo::onlyOmistajanYhteyshenkilo).isFalse()
         }
+
+        @Test
+        fun `returns each hakemus only once when the user is a contact is different roles`() {
+            val hanke = hankeFactory.saveWithAlue()
+            val founder = hankeKayttajaService.getKayttajaByUserId(hanke.id, USERNAME)!!
+            hakemusFactory
+                .builder(hankeEntity = hanke)
+                .withName("Draft")
+                .withEachCustomer(founder)
+                .save()
+            hakemusFactory
+                .builder(hankeEntity = hanke)
+                .withName("Pending")
+                .inHandling()
+                .withEachCustomer(founder)
+                .save()
+
+            val response: DeleteInfo = deleteService.checkForDelete(founder.id)
+
+            assertThat(response).prop(DeleteInfo::draftHakemukset).single()
+            assertThat(response).prop(DeleteInfo::activeHakemukset).single()
+        }
     }
 
     @Nested

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankekayttajaDeleteService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankekayttajaDeleteService.kt
@@ -103,6 +103,7 @@ class HankekayttajaDeleteService(
         kayttaja.hakemusyhteyshenkilot
             .map { it.hakemusyhteystieto }
             .map { it.application }
+            .distinctBy { it.id }
             .map { it.toHakemus() }
 
     data class DeleteInfo(

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusBuilder.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusBuilder.kt
@@ -229,6 +229,16 @@ data class HakemusBuilder(
         vararg yhteyshenkilot: HankekayttajaEntity
     ): HakemusBuilder = asianhoitaja(yhteyshenkilot = arrayOf(first) + yhteyshenkilot)
 
+    /** Creates each customer and saves the given hankekayttaja as contacts to all of them. */
+    fun withEachCustomer(
+        first: HankekayttajaEntity,
+        vararg yhteyshenkilot: HankekayttajaEntity
+    ): HakemusBuilder =
+        hakija(first, *yhteyshenkilot)
+            .tyonSuorittaja(first, *yhteyshenkilot)
+            .rakennuttaja(first, *yhteyshenkilot)
+            .asianhoitaja(first, *yhteyshenkilot)
+
     private fun yhteystieto(
         rooli: ApplicationContactType,
         yhteystieto: Hakemusyhteystieto = HakemusyhteystietoFactory.create(),


### PR DESCRIPTION
# Description

Currently, when the hankekayttaja is a contact in several roles of the same application, the delete info endpoint returns copies of those applications. This is not correct, and shows up as duplicates to the user.

Return each distinct application just once.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2370

## Type of change

- [X] Bug fix 
- [ ] New feature 
- [ ] Other

# Instructions for testing
1. When making johtoselvityshakemus, create a new contact and add it to several roles.
2. Save and go to user management.
3. Click on remove user for the user you created earlier.
4. See that the application is mentioned only once in the confirmation popup.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 