### PR TITLE
HAI-2231 Add startup trigger for the migration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -116,6 +116,7 @@ services:
       HAITATON_TESTDATA_ENABLED: true
       HAITATON_FEATURE_HANKE_EDITING: ${HAITATON_FEATURE_HANKE_EDITING:-true}
       HAITATON_FEATURE_USER_MANAGEMENT: ${HAITATON_FEATURE_USER_MANAGEMENT:-true}
+      HAITATON_MIGRATION_ENABLED: ${HAITATON_MIGRATION_ENABLED:-false}
     depends_on:
       - db
       - clamav-api
@@ -139,6 +140,8 @@ services:
       # - haitaton-admin-ui-dev for Helsinki AD authentication
       REACT_APP_OIDC_CLIENT_ID: haitaton-ui-dev
       LOGIN_SERVER: https://tunnistamo.test.hel.ninja
+      REACT_APP_FEATURE_HANKE: 1
+      REACT_APP_FEATURE_ACCESS_RIGHTS: 1
     ports:
       - 8000:8000
     volumes:

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusMigrationServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusMigrationServiceITest.kt
@@ -78,7 +78,7 @@ class HakemusMigrationServiceITest(
                             .withContact(email = "asianhoitaja@email", orderer = false),
                     representativeWithContacts =
                         ApplicationFactory.createCompanyCustomer(name = "Asianhoitaja Oy")
-                            .withContacts(),
+                            .withContact(firstName = "", lastName = "", email = "", phone = ""),
                 )
             applicationFactory.saveApplicationEntity(USERNAME, hanke, applicationData = data)
 
@@ -167,7 +167,7 @@ class HakemusMigrationServiceITest(
         }
 
         @Test
-        fun `removes customer and contacts from the application data`() {
+        fun `removes customers and contacts from the application data`() {
             val (hanke, _) = setup()
 
             hakemusMigrationService.migrateOneHanke(hanke.id)

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusMigrationServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusMigrationServiceITest.kt
@@ -28,7 +28,6 @@ import fi.hel.haitaton.hanke.factory.ApplicationFactory.Companion.TESTIHENKILO
 import fi.hel.haitaton.hanke.factory.ApplicationFactory.Companion.withContact
 import fi.hel.haitaton.hanke.factory.ApplicationFactory.Companion.withContacts
 import fi.hel.haitaton.hanke.factory.HankeFactory
-import fi.hel.haitaton.hanke.factory.HankeKayttajaFactory
 import fi.hel.haitaton.hanke.permissions.HankeKayttajaService
 import fi.hel.haitaton.hanke.permissions.HankekayttajaEntity
 import fi.hel.haitaton.hanke.permissions.HankekayttajaRepository
@@ -153,7 +152,7 @@ class HakemusMigrationServiceITest(
             hakemusMigrationService.migrateOneHanke(hanke.id)
 
             assertThat(hakemusyhteyshenkiloRepository.findAll()).hasSize(3)
-            val applicationId = hakemusRepository.findAll().first().id!!
+            val applicationId = hakemusRepository.findAll().single().id
             val yhteyshenkilot =
                 hakemusService.getById(applicationId).applicationData.yhteystiedot().flatMap {
                     it.yhteyshenkilot
@@ -181,6 +180,22 @@ class HakemusMigrationServiceITest(
                 prop(CableReportApplicationData::representativeWithContacts).isNull()
             }
         }
+
+        @Test
+        fun `doesn't change anything when called a second time on the same hanke`() {
+            val (hanke, _) = setup()
+            hakemusMigrationService.migrateOneHanke(hanke.id)
+            val kayttajatAfterFirst = hankeKayttajaService.getKayttajatByHankeId(hanke.id)
+            val applicationId = hakemusRepository.findAll().single().id
+            // Hakemus contains yhteystiedot and yhteyshenkilot
+            val hakemusAfterFirst = hakemusService.getById(applicationId)
+
+            hakemusMigrationService.migrateOneHanke(hanke.id)
+
+            assertThat(hankeKayttajaService.getKayttajatByHankeId(hanke.id))
+                .isEqualTo(kayttajatAfterFirst)
+            assertThat(hakemusService.getById(applicationId)).isEqualTo(hakemusAfterFirst)
+        }
     }
 
     @Nested
@@ -193,7 +208,7 @@ class HakemusMigrationServiceITest(
                     customerWithContacts = ApplicationFactory.createCompanyCustomer().withContact()
                 )
 
-            val response = hakemusMigrationService.createFounderKayttaja(hanke.id, data)
+            val response = hakemusMigrationService.createFounderKayttaja(hanke.id, data, setOf())
 
             assertThat(response).isNull()
             assertThat(hankekayttajaRepository.findAll()).isEmpty()
@@ -211,7 +226,24 @@ class HakemusMigrationServiceITest(
                             .withContact(orderer = true, email = email)
                 )
 
-            val response = hakemusMigrationService.createFounderKayttaja(hanke.id, data)
+            val response = hakemusMigrationService.createFounderKayttaja(hanke.id, data, setOf())
+
+            assertThat(response).isNull()
+            assertThat(hankekayttajaRepository.findAll()).isEmpty()
+        }
+
+        @Test
+        fun `returns null and saves nothing if a hankekayttaja already exists for the orderer`() {
+            val hanke = hankeFactory.saveMinimal()
+            val data =
+                ApplicationFactory.createCableReportApplicationData(
+                    customerWithContacts =
+                        ApplicationFactory.createCompanyCustomer()
+                            .withContact(email = "hakija@email")
+                )
+            val emails = setOf("hakija@email")
+
+            val response = hakemusMigrationService.createFounderKayttaja(hanke.id, data, emails)
 
             assertThat(response).isNull()
             assertThat(hankekayttajaRepository.findAll()).isEmpty()
@@ -222,7 +254,7 @@ class HakemusMigrationServiceITest(
             val hanke = hankeFactory.saveMinimal()
             val data = ApplicationFactory.createCableReportApplicationData()
 
-            val response = hakemusMigrationService.createFounderKayttaja(hanke.id, data)
+            val response = hakemusMigrationService.createFounderKayttaja(hanke.id, data, setOf())
 
             fun Assert<HankekayttajaEntity>.hasCorrectFields() = all {
                 prop(HankekayttajaEntity::etunimi).isEqualTo(TEPPO)
@@ -250,7 +282,7 @@ class HakemusMigrationServiceITest(
                             )
                 )
 
-            val response = hakemusMigrationService.createFounderKayttaja(hanke.id, data)
+            val response = hakemusMigrationService.createFounderKayttaja(hanke.id, data, setOf())
 
             fun Assert<HankekayttajaEntity>.hasCorrectFields() = all {
                 prop(HankekayttajaEntity::etunimi).isEqualTo("-")
@@ -277,7 +309,7 @@ class HakemusMigrationServiceITest(
                     representativeWithContacts = null,
                 )
 
-            hakemusMigrationService.createOtherKayttajat(data, null, hanke.id)
+            hakemusMigrationService.createOtherKayttajat(data, setOf(), hanke.id)
 
             assertThat(hankekayttajaRepository.findAll()).isEmpty()
             assertThat(kayttajakutsuRepository.findAll()).isEmpty()
@@ -294,7 +326,7 @@ class HakemusMigrationServiceITest(
                     representativeWithContacts = null,
                 )
 
-            hakemusMigrationService.createOtherKayttajat(data, null, hanke.id)
+            hakemusMigrationService.createOtherKayttajat(data, setOf(), hanke.id)
 
             val kayttajat = hankekayttajaRepository.findAll()
             assertThat(kayttajat).hasSize(2)
@@ -315,9 +347,9 @@ class HakemusMigrationServiceITest(
         }
 
         @Test
-        fun `skips contacts with the founder's email`() {
+        fun `skips a contact when there already is a hanke kayttaja for them`() {
             val hanke = hankeFactory.saveMinimal()
-            val founder = HankeKayttajaFactory.createEntity(sahkoposti = "pekka@pelko")
+            val founder = "pekka@pelko"
             val data =
                 ApplicationFactory.createCableReportApplicationData(
                     customerWithContacts = customerWithContacts("1"),
@@ -326,7 +358,7 @@ class HakemusMigrationServiceITest(
                     representativeWithContacts = null,
                 )
 
-            hakemusMigrationService.createOtherKayttajat(data, founder, hanke.id)
+            hakemusMigrationService.createOtherKayttajat(data, setOf(founder), hanke.id)
 
             assertThat(hankekayttajaRepository.findAll())
                 .single()
@@ -352,7 +384,7 @@ class HakemusMigrationServiceITest(
                     representativeWithContacts = null,
                 )
 
-            hakemusMigrationService.createOtherKayttajat(data, null, hanke.id)
+            hakemusMigrationService.createOtherKayttajat(data, setOf(), hanke.id)
 
             val kayttajat = hankekayttajaRepository.findAll()
             assertThat(kayttajat).hasSize(3)
@@ -386,7 +418,7 @@ class HakemusMigrationServiceITest(
                     representativeWithContacts = null,
                 )
 
-            hakemusMigrationService.createOtherKayttajat(data, null, hanke.id)
+            hakemusMigrationService.createOtherKayttajat(data, setOf(), hanke.id)
 
             assertThat(hankekayttajaRepository.findAll()).isEmpty()
             assertThat(kayttajakutsuRepository.findAll()).isEmpty()

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusMigrationServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusMigrationServiceITest.kt
@@ -309,7 +309,7 @@ class HakemusMigrationServiceITest(
                     representativeWithContacts = null,
                 )
 
-            hakemusMigrationService.createOtherKayttajat(data, setOf(), hanke.id)
+            hakemusMigrationService.createOtherKayttajat(hanke.id, data, setOf())
 
             assertThat(hankekayttajaRepository.findAll()).isEmpty()
             assertThat(kayttajakutsuRepository.findAll()).isEmpty()
@@ -326,7 +326,7 @@ class HakemusMigrationServiceITest(
                     representativeWithContacts = null,
                 )
 
-            hakemusMigrationService.createOtherKayttajat(data, setOf(), hanke.id)
+            hakemusMigrationService.createOtherKayttajat(hanke.id, data, setOf())
 
             val kayttajat = hankekayttajaRepository.findAll()
             assertThat(kayttajat).hasSize(2)
@@ -358,7 +358,7 @@ class HakemusMigrationServiceITest(
                     representativeWithContacts = null,
                 )
 
-            hakemusMigrationService.createOtherKayttajat(data, setOf(founder), hanke.id)
+            hakemusMigrationService.createOtherKayttajat(hanke.id, data, setOf(founder))
 
             assertThat(hankekayttajaRepository.findAll())
                 .single()
@@ -384,7 +384,7 @@ class HakemusMigrationServiceITest(
                     representativeWithContacts = null,
                 )
 
-            hakemusMigrationService.createOtherKayttajat(data, setOf(), hanke.id)
+            hakemusMigrationService.createOtherKayttajat(hanke.id, data, setOf())
 
             val kayttajat = hankekayttajaRepository.findAll()
             assertThat(kayttajat).hasSize(3)
@@ -418,7 +418,7 @@ class HakemusMigrationServiceITest(
                     representativeWithContacts = null,
                 )
 
-            hakemusMigrationService.createOtherKayttajat(data, setOf(), hanke.id)
+            hakemusMigrationService.createOtherKayttajat(hanke.id, data, setOf())
 
             assertThat(hankekayttajaRepository.findAll()).isEmpty()
             assertThat(kayttajakutsuRepository.findAll()).isEmpty()

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Persistence.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Persistence.kt
@@ -130,6 +130,8 @@ class HankeEntity(
 }
 
 interface HankeRepository : JpaRepository<HankeEntity, Int> {
+    @Query("select h.id from HankeEntity h") fun getAllIds(): List<Int>
+
     fun findOneById(id: Int): HankeIdentifier?
 
     fun findOneByHankeTunnus(hankeTunnus: String): HankeIdentifier?
@@ -156,7 +158,7 @@ enum class CounterType {
 @Table(name = "idcounter")
 class IdCounter(
     @Id @Enumerated(EnumType.STRING) var counterType: CounterType? = null,
-    var value: Long? = null
+    var value: Long? = null,
 )
 
 interface IdCounterRepository : JpaRepository<IdCounter, CounterType> {

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusMigrationScheduler.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusMigrationScheduler.kt
@@ -1,0 +1,38 @@
+package fi.hel.haitaton.hanke.hakemus
+
+import fi.hel.haitaton.hanke.HankeRepository
+import fi.hel.haitaton.hanke.configuration.LockService
+import mu.KotlinLogging
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.boot.context.event.ApplicationReadyEvent
+import org.springframework.context.event.EventListener
+import org.springframework.stereotype.Service
+
+private val logger = KotlinLogging.logger {}
+
+@Service
+@ConditionalOnProperty("haitaton.migration.enabled")
+class HakemusMigrationScheduler(
+    private val hakemusMigrationService: HakemusMigrationService,
+    private val hankeRepository: HankeRepository,
+    private val lockService: LockService,
+) {
+    private val lockName = "kortistoMigration"
+
+    @EventListener(ApplicationReadyEvent::class)
+    fun startMigration() {
+        lockService.doIfUnlocked(lockName, this::migrate)
+    }
+
+    private fun migrate() {
+        logger.info("Starting migration to Kortisto")
+        val hankeIds = hankeRepository.getAllIds()
+        logger.info("Found ${hankeIds.size} hanke to migrate")
+        for ((i, hankeId) in hankeIds.withIndex()) {
+            logger.info { "Migrating hanke ${i+1}/${hankeIds.size}, id=$hankeId" }
+            hakemusMigrationService.migrateOneHanke(hankeId)
+            logger.info { "Done migrating hanke ${i+1}/${hankeIds.size}, id=$hankeId" }
+        }
+        logger.info("Finished migration to Kortisto")
+    }
+}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusMigrationService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusMigrationService.kt
@@ -94,6 +94,7 @@ class HakemusMigrationService(
 
             val yhteyshenkilot =
                 customerWithContacts.contacts
+                    .filter { !it.email.isNullOrBlank() }
                     .groupBy { it.email }
                     .mapNotNull { (email, contacts) ->
                         val contact = contacts.contactWithLeastMissingFields()

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusMigrationService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusMigrationService.kt
@@ -54,7 +54,7 @@ class HakemusMigrationService(
                 logger.info { "No founder found in hakemus data." }
             }
             val otherKayttajat =
-                createOtherKayttajat(hakemus.applicationData, existingKayttajaEmails, hanke.id)
+                createOtherKayttajat(hanke.id, hakemus.applicationData, existingKayttajaEmails)
             logger.info {
                 "Created hankekayttajat for other contacts. ${otherKayttajat.size} users with IDs: " +
                     otherKayttajat.map { it.id }.joinToString()
@@ -148,9 +148,9 @@ class HakemusMigrationService(
 
     @Transactional
     fun createOtherKayttajat(
+        hankeId: Int,
         applicationData: ApplicationData,
         existingKayttajaEmails: Set<String>,
-        hankeId: Int,
     ): List<HankekayttajaEntity> {
         val byEmail: Map<String, List<Contact>> =
             applicationData

--- a/services/hanke-service/src/main/resources/application.yml
+++ b/services/hanke-service/src/main/resources/application.yml
@@ -44,6 +44,8 @@ haitaton:
     issuer: ${HAITATON_GDPR_ISSUER:http://gdpr-api-tester:8888/}
     query-scope: ${HAITATON_GDPR_QUERY_SCOPE:haitaton.gdprquery}
     # For dev and test environments, enable the testdata controller for resetting data
+  migration:
+    enabled: ${HAITATON_MIGRATION_ENABLED:false}
   profiili-api:
     api-tokens-url: ${PROFIILI_API_TOKENS_URL:https://tunnistamo.test.hel.ninja/api-tokens/}
     graph-ql-url: ${PROFIILI_GRAPHQL_URL:https://profile-api.test.hel.ninja/graphql/}


### PR DESCRIPTION
# Description

Add a startup trigger for migrating hakemus customers and contacts to separate tables. Also, add logging for tracking the migration progress.

There are no customers in hankkeet in production, so those are not migrated.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2231

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
To test this, the database needs to be consistent, i.e. each application should have either customers in application data or in the separate table.

To see it working, create some johtoselvityshakemus with the old system:
1. Set `HAITATON_FEATURE_HANKE_EDITING` and `HAITATON_FEATURE_USER_MANAGEMENT` to false in either `docker-compose.yml` or `.env`.
2. Set `REACT_APP_FEATURE_HANKE` and `REACT_APP_FEATURE_ACCESS_RIGHTS` to 0 in `docker-compose.yml`.
3. Restart hanke-service and UI containers.
4. Create some johtoselvityshakemus from the Haitaton UI.
5. Re-enable the features and set `HAITATON_MIGRATION_ENABLED` to true.
6. Restart the hanke-service container.
7. The migration progress can be seen in the logs.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 