### PR TITLE
HAI-2483 Clear kutsuja id when deleting user

### DIFF
--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttaja.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttaja.kt
@@ -84,7 +84,7 @@ class HankekayttajaEntity(
     @OneToOne(mappedBy = "hankekayttaja") var kayttajakutsu: KayttajakutsuEntity? = null,
 
     /** Identifier of the inviter. */
-    @Column(name = "kutsuja_id") val kutsujaId: UUID? = null,
+    @Column(name = "kutsuja_id") var kutsujaId: UUID? = null,
     @OneToMany(
         fetch = FetchType.LAZY,
         mappedBy = "hankeKayttaja",
@@ -189,4 +189,6 @@ interface HankekayttajaRepository : JpaRepository<HankekayttajaEntity, UUID> {
     fun findByPermissionId(permissionId: Int): HankekayttajaEntity?
 
     fun findByPermissionIdIn(permissionIds: Collection<Int>): List<HankekayttajaEntity>
+
+    fun findByKutsujaId(kutsujaId: UUID): List<HankekayttajaEntity>
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankekayttajaDeleteService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankekayttajaDeleteService.kt
@@ -60,6 +60,10 @@ class HankekayttajaDeleteService(
             throw HasActiveApplicationsException(kayttajaId, activeHakemukset.map { it.id })
         }
 
+        val kutsutut = hankekayttajaRepository.findByKutsujaId(kayttaja.id)
+        kutsutut.forEach { it.kutsujaId = null }
+        hankekayttajaRepository.saveAll(kutsutut)
+
         hankekayttajaRepository.delete(kayttaja)
 
         emailSenderService.sendRemovalFromHankeNotificationEmail(

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeKayttajaFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeKayttajaFactory.kt
@@ -60,6 +60,7 @@ class HankeKayttajaFactory(
         sahkoposti: String = KAKE_EMAIL,
         puhelin: String = KAKE_PUHELIN,
         kayttooikeustaso: Kayttooikeustaso = KATSELUOIKEUS,
+        kutsujaId: UUID? = null,
         userId: String = FAKE_USERID,
     ): HankekayttajaEntity =
         saveUser(
@@ -68,6 +69,7 @@ class HankeKayttajaFactory(
             sukunimi = sukunimi,
             sahkoposti = sahkoposti,
             puhelin = puhelin,
+            kutsujaId = kutsujaId,
             permissionEntity = permissionService.create(hankeId, userId, kayttooikeustaso),
         )
 
@@ -96,6 +98,7 @@ class HankeKayttajaFactory(
         puhelin: String = KAKE_PUHELIN,
         permissionEntity: PermissionEntity? = null,
         kayttajakutsuEntity: KayttajakutsuEntity? = null,
+        kutsujaId: UUID? = null,
     ): HankekayttajaEntity =
         hankeKayttajaRepository.save(
             HankekayttajaEntity(
@@ -106,6 +109,7 @@ class HankeKayttajaFactory(
                 puhelin = puhelin,
                 permission = permissionEntity,
                 kayttajakutsu = kayttajakutsuEntity,
+                kutsujaId = kutsujaId,
             )
         )
 


### PR DESCRIPTION
# Description

Kutsuja ID field is set to be the ID of the hankekayttaja that invited the user. When a user is deleted, this ID isn't cleared, which blocks the deletion of the user because of database constraints.

When deleting a user, set the kutsuja ID to null for all hankekayttaja with the user as their kutsuja.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2483

## Type of change

- [X] Bug fix 
- [ ] New feature 
- [ ] Other

# Instructions for testing
Create a hanke and add people as contacts. Set one of them as a contact for the owner and give them KAIKKI_OIKEUDET. Try to delete yourself from the hanke.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 