### PR TITLE
HAI-2486 Remove permission when deleting hankekayttaja

### DIFF
--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/HankeKayttajaLoggingService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/HankeKayttajaLoggingService.kt
@@ -44,4 +44,11 @@ class HankeKayttajaLoggingService(private val auditLogService: AuditLogService) 
             AuditLogService.createEntry(currentUser, ObjectType.HANKE_KAYTTAJA, hankeKayttaja)
         )
     }
+
+    @Transactional(propagation = Propagation.MANDATORY)
+    fun logDelete(hankeKayttaja: HankeKayttaja, currentUserId: String) {
+        auditLogService.create(
+            AuditLogService.deleteEntry(currentUserId, ObjectType.HANKE_KAYTTAJA, hankeKayttaja)
+        )
+    }
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/PermissionLoggingService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/PermissionLoggingService.kt
@@ -31,4 +31,11 @@ class PermissionLoggingService(private val auditLogService: AuditLogService) {
             AuditLogService.createEntry(userId, ObjectType.PERMISSION, permission)
         )
     }
+
+    @Transactional(propagation = Propagation.MANDATORY)
+    fun logDelete(permission: Permission, currentUserId: String) {
+        auditLogService.create(
+            AuditLogService.deleteEntry(currentUserId, ObjectType.PERMISSION, permission)
+        )
+    }
 }


### PR DESCRIPTION
# Description

Delete the associated permission entry when deleting a hankekayttaja. Otherwise, the user will still have access to the hanke after deleting, but they will not show up in the user management view.

Also add audit logging to deleting hankekayttaja. Log deletions of both the hankekayttaja and permission.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2486

## Type of change

- [X] Bug fix 
- [ ] New feature 
- [ ] Other

# Instructions for testing
Delete your own permissions. You shouldn't be able to access the hanke anymore.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 