### PR TITLE
HAI-2374 copy POST /hakemukset to hakemus controller

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationControllerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationControllerITest.kt
@@ -301,12 +301,12 @@ class ApplicationControllerITest(@Autowired override val mockMvc: MockMvc) : Con
                             endTime = ZonedDateTime.now().minusDays(1)
                         )
                 )
-            every { authorizer.authorizeCreate(any()) } returns true
+            every { authorizer.authorizeCreate(any<Application>()) } returns true
 
             post(BASE_URL, application).andExpect(status().isBadRequest)
 
             verify {
-                authorizer.authorizeCreate(any())
+                authorizer.authorizeCreate(any<Application>())
                 applicationService wasNot Called
             }
         }

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusControllerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusControllerITest.kt
@@ -309,7 +309,27 @@ class HakemusControllerITest(@Autowired override val mockMvc: MockMvc) : Control
         }
 
         @Test
-        fun `returns 200 and created hakemus`() {
+        fun `returns 200 and the created hakemus`() {
+            every { authorizer.authorizeCreate(request) } returns true
+            val hakemus = HakemusFactory.create(hankeTunnus = hankeTunnus)
+            every { hakemusService.create(request, USERNAME) } returns hakemus
+
+            val response: HakemusResponse =
+                post(url, request).andExpect(status().isOk).andReturnBody()
+
+            assertThat(response).all {
+                prop(HakemusResponse::id).isEqualTo(hakemus.id)
+                prop(HakemusResponse::hankeTunnus).isEqualTo(hankeTunnus)
+            }
+            verifySequence {
+                authorizer.authorizeCreate(request)
+                hakemusService.create(request, USERNAME)
+            }
+        }
+
+        @Test
+        fun `returns 200 and the created hakemus when the hakemus is a kaivuilmoitus`() {
+            val request = CreateHakemusRequestFactory.kaivuilmoitusRequest()
             every { authorizer.authorizeCreate(request) } returns true
             val hakemus = HakemusFactory.create(hankeTunnus = hankeTunnus)
             every { hakemusService.create(request, USERNAME) } returns hakemus

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationAuthorizer.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationAuthorizer.kt
@@ -3,6 +3,7 @@ package fi.hel.haitaton.hanke.application
 import fi.hel.haitaton.hanke.HankeRepository
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentRepository
 import fi.hel.haitaton.hanke.attachment.common.AttachmentNotFoundException
+import fi.hel.haitaton.hanke.hakemus.CreateHakemusRequest
 import fi.hel.haitaton.hanke.permissions.Authorizer
 import fi.hel.haitaton.hanke.permissions.PermissionCode
 import fi.hel.haitaton.hanke.permissions.PermissionService
@@ -36,6 +37,10 @@ class ApplicationAuthorizer(
     @Transactional(readOnly = true)
     fun authorizeCreate(application: Application): Boolean =
         authorizeHankeTunnus(application.hankeTunnus, PermissionCode.EDIT_APPLICATIONS)
+
+    @Transactional(readOnly = true)
+    fun authorizeCreate(hakemus: CreateHakemusRequest): Boolean =
+        authorizeHankeTunnus(hakemus.hankeTunnus, PermissionCode.EDIT_APPLICATIONS)
 
     @Transactional(readOnly = true)
     fun authorizeAttachment(

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/CreateHakemusRequest.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/CreateHakemusRequest.kt
@@ -1,0 +1,81 @@
+package fi.hel.haitaton.hanke.hakemus
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonSubTypes
+import com.fasterxml.jackson.annotation.JsonTypeInfo
+import fi.hel.haitaton.hanke.application.ApplicationType
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NAME,
+    include = JsonTypeInfo.As.EXISTING_PROPERTY,
+    property = "applicationType",
+    visible = true
+)
+@JsonSubTypes(
+    JsonSubTypes.Type(value = CreateJohtoselvityshakemusRequest::class, name = "CABLE_REPORT"),
+    JsonSubTypes.Type(value = CreateKaivuilmoitusRequest::class, name = "EXCAVATION_NOTIFICATION")
+)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+sealed interface CreateHakemusRequest {
+    val applicationType: ApplicationType
+    val name: String
+    val workDescription: String
+    val hankeTunnus: String
+}
+
+data class CreateJohtoselvityshakemusRequest(
+    override val applicationType: ApplicationType = ApplicationType.CABLE_REPORT,
+    /** Työn nimi */
+    override val name: String,
+    /** Katuosoite */
+    val postalAddress: PostalAddressRequest?,
+    /** Työssä on kyse: Uuden rakenteen tai johdon rakentamisesta */
+    val constructionWork: Boolean,
+    /** Työssä on kyse: Olemassaolevan rakenteen kunnossapitotyöstä */
+    val maintenanceWork: Boolean,
+    /** Työssä on kyse: Kiinteistöliittymien rakentamisesta */
+    val propertyConnectivity: Boolean,
+    /**
+     * Työssä on kyse: Kaivutyö on aloitettu ennen johtoselvityksen tilaamista merkittävien
+     * vahinkojen välttämiseksi
+     */
+    val emergencyWork: Boolean,
+    /** Louhitaanko työn yhteydessä, esimerkiksi kallioperää? */
+    val rockExcavation: Boolean,
+    /** Työn kuvaus */
+    override val workDescription: String,
+    override val hankeTunnus: String,
+) : CreateHakemusRequest
+
+data class CreateKaivuilmoitusRequest(
+    override val applicationType: ApplicationType = ApplicationType.EXCAVATION_NOTIFICATION,
+    /** Työn nimi */
+    override val name: String,
+    /** Työn kuvaus */
+    override val workDescription: String,
+    /** Työssä on kyse: Uuden rakenteen tai johdon rakentamisesta */
+    val constructionWork: Boolean,
+    /** Työssä on kyse: Olemassaolevan rakenteen kunnossapitotyöstä */
+    val maintenanceWork: Boolean,
+    /**
+     * Työssä on kyse: Kaivutyö on aloitettu ennen johtoselvityksen tilaamista merkittävien
+     * vahinkojen välttämiseksi
+     */
+    val emergencyWork: Boolean,
+    /** Hae uusi johtoselvitys? false = kyllä, true = ei */
+    val cableReportDone: Boolean,
+    /**
+     * Uusi johtoselvitys - Louhitaanko työn yhteydessä, esimerkiksi kallioperää? Täytyy olla
+     * annettu, jos [cableReportDone] == false
+     */
+    val rockExcavation: Boolean? = null,
+    /** Tehtyjen johtoselvitysten tunnukset */
+    val cableReports: List<String>? = emptyList(),
+    /** Sijoitussopimukset */
+    val placementContracts: List<String>? = emptyList(),
+    /** Työhön vaadittava pätevyys */
+    val requiredCompetence: Boolean = false,
+    override val hankeTunnus: String,
+) : CreateHakemusRequest

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/CreateHakemusRequestValidator.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/CreateHakemusRequestValidator.kt
@@ -1,0 +1,62 @@
+package fi.hel.haitaton.hanke.hakemus
+
+import fi.hel.haitaton.hanke.hakemus.CreateHakemusRequestValidators.validateForErrors
+import fi.hel.haitaton.hanke.validation.ValidationResult
+import fi.hel.haitaton.hanke.validation.ValidationResult.Companion.whenNotNull
+import fi.hel.haitaton.hanke.validation.Validators.given
+import fi.hel.haitaton.hanke.validation.Validators.notJustWhitespace
+import fi.hel.haitaton.hanke.validation.Validators.notNull
+import fi.hel.haitaton.hanke.validation.Validators.validate
+import jakarta.validation.Constraint
+import jakarta.validation.ConstraintValidator
+import jakarta.validation.ConstraintValidatorContext
+import jakarta.validation.Payload
+import kotlin.reflect.KClass
+
+@Target(AnnotationTarget.VALUE_PARAMETER)
+@Retention(AnnotationRetention.RUNTIME)
+@Constraint(validatedBy = [CreateHakemusRequestValidator::class])
+@MustBeDocumented
+annotation class ValidCreateHakemusRequest(
+    val message: String = "",
+    val groups: Array<KClass<*>> = [],
+    val payload: Array<KClass<out Payload>> = []
+)
+
+class CreateHakemusRequestValidator :
+    ConstraintValidator<ValidCreateHakemusRequest, CreateHakemusRequest> {
+
+    override fun isValid(
+        request: CreateHakemusRequest,
+        context: ConstraintValidatorContext?
+    ): Boolean {
+        val result = request.validateForErrors()
+        return result.okOrThrow()
+    }
+
+    private fun ValidationResult.okOrThrow(): Boolean {
+        if (isOk()) {
+            return true
+        }
+        throw InvalidHakemusDataException(errorPaths())
+    }
+}
+
+object CreateHakemusRequestValidators {
+
+    fun CreateHakemusRequest.validateForErrors(): ValidationResult =
+        validate { notJustWhitespace(name, "name") }
+            .and { notJustWhitespace(workDescription, "workDescription") }
+            .and {
+                when (this) {
+                    is CreateJohtoselvityshakemusRequest -> validateForErrors()
+                    is CreateKaivuilmoitusRequest -> validateForErrors()
+                }
+            }
+
+    private fun CreateJohtoselvityshakemusRequest.validateForErrors(): ValidationResult =
+        whenNotNull(postalAddress) { it.validateForErrors("postalAddress") }
+
+    private fun CreateKaivuilmoitusRequest.validateForErrors(): ValidationResult =
+        given(!cableReportDone) { notNull(rockExcavation, "rockExcavation") }
+}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusController.kt
@@ -108,6 +108,33 @@ class HakemusController(
         return response
     }
 
+    @PostMapping("/hakemukset")
+    @Operation(
+        summary = "Create a new application",
+        description =
+            "Returns the created application. The new application is created as a draft, " +
+                "i.e. with true in pendingOnClient. The draft is not sent to Allu."
+    )
+    @ApiResponses(
+        value =
+            [
+                ApiResponse(description = "The created application", responseCode = "200"),
+                ApiResponse(
+                    description = "The request body was invalid",
+                    responseCode = "400",
+                    content = [Content(schema = Schema(implementation = HankeError::class))]
+                ),
+            ]
+    )
+    @PreAuthorize("@applicationAuthorizer.authorizeCreate(#createHakemusRequest)")
+    fun create(
+        @ValidCreateHakemusRequest @RequestBody createHakemusRequest: CreateHakemusRequest
+    ): HakemusResponse {
+        val userId = currentUserId()
+        val createdHakemus = hakemusService.create(createHakemusRequest, userId)
+        return createdHakemus.toResponse()
+    }
+
     @PostMapping("/johtoselvityshakemus")
     @Operation(
         summary =

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusUpdateRequestValidator.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusUpdateRequestValidator.kt
@@ -67,7 +67,7 @@ fun CustomerRequest.validateForErrors(path: String): ValidationResult =
             validateTrue(registryKey.isValidBusinessId(), "$path.registryKey")
         }
 
-fun JohtoselvityshakemusUpdateRequest.validateForErrors(): ValidationResult =
+private fun JohtoselvityshakemusUpdateRequest.validateForErrors(): ValidationResult =
     whenNotNull(postalAddress) { it.validateForErrors("postalAddress") }
         .whenNotNull(contractorWithContacts) { it.validateForErrors("contractorWithContacts") }
         .whenNotNull(propertyDeveloperWithContacts) {
@@ -78,7 +78,7 @@ fun PostalAddressRequest.validateForErrors(path: String) = validate {
     notJustWhitespace(streetAddress.streetName, "$path.streetAddress.streetName")
 }
 
-fun KaivuilmoitusUpdateRequest.validateForErrors(): ValidationResult =
+private fun KaivuilmoitusUpdateRequest.validateForErrors(): ValidationResult =
     given(!cableReportDone) { notNull(rockExcavation, "rockExcavation") }
         .whenNotNull(contractorWithContacts) { it.validateForErrors("contractorWithContacts") }
         .whenNotNull(propertyDeveloperWithContacts) {

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/CreateHakemusRequestFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/CreateHakemusRequestFactory.kt
@@ -1,0 +1,59 @@
+package fi.hel.haitaton.hanke.factory
+
+import fi.hel.haitaton.hanke.application.StreetAddress
+import fi.hel.haitaton.hanke.hakemus.CreateJohtoselvityshakemusRequest
+import fi.hel.haitaton.hanke.hakemus.CreateKaivuilmoitusRequest
+import fi.hel.haitaton.hanke.hakemus.PostalAddressRequest
+
+object CreateHakemusRequestFactory {
+
+    fun johtoselvitysRequest(
+        name: String = ApplicationFactory.DEFAULT_APPLICATION_NAME,
+        postalAddress: String? = "Kotikatu 1",
+        constructionWork: Boolean = false,
+        maintenanceWork: Boolean = false,
+        propertyConnectivity: Boolean = false,
+        emergencyWork: Boolean = false,
+        rockExcavation: Boolean = false,
+        workDescription: String = ApplicationFactory.DEFAULT_WORK_DESCRIPTION,
+        hankeTunnus: String = HankeFactory.defaultHankeTunnus,
+    ): CreateJohtoselvityshakemusRequest =
+        CreateJohtoselvityshakemusRequest(
+            name = name,
+            postalAddress = postalAddress?.let { PostalAddressRequest(StreetAddress(it)) },
+            constructionWork = constructionWork,
+            maintenanceWork = maintenanceWork,
+            propertyConnectivity = propertyConnectivity,
+            emergencyWork = emergencyWork,
+            rockExcavation = rockExcavation,
+            workDescription = workDescription,
+            hankeTunnus = hankeTunnus,
+        )
+
+    fun kaivuilmoitusRequest(
+        name: String = ApplicationFactory.DEFAULT_APPLICATION_NAME,
+        workDescription: String = ApplicationFactory.DEFAULT_WORK_DESCRIPTION,
+        constructionWork: Boolean = false,
+        maintenanceWork: Boolean = false,
+        emergencyWork: Boolean = false,
+        cableReportDone: Boolean = false,
+        rockExcavation: Boolean? = false,
+        cableReports: List<String>? = emptyList(),
+        placementContracts: List<String>? = emptyList(),
+        requiredCompetence: Boolean = false,
+        hankeTunnus: String = HankeFactory.defaultHankeTunnus,
+    ): CreateKaivuilmoitusRequest =
+        CreateKaivuilmoitusRequest(
+            name = name,
+            workDescription = workDescription,
+            constructionWork = constructionWork,
+            maintenanceWork = maintenanceWork,
+            emergencyWork = emergencyWork,
+            cableReportDone = cableReportDone,
+            cableReports = cableReports,
+            placementContracts = placementContracts,
+            requiredCompetence = requiredCompetence,
+            rockExcavation = rockExcavation,
+            hankeTunnus = hankeTunnus,
+        )
+}

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/CreateHakemusRequestValidatorsTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/CreateHakemusRequestValidatorsTest.kt
@@ -1,0 +1,126 @@
+package fi.hel.haitaton.hanke.hakemus
+
+import assertk.assertThat
+import assertk.assertions.containsExactlyInAnyOrder
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isTrue
+import assertk.assertions.single
+import fi.hel.haitaton.hanke.factory.CreateHakemusRequestFactory.johtoselvitysRequest
+import fi.hel.haitaton.hanke.factory.CreateHakemusRequestFactory.kaivuilmoitusRequest
+import fi.hel.haitaton.hanke.hakemus.CreateHakemusRequestValidators.validateForErrors
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import org.junit.jupiter.params.provider.NullSource
+import org.junit.jupiter.params.provider.ValueSource
+
+class CreateHakemusRequestValidatorsTest {
+
+    @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    inner class ValidateForErrors {
+        @ParameterizedTest
+        @MethodSource("fullCases")
+        fun `succeeds with full information`(request: CreateHakemusRequest) {
+            val result = request.validateForErrors()
+
+            assertThat(result.isOk()).isTrue()
+        }
+
+        private fun fullCases(): List<CreateHakemusRequest> =
+            listOf(johtoselvitysRequest(), kaivuilmoitusRequest())
+
+        @ParameterizedTest
+        @MethodSource("blankCases")
+        fun `fails when the request has blank fields`(request: CreateHakemusRequest, path: String) {
+            val result = request.validateForErrors()
+
+            assertThat(result.isOk()).isFalse()
+            assertThat(result.errorPaths()).single().isEqualTo(path)
+        }
+
+        private fun blankCases(): List<Arguments> =
+            listOf(
+                Arguments.of(johtoselvitysRequest(name = " "), "name"),
+                Arguments.of(johtoselvitysRequest(workDescription = " "), "workDescription"),
+                Arguments.of(
+                    johtoselvitysRequest(postalAddress = " "),
+                    "postalAddress.streetAddress.streetName"
+                ),
+                Arguments.of(kaivuilmoitusRequest(name = " "), "name"),
+                Arguments.of(kaivuilmoitusRequest(workDescription = " "), "workDescription"),
+            )
+
+        @ParameterizedTest
+        @MethodSource("emptyCases")
+        fun `succeeds when the request has empty fields`(request: CreateHakemusRequest) {
+            val result = request.validateForErrors()
+
+            assertThat(result.isOk()).isTrue()
+        }
+
+        private fun emptyCases(): List<CreateHakemusRequest> =
+            listOf(
+                johtoselvitysRequest(name = ""),
+                johtoselvitysRequest(workDescription = ""),
+                johtoselvitysRequest(postalAddress = ""),
+                kaivuilmoitusRequest(name = ""),
+                kaivuilmoitusRequest(workDescription = ""),
+            )
+
+        @Test
+        fun `fails when cableReportDone is false and rockExcavation is null`() {
+            val request = kaivuilmoitusRequest(cableReportDone = false, rockExcavation = null)
+
+            val result = request.validateForErrors()
+
+            assertThat(result.isOk()).isFalse()
+            assertThat(result.errorPaths()).single().isEqualTo("rockExcavation")
+        }
+
+        @ParameterizedTest
+        @ValueSource(booleans = [true, false])
+        @NullSource
+        fun `succeeds when cableReportDone is true`(rockExcavation: Boolean?) {
+            val request =
+                kaivuilmoitusRequest(cableReportDone = true, rockExcavation = rockExcavation)
+
+            val result = request.validateForErrors()
+
+            assertThat(result.isOk()).isTrue()
+        }
+
+        @ParameterizedTest
+        @ValueSource(booleans = [true, false])
+        fun `succeeds when cableReportDone is false and rockExcavation has value`(
+            rockExcavation: Boolean?
+        ) {
+            val request =
+                kaivuilmoitusRequest(cableReportDone = false, rockExcavation = rockExcavation)
+
+            val result = request.validateForErrors()
+
+            assertThat(result.isOk()).isTrue()
+        }
+
+        @Test
+        fun `returns all failing paths when there are several`() {
+            val request =
+                johtoselvitysRequest(name = " ", workDescription = " ", postalAddress = " ")
+
+            val result = request.validateForErrors()
+
+            assertThat(result.isOk()).isFalse()
+            assertThat(result.errorPaths())
+                .containsExactlyInAnyOrder(
+                    "name",
+                    "workDescription",
+                    "postalAddress.streetAddress.streetName"
+                )
+        }
+    }
+}

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusResponseDeserializer.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusResponseDeserializer.kt
@@ -8,48 +8,37 @@ import com.fasterxml.jackson.databind.node.ObjectNode
 import fi.hel.haitaton.hanke.OBJECT_MAPPER
 import fi.hel.haitaton.hanke.allu.ApplicationStatus
 import fi.hel.haitaton.hanke.application.ApplicationType
-import java.io.IOException
 
-/**
- * Custom deserializer for Hakemus. Because applicationData is polymorphic, this can't be
- * deserialized without some sort of customization. The easy way would be to use JsonSubTypes like
- * in [HakemusUpdateRequest]. But that would be in use always, even in production code.
- *
- * We don't need to deserialize Hakemus data in production code, just in tests. That's easiest to do
- * with a custom serializer we register when the tests start.
- */
-class HakemusDeserializer : JsonDeserializer<Hakemus>() {
-    @Throws(IOException::class)
+class HakemusResponseDeserializer : JsonDeserializer<HakemusResponse>() {
     override fun deserialize(
         jsonParser: JsonParser,
         deserializationContext: DeserializationContext
-    ): Hakemus {
+    ): HakemusResponse {
         val root = jsonParser.readValueAsTree<ObjectNode>()
-        val basicHakemus = OBJECT_MAPPER.treeToValue(root, BasicHakemus::class.java)
+        val basicHakemus = OBJECT_MAPPER.treeToValue(root, BasicResponse::class.java)
 
         val dataClass =
             when (basicHakemus.applicationType) {
-                ApplicationType.CABLE_REPORT -> JohtoselvityshakemusData::class.java
-                ApplicationType.EXCAVATION_NOTIFICATION -> KaivuilmoitusData::class.java
+                ApplicationType.CABLE_REPORT -> JohtoselvitysHakemusDataResponse::class.java
+                ApplicationType.EXCAVATION_NOTIFICATION -> KaivuilmoitusDataResponse::class.java
             }
 
         val dataNode = root.path("applicationData") as ObjectNode
         val hakemusData = OBJECT_MAPPER.treeToValue(dataNode, dataClass)
-        return basicHakemus.toHakemus(hakemusData)
+        return basicHakemus.toHakemusResponse(hakemusData)
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
-    data class BasicHakemus(
+    data class BasicResponse(
         val id: Long,
         val alluid: Int?,
         val alluStatus: ApplicationStatus?,
         val applicationIdentifier: String?,
         val applicationType: ApplicationType,
         val hankeTunnus: String,
-        val hankeId: Int,
     ) {
-        fun toHakemus(hakemusData: HakemusData) =
-            Hakemus(
+        fun toHakemusResponse(hakemusData: HakemusDataResponse) =
+            HakemusResponse(
                 id,
                 alluid,
                 alluStatus,
@@ -57,7 +46,6 @@ class HakemusDeserializer : JsonDeserializer<Hakemus>() {
                 applicationType,
                 hakemusData,
                 hankeTunnus,
-                hankeId,
             )
     }
 }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/test/Asserts.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/test/Asserts.kt
@@ -10,6 +10,8 @@ import assertk.assertions.isInstanceOf
 import assertk.assertions.isNotNull
 import assertk.assertions.prop
 import assertk.assertions.single
+import fi.hel.haitaton.hanke.application.PostalAddress
+import fi.hel.haitaton.hanke.application.StreetAddress
 import fi.hel.haitaton.hanke.domain.Hankealue
 import fi.hel.haitaton.hanke.domain.HasFeatures
 import fi.hel.haitaton.hanke.zonedDateTime
@@ -75,4 +77,10 @@ object Asserts {
         assertThat(idPart.toLongOrNull()).isEqualTo(id.toLong())
         assertThat(UUID.fromString(uuidPart)).isNotNull()
     }
+
+    fun Assert<PostalAddress?>.hasStreetName(street: String) =
+        isNotNull()
+            .prop(PostalAddress::streetAddress)
+            .prop(StreetAddress::streetName)
+            .isEqualTo(street)
 }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/test/JacksonTestExtension.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/test/JacksonTestExtension.kt
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.databind.module.SimpleModule
 import fi.hel.haitaton.hanke.OBJECT_MAPPER
 import fi.hel.haitaton.hanke.hakemus.Hakemus
 import fi.hel.haitaton.hanke.hakemus.HakemusDeserializer
+import fi.hel.haitaton.hanke.hakemus.HakemusResponse
+import fi.hel.haitaton.hanke.hakemus.HakemusResponseDeserializer
 import org.junit.jupiter.api.extension.BeforeAllCallback
 import org.junit.jupiter.api.extension.ExtensionContext
 
@@ -25,6 +27,7 @@ class JacksonTestExtension : BeforeAllCallback {
 
         val module = SimpleModule()
         module.addDeserializer(Hakemus::class.java, HakemusDeserializer())
+        module.addDeserializer(HakemusResponse::class.java, HakemusResponseDeserializer())
         OBJECT_MAPPER.registerModule(module)
     }
 


### PR DESCRIPTION
# Description

Implement creating a new hakemus in HakemusController. This has a couple of key differences from the previous implementation in ApplicationController:
- The endpoint supports kaivuilmoitus.
- The endpoint only accepts hakemusdata from the application form's first page.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2374

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
Can be tested with Swagger UI.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 