### PR TITLE
HAI-2456 Send a notification email when a user is added on the application as a contact person

### DIFF
--- a/email/kayttaja-lisatty-hakemus.mjml
+++ b/email/kayttaja-lisatty-hakemus.mjml
@@ -7,12 +7,11 @@
         <mj-section>
             <mj-column>
                 <mj-text mj-class="header-txt">
-                    Sinut on lisätty hakemukselle {{applicationIdentifier}} / Du har lagts till i ansökan
-                    {{applicationIdentifier}} / You have been added to application {{applicationIdentifier}}
+                    Sinut on lisätty hakemukselle / Du har lagts till i en ansökan / You have been added to an application
                 </mj-text>
                 <mj-text mj-class="basic-txt">
-                    {{senderName}} ({{senderEmail}}) on tehnyt {{applicationType.fi}} ({{applicationIdentifier}})
-                    hankkeella {{hankeTunnus}}, ja lähettänyt sen käsittelyyn. Sinut on lisätty kyseiselle hakemukselle.
+                    {{senderName}} ({{senderEmail}}) on laatimassa {{applicationType.fi}}
+                    hankkeelle <b>{{hankeNimi}} {{hankeTunnus}}</b>. Sinut on lisätty hakemukselle.
                     Tarkastele hakemusta Haitattomassa:
                     <a href="{{baseUrl}}">{{baseUrl}}</a>
                 </mj-text>
@@ -26,9 +25,9 @@
                 <mj-divider mj-class="language-separator" />
 
                 <mj-text mj-class="basic-txt">
-                    {{senderName}} ({{senderEmail}}) har gjort en ansökan om {{applicationType.sv}}
-                    ({{applicationIdentifier}}) i projektet {{hankeTunnus}} och skickat in den för behandling.
-                    Du har rollen i ansökan. Kontrollera ansökan i Haitaton:
+                    {{senderName}} ({{senderEmail}}) on laatimassa {{applicationType.fi}}
+                    hankkeelle <b>{{hankeNimi}} {{hankeTunnus}}</b>. Sinut on lisätty hakemukselle.
+                    Kontrollera ansökan i Haitaton:
                     <a href="{{baseUrl}}">{{baseUrl}}</a>
                 </mj-text>
                 <mj-text mj-class="basic-txt">
@@ -40,9 +39,9 @@
                 <mj-divider mj-class="language-separator" />
 
                 <mj-text mj-class="basic-txt">
-                    {{senderName}} ({{senderEmail}}) has created {{applicationType.en}} ({{applicationIdentifier}}) for
-                    project {{hankeTunnus}} and submitted it for processing. In the application, you have been
-                    designated as a role. View the application in the Haitaton system:
+                    {{senderName}} ({{senderEmail}}) on laatimassa {{applicationType.fi}}
+                    hankkeelle <b>{{hankeNimi}} {{hankeTunnus}}</b>. Sinut on lisätty hakemukselle.
+                    View the application in the Haitaton system:
                     <a href="{{baseUrl}}">{{baseUrl}}</a>
                 </mj-text>
                 <mj-text mj-class="basic-txt">

--- a/email/kayttaja-lisatty-hakemus.mjml
+++ b/email/kayttaja-lisatty-hakemus.mjml
@@ -11,7 +11,7 @@
                 </mj-text>
                 <mj-text mj-class="basic-txt">
                     {{senderName}} ({{senderEmail}}) on laatimassa {{applicationType.fi}}
-                    hankkeelle <b>{{hankeNimi}} {{hankeTunnus}}</b>. Sinut on lisätty hakemukselle.
+                    hankkeelle <b>{{hankeNimi}} ({{hankeTunnus}})</b>. Sinut on lisätty hakemukselle.
                     Tarkastele hakemusta Haitattomassa:
                     <a href="{{baseUrl}}">{{baseUrl}}</a>
                 </mj-text>
@@ -26,7 +26,7 @@
 
                 <mj-text mj-class="basic-txt">
                     {{senderName}} ({{senderEmail}}) on laatimassa {{applicationType.fi}}
-                    hankkeelle <b>{{hankeNimi}} {{hankeTunnus}}</b>. Sinut on lisätty hakemukselle.
+                    hankkeelle <b>{{hankeNimi}} ({{hankeTunnus}})</b>. Sinut on lisätty hakemukselle.
                     Kontrollera ansökan i Haitaton:
                     <a href="{{baseUrl}}">{{baseUrl}}</a>
                 </mj-text>
@@ -40,7 +40,7 @@
 
                 <mj-text mj-class="basic-txt">
                     {{senderName}} ({{senderEmail}}) on laatimassa {{applicationType.fi}}
-                    hankkeelle <b>{{hankeNimi}} {{hankeTunnus}}</b>. Sinut on lisätty hakemukselle.
+                    hankkeelle <b>{{hankeNimi}} ({{hankeTunnus}})</b>. Sinut on lisätty hakemukselle.
                     View the application in the Haitaton system:
                     <a href="{{baseUrl}}">{{baseUrl}}</a>
                 </mj-text>

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceITest.kt
@@ -814,7 +814,8 @@ class ApplicationServiceITest : IntegrationTest() {
 
             val capturedEmails = getApplicationNotifications()
             assertThat(capturedEmails).hasSize(3) // 4 contacts, but one is the sender
-            assertThat(capturedEmails).areValid(application.applicationType, hanke.hankeTunnus)
+            assertThat(capturedEmails)
+                .areValid(application.applicationType, hanke.hankeTunnus, hanke.nimi)
             verifySequence {
                 cableReportServiceAllu.create(any())
                 cableReportServiceAllu.addAttachment(any(), any())
@@ -1381,18 +1382,24 @@ class ApplicationServiceITest : IntegrationTest() {
             it.subject.startsWith("Haitaton: Sinut on lisätty hakemukselle")
         }
 
-    private fun Assert<List<MimeMessage>>.areValid(type: ApplicationType, hankeTunnus: String?) {
-        each { it.isValid(type, hankeTunnus) }
+    private fun Assert<List<MimeMessage>>.areValid(
+        type: ApplicationType,
+        hankeTunnus: String,
+        hankeNimi: String
+    ) {
+        each { it.isValid(type, hankeTunnus, hankeNimi) }
     }
 
-    private fun Assert<MimeMessage>.isValid(type: ApplicationType, hankeTunnus: String?) {
+    private fun Assert<MimeMessage>.isValid(
+        type: ApplicationType,
+        hankeTunnus: String,
+        hankeNimi: String
+    ) {
         val name = "${KAYTTAJA_INPUT_HAKIJA.etunimi} ${KAYTTAJA_INPUT_HAKIJA.sukunimi}"
         val email = KAYTTAJA_INPUT_HAKIJA.email
         prop(MimeMessage::textBody).all {
-            contains("$name ($email) on tehnyt")
-            contains("hakemukselle ${ApplicationFactory.DEFAULT_APPLICATION_IDENTIFIER}")
-            contains("on tehnyt ${type.translations().fi}")
-            contains("hankkeella $hankeTunnus")
+            contains("$name ($email) on laatimassa ${type.translations().fi}")
+            contains("hankkeelle \"$hankeNimi\" ($hankeTunnus)")
         }
 
         transform { it.allRecipients.first().toString() }.isIn(*expectedRecipients)

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/email/EmailSenderServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/email/EmailSenderServiceITest.kt
@@ -185,8 +185,8 @@ class EmailSenderServiceITest : IntegrationTest() {
                 senderEmail = INVITER_EMAIL,
                 recipientEmail = TEST_EMAIL,
                 applicationType = ApplicationType.CABLE_REPORT,
-                applicationIdentifier = APPLICATION_IDENTIFIER,
                 hankeTunnus = HANKE_TUNNUS,
+                hankeNimi = HANKE_NIMI,
             )
 
         @Test
@@ -214,9 +214,9 @@ class EmailSenderServiceITest : IntegrationTest() {
             val email = greenMail.firstReceivedMessage()
             assertThat(email.subject)
                 .isEqualTo(
-                    "Haitaton: Sinut on lisätty hakemukselle JS2300001 " +
-                        "/ Du har lagts till i ansökan JS2300001 " +
-                        "/ You have been added to application JS2300001"
+                    "Haitaton: Sinut on lisätty hakemukselle " +
+                        "/ Du har lagts till i en ansökan " +
+                        "/ You have been added to an application"
                 )
         }
 
@@ -228,14 +228,17 @@ class EmailSenderServiceITest : IntegrationTest() {
             val (textBody, htmlBody) = email.bodies()
             assertThat(textBody).all {
                 contains("${notification.senderName} (${notification.senderEmail}) on")
-                contains("tehnyt johtoselvityshakemuksen (${notification.applicationIdentifier})")
-                contains("hankkeella ${notification.hankeTunnus}")
+                contains(
+                    "laatimassa johtoselvityshakemusta hankkeelle \"${notification.hankeNimi}\" (${notification.hankeTunnus})"
+                )
                 contains("Tarkastele hakemusta Haitattomassa: http://localhost:3001")
             }
             assertThat(htmlBody).all {
                 val htmlEscapedName = "Matti Meik&auml;l&auml;inen"
                 contains("$htmlEscapedName (${notification.senderEmail})")
-                contains("johtoselvityshakemuksen (${notification.applicationIdentifier})")
+                contains(
+                    "laatimassa johtoselvityshakemusta hankkeelle <b>${notification.hankeNimi} ${notification.hankeTunnus}</b>"
+                )
                 contains("""<a href="http://localhost:3001">""")
             }
         }

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/email/EmailSenderServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/email/EmailSenderServiceITest.kt
@@ -237,7 +237,7 @@ class EmailSenderServiceITest : IntegrationTest() {
                 val htmlEscapedName = "Matti Meik&auml;l&auml;inen"
                 contains("$htmlEscapedName (${notification.senderEmail})")
                 contains(
-                    "laatimassa johtoselvityshakemusta hankkeelle <b>${notification.hankeNimi} ${notification.hankeTunnus}</b>"
+                    "laatimassa johtoselvityshakemusta hankkeelle <b>${notification.hankeNimi} (${notification.hankeTunnus})</b>"
                 )
                 contains("""<a href="http://localhost:3001">""")
             }

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/email/FilteredEmailSenderServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/email/FilteredEmailSenderServiceITest.kt
@@ -94,8 +94,8 @@ class FilteredEmailSenderServiceITest : IntegrationTest() {
                 senderEmail = "kalle.kutsuja@mail.com",
                 recipientEmail = "test@test.test",
                 applicationType = CABLE_REPORT,
-                applicationIdentifier = "JS002",
                 hankeTunnus = "HAI24-1",
+                hankeNimi = "Testihanke",
             )
         )
 

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceITest.kt
@@ -59,6 +59,7 @@ import fi.hel.haitaton.hanke.attachment.application.ApplicationAttachmentContent
 import fi.hel.haitaton.hanke.attachment.azure.Container
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentRepository
 import fi.hel.haitaton.hanke.attachment.common.MockFileClient
+import fi.hel.haitaton.hanke.email.textBody
 import fi.hel.haitaton.hanke.factory.AlluFactory
 import fi.hel.haitaton.hanke.factory.ApplicationAttachmentFactory
 import fi.hel.haitaton.hanke.factory.ApplicationFactory
@@ -899,6 +900,10 @@ class HakemusServiceITest(
                     .isEqualTo(
                         "Haitaton: Sinut on lisätty hakemukselle / Du har lagts till i en ansökan / You have been added to an application"
                     )
+                assertThat(email.textBody())
+                    .contains(
+                        "laatimassa johtoselvityshakemusta hankkeelle \"${hanke.nimi}\" (${hanke.hankeTunnus})"
+                    )
             }
         }
 
@@ -1232,6 +1237,37 @@ class HakemusServiceITest(
                     .prop(CustomerWithContactsResponse::contacts)
                     .extracting { it.hankekayttajaId }
                     .containsExactly(newKayttaja.id)
+            }
+
+            @Test
+            fun `sends email for new contacts`() {
+                val hanke = hankeFactory.builder(USERNAME).withHankealue().saveEntity()
+                val entity =
+                    hakemusFactory
+                        .builder(USERNAME, hanke, ApplicationType.EXCAVATION_NOTIFICATION)
+                        .hakija()
+                        .saveEntity()
+                val hakemus = hakemusService.hakemusResponse(entity.id)
+                val yhteystieto = hakemusyhteystietoRepository.findAll().first()
+                val newKayttaja = hankeKayttajaFactory.saveUser(hanke.id)
+                val request =
+                    hakemus
+                        .toUpdateRequest()
+                        .withCustomer(CustomerType.COMPANY, yhteystieto.id, newKayttaja.id)
+
+                hakemusService.updateHakemus(hakemus.id, request, USERNAME)
+
+                val email = greenMail.firstReceivedMessage()
+                assertThat(email.allRecipients).hasSize(1)
+                assertThat(email.allRecipients[0].toString()).isEqualTo(newKayttaja.sahkoposti)
+                assertThat(email.subject)
+                    .isEqualTo(
+                        "Haitaton: Sinut on lisätty hakemukselle / Du har lagts till i en ansökan / You have been added to an application"
+                    )
+                assertThat(email.textBody())
+                    .contains(
+                        "laatimassa kaivuilmoitusta hankkeelle \"${hanke.nimi}\" (${hanke.hankeTunnus})"
+                    )
             }
         }
     }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationEntity.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationEntity.kt
@@ -75,6 +75,6 @@ data class ApplicationEntity(
         )
     }
 
-    fun allContactUsers(): Set<HankekayttajaEntity> =
-        yhteystiedot.values.flatMap { it.yhteyshenkilot }.map { it.hankekayttaja }.toSet()
+    fun allContactUsers(): List<HankekayttajaEntity> =
+        yhteystiedot.values.flatMap { it.yhteyshenkilot }.map { it.hankekayttaja }
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationEntity.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationEntity.kt
@@ -75,9 +75,6 @@ data class ApplicationEntity(
         )
     }
 
-    fun allContactUsers(): List<HankekayttajaEntity> =
-        yhteystiedot.values
-            .flatMap { it.yhteyshenkilot }
-            .map { it.hankekayttaja }
-            .distinctBy { it.sahkoposti }
+    fun allContactUsers(): Set<HankekayttajaEntity> =
+        yhteystiedot.values.flatMap { it.yhteyshenkilot }.map { it.hankekayttaja }.toSet()
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationService.kt
@@ -375,7 +375,7 @@ class ApplicationService(
         emailRecipients.forEach { email ->
             notifyOnApplication(
                 hanke.hankeTunnus,
-                application.applicationIdentifier!!,
+                hanke.nimi,
                 application.applicationType,
                 currentKayttaja,
                 email,
@@ -385,7 +385,7 @@ class ApplicationService(
 
     private fun notifyOnApplication(
         hankeTunnus: String,
-        applicationIdentifier: String,
+        hankeNimi: String,
         applicationType: ApplicationType,
         currentKayttaja: HankekayttajaEntity?,
         recipientEmail: String,
@@ -402,9 +402,9 @@ class ApplicationService(
                 senderName = currentKayttaja.fullName(),
                 senderEmail = currentKayttaja.sahkoposti,
                 recipientEmail = recipientEmail,
-                hankeTunnus = hankeTunnus,
-                applicationIdentifier = applicationIdentifier,
                 applicationType = applicationType,
+                hankeTunnus = hankeTunnus,
+                hankeNimi = hankeNimi,
             )
         )
     }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/email/EmailSenderService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/email/EmailSenderService.kt
@@ -38,8 +38,8 @@ data class ApplicationNotificationData(
     val senderEmail: String,
     val recipientEmail: String,
     val applicationType: ApplicationType,
-    val applicationIdentifier: String,
     val hankeTunnus: String,
+    val hankeNimi: String,
 )
 
 data class HankeInvitationData(
@@ -133,8 +133,8 @@ class EmailSenderService(
                 "senderName" to data.senderName,
                 "senderEmail" to data.senderEmail,
                 "applicationType" to data.applicationType.translations(),
-                "applicationIdentifier" to data.applicationIdentifier,
                 "hankeTunnus" to data.hankeTunnus,
+                "hankeNimi" to data.hankeNimi,
                 "signatures" to signatures(),
             )
 
@@ -230,11 +230,16 @@ class EmailSenderService(
             when (this) {
                 ApplicationType.CABLE_REPORT ->
                     Translations(
-                        fi = "johtoselvityshakemuksen",
+                        fi = "johtoselvityshakemusta",
                         sv = "ledningsutredning",
                         en = "a cable report application",
                     )
-                ApplicationType.EXCAVATION_NOTIFICATION -> TODO("Not yet implemented")
+                ApplicationType.EXCAVATION_NOTIFICATION ->
+                    Translations(
+                        fi = "kaivuilmoitusta",
+                        sv = "kaivuilmoitusta", // TODO translate
+                        en = "kaivuilmoitusta", // TODO translate
+                    )
             }
 
         fun Kayttooikeustaso.translations() =

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
@@ -828,8 +828,8 @@ class HakemusService(
                     inviter.sahkoposti,
                     it.sahkoposti,
                     applicationEntity.applicationType,
-                    applicationEntity.applicationIdentifier ?: "",
-                    applicationEntity.hanke.hankeTunnus
+                    applicationEntity.hanke.hankeTunnus,
+                    applicationEntity.hanke.nimi,
                 )
             )
         }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttaja.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttaja.kt
@@ -146,19 +146,6 @@ class HankekayttajaEntity(
         yhteyshenkilot.map { it.hankeYhteystieto.contactType }
 
     fun fullName() = listOf(etunimi, sukunimi).filter { it.isNotBlank() }.joinToString(" ")
-
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (javaClass != other?.javaClass) return false
-
-        other as HankekayttajaEntity
-
-        return sahkoposti == other.sahkoposti
-    }
-
-    override fun hashCode(): Int {
-        return sahkoposti.hashCode()
-    }
 }
 
 data class HankeKayttaja(

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttaja.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttaja.kt
@@ -146,6 +146,19 @@ class HankekayttajaEntity(
         yhteyshenkilot.map { it.hankeYhteystieto.contactType }
 
     fun fullName() = listOf(etunimi, sukunimi).filter { it.isNotBlank() }.joinToString(" ")
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as HankekayttajaEntity
+
+        return sahkoposti == other.sahkoposti
+    }
+
+    override fun hashCode(): Int {
+        return sahkoposti.hashCode()
+    }
 }
 
 data class HankeKayttaja(

--- a/services/hanke-service/src/main/resources/email/template/kayttaja-lisatty-hakemus.html.mustache
+++ b/services/hanke-service/src/main/resources/email/template/kayttaja-lisatty-hakemus.html.mustache
@@ -67,12 +67,12 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0;padding:16px 24px 16px 24px;word-break:break-word">
-                        <div style="font-family:Arial;font-size:36px;line-height:43px;text-align:left;color:#000">Sinut on lisätty hakemukselle {{applicationIdentifier}} / Du har lagts till i ansökan {{applicationIdentifier}} / You have been added to application {{applicationIdentifier}}</div>
+                        <div style="font-family:Arial;font-size:36px;line-height:43px;text-align:left;color:#000">Sinut on lisätty hakemukselle / Du har lagts till i en ansökan / You have been added to an application</div>
                       </td>
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0;padding:16px 24px 0 24px;word-break:break-word">
-                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">{{senderName}} ({{senderEmail}}) on tehnyt {{applicationType.fi}} ({{applicationIdentifier}}) hankkeella {{hankeTunnus}}, ja lähettänyt sen käsittelyyn. Sinut on lisätty kyseiselle hakemukselle. Tarkastele hakemusta Haitattomassa: <a href="{{baseUrl}}">{{baseUrl}}</a></div>
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">{{senderName}} ({{senderEmail}}) on laatimassa {{applicationType.fi}} hankkeelle <b>{{hankeNimi}} {{hankeTunnus}}</b>. Sinut on lisätty hakemukselle. Tarkastele hakemusta Haitattomassa: <a href="{{baseUrl}}">{{baseUrl}}</a></div>
                       </td>
                     </tr>
                     <tr>
@@ -110,7 +110,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0;padding:16px 24px 0 24px;word-break:break-word">
-                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">{{senderName}} ({{senderEmail}}) har gjort en ansökan om {{applicationType.sv}} ({{applicationIdentifier}}) i projektet {{hankeTunnus}} och skickat in den för behandling. Du har rollen i ansökan. Kontrollera ansökan i Haitaton: <a href="{{baseUrl}}">{{baseUrl}}</a></div>
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">{{senderName}} ({{senderEmail}}) on laatimassa {{applicationType.fi}} hankkeelle <b>{{hankeNimi}} {{hankeTunnus}}</b>. Sinut on lisätty hakemukselle. Kontrollera ansökan i Haitaton: <a href="{{baseUrl}}">{{baseUrl}}</a></div>
                       </td>
                     </tr>
                     <tr>
@@ -148,7 +148,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0;padding:16px 24px 0 24px;word-break:break-word">
-                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">{{senderName}} ({{senderEmail}}) has created {{applicationType.en}} ({{applicationIdentifier}}) for project {{hankeTunnus}} and submitted it for processing. In the application, you have been designated as a role. View the application in the Haitaton system: <a href="{{baseUrl}}">{{baseUrl}}</a></div>
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">{{senderName}} ({{senderEmail}}) on laatimassa {{applicationType.fi}} hankkeelle <b>{{hankeNimi}} {{hankeTunnus}}</b>. Sinut on lisätty hakemukselle. View the application in the Haitaton system: <a href="{{baseUrl}}">{{baseUrl}}</a></div>
                       </td>
                     </tr>
                     <tr>

--- a/services/hanke-service/src/main/resources/email/template/kayttaja-lisatty-hakemus.html.mustache
+++ b/services/hanke-service/src/main/resources/email/template/kayttaja-lisatty-hakemus.html.mustache
@@ -72,7 +72,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0;padding:16px 24px 0 24px;word-break:break-word">
-                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">{{senderName}} ({{senderEmail}}) on laatimassa {{applicationType.fi}} hankkeelle <b>{{hankeNimi}} {{hankeTunnus}}</b>. Sinut on lisätty hakemukselle. Tarkastele hakemusta Haitattomassa: <a href="{{baseUrl}}">{{baseUrl}}</a></div>
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">{{senderName}} ({{senderEmail}}) on laatimassa {{applicationType.fi}} hankkeelle <b>{{hankeNimi}} ({{hankeTunnus}})</b>. Sinut on lisätty hakemukselle. Tarkastele hakemusta Haitattomassa: <a href="{{baseUrl}}">{{baseUrl}}</a></div>
                       </td>
                     </tr>
                     <tr>
@@ -110,7 +110,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0;padding:16px 24px 0 24px;word-break:break-word">
-                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">{{senderName}} ({{senderEmail}}) on laatimassa {{applicationType.fi}} hankkeelle <b>{{hankeNimi}} {{hankeTunnus}}</b>. Sinut on lisätty hakemukselle. Kontrollera ansökan i Haitaton: <a href="{{baseUrl}}">{{baseUrl}}</a></div>
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">{{senderName}} ({{senderEmail}}) on laatimassa {{applicationType.fi}} hankkeelle <b>{{hankeNimi}} ({{hankeTunnus}})</b>. Sinut on lisätty hakemukselle. Kontrollera ansökan i Haitaton: <a href="{{baseUrl}}">{{baseUrl}}</a></div>
                       </td>
                     </tr>
                     <tr>
@@ -148,7 +148,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0;padding:16px 24px 0 24px;word-break:break-word">
-                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">{{senderName}} ({{senderEmail}}) on laatimassa {{applicationType.fi}} hankkeelle <b>{{hankeNimi}} {{hankeTunnus}}</b>. Sinut on lisätty hakemukselle. View the application in the Haitaton system: <a href="{{baseUrl}}">{{baseUrl}}</a></div>
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">{{senderName}} ({{senderEmail}}) on laatimassa {{applicationType.fi}} hankkeelle <b>{{hankeNimi}} ({{hankeTunnus}})</b>. Sinut on lisätty hakemukselle. View the application in the Haitaton system: <a href="{{baseUrl}}">{{baseUrl}}</a></div>
                       </td>
                     </tr>
                     <tr>

--- a/services/hanke-service/src/main/resources/email/template/kayttaja-lisatty-hakemus.subject.mustache
+++ b/services/hanke-service/src/main/resources/email/template/kayttaja-lisatty-hakemus.subject.mustache
@@ -1,1 +1,1 @@
-Haitaton: Sinut on lisätty hakemukselle {{applicationIdentifier}} / Du har lagts till i ansökan {{applicationIdentifier}} / You have been added to application {{applicationIdentifier}}
+Haitaton: Sinut on lisätty hakemukselle / Du har lagts till i en ansökan / You have been added to an application

--- a/services/hanke-service/src/main/resources/email/template/kayttaja-lisatty-hakemus.text.mustache
+++ b/services/hanke-service/src/main/resources/email/template/kayttaja-lisatty-hakemus.text.mustache
@@ -1,20 +1,20 @@
-Sinut on lisätty hakemukselle {{applicationIdentifier}} / Du har lagts till i ansökan {{applicationIdentifier}} / You have been added to application {{applicationIdentifier}}
+Sinut on lisätty hakemukselle / Du har lagts till i en ansökan / You have been added to an application
 
-{{{senderName}}} ({{{senderEmail}}}) on tehnyt {{applicationType.fi}} ({{applicationIdentifier}}) hankkeella {{hankeTunnus}}, ja lähettänyt sen käsittelyyn. Sinut on lisätty kyseiselle hakemukselle. Tarkastele hakemusta Haitattomassa: {{baseUrl}}
+{{{senderName}}} ({{{senderEmail}}}) on laatimassa {{applicationType.fi}} hankkeelle "{{{hankeNimi}}}" ({{hankeTunnus}}). Sinut on lisätty hakemukselle. Tarkastele hakemusta Haitattomassa: {{baseUrl}}
 
 Löydät hakemuksesi siirtymällä etusivulta Omiin hankkeisiin ja valitsemalla sieltä oikean hankkeen. Avaa listanäkymässä hankkeen tiedot ja valitse “Näytä hankkeen hakemukset”.
 
 {{{signatures.fi}}}
 
 
-{{{senderName}}} ({{{senderEmail}}}) har gjort en ansökan om {{applicationType.sv}} ({{applicationIdentifier}}) i projektet {{hankeTunnus}} och skickat in den för behandling. Du har rollen i ansökan. Kontrollera ansökan i Haitaton: {{baseUrl}}
+{{{senderName}}} ({{{senderEmail}}}) on laatimassa {{applicationType.sv}} hankkeelle "{{{hankeNimi}}}" ({{hankeTunnus}}). Sinut on lisätty hakemukselle. Kontrollera ansökan i Haitaton: {{baseUrl}}
 
 Du hittar din ansökan genom att gå från startsidan till Egna projekt och välja rätt projekt. Öppna projektets uppgifter i listvyn och välj ”Visa projektets ansökningar”.
 
 {{{signatures.sv}}}
 
 
-{{{senderName}}} ({{{senderEmail}}}) has created {{applicationType.en}} ({{applicationIdentifier}}) for project {{hankeTunnus}} and submitted it for processing. In the application, you have been designated as a role. View the application in the Haitaton system: {{baseUrl}}
+{{{senderName}}} ({{{senderEmail}}}) on laatimassa {{applicationType.en}} hankkeelle "{{{hankeNimi}}}" ({{hankeTunnus}}). Sinut on lisätty hakemukselle. View the application in the Haitaton system: {{baseUrl}}
 
 You can find your application by selecting ‘Own projects’ on the front page and then selecting the project in question. Open the project information in the list view and select ‘Show project applications’.
 

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/email/EmailSenderServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/email/EmailSenderServiceTest.kt
@@ -31,7 +31,6 @@ private const val INVITER_EMAIL = "matti.meikalainen@test.fi"
 private const val TEST_EMAIL = "test@test.test"
 private const val HANKE_TUNNUS = "HAI24-1"
 private const val HANKE_NIMI = "Mannerheimintien liikenneuudistus"
-private const val APPLICATION_IDENTIFIER = "JS2300001"
 
 class EmailSenderServiceTest {
 
@@ -201,8 +200,8 @@ class EmailSenderServiceTest {
                 senderEmail = "matti.meikalainen@test.fi",
                 recipientEmail = TEST_EMAIL,
                 applicationType = ApplicationType.CABLE_REPORT,
-                applicationIdentifier = APPLICATION_IDENTIFIER,
-                hankeTunnus = "HAI24-1",
+                hankeTunnus = HANKE_TUNNUS,
+                hankeNimi = HANKE_NIMI,
             )
 
         private fun sendAndCapture(): MimeMessage {
@@ -220,9 +219,9 @@ class EmailSenderServiceTest {
 
             assertThat(email.subject)
                 .isEqualTo(
-                    "Haitaton: Sinut on lisätty hakemukselle $APPLICATION_IDENTIFIER " +
-                        "/ Du har lagts till i ansökan $APPLICATION_IDENTIFIER " +
-                        "/ You have been added to application $APPLICATION_IDENTIFIER"
+                    "Haitaton: Sinut on lisätty hakemukselle " +
+                        "/ Du har lagts till i en ansökan " +
+                        "/ You have been added to an application"
                 )
         }
 
@@ -231,24 +230,24 @@ class EmailSenderServiceTest {
             val (textBody, htmlBody) = sendAndCapture().bodies()
 
             val expectedBody =
-                "Sinut on lisätty hakemukselle $APPLICATION_IDENTIFIER " +
-                    "/ Du har lagts till i ansökan $APPLICATION_IDENTIFIER " +
-                    "/ You have been added to application $APPLICATION_IDENTIFIER"
+                "Sinut on lisätty hakemukselle " +
+                    "/ Du har lagts till i en ansökan " +
+                    "/ You have been added to an application"
             assertThat(textBody).contains(expectedBody)
             assertThat(htmlBody).contains(expectedBody)
         }
 
         @Nested
         open inner class BodyInFinnish {
-            open fun inviterInformation(name: String, email: String) = "$name ($email) on tehnyt "
+            open fun inviterInformation(name: String, email: String) =
+                "$name ($email) on laatimassa "
 
-            open val applicationInformation =
-                "on tehnyt johtoselvityshakemuksen ($APPLICATION_IDENTIFIER) hankkeella"
-
-            open val hankeInformation = "hankkeella $HANKE_TUNNUS, ja lähettänyt sen käsittelyyn."
-
+            open val applicationInformation = "on laatimassa johtoselvityshakemusta hankkeelle"
+            open val hankeInformationText =
+                "hankkeelle \"$HANKE_NIMI\" ($HANKE_TUNNUS). Sinut on lisätty hakemukselle."
+            open val hankeInformationHtml =
+                "hankkeelle <b>$HANKE_NIMI $HANKE_TUNNUS</b>. Sinut on lisätty hakemukselle."
             open val linkPrefix = "Tarkastele hakemusta Haitattomassa:"
-
             open val signatureLines =
                 listOf(
                     "Tämä on automaattinen sähköposti – älä vastaa tähän viestiin.",
@@ -278,8 +277,8 @@ class EmailSenderServiceTest {
             open fun `contains hanke information`() {
                 val (textBody, htmlBody) = sendAndCapture().bodies()
 
-                assertThat(textBody).contains(hankeInformation)
-                assertThat(htmlBody).contains(hankeInformation)
+                assertThat(textBody).contains(hankeInformationText)
+                assertThat(htmlBody).contains(hankeInformationHtml)
             }
 
             @Test
@@ -302,19 +301,18 @@ class EmailSenderServiceTest {
             }
         }
 
+        // TODO needs translations
         @Nested
         inner class BodyInSwedish : BodyInFinnish() {
             override fun inviterInformation(name: String, email: String) =
-                "$name ($email) har gjort en ansökan"
+                "$name ($email) on laatimassa"
 
-            override val applicationInformation =
-                "har gjort en ansökan om ledningsutredning ($APPLICATION_IDENTIFIER) i projektet"
-
-            override val hankeInformation =
-                "i projektet $HANKE_TUNNUS och skickat in den för behandling."
-
+            override val applicationInformation = "on laatimassa johtoselvityshakemusta hankkeelle"
+            override val hankeInformationText =
+                "hankkeelle \"$HANKE_NIMI\" ($HANKE_TUNNUS). Sinut on lisätty hakemukselle."
+            override val hankeInformationHtml =
+                "hankkeelle <b>$HANKE_NIMI $HANKE_TUNNUS</b>. Sinut on lisätty hakemukselle."
             override val linkPrefix = "Kontrollera ansökan i Haitaton:"
-
             override val signatureLines =
                 listOf(
                     "Det här är ett automatiskt e-postmeddelande – svara inte på det.",
@@ -325,19 +323,18 @@ class EmailSenderServiceTest {
                 )
         }
 
+        // TODO needs translations
         @Nested
         inner class BodyInEnglish : BodyInFinnish() {
             override fun inviterInformation(name: String, email: String) =
-                "$name ($email) has created"
+                "$name ($email) on laatimassa"
 
-            override val applicationInformation =
-                "has created a cable report application ($APPLICATION_IDENTIFIER) for project"
-
-            override val hankeInformation =
-                "for project $HANKE_TUNNUS and submitted it for processing."
-
+            override val applicationInformation = "on laatimassa johtoselvityshakemusta hankkeelle"
+            override val hankeInformationText =
+                "hankkeelle \"$HANKE_NIMI\" ($HANKE_TUNNUS). Sinut on lisätty hakemukselle."
+            override val hankeInformationHtml =
+                "hankkeelle <b>$HANKE_NIMI $HANKE_TUNNUS</b>. Sinut on lisätty hakemukselle."
             override val linkPrefix = "View the application in the Haitaton system:"
-
             override val signatureLines =
                 listOf(
                     "This email was generated automatically – please do not reply to this message.",

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/email/EmailSenderServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/email/EmailSenderServiceTest.kt
@@ -246,7 +246,7 @@ class EmailSenderServiceTest {
             open val hankeInformationText =
                 "hankkeelle \"$HANKE_NIMI\" ($HANKE_TUNNUS). Sinut on lisätty hakemukselle."
             open val hankeInformationHtml =
-                "hankkeelle <b>$HANKE_NIMI $HANKE_TUNNUS</b>. Sinut on lisätty hakemukselle."
+                "hankkeelle <b>$HANKE_NIMI ($HANKE_TUNNUS)</b>. Sinut on lisätty hakemukselle."
             open val linkPrefix = "Tarkastele hakemusta Haitattomassa:"
             open val signatureLines =
                 listOf(
@@ -311,7 +311,7 @@ class EmailSenderServiceTest {
             override val hankeInformationText =
                 "hankkeelle \"$HANKE_NIMI\" ($HANKE_TUNNUS). Sinut on lisätty hakemukselle."
             override val hankeInformationHtml =
-                "hankkeelle <b>$HANKE_NIMI $HANKE_TUNNUS</b>. Sinut on lisätty hakemukselle."
+                "hankkeelle <b>$HANKE_NIMI ($HANKE_TUNNUS)</b>. Sinut on lisätty hakemukselle."
             override val linkPrefix = "Kontrollera ansökan i Haitaton:"
             override val signatureLines =
                 listOf(
@@ -333,7 +333,7 @@ class EmailSenderServiceTest {
             override val hankeInformationText =
                 "hankkeelle \"$HANKE_NIMI\" ($HANKE_TUNNUS). Sinut on lisätty hakemukselle."
             override val hankeInformationHtml =
-                "hankkeelle <b>$HANKE_NIMI $HANKE_TUNNUS</b>. Sinut on lisätty hakemukselle."
+                "hankkeelle <b>$HANKE_NIMI ($HANKE_TUNNUS)</b>. Sinut on lisätty hakemukselle."
             override val linkPrefix = "View the application in the Haitaton system:"
             override val signatureLines =
                 listOf(


### PR DESCRIPTION
# Description
Send a notification email when a user is added on the application as a contact person. Since the email subject and text changed a bit they will need a translation (information about this was added in translation issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2446).

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2456

## Type of change

- [ ] Bug fix 
- [x] New feature 
- [ ] Other

# Instructions for testing
Create a new Johtoselvityshakemus, fill it up until Yhteystiedot, add a new contact person. It should receive an email notification.

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [x] I (and PO) have made necessary changes to the documentation, link to confluence
 or other location: https://helsinkisolutionoffice.atlassian.net/wiki/spaces/HAI/pages/8189902867/S+hk+posti-ilmoitukset+k+ytt+j+lle

# Other relevant info
Please describe here if there is e.g. some requirements for this change or
 other info that the tester/user needs to know.