### PR TITLE
HAI-2468 Bugfix for not-enabling API blocking when the environment variable is not set

### DIFF
--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/ApiBlockingFilter.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/ApiBlockingFilter.kt
@@ -21,7 +21,7 @@ private val log =
     -101
 ) // comes before Spring Security Filter (see spring.security.filter.order in application.yml)
 @Component
-@ConditionalOnProperty("haitaton.api.disabled")
+@ConditionalOnProperty(name = ["haitaton.api.disabled"], havingValue = "true")
 class ApiBlockingFilter : OncePerRequestFilter() {
 
     override fun initFilterBean() {

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusMigrationScheduler.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusMigrationScheduler.kt
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Service
 private val logger = KotlinLogging.logger {}
 
 @Service
-@ConditionalOnProperty("haitaton.migration.enabled")
+@ConditionalOnProperty(name = ["haitaton.migration.enabled"], havingValue = "true")
 class HakemusMigrationScheduler(
     private val hakemusMigrationService: HakemusMigrationService,
     private val hankeRepository: HankeRepository,


### PR DESCRIPTION
# Description

@ConditionalOnProperty.havingValue is by-default '' and this empty string is used for environments when the actual value is not yet used. This caused the API to be disabled when it should not have been.

This error affected both `haitaton.api.disabled` and `haitaton.migration.enabled` environment variables.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2468

## Type of change

- [x] Bug fix 
- [ ] New feature 
- [ ] Other

# Instructions for testing
Please describe tests how this change or new feature can be tested.

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 

# Other relevant info
Please describe here if there is e.g. some requirements for this change or
 other info that the tester/user needs to know.