### PR TITLE
New translations for email messages

### DIFF
--- a/email/kayttaja-lisatty-hakemus.mjml
+++ b/email/kayttaja-lisatty-hakemus.mjml
@@ -26,7 +26,7 @@
 
                 <mj-text mj-class="basic-txt">
                     {{senderName}} ({{senderEmail}}) on laatimassa {{applicationType.fi}}
-                    hankkeelle <b>{{hankeNimi}} ({{hankeTunnus}})</b>. Sinut on lisätty hakemukselle.
+                    hankkeelle <b>{{hankeNimi}} ({{hankeTunnus}})</b>. Du har lagts till i ansökan.
                     Kontrollera ansökan i Haitaton:
                     <a href="{{baseUrl}}">{{baseUrl}}</a>
                 </mj-text>
@@ -40,7 +40,7 @@
 
                 <mj-text mj-class="basic-txt">
                     {{senderName}} ({{senderEmail}}) on laatimassa {{applicationType.fi}}
-                    hankkeelle <b>{{hankeNimi}} ({{hankeTunnus}})</b>. Sinut on lisätty hakemukselle.
+                    hankkeelle <b>{{hankeNimi}} ({{hankeTunnus}})</b>. You have been added to the application.
                     View the application in the Haitaton system:
                     <a href="{{baseUrl}}">{{baseUrl}}</a>
                 </mj-text>

--- a/email/kayttaja-poistettu-hanke.mjml
+++ b/email/kayttaja-poistettu-hanke.mjml
@@ -7,7 +7,7 @@
         <mj-section>
             <mj-column>
                 <mj-text mj-class="header-txt">
-                    Sinut on poistettu hankkeelta ({{hankeTunnus}}) / Sinut on poistettu hankkeelta ({{hankeTunnus}}) / Sinut on poistettu hankkeelta ({{hankeTunnus}})
+                    Sinut on poistettu hankkeelta ({{hankeTunnus}}) / Du har tagits bort från projektet ({{hankeTunnus}}) / You have been removed from the project ({{hankeTunnus}})
                 </mj-text>
                 <mj-text mj-class="basic-txt">
                     {{deletedByName}} ({{deletedByEmail}}) on poistanut sinut hankkeelta <b>{{hankeNimi}} ({{hankeTunnus}})</b>,
@@ -18,16 +18,16 @@
                 <mj-divider mj-class="language-separator" />
 
                 <mj-text mj-class="basic-txt">
-                    {{deletedByName}} ({{deletedByEmail}}) on poistanut sinut hankkeelta <b>{{hankeNimi}} ({{hankeTunnus}})</b>.
-                    eikä sinulla ole enää pääsyä hankkeelle.
+                    {{deletedByName}} ({{deletedByEmail}}) har tagit bort dig från projektet <b>{{hankeNimi}} ({{hankeTunnus}})</b>
+                    och du har tagit bort dig från projektet.
                 </mj-text>
                 <mj-include path="common/signature-sv.partial"/>
 
                 <mj-divider mj-class="language-separator" />
 
                 <mj-text mj-class="basic-txt">
-                    {{deletedByName}} ({{deletedByEmail}}) on poistanut sinut hankkeelta <b>{{hankeNimi}} ({{hankeTunnus}})</b>.
-                    eikä sinulla ole enää pääsyä hankkeelle.
+                    {{deletedByName}} ({{deletedByEmail}}) has removed you from the project <b>{{hankeNimi}} ({{hankeTunnus}})</b>,
+                    and you no longer have access to the project.
                 </mj-text>
                 <mj-include path="common/signature-en.partial"/>
             </mj-column>

--- a/email/kayttooikeustason-muutos.mjml
+++ b/email/kayttooikeustason-muutos.mjml
@@ -7,7 +7,7 @@
         <mj-section>
             <mj-column>
                 <mj-text mj-class="header-txt">
-                    Käyttöoikeustasoasi on muutettu ({{hankeTunnus}}) / Käyttöoikeustasoasi on muutettu ({{hankeTunnus}}) / Käyttöoikeustasoasi on muutettu ({{hankeTunnus}})
+                    Käyttöoikeustasoasi on muutettu ({{hankeTunnus}}) / Dina användarrättigheter har förändrats ({{hankeTunnus}}) / Your access right level has been changed ({{hankeTunnus}})
                 </mj-text>
                 <mj-text mj-class="basic-txt">
                     {{updatedByName}} ({{updatedByEmail}}) on muuttanut käyttöoikeustasoasi hankkeella <b>{{hankeNimi}} ({{hankeTunnus}})</b>.
@@ -19,18 +19,18 @@
                 <mj-divider mj-class="language-separator" />
 
                 <mj-text mj-class="basic-txt">
-                    {{updatedByName}} ({{updatedByEmail}}) on muuttanut käyttöoikeustasoasi hankkeella <b>{{hankeNimi}} ({{hankeTunnus}})</b>.
-                    Uusi käyttöoikeutesi on <b>{{newAccessRights.sv}}</b>.
-                    Tarkastele hanketta täällä: <a href="{{baseUrl}}/sv/projektportfolj/{{hankeTunnus}}">{{baseUrl}}/sv/projektportfolj/{{hankeTunnus}}</a>.
+                    {{updatedByName}} ({{updatedByEmail}}) har ändrat dina användarrättigheter på projektet <b>{{hankeNimi}} ({{hankeTunnus}})</b>.
+                    Din nya användarrättighet är <b>{{newAccessRights.sv}}</b>.
+                    Granska projektet här: <a href="{{baseUrl}}/sv/projektportfolj/{{hankeTunnus}}">{{baseUrl}}/sv/projektportfolj/{{hankeTunnus}}</a>.
                 </mj-text>
                 <mj-include path="common/signature-sv.partial"/>
 
                 <mj-divider mj-class="language-separator" />
 
                 <mj-text mj-class="basic-txt">
-                    {{updatedByName}} ({{updatedByEmail}}) on muuttanut käyttöoikeustasoasi hankkeella <b>{{hankeNimi}} ({{hankeTunnus}})</b>.
-                    Uusi käyttöoikeutesi on <b>{{newAccessRights.en}}</b>.
-                    Tarkastele hanketta täällä: <a href="{{baseUrl}}/en/projectportfolio/{{hankeTunnus}}">{{baseUrl}}/en/projectportfolio/{{hankeTunnus}}</a>.
+                    {{updatedByName}} ({{updatedByEmail}}) has changed your access right level for the project <b>{{hankeNimi}} ({{hankeTunnus}})</b>.
+                    Your new access right level is <b>{{newAccessRights.en}}</b>.
+                    View the project here: <a href="{{baseUrl}}/en/projectportfolio/{{hankeTunnus}}">{{baseUrl}}/en/projectportfolio/{{hankeTunnus}}</a>.
                 </mj-text>
                 <mj-include path="common/signature-en.partial"/>
             </mj-column>

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/email/EmailSenderServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/email/EmailSenderServiceITest.kt
@@ -279,10 +279,9 @@ class EmailSenderServiceITest : IntegrationTest() {
             emailSenderService.sendAccessRightsUpdateNotificationEmail(notification)
 
             val email = greenMail.firstReceivedMessage()
-            // TODO needs translations
             assertThat(email.subject)
                 .isEqualTo(
-                    "Haitaton: Käyttöoikeustasoasi on muutettu (HAI24-1) / Käyttöoikeustasoasi on muutettu (HAI24-1) / Käyttöoikeustasoasi on muutettu (HAI24-1)"
+                    "Haitaton: Käyttöoikeustasoasi on muutettu (HAI24-1) / Dina användarrättigheter har förändrats (HAI24-1) / Your access right level has been changed (HAI24-1)"
                 )
         }
 
@@ -355,10 +354,9 @@ class EmailSenderServiceITest : IntegrationTest() {
             emailSenderService.sendRemovalFromHankeNotificationEmail(notification)
 
             val email = greenMail.firstReceivedMessage()
-            // TODO needs translations
             assertThat(email.subject)
                 .isEqualTo(
-                    "Haitaton: Sinut on poistettu hankkeelta (HAI24-1) / Sinut on poistettu hankkeelta (HAI24-1) / Sinut on poistettu hankkeelta (HAI24-1)"
+                    "Haitaton: Sinut on poistettu hankkeelta (HAI24-1) / Du har tagits bort från projektet (HAI24-1) / You have been removed from the project (HAI24-1)"
                 )
         }
 

--- a/services/hanke-service/src/main/resources/email/template/kayttaja-lisatty-hakemus.html.mustache
+++ b/services/hanke-service/src/main/resources/email/template/kayttaja-lisatty-hakemus.html.mustache
@@ -110,7 +110,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0;padding:16px 24px 0 24px;word-break:break-word">
-                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">{{senderName}} ({{senderEmail}}) on laatimassa {{applicationType.fi}} hankkeelle <b>{{hankeNimi}} ({{hankeTunnus}})</b>. Sinut on lisätty hakemukselle. Kontrollera ansökan i Haitaton: <a href="{{baseUrl}}">{{baseUrl}}</a></div>
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">{{senderName}} ({{senderEmail}}) on laatimassa {{applicationType.fi}} hankkeelle <b>{{hankeNimi}} ({{hankeTunnus}})</b>. Du har lagts till i ansökan. Kontrollera ansökan i Haitaton: <a href="{{baseUrl}}">{{baseUrl}}</a></div>
                       </td>
                     </tr>
                     <tr>
@@ -148,7 +148,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0;padding:16px 24px 0 24px;word-break:break-word">
-                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">{{senderName}} ({{senderEmail}}) on laatimassa {{applicationType.fi}} hankkeelle <b>{{hankeNimi}} ({{hankeTunnus}})</b>. Sinut on lisätty hakemukselle. View the application in the Haitaton system: <a href="{{baseUrl}}">{{baseUrl}}</a></div>
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">{{senderName}} ({{senderEmail}}) on laatimassa {{applicationType.fi}} hankkeelle <b>{{hankeNimi}} ({{hankeTunnus}})</b>. You have been added to the application. View the application in the Haitaton system: <a href="{{baseUrl}}">{{baseUrl}}</a></div>
                       </td>
                     </tr>
                     <tr>

--- a/services/hanke-service/src/main/resources/email/template/kayttaja-lisatty-hakemus.text.mustache
+++ b/services/hanke-service/src/main/resources/email/template/kayttaja-lisatty-hakemus.text.mustache
@@ -7,14 +7,14 @@ Löydät hakemuksesi siirtymällä etusivulta Omiin hankkeisiin ja valitsemalla 
 {{{signatures.fi}}}
 
 
-{{{senderName}}} ({{{senderEmail}}}) on laatimassa {{applicationType.sv}} hankkeelle "{{{hankeNimi}}}" ({{hankeTunnus}}). Sinut on lisätty hakemukselle. Kontrollera ansökan i Haitaton: {{baseUrl}}
+{{{senderName}}} ({{{senderEmail}}}) on laatimassa {{applicationType.sv}} hankkeelle "{{{hankeNimi}}}" ({{hankeTunnus}}). Du har lagts till i ansökan. Kontrollera ansökan i Haitaton: {{baseUrl}}
 
 Du hittar din ansökan genom att gå från startsidan till Egna projekt och välja rätt projekt. Öppna projektets uppgifter i listvyn och välj ”Visa projektets ansökningar”.
 
 {{{signatures.sv}}}
 
 
-{{{senderName}}} ({{{senderEmail}}}) on laatimassa {{applicationType.en}} hankkeelle "{{{hankeNimi}}}" ({{hankeTunnus}}). Sinut on lisätty hakemukselle. View the application in the Haitaton system: {{baseUrl}}
+{{{senderName}}} ({{{senderEmail}}}) on laatimassa {{applicationType.en}} hankkeelle "{{{hankeNimi}}}" ({{hankeTunnus}}). You have been added to the application. View the application in the Haitaton system: {{baseUrl}}
 
 You can find your application by selecting ‘Own projects’ on the front page and then selecting the project in question. Open the project information in the list view and select ‘Show project applications’.
 

--- a/services/hanke-service/src/main/resources/email/template/kayttaja-poistettu-hanke.html.mustache
+++ b/services/hanke-service/src/main/resources/email/template/kayttaja-poistettu-hanke.html.mustache
@@ -67,7 +67,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0;padding:16px 24px 16px 24px;word-break:break-word">
-                        <div style="font-family:Arial;font-size:36px;line-height:43px;text-align:left;color:#000">Sinut on poistettu hankkeelta ({{hankeTunnus}}) / Sinut on poistettu hankkeelta ({{hankeTunnus}}) / Sinut on poistettu hankkeelta ({{hankeTunnus}})</div>
+                        <div style="font-family:Arial;font-size:36px;line-height:43px;text-align:left;color:#000">Sinut on poistettu hankkeelta ({{hankeTunnus}}) / Du har tagits bort från projektet ({{hankeTunnus}}) / You have been removed from the project ({{hankeTunnus}})</div>
                       </td>
                     </tr>
                     <tr>
@@ -105,7 +105,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0;padding:16px 24px 0 24px;word-break:break-word">
-                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">{{deletedByName}} ({{deletedByEmail}}) on poistanut sinut hankkeelta <b>{{hankeNimi}} ({{hankeTunnus}})</b>. eikä sinulla ole enää pääsyä hankkeelle.</div>
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">{{deletedByName}} ({{deletedByEmail}}) har tagit bort dig från projektet <b>{{hankeNimi}} ({{hankeTunnus}})</b> och du har tagit bort dig från projektet.</div>
                       </td>
                     </tr>
                     <tr>
@@ -138,7 +138,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0;padding:16px 24px 0 24px;word-break:break-word">
-                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">{{deletedByName}} ({{deletedByEmail}}) on poistanut sinut hankkeelta <b>{{hankeNimi}} ({{hankeTunnus}})</b>. eikä sinulla ole enää pääsyä hankkeelle.</div>
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">{{deletedByName}} ({{deletedByEmail}}) has removed you from the project <b>{{hankeNimi}} ({{hankeTunnus}})</b>, and you no longer have access to the project.</div>
                       </td>
                     </tr>
                     <tr>

--- a/services/hanke-service/src/main/resources/email/template/kayttaja-poistettu-hanke.subject.mustache
+++ b/services/hanke-service/src/main/resources/email/template/kayttaja-poistettu-hanke.subject.mustache
@@ -1,1 +1,1 @@
-Haitaton: Sinut on poistettu hankkeelta ({{hankeTunnus}}) / Sinut on poistettu hankkeelta ({{hankeTunnus}}) / Sinut on poistettu hankkeelta ({{hankeTunnus}})
+Haitaton: Sinut on poistettu hankkeelta ({{hankeTunnus}}) / Du har tagits bort från projektet ({{hankeTunnus}}) / You have been removed from the project ({{hankeTunnus}})

--- a/services/hanke-service/src/main/resources/email/template/kayttaja-poistettu-hanke.text.mustache
+++ b/services/hanke-service/src/main/resources/email/template/kayttaja-poistettu-hanke.text.mustache
@@ -1,15 +1,15 @@
-Sinut on poistettu hankkeelta ({{hankeTunnus}}) / Sinut on poistettu hankkeelta ({{hankeTunnus}}) / Sinut on poistettu hankkeelta ({{hankeTunnus}})
+Sinut on poistettu hankkeelta ({{hankeTunnus}}) / Du har tagits bort från projektet ({{hankeTunnus}}) / You have been removed from the project ({{hankeTunnus}})
 
 {{{deletedByName}}} ({{{deletedByEmail}}}) on poistanut sinut hankkeelta "{{{hankeNimi}}}" ({{hankeTunnus}}), eikä sinulla ole enää pääsyä hankkeelle.
 
 {{{signatures.fi}}}
 
 
-{{{deletedByName}}} ({{{deletedByEmail}}}) on poistanut sinut hankkeelta "{{{hankeNimi}}}" ({{hankeTunnus}}), eikä sinulla ole enää pääsyä hankkeelle.
+{{{deletedByName}}} ({{{deletedByEmail}}}) har tagit bort dig från projektet "{{{hankeNimi}}}" ({{hankeTunnus}}) och du har tagit bort dig från projektet.
 
 {{{signatures.sv}}}
 
 
-{{{deletedByName}}} ({{{deletedByEmail}}}) on poistanut sinut hankkeelta "{{{hankeNimi}}}" ({{hankeTunnus}}), eikä sinulla ole enää pääsyä hankkeelle.
+{{{deletedByName}}} ({{{deletedByEmail}}}) has removed you from the project "{{{hankeNimi}}}" ({{hankeTunnus}}), and you no longer have access to the project.
 
 {{{signatures.en}}}

--- a/services/hanke-service/src/main/resources/email/template/kayttooikeustason-muutos.html.mustache
+++ b/services/hanke-service/src/main/resources/email/template/kayttooikeustason-muutos.html.mustache
@@ -67,7 +67,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0;padding:16px 24px 16px 24px;word-break:break-word">
-                        <div style="font-family:Arial;font-size:36px;line-height:43px;text-align:left;color:#000">Käyttöoikeustasoasi on muutettu ({{hankeTunnus}}) / Käyttöoikeustasoasi on muutettu ({{hankeTunnus}}) / Käyttöoikeustasoasi on muutettu ({{hankeTunnus}})</div>
+                        <div style="font-family:Arial;font-size:36px;line-height:43px;text-align:left;color:#000">Käyttöoikeustasoasi on muutettu ({{hankeTunnus}}) / Dina användarrättigheter har förändrats ({{hankeTunnus}}) / Your access right level has been changed ({{hankeTunnus}})</div>
                       </td>
                     </tr>
                     <tr>
@@ -105,7 +105,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0;padding:16px 24px 0 24px;word-break:break-word">
-                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">{{updatedByName}} ({{updatedByEmail}}) on muuttanut käyttöoikeustasoasi hankkeella <b>{{hankeNimi}} ({{hankeTunnus}})</b>. Uusi käyttöoikeutesi on <b>{{newAccessRights.sv}}</b>. Tarkastele hanketta täällä: <a href="{{baseUrl}}/sv/projektportfolj/{{hankeTunnus}}">{{baseUrl}}/sv/projektportfolj/{{hankeTunnus}}</a>.</div>
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">{{updatedByName}} ({{updatedByEmail}}) har ändrat dina användarrättigheter på projektet <b>{{hankeNimi}} ({{hankeTunnus}})</b>. Din nya användarrättighet är <b>{{newAccessRights.sv}}</b>. Granska projektet här: <a href="{{baseUrl}}/sv/projektportfolj/{{hankeTunnus}}">{{baseUrl}}/sv/projektportfolj/{{hankeTunnus}}</a>.</div>
                       </td>
                     </tr>
                     <tr>
@@ -138,7 +138,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0;padding:16px 24px 0 24px;word-break:break-word">
-                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">{{updatedByName}} ({{updatedByEmail}}) on muuttanut käyttöoikeustasoasi hankkeella <b>{{hankeNimi}} ({{hankeTunnus}})</b>. Uusi käyttöoikeutesi on <b>{{newAccessRights.en}}</b>. Tarkastele hanketta täällä: <a href="{{baseUrl}}/en/projectportfolio/{{hankeTunnus}}">{{baseUrl}}/en/projectportfolio/{{hankeTunnus}}</a>.</div>
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">{{updatedByName}} ({{updatedByEmail}}) has changed your access right level for the project <b>{{hankeNimi}} ({{hankeTunnus}})</b>. Your new access right level is <b>{{newAccessRights.en}}</b>. View the project here: <a href="{{baseUrl}}/en/projectportfolio/{{hankeTunnus}}">{{baseUrl}}/en/projectportfolio/{{hankeTunnus}}</a>.</div>
                       </td>
                     </tr>
                     <tr>

--- a/services/hanke-service/src/main/resources/email/template/kayttooikeustason-muutos.subject.mustache
+++ b/services/hanke-service/src/main/resources/email/template/kayttooikeustason-muutos.subject.mustache
@@ -1,1 +1,1 @@
-Haitaton: Käyttöoikeustasoasi on muutettu ({{hankeTunnus}}) / Käyttöoikeustasoasi on muutettu ({{hankeTunnus}}) / Käyttöoikeustasoasi on muutettu ({{hankeTunnus}})
+Haitaton: Käyttöoikeustasoasi on muutettu ({{hankeTunnus}}) / Dina användarrättigheter har förändrats ({{hankeTunnus}}) / Your access right level has been changed ({{hankeTunnus}})

--- a/services/hanke-service/src/main/resources/email/template/kayttooikeustason-muutos.text.mustache
+++ b/services/hanke-service/src/main/resources/email/template/kayttooikeustason-muutos.text.mustache
@@ -1,15 +1,15 @@
-Käyttöoikeustasoasi on muutettu ({{hankeTunnus}}) / Käyttöoikeustasoasi on muutettu ({{hankeTunnus}}) / Käyttöoikeustasoasi on muutettu ({{hankeTunnus}})
+Käyttöoikeustasoasi on muutettu ({{hankeTunnus}}) / Dina användarrättigheter har förändrats ({{hankeTunnus}}) / Your access right level has been changed ({{hankeTunnus}})
 
 {{{updatedByName}}} ({{{updatedByEmail}}}) on muuttanut käyttöoikeustasoasi hankkeella "{{{hankeNimi}}}" ({{hankeTunnus}}). Uusi käyttöoikeutesi on "{{{newAccessRights.fi}}}". Tarkastele hanketta täällä: {{baseUrl}}/fi/hankesalkku/{{hankeTunnus}}
 
 {{{signatures.fi}}}
 
 
-{{{updatedByName}}} ({{{updatedByEmail}}}) on muuttanut käyttöoikeustasoasi hankkeella "{{{hankeNimi}}}" ({{hankeTunnus}}). Uusi käyttöoikeutesi on "{{{newAccessRights.sv}}}". Tarkastele hanketta täällä: {{baseUrl}}/sv/projektportfolj/{{hankeTunnus}}
+{{{updatedByName}}} ({{{updatedByEmail}}}) har ändrat dina användarrättigheter på projektet "{{{hankeNimi}}}" ({{hankeTunnus}}). Din nya användarrättighet är "{{{newAccessRights.sv}}}". Granska projektet här: {{baseUrl}}/sv/projektportfolj/{{hankeTunnus}}
 
 {{{signatures.sv}}}
 
 
-{{{updatedByName}}} ({{{updatedByEmail}}}) on muuttanut käyttöoikeustasoasi hankkeella "{{{hankeNimi}}}" ({{hankeTunnus}}). Uusi käyttöoikeutesi on "{{{newAccessRights.en}}}". Tarkastele hanketta täällä: {{baseUrl}}/en/projectportfolio/{{hankeTunnus}}
+{{{updatedByName}}} ({{{updatedByEmail}}}) has changed your access right level for the project "{{{hankeNimi}}}" ({{hankeTunnus}}). Your new access right level is "{{{newAccessRights.en}}}". View the project here: {{baseUrl}}/en/projectportfolio/{{hankeTunnus}}
 
 {{{signatures.en}}}

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/email/EmailSenderServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/email/EmailSenderServiceTest.kt
@@ -309,9 +309,9 @@ class EmailSenderServiceTest {
 
             override val applicationInformation = "on laatimassa johtoselvityshakemusta hankkeelle"
             override val hankeInformationText =
-                "hankkeelle \"$HANKE_NIMI\" ($HANKE_TUNNUS). Sinut on lisätty hakemukselle."
+                "hankkeelle \"$HANKE_NIMI\" ($HANKE_TUNNUS). Du har lagts till i ansökan."
             override val hankeInformationHtml =
-                "hankkeelle <b>$HANKE_NIMI ($HANKE_TUNNUS)</b>. Sinut on lisätty hakemukselle."
+                "hankkeelle <b>$HANKE_NIMI ($HANKE_TUNNUS)</b>. Du har lagts till i ansökan."
             override val linkPrefix = "Kontrollera ansökan i Haitaton:"
             override val signatureLines =
                 listOf(
@@ -331,9 +331,9 @@ class EmailSenderServiceTest {
 
             override val applicationInformation = "on laatimassa johtoselvityshakemusta hankkeelle"
             override val hankeInformationText =
-                "hankkeelle \"$HANKE_NIMI\" ($HANKE_TUNNUS). Sinut on lisätty hakemukselle."
+                "hankkeelle \"$HANKE_NIMI\" ($HANKE_TUNNUS). You have been added to the application."
             override val hankeInformationHtml =
-                "hankkeelle <b>$HANKE_NIMI ($HANKE_TUNNUS)</b>. Sinut on lisätty hakemukselle."
+                "hankkeelle <b>$HANKE_NIMI ($HANKE_TUNNUS)</b>. You have been added to the application."
             override val linkPrefix = "View the application in the Haitaton system:"
             override val signatureLines =
                 listOf(
@@ -373,7 +373,7 @@ class EmailSenderServiceTest {
 
             assertThat(email.subject)
                 .isEqualTo(
-                    "Haitaton: Käyttöoikeustasoasi on muutettu ($HANKE_TUNNUS) / Käyttöoikeustasoasi on muutettu ($HANKE_TUNNUS) / Käyttöoikeustasoasi on muutettu ($HANKE_TUNNUS)"
+                    "Haitaton: Käyttöoikeustasoasi on muutettu ($HANKE_TUNNUS) / Dina användarrättigheter har förändrats ($HANKE_TUNNUS) / Your access right level has been changed ($HANKE_TUNNUS)"
                 )
         }
 
@@ -382,7 +382,7 @@ class EmailSenderServiceTest {
             val (textBody, htmlBody) = sendAndCapture().bodies()
 
             val expectedBody =
-                "Käyttöoikeustasoasi on muutettu ($HANKE_TUNNUS) / Käyttöoikeustasoasi on muutettu ($HANKE_TUNNUS) / Käyttöoikeustasoasi on muutettu ($HANKE_TUNNUS)"
+                "Käyttöoikeustasoasi on muutettu ($HANKE_TUNNUS) / Dina användarrättigheter har förändrats ($HANKE_TUNNUS) / Your access right level has been changed ($HANKE_TUNNUS)"
             assertThat(textBody).contains(expectedBody)
             assertThat(htmlBody).contains(expectedBody)
         }
@@ -444,19 +444,18 @@ class EmailSenderServiceTest {
             }
         }
 
-        // TODO needs translations
         @Nested
         inner class BodyInSwedish : BodyInFinnish() {
             override fun updatedByInformation(name: String, email: String) =
-                "$name ($email) on muuttanut"
+                "$name ($email) har ändrat"
 
             override val updateInformationText =
-                "käyttöoikeustasoasi hankkeella \"$HANKE_NIMI\" ($HANKE_TUNNUS). Uusi käyttöoikeutesi on \"Ändring i projekt\"."
+                "dina användarrättigheter på projektet \"$HANKE_NIMI\" ($HANKE_TUNNUS). Din nya användarrättighet är \"Ändring i projekt\"."
 
             override val updateInformationHtml =
-                "käyttöoikeustasoasi hankkeella <b>$HANKE_NIMI ($HANKE_TUNNUS)</b>. Uusi käyttöoikeutesi on <b>${StringEscapeUtils.escapeHtml4("Ändring i projekt")}</b>."
+                "dina användarrättigheter på projektet <b>$HANKE_NIMI ($HANKE_TUNNUS)</b>. Din nya användarrättighet är <b>${StringEscapeUtils.escapeHtml4("Ändring i projekt")}</b>."
 
-            override val linkPrefix = "Tarkastele hanketta täällä:"
+            override val linkPrefix = "Granska projektet här:"
 
             override val hankeLink = "https://haitaton.hel.fi/sv/projektportfolj/$HANKE_TUNNUS"
 
@@ -470,19 +469,18 @@ class EmailSenderServiceTest {
                 )
         }
 
-        // TODO needs translations
         @Nested
         inner class BodyInEnglish : BodyInFinnish() {
             override fun updatedByInformation(name: String, email: String) =
-                "$name ($email) on muuttanut"
+                "$name ($email) has changed"
 
             override val updateInformationText =
-                "käyttöoikeustasoasi hankkeella \"$HANKE_NIMI\" ($HANKE_TUNNUS). Uusi käyttöoikeutesi on \"Project editing\"."
+                "your access right level for the project \"$HANKE_NIMI\" ($HANKE_TUNNUS). Your new access right level is \"Project editing\"."
 
             override val updateInformationHtml =
-                "käyttöoikeustasoasi hankkeella <b>$HANKE_NIMI ($HANKE_TUNNUS)</b>. Uusi käyttöoikeutesi on <b>Project editing</b>."
+                "your access right level for the project <b>$HANKE_NIMI ($HANKE_TUNNUS)</b>. Your new access right level is <b>Project editing</b>."
 
-            override val linkPrefix = "Tarkastele hanketta täällä:"
+            override val linkPrefix = "View the project here:"
 
             override val hankeLink = "https://haitaton.hel.fi/en/projectportfolio/$HANKE_TUNNUS"
 
@@ -523,7 +521,7 @@ class EmailSenderServiceTest {
 
             assertThat(email.subject)
                 .isEqualTo(
-                    "Haitaton: Sinut on poistettu hankkeelta ($HANKE_TUNNUS) / Sinut on poistettu hankkeelta ($HANKE_TUNNUS) / Sinut on poistettu hankkeelta ($HANKE_TUNNUS)"
+                    "Haitaton: Sinut on poistettu hankkeelta ($HANKE_TUNNUS) / Du har tagits bort från projektet ($HANKE_TUNNUS) / You have been removed from the project ($HANKE_TUNNUS)"
                 )
         }
 
@@ -532,7 +530,7 @@ class EmailSenderServiceTest {
             val (textBody, htmlBody) = sendAndCapture().bodies()
 
             val expectedBody =
-                "Sinut on poistettu hankkeelta ($HANKE_TUNNUS) / Sinut on poistettu hankkeelta ($HANKE_TUNNUS) / Sinut on poistettu hankkeelta ($HANKE_TUNNUS)"
+                "Sinut on poistettu hankkeelta ($HANKE_TUNNUS) / Du har tagits bort från projektet ($HANKE_TUNNUS) / You have been removed from the project ($HANKE_TUNNUS)"
             assertThat(textBody).contains(expectedBody)
             assertThat(htmlBody).contains(expectedBody)
         }
@@ -582,17 +580,16 @@ class EmailSenderServiceTest {
             }
         }
 
-        // TODO needs translations
         @Nested
         inner class BodyInSwedish : BodyInFinnish() {
             override fun deletedByInformation(name: String, email: String) =
-                "$name ($email) on poistanut sinut"
+                "$name ($email) har tagit bort dig"
 
             override val deleteInformationText =
-                "hankkeelta \"$HANKE_NIMI\" ($HANKE_TUNNUS), eikä sinulla ole enää pääsyä hankkeelle."
+                "från projektet \"$HANKE_NIMI\" ($HANKE_TUNNUS) och du har tagit bort dig från projektet."
 
             override val deleteInformationHtml =
-                "hankkeelta <b>$HANKE_NIMI ($HANKE_TUNNUS)</b>, eikä sinulla ole enää pääsyä hankkeelle."
+                "från projektet <b>$HANKE_NIMI ($HANKE_TUNNUS)</b> och du har tagit bort dig från projektet."
 
             override val signatureLines =
                 listOf(
@@ -604,17 +601,16 @@ class EmailSenderServiceTest {
                 )
         }
 
-        // TODO needs translations
         @Nested
         inner class BodyInEnglish : BodyInFinnish() {
             override fun deletedByInformation(name: String, email: String) =
-                "$name ($email) on poistanut sinut"
+                "$name ($email) has removed you"
 
             override val deleteInformationText =
-                "hankkeelta \"$HANKE_NIMI\" ($HANKE_TUNNUS), eikä sinulla ole enää pääsyä hankkeelle."
+                "from the project \"$HANKE_NIMI\" ($HANKE_TUNNUS), and you no longer have access to the project."
 
             override val deleteInformationHtml =
-                "hankkeelta <b>$HANKE_NIMI ($HANKE_TUNNUS)</b>, eikä sinulla ole enää pääsyä hankkeelle."
+                "from the project <b>$HANKE_NIMI ($HANKE_TUNNUS)</b>, and you no longer have access to the project."
 
             override val signatureLines =
                 listOf(


### PR DESCRIPTION
# Description

Added translations for email messages. Still missing one though: adding a new user to the application (text has been slightly changed and translations are still missing).

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2446

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [x] Other

# Instructions for testing
Please describe tests how this change or new feature can be tested.

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 

# Other relevant info
Please describe here if there is e.g. some requirements for this change or
 other info that the tester/user needs to know.