### PR TITLE
HAI-1542 Separate ApplicationArea for cable report and excavation notification

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/application/ApplicationServiceITest.kt
@@ -58,7 +58,7 @@ import fi.hel.haitaton.hanke.factory.ApplicationFactory.Companion.TEPPO_PHONE
 import fi.hel.haitaton.hanke.factory.ApplicationFactory.Companion.TESTIHENKILO
 import fi.hel.haitaton.hanke.factory.ApplicationFactory.Companion.asianHoitajaCustomerContact
 import fi.hel.haitaton.hanke.factory.ApplicationFactory.Companion.createApplication
-import fi.hel.haitaton.hanke.factory.ApplicationFactory.Companion.createApplicationArea
+import fi.hel.haitaton.hanke.factory.ApplicationFactory.Companion.createCableReportApplicationArea
 import fi.hel.haitaton.hanke.factory.ApplicationFactory.Companion.createCableReportApplicationData
 import fi.hel.haitaton.hanke.factory.ApplicationFactory.Companion.expectedRecipients
 import fi.hel.haitaton.hanke.factory.ApplicationFactory.Companion.hakijaCustomerContact
@@ -369,7 +369,7 @@ class ApplicationServiceITest : IntegrationTest() {
             val newApplicationData =
                 createCableReportApplicationData(
                     name = "Uudistettu johtoselvitys",
-                    areas = application.applicationData.areas
+                    areas = (application.applicationData as CableReportApplicationData).areas
                 )
 
             val exception = assertFailure {
@@ -430,7 +430,7 @@ class ApplicationServiceITest : IntegrationTest() {
                 createCableReportApplicationData(
                     pendingOnClient = true,
                     name = "Uudistettu johtoselvitys",
-                    areas = listOf(createApplicationArea(geometry = newGeometry))
+                    areas = listOf(createCableReportApplicationArea(geometry = newGeometry))
                 )
 
             val response =
@@ -481,7 +481,7 @@ class ApplicationServiceITest : IntegrationTest() {
             val newApplicationData =
                 createCableReportApplicationData(
                     name = "Uudistettu johtoselvitys",
-                    areas = application.applicationData.areas
+                    areas = (application.applicationData as CableReportApplicationData).areas
                 )
 
             val response =
@@ -516,7 +516,7 @@ class ApplicationServiceITest : IntegrationTest() {
                 createCableReportApplicationData(
                     name = "Päivitetty hakemus",
                     pendingOnClient = true,
-                    areas = application.applicationData.areas
+                    areas = (application.applicationData as CableReportApplicationData).areas
                 )
 
             val response =
@@ -1408,18 +1408,18 @@ class ApplicationServiceITest : IntegrationTest() {
     private fun initializedHanke(): HankeEntity =
         hankeRepository.findByHankeTunnus("HAI23-5") ?: throw NoSuchElementException()
 
-    private val aleksanterinpatsas: ApplicationArea =
-        createApplicationArea(
+    private val aleksanterinpatsas =
+        createCableReportApplicationArea(
             geometry = "/fi/hel/haitaton/hanke/geometria/aleksanterin-patsas.json".asJsonResource()
         )
 
-    private val havisAmanda: ApplicationArea =
-        createApplicationArea(
+    private val havisAmanda =
+        createCableReportApplicationArea(
             geometry = "/fi/hel/haitaton/hanke/geometria/havis-amanda.json".asJsonResource()
         )
 
     private val intersectingArea =
-        createApplicationArea(
+        createCableReportApplicationArea(
             name = "area",
             geometry = "/fi/hel/haitaton/hanke/geometria/intersecting-polygon.json".asJsonResource()
         )

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceITest.kt
@@ -575,21 +575,23 @@ class HakemusServiceITest(
     @Nested
     inner class UpdateHakemus {
 
-        private val intersectingArea =
-            ApplicationFactory.createApplicationArea(
-                name = "area",
-                geometry =
-                    "/fi/hel/haitaton/hanke/geometria/intersecting-polygon.json".asJsonResource()
-            )
-
-        private val notInHankeArea =
-            ApplicationFactory.createApplicationArea(
-                name = "area",
-                geometry = GeometriaFactory.polygon
-            )
-
         @Nested
         inner class WithJohtoselvitys {
+
+            private val intersectingArea =
+                ApplicationFactory.createCableReportApplicationArea(
+                    name = "area",
+                    geometry =
+                        "/fi/hel/haitaton/hanke/geometria/intersecting-polygon.json"
+                            .asJsonResource()
+                )
+
+            private val notInHankeArea =
+                ApplicationFactory.createCableReportApplicationArea(
+                    name = "area",
+                    geometry = GeometriaFactory.polygon
+                )
+
             @Test
             fun `throws exception when the application does not exist`() {
                 assertThat(applicationRepository.findAll()).isEmpty()
@@ -925,6 +927,20 @@ class HakemusServiceITest(
 
         @Nested
         inner class WithKaivuilmoitus {
+
+            private val intersectingArea =
+                ApplicationFactory.createExcavationNotificationArea(
+                    name = "area",
+                    geometry =
+                        "/fi/hel/haitaton/hanke/geometria/intersecting-polygon.json"
+                            .asJsonResource()
+                )
+
+            private val notInHankeArea =
+                ApplicationFactory.createExcavationNotificationArea(
+                    name = "area",
+                    geometry = GeometriaFactory.polygon
+                )
 
             @Test
             fun `throws exception when the application does not exist`() {
@@ -1310,7 +1326,9 @@ class HakemusServiceITest(
         private val alluId = 35124
 
         private val areaOutsideDefaultHanke: ApplicationArea =
-            ApplicationFactory.createApplicationArea(geometry = GeometriaFactory.thirdPolygon)
+            ApplicationFactory.createCableReportApplicationArea(
+                geometry = GeometriaFactory.thirdPolygon
+            )
 
         @Test
         fun `throws exception when the application doesn't exist`() {

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaServiceITest.kt
@@ -642,7 +642,7 @@ class HankeKayttajaServiceITest : IntegrationTest() {
                     .withPerustaja(KAYTTAJA_INPUT_HAKIJA)
                     .saveAsGenerated(applicationData)
             val applicationEntity =
-                applicationRepository.getReferenceById(application.id!!).apply {
+                applicationRepository.getReferenceById(application.id).apply {
                     applicationIdentifier = DEFAULT_APPLICATION_IDENTIFIER
                 }
             val inviter = findKayttaja(hanke.id, KAYTTAJA_INPUT_HAKIJA.email)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationArea.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationArea.kt
@@ -2,4 +2,13 @@ package fi.hel.haitaton.hanke.application
 
 import org.geojson.Polygon
 
-data class ApplicationArea(val name: String, val geometry: Polygon)
+sealed interface ApplicationArea {
+    val name: String
+    val geometry: Polygon
+}
+
+data class CableReportApplicationArea(override val name: String, override val geometry: Polygon) :
+    ApplicationArea
+
+data class ExcavationNotificationArea(override val name: String, override val geometry: Polygon) :
+    ApplicationArea

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationData.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationData.kt
@@ -80,7 +80,7 @@ data class CableReportApplicationData(
     val workDescription: String,
     override val startTime: ZonedDateTime?,
     override val endTime: ZonedDateTime?,
-    override val areas: List<ApplicationArea>?,
+    override val areas: List<CableReportApplicationArea>?,
     override val customerWithContacts: CustomerWithContacts?,
     val contractorWithContacts: CustomerWithContacts?,
     val propertyDeveloperWithContacts: CustomerWithContacts? = null,
@@ -151,7 +151,7 @@ data class ExcavationNotificationData(
     val requiredCompetence: Boolean? = false, // oltava true, jotta voi lähettää
     override val startTime: ZonedDateTime?,
     override val endTime: ZonedDateTime?,
-    override val areas: List<ApplicationArea>?,
+    override val areas: List<ExcavationNotificationArea>?,
     override val customerWithContacts: CustomerWithContacts?,
     val contractorWithContacts: CustomerWithContacts?,
     val propertyDeveloperWithContacts: CustomerWithContacts? = null,

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/Hakemus.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/Hakemus.kt
@@ -4,6 +4,8 @@ import fi.hel.haitaton.hanke.allu.ApplicationStatus
 import fi.hel.haitaton.hanke.application.ApplicationArea
 import fi.hel.haitaton.hanke.application.ApplicationMetaData
 import fi.hel.haitaton.hanke.application.ApplicationType
+import fi.hel.haitaton.hanke.application.CableReportApplicationArea
+import fi.hel.haitaton.hanke.application.ExcavationNotificationArea
 import fi.hel.haitaton.hanke.application.PostalAddress
 import fi.hel.haitaton.hanke.domain.HasId
 import java.time.ZonedDateTime
@@ -67,7 +69,7 @@ data class JohtoselvityshakemusData(
     override val startTime: ZonedDateTime? = null,
     override val endTime: ZonedDateTime? = null,
     override val pendingOnClient: Boolean,
-    override val areas: List<ApplicationArea>? = null,
+    override val areas: List<CableReportApplicationArea>? = null,
     override val customerWithContacts: Hakemusyhteystieto? = null,
     val contractorWithContacts: Hakemusyhteystieto? = null,
     val propertyDeveloperWithContacts: Hakemusyhteystieto? = null,
@@ -118,7 +120,7 @@ data class KaivuilmoitusData(
     val requiredCompetence: Boolean = false,
     override val startTime: ZonedDateTime? = null,
     override val endTime: ZonedDateTime? = null,
-    override val areas: List<ApplicationArea>? = null,
+    override val areas: List<ExcavationNotificationArea>? = null,
     override val customerWithContacts: Hakemusyhteystieto? = null,
     val contractorWithContacts: Hakemusyhteystieto? = null,
     val propertyDeveloperWithContacts: Hakemusyhteystieto? = null,

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusResponse.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusResponse.kt
@@ -7,6 +7,8 @@ import fi.hel.haitaton.hanke.allu.CustomerType
 import fi.hel.haitaton.hanke.application.ApplicationArea
 import fi.hel.haitaton.hanke.application.ApplicationContactType
 import fi.hel.haitaton.hanke.application.ApplicationType
+import fi.hel.haitaton.hanke.application.CableReportApplicationArea
+import fi.hel.haitaton.hanke.application.ExcavationNotificationArea
 import fi.hel.haitaton.hanke.application.PostalAddress
 import fi.hel.haitaton.hanke.application.isNullOrBlank
 import java.time.ZonedDateTime
@@ -63,7 +65,7 @@ data class JohtoselvitysHakemusDataResponse(
     /** Työn arvioitu loppupäivä */
     override val endTime: ZonedDateTime?,
     /** Työalueet */
-    override val areas: List<ApplicationArea>,
+    override val areas: List<CableReportApplicationArea>,
     // 3. sivu Yhteystiedot
     /** Hakijan tiedot */
     override val customerWithContacts: CustomerWithContactsResponse?,
@@ -119,7 +121,7 @@ data class KaivuilmoitusDataResponse(
     /** Työn loppupäivämäärä */
     override val endTime: ZonedDateTime?,
     /** Työalueet */
-    override val areas: List<ApplicationArea>,
+    override val areas: List<ExcavationNotificationArea>,
     // 3. sivu Haittojen hallinta - included in areas
     // 4. sivu Yhteystiedot
     /** Hakijan tiedot */

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusUpdateRequest.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusUpdateRequest.kt
@@ -10,7 +10,9 @@ import fi.hel.haitaton.hanke.application.ApplicationContactType
 import fi.hel.haitaton.hanke.application.ApplicationData
 import fi.hel.haitaton.hanke.application.ApplicationEntity
 import fi.hel.haitaton.hanke.application.ApplicationType
+import fi.hel.haitaton.hanke.application.CableReportApplicationArea
 import fi.hel.haitaton.hanke.application.CableReportApplicationData
+import fi.hel.haitaton.hanke.application.ExcavationNotificationArea
 import fi.hel.haitaton.hanke.application.ExcavationNotificationData
 import fi.hel.haitaton.hanke.application.InvoicingCustomer
 import fi.hel.haitaton.hanke.application.PostalAddress
@@ -84,7 +86,7 @@ data class JohtoselvityshakemusUpdateRequest(
     /** Työn arvioitu loppupäivä */
     override val endTime: ZonedDateTime? = null,
     /** Työalueet */
-    override val areas: List<ApplicationArea>? = null,
+    override val areas: List<CableReportApplicationArea>? = null,
     // 3. sivu Yhteystiedot
     /** Hakijan tiedot */
     override val customerWithContacts: CustomerWithContactsRequest? = null,
@@ -186,7 +188,7 @@ data class KaivuilmoitusUpdateRequest(
     /** Työn arvioitu loppupäivä */
     override val endTime: ZonedDateTime? = null,
     /** Työalueet */
-    override val areas: List<ApplicationArea>? = null,
+    override val areas: List<ExcavationNotificationArea>? = null,
     // 3. sivu Yhteystiedot
     /** Hakijan tiedot */
     override val customerWithContacts: CustomerWithContactsRequest? = null,

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/allu/ApplicationPdfServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/allu/ApplicationPdfServiceTest.kt
@@ -6,7 +6,7 @@ import assertk.assertions.contains
 import assertk.assertions.doesNotContain
 import com.lowagie.text.pdf.PdfReader
 import com.lowagie.text.pdf.parser.PdfTextExtractor
-import fi.hel.haitaton.hanke.application.ApplicationArea
+import fi.hel.haitaton.hanke.application.CableReportApplicationArea
 import fi.hel.haitaton.hanke.factory.ApplicationFactory
 import fi.hel.haitaton.hanke.factory.ApplicationFactory.Companion.createPostalAddress
 import fi.hel.haitaton.hanke.factory.ApplicationFactory.Companion.withContacts
@@ -142,9 +142,9 @@ internal class ApplicationPdfServiceTest {
                     endTime = ZonedDateTime.parse("2022-11-28T21:59:59.999Z"),
                     areas =
                         listOf(
-                            ApplicationArea("Ensimmäinen työalue", Polygon()),
-                            ApplicationArea("Toinen alue", Polygon()),
-                            ApplicationArea("", Polygon()),
+                            CableReportApplicationArea("Ensimmäinen työalue", Polygon()),
+                            CableReportApplicationArea("Toinen alue", Polygon()),
+                            CableReportApplicationArea("", Polygon()),
                         )
                 )
 

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/application/ApplicationDataMapperTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/application/ApplicationDataMapperTest.kt
@@ -175,7 +175,7 @@ internal class ApplicationDataMapperTest {
         fun `uses areas if they are present`() {
             val applicationData =
                 ApplicationFactory.createCableReportApplicationData(
-                    areas = listOf(ApplicationArea(areaName, polygon)),
+                    areas = listOf(CableReportApplicationArea(areaName, polygon)),
                 )
 
             val geometry = ApplicationDataMapper.getGeometry(applicationData)
@@ -204,9 +204,9 @@ internal class ApplicationDataMapperTest {
                 ApplicationFactory.createCableReportApplicationData(
                     areas =
                         listOf(
-                            ApplicationArea(areaName, polygon),
-                            ApplicationArea("other area", otherPolygon),
-                            ApplicationArea("third area", thirdPolygon),
+                            CableReportApplicationArea(areaName, polygon),
+                            CableReportApplicationArea("other area", otherPolygon),
+                            CableReportApplicationArea("third area", thirdPolygon),
                         ),
                 )
 
@@ -227,7 +227,7 @@ internal class ApplicationDataMapperTest {
         fun `remove crs from the geometries`() {
             val applicationData =
                 ApplicationFactory.createCableReportApplicationData(
-                    areas = listOf(ApplicationArea(areaName, polygon))
+                    areas = listOf(CableReportApplicationArea(areaName, polygon))
                 )
             assertThat(polygon.crs).isNotNull()
 
@@ -240,7 +240,7 @@ internal class ApplicationDataMapperTest {
         fun `add crs to the geometry collection`() {
             val applicationData =
                 ApplicationFactory.createCableReportApplicationData(
-                    areas = listOf(ApplicationArea(areaName, polygon))
+                    areas = listOf(CableReportApplicationArea(areaName, polygon))
                 )
 
             val geometry = ApplicationDataMapper.getGeometry(applicationData)
@@ -255,7 +255,7 @@ internal class ApplicationDataMapperTest {
             polygon.crs = polygon.crs.apply { this.properties["name"] = "InvalidCode" }
             val applicationData =
                 ApplicationFactory.createCableReportApplicationData(
-                    areas = listOf(ApplicationArea(areaName, polygon))
+                    areas = listOf(CableReportApplicationArea(areaName, polygon))
                 )
 
             val exception = assertFailure { ApplicationDataMapper.getGeometry(applicationData) }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/ApplicationFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/ApplicationFactory.kt
@@ -9,11 +9,13 @@ import fi.hel.haitaton.hanke.application.ApplicationData
 import fi.hel.haitaton.hanke.application.ApplicationEntity
 import fi.hel.haitaton.hanke.application.ApplicationRepository
 import fi.hel.haitaton.hanke.application.ApplicationType
+import fi.hel.haitaton.hanke.application.CableReportApplicationArea
 import fi.hel.haitaton.hanke.application.CableReportApplicationData
 import fi.hel.haitaton.hanke.application.CableReportWithoutHanke
 import fi.hel.haitaton.hanke.application.Contact
 import fi.hel.haitaton.hanke.application.Customer
 import fi.hel.haitaton.hanke.application.CustomerWithContacts
+import fi.hel.haitaton.hanke.application.ExcavationNotificationArea
 import fi.hel.haitaton.hanke.application.ExcavationNotificationData
 import fi.hel.haitaton.hanke.application.InvoicingCustomer
 import fi.hel.haitaton.hanke.application.PostalAddress
@@ -150,15 +152,27 @@ class ApplicationFactory(
             orderer: Boolean = false
         ) = Contact(firstName, lastName, email, phone, orderer)
 
-        fun createApplicationArea(
+        fun createCableReportApplicationArea(
             name: String = "Alue",
             geometry: Polygon = GeometriaFactory.secondPolygon,
-        ): ApplicationArea = ApplicationArea(name, geometry)
+        ): CableReportApplicationArea = CableReportApplicationArea(name, geometry)
+
+        fun createExcavationNotificationArea(
+            name: String = "Alue",
+            geometry: Polygon = GeometriaFactory.secondPolygon,
+        ): ExcavationNotificationArea = ExcavationNotificationArea(name, geometry)
 
         fun Application.withApplicationData(
             type: ApplicationType = ApplicationType.CABLE_REPORT,
             name: String = DEFAULT_APPLICATION_NAME,
-            areas: List<ApplicationArea>? = listOf(createApplicationArea()),
+            areas: List<ApplicationArea>? =
+                listOf(
+                    when (applicationType) {
+                        ApplicationType.CABLE_REPORT -> createCableReportApplicationArea()
+                        ApplicationType.EXCAVATION_NOTIFICATION ->
+                            createExcavationNotificationArea()
+                    }
+                ),
             startTime: ZonedDateTime? = DateFactory.getStartDatetime(),
             endTime: ZonedDateTime? = DateFactory.getEndDatetime(),
             pendingOnClient: Boolean = false,
@@ -175,7 +189,7 @@ class ApplicationFactory(
                 ApplicationType.CABLE_REPORT ->
                     withCableReportApplicationData(
                         name,
-                        areas,
+                        areas?.map { it as CableReportApplicationArea },
                         startTime,
                         endTime,
                         pendingOnClient,
@@ -199,7 +213,7 @@ class ApplicationFactory(
                         true,
                         emptyList(),
                         emptyList(),
-                        areas,
+                        areas?.map { it as ExcavationNotificationArea },
                         startTime,
                         endTime,
                         customerWithContacts,
@@ -213,7 +227,7 @@ class ApplicationFactory(
 
         fun Application.withCableReportApplicationData(
             name: String = DEFAULT_APPLICATION_NAME,
-            areas: List<ApplicationArea>? = listOf(createApplicationArea()),
+            areas: List<CableReportApplicationArea>? = listOf(createCableReportApplicationArea()),
             startTime: ZonedDateTime? = DateFactory.getStartDatetime(),
             endTime: ZonedDateTime? = DateFactory.getEndDatetime(),
             pendingOnClient: Boolean = false,
@@ -256,7 +270,7 @@ class ApplicationFactory(
             requiredCompetence: Boolean = true,
             cableReports: List<String> = emptyList(),
             placementContracts: List<String> = emptyList(),
-            areas: List<ApplicationArea>? = listOf(createApplicationArea()),
+            areas: List<ExcavationNotificationArea>? = listOf(createExcavationNotificationArea()),
             startTime: ZonedDateTime? = DateFactory.getStartDatetime(),
             endTime: ZonedDateTime? = DateFactory.getEndDatetime(),
             customerWithContacts: CustomerWithContacts =
@@ -307,7 +321,7 @@ class ApplicationFactory(
 
         fun createCableReportApplicationData(
             name: String = DEFAULT_APPLICATION_NAME,
-            areas: List<ApplicationArea>? = listOf(createApplicationArea()),
+            areas: List<CableReportApplicationArea>? = listOf(createCableReportApplicationArea()),
             startTime: ZonedDateTime? = DateFactory.getStartDatetime(),
             endTime: ZonedDateTime? = DateFactory.getEndDatetime(),
             pendingOnClient: Boolean = false,
@@ -364,7 +378,7 @@ class ApplicationFactory(
             cableReports: List<String>? = null,
             placementContracts: List<String>? = null,
             requiredCompetence: Boolean = false,
-            areas: List<ApplicationArea>? = listOf(createApplicationArea()),
+            areas: List<ExcavationNotificationArea>? = listOf(createExcavationNotificationArea()),
             startTime: ZonedDateTime? = DateFactory.getStartDatetime(),
             endTime: ZonedDateTime? = DateFactory.getEndDatetime(),
             customerWithContacts: CustomerWithContacts? =
@@ -464,7 +478,7 @@ class ApplicationFactory(
         ) = this.copy(postalAddress = PostalAddress(StreetAddress(streetAddress), postalCode, city))
 
         fun CableReportApplicationData.withArea(name: String, geometry: Polygon) =
-            this.copy(areas = (areas ?: listOf()) + ApplicationArea(name, geometry))
+            this.copy(areas = (areas ?: listOf()) + CableReportApplicationArea(name, geometry))
 
         fun cableReportWithoutHanke(
             applicationData: CableReportApplicationData = createCableReportApplicationData(),

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusBuilder.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusBuilder.kt
@@ -7,7 +7,9 @@ import fi.hel.haitaton.hanke.application.ApplicationContactType
 import fi.hel.haitaton.hanke.application.ApplicationEntity
 import fi.hel.haitaton.hanke.application.ApplicationRepository
 import fi.hel.haitaton.hanke.application.ApplicationType
+import fi.hel.haitaton.hanke.application.CableReportApplicationArea
 import fi.hel.haitaton.hanke.application.CableReportApplicationData
+import fi.hel.haitaton.hanke.application.ExcavationNotificationArea
 import fi.hel.haitaton.hanke.application.ExcavationNotificationData
 import fi.hel.haitaton.hanke.hakemus.Hakemus
 import fi.hel.haitaton.hanke.hakemus.HakemusService
@@ -83,10 +85,10 @@ data class HakemusBuilder(
             { copy(pendingOnClient = pendingOnClient) },
         )
 
-    fun withArea(area: ApplicationArea = ApplicationFactory.createApplicationArea()) =
+    fun withArea(area: ApplicationArea = ApplicationFactory.createCableReportApplicationArea()) =
         updateApplicationData(
-            { copy(areas = (areas ?: listOf()).plus(area)) },
-            { copy(areas = (areas ?: listOf()).plus(area)) },
+            { copy(areas = (areas ?: listOf()).plus(area as CableReportApplicationArea)) },
+            { copy(areas = (areas ?: listOf()).plus(area as ExcavationNotificationArea)) },
         )
 
     fun withStartTime(time: ZonedDateTime? = DateFactory.getStartDatetime()) =

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusFactory.kt
@@ -3,11 +3,12 @@ package fi.hel.haitaton.hanke.factory
 import fi.hel.haitaton.hanke.HankeEntity
 import fi.hel.haitaton.hanke.HankeRepository
 import fi.hel.haitaton.hanke.allu.ApplicationStatus
-import fi.hel.haitaton.hanke.application.ApplicationArea
 import fi.hel.haitaton.hanke.application.ApplicationData
 import fi.hel.haitaton.hanke.application.ApplicationEntity
 import fi.hel.haitaton.hanke.application.ApplicationRepository
 import fi.hel.haitaton.hanke.application.ApplicationType
+import fi.hel.haitaton.hanke.application.CableReportApplicationArea
+import fi.hel.haitaton.hanke.application.ExcavationNotificationArea
 import fi.hel.haitaton.hanke.application.PostalAddress
 import fi.hel.haitaton.hanke.domain.CreateHankeRequest
 import fi.hel.haitaton.hanke.domain.HankePerustaja
@@ -118,7 +119,8 @@ class HakemusFactory(
             startTime: ZonedDateTime? = DateFactory.getStartDatetime(),
             endTime: ZonedDateTime? = DateFactory.getEndDatetime(),
             pendingOnClient: Boolean = false,
-            areas: List<ApplicationArea>? = listOf(ApplicationFactory.createApplicationArea()),
+            areas: List<CableReportApplicationArea>? =
+                listOf(ApplicationFactory.createCableReportApplicationArea()),
             customerWithContacts: Hakemusyhteystieto? = null,
             contractorWithContacts: Hakemusyhteystieto? = null,
             representativeWithContacts: Hakemusyhteystieto? = null,
@@ -153,7 +155,8 @@ class HakemusFactory(
             workDescription: String = "Work description.",
             startTime: ZonedDateTime? = DateFactory.getStartDatetime(),
             endTime: ZonedDateTime? = DateFactory.getEndDatetime(),
-            areas: List<ApplicationArea>? = listOf(ApplicationFactory.createApplicationArea()),
+            areas: List<ExcavationNotificationArea>? =
+                listOf(ApplicationFactory.createExcavationNotificationArea()),
             customerWithContacts: Hakemusyhteystieto? = null,
             contractorWithContacts: Hakemusyhteystieto? = null,
             representativeWithContacts: Hakemusyhteystieto? = null,

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusResponseFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusResponseFactory.kt
@@ -2,8 +2,9 @@ package fi.hel.haitaton.hanke.factory
 
 import fi.hel.haitaton.hanke.allu.ApplicationStatus
 import fi.hel.haitaton.hanke.allu.CustomerType
-import fi.hel.haitaton.hanke.application.ApplicationArea
 import fi.hel.haitaton.hanke.application.ApplicationType
+import fi.hel.haitaton.hanke.application.CableReportApplicationArea
+import fi.hel.haitaton.hanke.application.ExcavationNotificationArea
 import fi.hel.haitaton.hanke.application.PostalAddress
 import fi.hel.haitaton.hanke.application.StreetAddress
 import fi.hel.haitaton.hanke.hakemus.ContactResponse
@@ -54,7 +55,8 @@ object HakemusResponseFactory {
         workDescription: String = ApplicationFactory.DEFAULT_WORK_DESCRIPTION,
         startTime: ZonedDateTime? = DateFactory.getStartDatetime(),
         endTime: ZonedDateTime? = DateFactory.getEndDatetime(),
-        areas: List<ApplicationArea> = listOf(ApplicationFactory.createApplicationArea()),
+        areas: List<CableReportApplicationArea> =
+            listOf(ApplicationFactory.createCableReportApplicationArea()),
         customerWithContacts: CustomerWithContactsResponse? =
             CustomerWithContactsResponse(
                 createCompanyCustomerResponse(),
@@ -98,7 +100,8 @@ object HakemusResponseFactory {
         requiredCompetence: Boolean = false,
         startTime: ZonedDateTime? = DateFactory.getStartDatetime(),
         endTime: ZonedDateTime? = DateFactory.getEndDatetime(),
-        areas: List<ApplicationArea> = listOf(ApplicationFactory.createApplicationArea()),
+        areas: List<ExcavationNotificationArea> =
+            listOf(ApplicationFactory.createExcavationNotificationArea()),
         customerWithContacts: CustomerWithContactsResponse? =
             CustomerWithContactsResponse(
                 createCompanyCustomerResponse(),

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusUpdateRequestFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusUpdateRequestFactory.kt
@@ -4,6 +4,8 @@ import fi.hel.haitaton.hanke.TZ_UTC
 import fi.hel.haitaton.hanke.allu.CustomerType
 import fi.hel.haitaton.hanke.application.ApplicationArea
 import fi.hel.haitaton.hanke.application.ApplicationType
+import fi.hel.haitaton.hanke.application.CableReportApplicationArea
+import fi.hel.haitaton.hanke.application.ExcavationNotificationArea
 import fi.hel.haitaton.hanke.application.StreetAddress
 import fi.hel.haitaton.hanke.hakemus.ContactRequest
 import fi.hel.haitaton.hanke.hakemus.CustomerRequest
@@ -94,7 +96,7 @@ object HakemusUpdateRequestFactory {
             workDescription = "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
             startTime = ZonedDateTime.now(TZ_UTC),
             endTime = ZonedDateTime.now(TZ_UTC).plusDays(5),
-            areas = listOf(ApplicationArea("Hankealue 1", GeometriaFactory.polygon)),
+            areas = listOf(CableReportApplicationArea("Hankealue 1", GeometriaFactory.polygon)),
             customerWithContacts =
                 createCustomerWithContactsRequest(
                     CustomerType.COMPANY,
@@ -117,7 +119,7 @@ object HakemusUpdateRequestFactory {
             rockExcavation = false,
             startTime = ZonedDateTime.now(TZ_UTC),
             endTime = ZonedDateTime.now(TZ_UTC).plusDays(5),
-            areas = listOf(ApplicationArea("Hankealue 1", GeometriaFactory.polygon)),
+            areas = listOf(ExcavationNotificationArea("Hankealue 1", GeometriaFactory.polygon)),
             customerWithContacts =
                 createCustomerWithContactsRequest(
                     CustomerType.COMPANY,
@@ -258,8 +260,10 @@ object HakemusUpdateRequestFactory {
 
     fun HakemusUpdateRequest.withAreas(areas: List<ApplicationArea>?) =
         when (this) {
-            is JohtoselvityshakemusUpdateRequest -> this.copy(areas = areas)
-            is KaivuilmoitusUpdateRequest -> this.copy(areas = areas)
+            is JohtoselvityshakemusUpdateRequest ->
+                this.copy(areas = areas?.map { it as CableReportApplicationArea })
+            is KaivuilmoitusUpdateRequest ->
+                this.copy(areas = areas?.map { it as ExcavationNotificationArea })
         }
 
     fun HakemusUpdateRequest.withTimes(startTime: ZonedDateTime?, endTime: ZonedDateTime?) =

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusPdfServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusPdfServiceTest.kt
@@ -6,7 +6,7 @@ import assertk.assertions.contains
 import assertk.assertions.doesNotContain
 import com.lowagie.text.pdf.PdfReader
 import com.lowagie.text.pdf.parser.PdfTextExtractor
-import fi.hel.haitaton.hanke.application.ApplicationArea
+import fi.hel.haitaton.hanke.application.CableReportApplicationArea
 import fi.hel.haitaton.hanke.factory.ApplicationFactory
 import fi.hel.haitaton.hanke.factory.ApplicationFactory.Companion.createPostalAddress
 import fi.hel.haitaton.hanke.factory.HakemusFactory
@@ -134,9 +134,9 @@ class HakemusPdfServiceTest {
                     endTime = ZonedDateTime.parse("2022-11-28T21:59:59.999Z"),
                     areas =
                         listOf(
-                            ApplicationArea("Ensimmäinen työalue", Polygon()),
-                            ApplicationArea("Toinen alue", Polygon()),
-                            ApplicationArea("", Polygon()),
+                            CableReportApplicationArea("Ensimmäinen työalue", Polygon()),
+                            CableReportApplicationArea("Toinen alue", Polygon()),
+                            CableReportApplicationArea("", Polygon()),
                         )
                 )
 


### PR DESCRIPTION
# Description

First PR for creating a separate application area data structure for excavation notifcation. In this PR the current `ApplicationArea` data class is refactored as a sealed interface and identical two implementation data classes have been made, one for cable report and other for excavation notification. In later PR the data needed for excavation notification application area is added.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1542

## Type of change

- [ ] Bug fix 
- [x] New feature 
- [ ] Other

# Instructions for testing
Please describe tests how this change or new feature can be tested.

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 

# Other relevant info
Please describe here if there is e.g. some requirements for this change or
 other info that the tester/user needs to know.