### PR TITLE
HAI-2537 Return hankekayttaja after resending the invitation

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaControllerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaControllerITest.kt
@@ -776,13 +776,20 @@ class HankeKayttajaControllerITest(
         }
 
         @Test
-        fun `Returns 204 if invitation resent`() {
+        fun `Returns 200 if invitation resent`() {
             every { authorizer.authorizeKayttajaId(kayttajaId, RESEND_INVITATION.name) } returns
                 true
-            justRun { hankeKayttajaService.resendInvitation(kayttajaId, USERNAME) }
+            val hankekayttaja = HankeKayttajaFactory.create()
+            every { hankeKayttajaService.resendInvitation(kayttajaId, USERNAME) } returns
+                hankekayttaja
 
-            post(url).andExpect(status().isNoContent).andExpect(content().string(""))
+            val response: HankeKayttajaDto = post(url).andExpect(status().isOk).andReturnBody()
 
+            assertThat(response).all {
+                prop(HankeKayttajaDto::id).isEqualTo(hankekayttaja.id)
+                prop(HankeKayttajaDto::kayttooikeustaso).isEqualTo(hankekayttaja.kayttooikeustaso)
+                prop(HankeKayttajaDto::kutsuttu).isEqualTo(hankekayttaja.kutsuttu)
+            }
             verifySequence {
                 authorizer.authorizeKayttajaId(kayttajaId, RESEND_INVITATION.name)
                 hankeKayttajaService.resendInvitation(kayttajaId, USERNAME)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaController.kt
@@ -316,7 +316,6 @@ Responds with information about the activated user and the hanke associated with
     }
 
     @PostMapping("/kayttajat/{kayttajaId}/kutsu")
-    @ResponseStatus(HttpStatus.NO_CONTENT)
     @Operation(
         summary = "Resend an invitation email",
         description =
@@ -327,6 +326,8 @@ hanke as a contact person.
 Regenerates the invitation token and link. This means that the link in the
 original email will not work anymore. It also means that the period of validity
 of the token and link will be reset.
+
+Returns the updated hankekayttaja.
 """
     )
     @ApiResponses(
@@ -352,9 +353,8 @@ of the token and link will be reset.
         "@featureService.isEnabled('USER_MANAGEMENT') && " +
             "@hankeKayttajaAuthorizer.authorizeKayttajaId(#kayttajaId, 'RESEND_INVITATION')"
     )
-    fun resendInvitations(@PathVariable kayttajaId: UUID) {
-        hankeKayttajaService.resendInvitation(kayttajaId, currentUserId())
-    }
+    fun resendInvitations(@PathVariable kayttajaId: UUID): HankeKayttajaDto =
+        hankeKayttajaService.resendInvitation(kayttajaId, currentUserId()).toDto()
 
     @PutMapping("/hankkeet/{hankeTunnus}/kayttajat/self")
     @Operation(

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaService.kt
@@ -257,7 +257,7 @@ class HankeKayttajaService(
     }
 
     @Transactional
-    fun resendInvitation(kayttajaId: UUID, currentUserId: String) {
+    fun resendInvitation(kayttajaId: UUID, currentUserId: String): HankeKayttaja {
         // Re-get the kayttaja under the transaction
         val kayttaja = hankekayttajaRepository.getReferenceById(kayttajaId)
         kayttaja.permission?.let {
@@ -270,6 +270,7 @@ class HankeKayttajaService(
         recreateKutsu(kayttaja, currentUserId)
         val hanke = hankeRepository.getReferenceById(kayttaja.hankeId)
         sendHankeInvitation(hanke.hankeTunnus, hanke.nimi, inviter, kayttaja)
+        return hankekayttajaRepository.getReferenceById(kayttajaId).toDomain()
     }
 
     @Transactional

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeKayttajaFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeKayttajaFactory.kt
@@ -38,6 +38,7 @@ class HankeKayttajaFactory(
         puhelin: String = KAKE_PUHELIN,
         kayttooikeustaso: Kayttooikeustaso = KATSELUOIKEUS,
         tunniste: String = "existing",
+        kutsuttu: OffsetDateTime = INVITATION_DATE,
     ): HankekayttajaEntity =
         addToken(
             hankeKayttaja =
@@ -51,6 +52,7 @@ class HankeKayttajaFactory(
                 ),
             tunniste = tunniste,
             kayttooikeustaso = kayttooikeustaso,
+            kutsuttu = kutsuttu,
         )
 
     fun saveIdentifiedUser(
@@ -117,19 +119,21 @@ class HankeKayttajaFactory(
         hankeKayttaja: HankekayttajaEntity,
         tunniste: String = "existing",
         kayttooikeustaso: Kayttooikeustaso = KATSELUOIKEUS,
+        kutsuttu: OffsetDateTime = INVITATION_DATE,
     ): HankekayttajaEntity {
-        hankeKayttaja.kayttajakutsu = hankeKayttaja.saveToken(tunniste, kayttooikeustaso)
+        hankeKayttaja.kayttajakutsu = hankeKayttaja.saveToken(tunniste, kayttooikeustaso, kutsuttu)
         return hankeKayttajaRepository.save(hankeKayttaja)
     }
 
     private fun HankekayttajaEntity.saveToken(
         tunniste: String = "existing",
         kayttooikeustaso: Kayttooikeustaso = KATSELUOIKEUS,
+        createdAt: OffsetDateTime = INVITATION_DATE,
     ) =
         kayttajakutsuRepository.save(
             KayttajakutsuEntity(
                 tunniste = tunniste,
-                createdAt = INVITATION_DATE,
+                createdAt = createdAt,
                 kayttooikeustaso = kayttooikeustaso,
                 hankekayttaja = this,
             )


### PR DESCRIPTION
# Description

Return the updated hankekayttaja after resending an invitation to a hanke. This enables the frontend to read the new invitation date from the response, so they don't have to request it separately.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2537

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
Resend an invitation from the UI and check the response from the network tab of the development tools.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 