### PR TITLE
HAI-2535 Add attachment names to application-form-data.pdf

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentControllerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentControllerITest.kt
@@ -94,9 +94,7 @@ class ApplicationAttachmentControllerITest(@Autowired override val mockMvc: Mock
         @Test
         fun `when valid request should return metadata list`() {
             val data =
-                (1..3).map {
-                    ApplicationAttachmentFactory.createMetadata(fileName = "${it}file.pdf")
-                }
+                (1..3).map { ApplicationAttachmentFactory.create(fileName = "$it$FILE_NAME_PDF") }
             every { authorizer.authorizeApplicationId(APPLICATION_ID, VIEW.name) } returns true
             every { applicationAttachmentService.getMetadataList(APPLICATION_ID) } returns data
             val result: List<ApplicationAttachmentMetadataDto> =
@@ -168,7 +166,7 @@ class ApplicationAttachmentControllerITest(@Autowired override val mockMvc: Mock
                 authorizer.authorizeApplicationId(APPLICATION_ID, EDIT_APPLICATIONS.name)
             } returns true
             every { applicationAttachmentService.addAttachment(APPLICATION_ID, MUU, file) } returns
-                ApplicationAttachmentFactory.createMetadata()
+                ApplicationAttachmentFactory.createDto()
 
             val result: ApplicationAttachmentMetadataDto =
                 postAttachment(file = file).andExpect(status().isOk).andReturnBody()

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentServiceITest.kt
@@ -27,7 +27,7 @@ import fi.hel.haitaton.hanke.attachment.FILE_NAME_PDF
 import fi.hel.haitaton.hanke.attachment.azure.Container.HAKEMUS_LIITTEET
 import fi.hel.haitaton.hanke.attachment.body
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentEntity
-import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentMetadataDto
+import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentMetadata
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentRepository
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType.MUU
@@ -119,16 +119,15 @@ class ApplicationAttachmentServiceITest(
 
             assertThat(result).hasSize(2)
             assertThat(result).each {
-                it.prop(ApplicationAttachmentMetadataDto::id).isNotNull()
-                it.prop(ApplicationAttachmentMetadataDto::fileName).endsWith("file.pdf")
-                it.prop(ApplicationAttachmentMetadataDto::contentType)
-                    .isEqualTo(APPLICATION_PDF_VALUE)
-                it.prop(ApplicationAttachmentMetadataDto::size).isEqualTo(DEFAULT_SIZE)
-                it.prop(ApplicationAttachmentMetadataDto::createdByUserId).isEqualTo(USERNAME)
-                it.prop(ApplicationAttachmentMetadataDto::createdAt)
+                it.prop(ApplicationAttachmentMetadata::id).isNotNull()
+                it.prop(ApplicationAttachmentMetadata::fileName).endsWith("file.pdf")
+                it.prop(ApplicationAttachmentMetadata::contentType).isEqualTo(APPLICATION_PDF_VALUE)
+                it.prop(ApplicationAttachmentMetadata::size).isEqualTo(DEFAULT_SIZE)
+                it.prop(ApplicationAttachmentMetadata::createdByUserId).isEqualTo(USERNAME)
+                it.prop(ApplicationAttachmentMetadata::createdAt)
                     .isSameInstantAs(ApplicationAttachmentFactory.CREATED_AT)
-                it.prop(ApplicationAttachmentMetadataDto::applicationId).isEqualTo(application.id)
-                it.prop(ApplicationAttachmentMetadataDto::attachmentType).isEqualTo(MUU)
+                it.prop(ApplicationAttachmentMetadata::applicationId).isEqualTo(application.id)
+                it.prop(ApplicationAttachmentMetadata::attachmentType).isEqualTo(MUU)
             }
         }
     }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentController.kt
@@ -55,7 +55,7 @@ class ApplicationAttachmentController(
     fun getApplicationAttachments(
         @PathVariable applicationId: Long
     ): List<ApplicationAttachmentMetadataDto> {
-        return applicationAttachmentService.getMetadataList(applicationId)
+        return applicationAttachmentService.getMetadataList(applicationId).map { it.toDto() }
     }
 
     @GetMapping("/{attachmentId}/content")

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentMetadataService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentMetadataService.kt
@@ -3,7 +3,6 @@ package fi.hel.haitaton.hanke.attachment.application
 import fi.hel.haitaton.hanke.ALLOWED_ATTACHMENT_COUNT
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentEntity
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentMetadata
-import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentMetadataDto
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentRepository
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType
 import fi.hel.haitaton.hanke.attachment.common.AttachmentLimitReachedException
@@ -13,7 +12,6 @@ import fi.hel.haitaton.hanke.hakemus.HakemusIdentifier
 import java.time.OffsetDateTime
 import java.util.UUID
 import mu.KotlinLogging
-import org.springframework.data.jpa.domain.AbstractPersistable_.id
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -25,8 +23,8 @@ class ApplicationAttachmentMetadataService(
     private val attachmentRepository: ApplicationAttachmentRepository,
 ) {
     @Transactional(readOnly = true)
-    fun getMetadataList(applicationId: Long): List<ApplicationAttachmentMetadataDto> =
-        attachmentRepository.findByApplicationId(applicationId).map { it.toDto() }
+    fun getMetadataList(applicationId: Long): List<ApplicationAttachmentMetadata> =
+        attachmentRepository.findByApplicationId(applicationId).map { it.toDomain() }
 
     @Transactional(readOnly = true)
     fun findAttachment(attachmentId: UUID): ApplicationAttachmentMetadata =

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentService.kt
@@ -4,6 +4,7 @@ import fi.hel.haitaton.hanke.allu.CableReportService
 import fi.hel.haitaton.hanke.application.Application
 import fi.hel.haitaton.hanke.application.ApplicationNotFoundException
 import fi.hel.haitaton.hanke.application.ApplicationRepository
+import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentMetadata
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentMetadataDto
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType
 import fi.hel.haitaton.hanke.attachment.common.AttachmentContent
@@ -31,7 +32,7 @@ class ApplicationAttachmentService(
     private val scanClient: FileScanClient,
 ) {
     /** Authorization in controller throws exception if application ID is unknown. */
-    fun getMetadataList(applicationId: Long): List<ApplicationAttachmentMetadataDto> =
+    fun getMetadataList(applicationId: Long): List<ApplicationAttachmentMetadata> =
         metadataService.getMetadataList(applicationId)
 
     fun getContent(attachmentId: UUID): AttachmentContent {

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusPdfService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusPdfService.kt
@@ -11,6 +11,7 @@ import com.lowagie.text.Rectangle
 import com.lowagie.text.pdf.PdfPTable
 import com.lowagie.text.pdf.PdfWriter
 import fi.hel.haitaton.hanke.application.PostalAddress
+import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentMetadata
 import java.io.ByteArrayOutputStream
 import java.time.ZoneId
 import java.time.ZonedDateTime
@@ -91,6 +92,7 @@ object HakemusPdfService {
         data: JohtoselvityshakemusData,
         totalArea: Float?,
         areas: List<Float?>,
+        attachments: List<ApplicationAttachmentMetadata>,
     ): ByteArray {
         val outputStream = ByteArrayOutputStream()
         val document = Document(PageSize.A4)
@@ -100,6 +102,7 @@ object HakemusPdfService {
             data,
             totalArea,
             areas,
+            attachments,
         )
         return outputStream.toByteArray()
     }
@@ -109,6 +112,7 @@ object HakemusPdfService {
         data: JohtoselvityshakemusData,
         totalArea: Float?,
         areas: List<Float?>,
+        attachments: List<ApplicationAttachmentMetadata>,
     ) {
         document.open()
 
@@ -160,7 +164,12 @@ object HakemusPdfService {
         document.newPage()
 
         document.section("Liitteet") { table ->
-            // TODO: Attachments
+            if (attachments.isNotEmpty()) {
+                table.row(
+                    "Lisätyt liitetiedostot",
+                    attachments.map { it.fileName }.joinToString("\n")
+                )
+            }
         }
 
         document.close()

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/ApplicationAttachmentFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/ApplicationAttachmentFactory.kt
@@ -13,7 +13,6 @@ import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentRepository
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType.MUU
 import fi.hel.haitaton.hanke.attachment.common.FileClient
-import fi.hel.haitaton.hanke.currentUserId
 import fi.hel.haitaton.hanke.factory.ApplicationFactory.Companion.DEFAULT_APPLICATION_ID
 import fi.hel.haitaton.hanke.test.USERNAME
 import java.time.OffsetDateTime
@@ -116,12 +115,12 @@ class ApplicationAttachmentFactory(
                 applicationId = applicationId,
             )
 
-        fun createMetadata(
+        fun createDto(
             attachmentId: UUID = defaultAttachmentId,
             fileName: String = FILE_NAME,
             contentType: String = APPLICATION_PDF_VALUE,
             size: Long = DEFAULT_SIZE,
-            createdBy: String = currentUserId(),
+            createdBy: String = USERNAME,
             createdAt: OffsetDateTime = OffsetDateTime.now(),
             applicationId: Long = 1L,
             attachmentType: ApplicationAttachmentType = MUU,

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusPdfServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusPdfServiceTest.kt
@@ -7,6 +7,7 @@ import assertk.assertions.doesNotContain
 import com.lowagie.text.pdf.PdfReader
 import com.lowagie.text.pdf.parser.PdfTextExtractor
 import fi.hel.haitaton.hanke.application.CableReportApplicationArea
+import fi.hel.haitaton.hanke.factory.ApplicationAttachmentFactory
 import fi.hel.haitaton.hanke.factory.ApplicationFactory
 import fi.hel.haitaton.hanke.factory.ApplicationFactory.Companion.createPostalAddress
 import fi.hel.haitaton.hanke.factory.HakemusFactory
@@ -26,7 +27,7 @@ class HakemusPdfServiceTest {
         fun `created PDF contains title and section headers`() {
             val hakemusData = HakemusFactory.createJohtoselvityshakemusData()
 
-            val pdfData = HakemusPdfService.createPdf(hakemusData, 1f, listOf())
+            val pdfData = HakemusPdfService.createPdf(hakemusData, 1f, listOf(), listOf())
 
             assertThat(getPdfAsText(pdfData))
                 .contains("Johtoselvityshakemus", "Perustiedot", "Alueet", "Yhteystiedot")
@@ -36,7 +37,7 @@ class HakemusPdfServiceTest {
         fun `created PDF contains headers for basic information`() {
             val hakemusData = HakemusFactory.createJohtoselvityshakemusData()
 
-            val pdfData = HakemusPdfService.createPdf(hakemusData, 614f, listOf())
+            val pdfData = HakemusPdfService.createPdf(hakemusData, 614f, listOf(), listOf())
 
             assertThat(getPdfAsText(pdfData)).all {
                 contains("Työn nimi")
@@ -59,7 +60,7 @@ class HakemusPdfServiceTest {
                     propertyConnectivity = true,
                 )
 
-            val pdfData = HakemusPdfService.createPdf(applicationData, 1f, listOf())
+            val pdfData = HakemusPdfService.createPdf(applicationData, 1f, listOf(), listOf())
 
             val pdfText = getPdfAsText(pdfData)
             assertThat(pdfText).all {
@@ -102,7 +103,7 @@ class HakemusPdfServiceTest {
                     propertyConnectivity = false,
                 )
 
-            val pdfData = HakemusPdfService.createPdf(hakemusData, 1f, listOf())
+            val pdfData = HakemusPdfService.createPdf(hakemusData, 1f, listOf(), listOf())
 
             assertThat(getPdfAsText(pdfData)).all {
                 doesNotContain("Uuden rakenteen tai johdon rakentamisesta")
@@ -116,7 +117,7 @@ class HakemusPdfServiceTest {
         fun `created PDF contains headers for area information`() {
             val hakemusData = HakemusFactory.createJohtoselvityshakemusData()
 
-            val pdfData = HakemusPdfService.createPdf(hakemusData, 614f, listOf())
+            val pdfData = HakemusPdfService.createPdf(hakemusData, 614f, listOf(), listOf())
 
             assertThat(getPdfAsText(pdfData)).all {
                 contains("Työn arvioitu alkupäivä")
@@ -140,7 +141,8 @@ class HakemusPdfServiceTest {
                         )
                 )
 
-            val pdfData = HakemusPdfService.createPdf(hakemusData, 614f, listOf(185f, 231f, 198f))
+            val pdfData =
+                HakemusPdfService.createPdf(hakemusData, 614f, listOf(185f, 231f, 198f), listOf())
 
             assertThat(getPdfAsText(pdfData)).all {
                 contains("18.11.2022")
@@ -167,7 +169,7 @@ class HakemusPdfServiceTest {
                         HakemusyhteystietoFactory.create().withYhteyshenkilo()
                 )
 
-            val pdfData = HakemusPdfService.createPdf(hakemusData, 1f, listOf())
+            val pdfData = HakemusPdfService.createPdf(hakemusData, 1f, listOf(), listOf())
 
             assertThat(getPdfAsText(pdfData)).all {
                 contains("Työstä vastaavat")
@@ -188,7 +190,7 @@ class HakemusPdfServiceTest {
                     propertyDeveloperWithContacts = null,
                 )
 
-            val pdfData = HakemusPdfService.createPdf(hakemusData, 614f, listOf())
+            val pdfData = HakemusPdfService.createPdf(hakemusData, 614f, listOf(), listOf())
 
             assertThat(getPdfAsText(pdfData)).all {
                 contains("Työstä vastaavat")
@@ -262,7 +264,7 @@ class HakemusPdfServiceTest {
                     propertyDeveloperWithContacts = rakennuttaja,
                 )
 
-            val pdfData = HakemusPdfService.createPdf(hakemusData, 614f, listOf())
+            val pdfData = HakemusPdfService.createPdf(hakemusData, 614f, listOf(), listOf())
 
             assertThat(getPdfAsText(pdfData)).all {
                 contains("Company Ltd")
@@ -293,6 +295,30 @@ class HakemusPdfServiceTest {
                 contains("Denise Developer")
                 contains("denise@developer.test")
                 contains("0502222222")
+            }
+        }
+
+        @Test
+        fun `created PDF contains attachment information`() {
+            val hakemusData =
+                HakemusFactory.createJohtoselvityshakemusData(
+                    startTime = ZonedDateTime.parse("2022-11-17T22:00:00.000Z"),
+                    endTime = ZonedDateTime.parse("2022-11-28T21:59:59.999Z"),
+                    areas = listOf()
+                )
+            val attachments =
+                listOf(
+                    ApplicationAttachmentFactory.create(fileName = "first.pdf"),
+                    ApplicationAttachmentFactory.create(fileName = "second.png"),
+                    ApplicationAttachmentFactory.create(fileName = "third.gt"),
+                )
+
+            val pdfData = HakemusPdfService.createPdf(hakemusData, 614f, listOf(), attachments)
+
+            assertThat(getPdfAsText(pdfData)).all {
+                contains("first.pdf")
+                contains("second.png")
+                contains("third.gt")
             }
         }
     }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceTest.kt
@@ -144,6 +144,7 @@ class HakemusServiceTest {
             every { geometriatDao.isInsideHankeAlueet(1, any()) } returns true
             every { geometriatDao.calculateCombinedArea(any()) } returns 11.0f
             every { geometriatDao.calculateArea(any()) } returns 11.0f
+            every { attachmentService.getMetadataList(applicationEntity.id) } returns listOf()
             justRun { alluClient.addAttachment(alluId, any()) }
             justRun { attachmentService.sendInitialAttachments(alluId, any()) }
             val applicationCapturingSlot = slot<AlluCableReportApplicationData>()
@@ -232,6 +233,7 @@ class HakemusServiceTest {
                 geometriatDao.isInsideHankeAlueet(1, any())
                 geometriatDao.calculateCombinedArea(any())
                 geometriatDao.calculateArea(any())
+                attachmentService.getMetadataList(applicationEntity.id)
                 alluClient.create(any())
                 disclosureLogService.saveDisclosureLogsForAllu(3, any(), Status.SUCCESS)
                 alluClient.addAttachment(alluId, any())
@@ -247,6 +249,7 @@ class HakemusServiceTest {
             every { applicationRepository.findOneById(3) } returns applicationEntity
             every { geometriatDao.calculateCombinedArea(any()) } returns 11.0f
             every { geometriatDao.calculateArea(any()) } returns 11.0f
+            every { attachmentService.getMetadataList(applicationEntity.id) } returns listOf()
             every { alluClient.create(any()) } throws AlluException()
             every { geometriatDao.isInsideHankeAlueet(1, any()) } returns true
 
@@ -257,6 +260,7 @@ class HakemusServiceTest {
                 geometriatDao.isInsideHankeAlueet(1, any())
                 geometriatDao.calculateCombinedArea(any())
                 geometriatDao.calculateArea(any())
+                attachmentService.getMetadataList(applicationEntity.id)
                 alluClient.create(any())
                 disclosureLogService.saveDisclosureLogsForAllu(
                     3,
@@ -274,6 +278,7 @@ class HakemusServiceTest {
             every { geometriatDao.isInsideHankeAlueet(any(), any()) } returns true
             every { geometriatDao.calculateCombinedArea(any()) } returns 11.0f
             every { geometriatDao.calculateArea(any()) } returns 11.0f
+            every { attachmentService.getMetadataList(applicationEntity.id) } returns listOf()
             every { alluClient.create(any()) } throws AlluLoginException(RuntimeException())
 
             assertThrows<AlluLoginException> { hakemusService.sendHakemus(3, USERNAME) }
@@ -283,6 +288,7 @@ class HakemusServiceTest {
                 geometriatDao.isInsideHankeAlueet(any(), any())
                 geometriatDao.calculateCombinedArea(any())
                 geometriatDao.calculateArea(any())
+                attachmentService.getMetadataList(applicationEntity.id)
                 alluClient.create(any())
             }
             verify { disclosureLogService wasNot called }
@@ -304,6 +310,7 @@ class HakemusServiceTest {
             every { geometriatDao.isInsideHankeAlueet(1, any()) } returns true
             every { geometriatDao.calculateCombinedArea(any()) } returns 11.0f
             every { geometriatDao.calculateArea(any()) } returns 11.0f
+            every { attachmentService.getMetadataList(applicationEntity.id) } returns listOf()
             val applicationCapturingSlot = slot<AlluCableReportApplicationData>()
             every { alluClient.create(capture(applicationCapturingSlot)) } returns alluId
             justRun { alluClient.addAttachment(alluId, any()) }
@@ -322,6 +329,7 @@ class HakemusServiceTest {
                 geometriatDao.isInsideHankeAlueet(1, any())
                 geometriatDao.calculateCombinedArea(any())
                 geometriatDao.calculateArea(any())
+                attachmentService.getMetadataList(applicationEntity.id)
                 alluClient.create(any())
                 disclosureLogService.saveDisclosureLogsForAllu(3, any(), Status.SUCCESS)
                 alluClient.addAttachment(alluId, any())


### PR DESCRIPTION
# Description

Add attachment names to the application-form-data.pdf that's sent to Allu alongside the application.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2535

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
Add attachments to a johtoselvityshakemus and send it to Allu. Check Allu that the form data PDF has the attachment names in it.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: