### PR TITLE
HAI-2463 Add indexes to haitat

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeControllerITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeControllerITests.kt
@@ -508,9 +508,9 @@ class HankeControllerITests(@Autowired override val mockMvc: MockMvc) : Controll
             alue.kaistaHaitta =
                 VaikutusAutoliikenteenKaistamaariin.VAHENTAA_KAISTAN_YHDELLA_AJOSUUNNALLA
             alue.kaistaPituusHaitta = AutoliikenteenKaistavaikutustenPituus.PITUUS_100_499_METRIA
-            alue.meluHaitta = Meluhaitta.SATUNNAINEN_HAITTA
-            alue.polyHaitta = Polyhaitta.LYHYTAIKAINEN_TOISTUVA_HAITTA
-            alue.tarinaHaitta = Tarinahaitta.PITKAKESTOINEN_TOISTUVA_HAITTA
+            alue.meluHaitta = Meluhaitta.SATUNNAINEN_MELUHAITTA
+            alue.polyHaitta = Polyhaitta.TOISTUVA_POLYHAITTA
+            alue.tarinaHaitta = Tarinahaitta.JATKUVA_TARINAHAITTA
             hankeToBeUpdated.alueet.add(alue)
             // Prepare the expected result/return
             // Note, "pvm" values should have become truncated to begin of the day

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
@@ -1047,9 +1047,9 @@ class HankeServiceITests(
                     VaikutusAutoliikenteenKaistamaariin
                         .VAHENTAA_SAMANAIKAISESTI_KAISTAN_KAHDELLA_AJOSUUNNALLA,
                 kaistaPituusHaitta = AutoliikenteenKaistavaikutustenPituus.PITUUS_10_99_METRIA,
-                meluHaitta = Meluhaitta.SATUNNAINEN_HAITTA,
-                polyHaitta = Polyhaitta.SATUNNAINEN_HAITTA,
-                tarinaHaitta = Tarinahaitta.SATUNNAINEN_HAITTA,
+                meluHaitta = Meluhaitta.SATUNNAINEN_MELUHAITTA,
+                polyHaitta = Polyhaitta.SATUNNAINEN_POLYHAITTA,
+                tarinaHaitta = Tarinahaitta.SATUNNAINEN_TARINAHAITTA,
             )
         val createdHanke =
             hankeFactory.builder(USERNAME).withHankealue().withHankealue(hankealue).save()
@@ -1067,9 +1067,9 @@ class HankeServiceITests(
             )
         assertThat(alue.kaistaPituusHaitta)
             .isEqualTo(AutoliikenteenKaistavaikutustenPituus.PITUUS_10_99_METRIA)
-        assertThat(alue.meluHaitta).isEqualTo(Meluhaitta.SATUNNAINEN_HAITTA)
-        assertThat(alue.polyHaitta).isEqualTo(Polyhaitta.SATUNNAINEN_HAITTA)
-        assertThat(alue.tarinaHaitta).isEqualTo(Tarinahaitta.SATUNNAINEN_HAITTA)
+        assertThat(alue.meluHaitta).isEqualTo(Meluhaitta.SATUNNAINEN_MELUHAITTA)
+        assertThat(alue.polyHaitta).isEqualTo(Polyhaitta.SATUNNAINEN_POLYHAITTA)
+        assertThat(alue.tarinaHaitta).isEqualTo(Tarinahaitta.SATUNNAINEN_TARINAHAITTA)
         assertThat(alue.geometriat).isNotNull()
     }
 
@@ -1336,9 +1336,9 @@ class HankeServiceITests(
                     VaikutusAutoliikenteenKaistamaariin
                         .VAHENTAA_SAMANAIKAISESTI_KAISTAN_KAHDELLA_AJOSUUNNALLA,
                 kaistaPituusHaitta = AutoliikenteenKaistavaikutustenPituus.PITUUS_10_99_METRIA,
-                meluHaitta = Meluhaitta.PITKAKESTOINEN_TOISTUVA_HAITTA,
-                polyHaitta = Polyhaitta.LYHYTAIKAINEN_TOISTUVA_HAITTA,
-                tarinaHaitta = Tarinahaitta.SATUNNAINEN_HAITTA,
+                meluHaitta = Meluhaitta.JATKUVA_MELUHAITTA,
+                polyHaitta = Polyhaitta.TOISTUVA_POLYHAITTA,
+                tarinaHaitta = Tarinahaitta.SATUNNAINEN_TARINAHAITTA,
             )
         createdHanke.alueet.add(hankealue)
         val request = createdHanke.toModifyRequest()
@@ -1358,9 +1358,9 @@ class HankeServiceITests(
             )
         assertThat(alue.kaistaPituusHaitta)
             .isEqualTo(AutoliikenteenKaistavaikutustenPituus.PITUUS_10_99_METRIA)
-        assertThat(alue.meluHaitta).isEqualTo(Meluhaitta.PITKAKESTOINEN_TOISTUVA_HAITTA)
-        assertThat(alue.polyHaitta).isEqualTo(Polyhaitta.LYHYTAIKAINEN_TOISTUVA_HAITTA)
-        assertThat(alue.tarinaHaitta).isEqualTo(Tarinahaitta.SATUNNAINEN_HAITTA)
+        assertThat(alue.meluHaitta).isEqualTo(Meluhaitta.JATKUVA_MELUHAITTA)
+        assertThat(alue.polyHaitta).isEqualTo(Polyhaitta.TOISTUVA_POLYHAITTA)
+        assertThat(alue.tarinaHaitta).isEqualTo(Tarinahaitta.SATUNNAINEN_TARINAHAITTA)
         assertThat(alue.geometriat).isNotNull()
     }
 
@@ -1408,9 +1408,9 @@ class HankeServiceITests(
                     VaikutusAutoliikenteenKaistamaariin
                         .VAHENTAA_SAMANAIKAISESTI_KAISTAN_KAHDELLA_AJOSUUNNALLA,
                 kaistaPituusHaitta = AutoliikenteenKaistavaikutustenPituus.PITUUS_10_99_METRIA,
-                meluHaitta = Meluhaitta.SATUNNAINEN_HAITTA,
-                polyHaitta = Polyhaitta.LYHYTAIKAINEN_TOISTUVA_HAITTA,
-                tarinaHaitta = Tarinahaitta.PITKAKESTOINEN_TOISTUVA_HAITTA,
+                meluHaitta = Meluhaitta.SATUNNAINEN_MELUHAITTA,
+                polyHaitta = Polyhaitta.TOISTUVA_POLYHAITTA,
+                tarinaHaitta = Tarinahaitta.JATKUVA_TARINAHAITTA,
             )
         val hanke = hankeFactory.builder(USERNAME).withHankealue().withHankealue(hankealue).save()
         assertThat(hanke.alueet).hasSize(2)
@@ -1431,10 +1431,9 @@ class HankeServiceITests(
                 )
             prop(SavedHankealue::kaistaPituusHaitta)
                 .isEqualTo(AutoliikenteenKaistavaikutustenPituus.PITUUS_10_99_METRIA)
-            prop(SavedHankealue::meluHaitta).isEqualTo(Meluhaitta.SATUNNAINEN_HAITTA)
-            prop(SavedHankealue::polyHaitta).isEqualTo(Polyhaitta.LYHYTAIKAINEN_TOISTUVA_HAITTA)
-            prop(SavedHankealue::tarinaHaitta)
-                .isEqualTo(Tarinahaitta.PITKAKESTOINEN_TOISTUVA_HAITTA)
+            prop(SavedHankealue::meluHaitta).isEqualTo(Meluhaitta.SATUNNAINEN_MELUHAITTA)
+            prop(SavedHankealue::polyHaitta).isEqualTo(Polyhaitta.TOISTUVA_POLYHAITTA)
+            prop(SavedHankealue::tarinaHaitta).isEqualTo(Tarinahaitta.JATKUVA_TARINAHAITTA)
             prop(SavedHankealue::geometriat).isNotNull()
         }
         val hankeFromDb = hankeService.loadHanke(hanke.hankeTunnus)

--- a/services/hanke-service/src/integrationTest/resources/fi/hel/haitaton/hanke/logging/expectedHankeWithPolygon.json.mustache
+++ b/services/hanke-service/src/integrationTest/resources/fi/hel/haitaton/hanke/logging/expectedHankeWithPolygon.json.mustache
@@ -88,9 +88,9 @@
       },
       "kaistaHaitta": "VAHENTAA_KAISTAN_YHDELLA_AJOSUUNNALLA",
       "kaistaPituusHaitta": "PITUUS_100_499_METRIA",
-      "meluHaitta": "SATUNNAINEN_HAITTA",
-      "polyHaitta": "LYHYTAIKAINEN_TOISTUVA_HAITTA",
-      "tarinaHaitta": "PITKAKESTOINEN_TOISTUVA_HAITTA",
+      "meluHaitta": "SATUNNAINEN_MELUHAITTA",
+      "polyHaitta": "TOISTUVA_POLYHAITTA",
+      "tarinaHaitta": "JATKUVA_TARINAHAITTA",
       "nimi": {{#alueNimi}}"{{alueNimi}}"{{/alueNimi}}{{^alueNimi}}null{{/alueNimi}}
     }
 {{/alueId}}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankealueEntity.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankealueEntity.kt
@@ -7,6 +7,8 @@ import fi.hel.haitaton.hanke.tormaystarkastelu.Polyhaitta
 import fi.hel.haitaton.hanke.tormaystarkastelu.Tarinahaitta
 import fi.hel.haitaton.hanke.tormaystarkastelu.VaikutusAutoliikenteenKaistamaariin
 import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
 import jakarta.persistence.FetchType
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
@@ -29,11 +31,12 @@ class HankealueEntity(
     var geometriat: Int? = null,
     var haittaAlkuPvm: LocalDate? = null,
     var haittaLoppuPvm: LocalDate? = null,
-    var kaistaHaitta: VaikutusAutoliikenteenKaistamaariin? = null,
+    @Enumerated(EnumType.STRING) var kaistaHaitta: VaikutusAutoliikenteenKaistamaariin? = null,
+    @Enumerated(EnumType.STRING)
     var kaistaPituusHaitta: AutoliikenteenKaistavaikutustenPituus? = null,
-    var meluHaitta: Meluhaitta? = null,
-    var polyHaitta: Polyhaitta? = null,
-    var tarinaHaitta: Tarinahaitta? = null,
+    @Enumerated(EnumType.STRING) var meluHaitta: Meluhaitta? = null,
+    @Enumerated(EnumType.STRING) var polyHaitta: Polyhaitta? = null,
+    @Enumerated(EnumType.STRING) var tarinaHaitta: Tarinahaitta? = null,
     var nimi: String
 ) : HasId<Int> {
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluLuokittelu.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluLuokittelu.kt
@@ -31,24 +31,27 @@ enum class AutoliikenteenKaistavaikutustenPituus(override val value: Int) : Luok
 }
 
 /** NOTE Järjestys täytyy olla pienimmästä suurimpaan */
-enum class Meluhaitta {
-    SATUNNAINEN_HAITTA,
-    LYHYTAIKAINEN_TOISTUVA_HAITTA,
-    PITKAKESTOINEN_TOISTUVA_HAITTA
+enum class Meluhaitta(override val value: Int) : Luokittelu {
+    EI_MELUHAITTAA(0),
+    SATUNNAINEN_MELUHAITTA(1),
+    TOISTUVA_MELUHAITTA(3),
+    JATKUVA_MELUHAITTA(5),
 }
 
 /** NOTE Järjestys täytyy olla pienimmästä suurimpaan */
-enum class Polyhaitta {
-    SATUNNAINEN_HAITTA,
-    LYHYTAIKAINEN_TOISTUVA_HAITTA,
-    PITKAKESTOINEN_TOISTUVA_HAITTA
+enum class Polyhaitta(override val value: Int) : Luokittelu {
+    EI_POLYHAITTAA(0),
+    SATUNNAINEN_POLYHAITTA(1),
+    TOISTUVA_POLYHAITTA(3),
+    JATKUVA_POLYHAITTA(5),
 }
 
 /** NOTE Järjestys täytyy olla pienimmästä suurimpaan */
-enum class Tarinahaitta {
-    SATUNNAINEN_HAITTA,
-    LYHYTAIKAINEN_TOISTUVA_HAITTA,
-    PITKAKESTOINEN_TOISTUVA_HAITTA
+enum class Tarinahaitta(override val value: Int) : Luokittelu {
+    EI_TARINAHAITTAA(0),
+    SATUNNAINEN_TARINAHAITTA(1),
+    TOISTUVA_TARINAHAITTA(3),
+    JATKUVA_TARINAHAITTA(5),
 }
 
 enum class HaittaAjanKestoLuokittelu(override val value: Int) : Luokittelu {

--- a/services/hanke-service/src/main/resources/db/changelog/changesets/073-change-haitat-to-enum-names.sql
+++ b/services/hanke-service/src/main/resources/db/changelog/changesets/073-change-haitat-to-enum-names.sql
@@ -1,0 +1,64 @@
+--liquibase formatted sql
+--changeset Topias Heinonen:073-change-haitat-to-enum-names
+--comment: Change the haitat in hankealue to use enum names instead of order numbers.
+
+ALTER TABLE hankealue
+    ADD COLUMN meluhaitta_temp         VARCHAR,
+    ADD COLUMN polyhaitta_temp         VARCHAR,
+    ADD COLUMN tarinahaitta_temp       VARCHAR,
+    ADD COLUMN kaistahaitta_temp       VARCHAR,
+    ADD COLUMN kaistapituushaitta_temp VARCHAR
+;
+
+UPDATE hankealue
+SET meluhaitta_temp         = CASE
+                                  WHEN meluhaitta = 0 THEN 'SATUNNAINEN_MELUHAITTA'
+                                  WHEN meluhaitta = 1 THEN 'TOISTUVA_MELUHAITTA'
+                                  WHEN meluhaitta = 2 THEN 'JATKUVA_MELUHAITTA'
+    END,
+    polyhaitta_temp         = CASE
+                                  WHEN polyhaitta = 0 THEN 'SATUNNAINEN_POLYHAITTA'
+                                  WHEN polyhaitta = 1 THEN 'TOISTUVA_POLYHAITTA'
+                                  WHEN polyhaitta = 2 THEN 'JATKUVA_POLYHAITTA'
+        END,
+    tarinahaitta_temp       = CASE
+                                  WHEN tarinahaitta = 0 THEN 'SATUNNAINEN_TARINAHAITTA'
+                                  WHEN tarinahaitta = 1 THEN 'TOISTUVA_TARINAHAITTA'
+                                  WHEN tarinahaitta = 2 THEN 'JATKUVA_TARINAHAITTA'
+        END,
+    kaistahaitta_temp       = CASE
+                                  WHEN kaistahaitta = 0 THEN 'EI_VAIKUTA'
+                                  WHEN kaistahaitta = 1 THEN 'VAHENTAA_KAISTAN_YHDELLA_AJOSUUNNALLA'
+                                  WHEN kaistahaitta = 2 THEN 'VAHENTAA_SAMANAIKAISESTI_KAISTAN_KAHDELLA_AJOSUUNNALLA'
+                                  WHEN kaistahaitta = 3
+                                      THEN 'VAHENTAA_SAMANAIKAISESTI_USEITA_KAISTOJA_KAHDELLA_AJOSUUNNALLA'
+                                  WHEN kaistahaitta = 4
+                                      THEN 'VAHENTAA_SAMANAIKAISESTI_USEITA_KAISTOJA_LIITTYMIEN_ERI_SUUNNILLA'
+        END,
+    kaistapituushaitta_temp = CASE
+                                  WHEN kaistapituushaitta = 0 THEN 'EI_VAIKUTA_KAISTAJARJESTELYIHIN'
+                                  WHEN kaistapituushaitta = 1 THEN 'PITUUS_ALLE_10_METRIA'
+                                  WHEN kaistapituushaitta = 2 THEN 'PITUUS_10_99_METRIA'
+                                  WHEN kaistapituushaitta = 3 THEN 'PITUUS_100_499_METRIA'
+                                  WHEN kaistapituushaitta = 4 THEN 'PITUUS_500_METRIA_TAI_ENEMMAN'
+        END
+;
+
+ALTER TABLE hankealue
+    DROP COLUMN meluhaitta,
+    DROP COLUMN polyhaitta,
+    DROP COLUMN tarinahaitta,
+    DROP COLUMN kaistahaitta,
+    DROP COLUMN kaistapituushaitta
+;
+
+ALTER TABLE hankealue
+    RENAME COLUMN meluhaitta_temp TO meluhaitta;
+ALTER TABLE hankealue
+    RENAME COLUMN polyhaitta_temp TO polyhaitta;
+ALTER TABLE hankealue
+    RENAME COLUMN tarinahaitta_temp TO tarinahaitta;
+ALTER TABLE hankealue
+    RENAME COLUMN kaistahaitta_temp TO kaistahaitta;
+ALTER TABLE hankealue
+    RENAME COLUMN kaistapituushaitta_temp TO kaistapituushaitta;

--- a/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -173,3 +173,5 @@ databaseChangeLog:
       file: db/changelog/changesets/071-grant-delete-user-permission-to-kayttooikeustasot.sql
   - include:
       file: db/changelog/changesets/072-add-on-delete-cascade-to-hakemus-yhteystieto-and-yhteyshenkilo.sql
+  - include:
+      file: db/changelog/changesets/073-change-haitat-to-enum-names.sql

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/domain/HankeTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/domain/HankeTest.kt
@@ -53,9 +53,9 @@ internal class HankeTest {
                     VaikutusAutoliikenteenKaistamaariin
                         .VAHENTAA_SAMANAIKAISESTI_KAISTAN_KAHDELLA_AJOSUUNNALLA,
                 kaistaPituusHaitta = AutoliikenteenKaistavaikutustenPituus.PITUUS_10_99_METRIA,
-                meluHaitta = Meluhaitta.PITKAKESTOINEN_TOISTUVA_HAITTA,
-                polyHaitta = Polyhaitta.PITKAKESTOINEN_TOISTUVA_HAITTA,
-                tarinaHaitta = Tarinahaitta.PITKAKESTOINEN_TOISTUVA_HAITTA,
+                meluHaitta = Meluhaitta.JATKUVA_MELUHAITTA,
+                polyHaitta = Polyhaitta.JATKUVA_POLYHAITTA,
+                tarinaHaitta = Tarinahaitta.JATKUVA_TARINAHAITTA,
             )
         hanke.alueet.add(hankealue)
 

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/ApplicationFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/ApplicationFactory.kt
@@ -171,9 +171,9 @@ class ApplicationFactory(
             tyoalueet: List<Tyoalue> = listOf(createTyoalue()),
             katuosoite: String = "Katu 1",
             tyonTarkoitukset: Set<TyomaaTyyppi> = setOf(TyomaaTyyppi.VESI),
-            meluhaitta: Meluhaitta = Meluhaitta.PITKAKESTOINEN_TOISTUVA_HAITTA,
-            polyhaitta: Polyhaitta = Polyhaitta.LYHYTAIKAINEN_TOISTUVA_HAITTA,
-            tarinahaitta: Tarinahaitta = Tarinahaitta.SATUNNAINEN_HAITTA,
+            meluhaitta: Meluhaitta = Meluhaitta.JATKUVA_MELUHAITTA,
+            polyhaitta: Polyhaitta = Polyhaitta.TOISTUVA_POLYHAITTA,
+            tarinahaitta: Tarinahaitta = Tarinahaitta.SATUNNAINEN_TARINAHAITTA,
             kaistahaitta: VaikutusAutoliikenteenKaistamaariin =
                 VaikutusAutoliikenteenKaistamaariin.VAHENTAA_KAISTAN_YHDELLA_AJOSUUNNALLA,
             kaistahaittojenPituus: AutoliikenteenKaistavaikutustenPituus =

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankealueFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankealueFactory.kt
@@ -24,9 +24,9 @@ object HankealueFactory {
             VaikutusAutoliikenteenKaistamaariin.VAHENTAA_KAISTAN_YHDELLA_AJOSUUNNALLA,
         kaistaPituusHaitta: AutoliikenteenKaistavaikutustenPituus? =
             AutoliikenteenKaistavaikutustenPituus.PITUUS_100_499_METRIA,
-        meluHaitta: Meluhaitta? = Meluhaitta.SATUNNAINEN_HAITTA,
-        polyHaitta: Polyhaitta? = Polyhaitta.LYHYTAIKAINEN_TOISTUVA_HAITTA,
-        tarinaHaitta: Tarinahaitta? = Tarinahaitta.PITKAKESTOINEN_TOISTUVA_HAITTA,
+        meluHaitta: Meluhaitta? = Meluhaitta.SATUNNAINEN_MELUHAITTA,
+        polyHaitta: Polyhaitta? = Polyhaitta.TOISTUVA_POLYHAITTA,
+        tarinaHaitta: Tarinahaitta? = Tarinahaitta.JATKUVA_TARINAHAITTA,
         nimi: String = "$HANKEALUE_DEFAULT_NAME 1",
     ): SavedHankealue {
         return SavedHankealue(


### PR DESCRIPTION
# Description

- Save all haitat as enum names instead of index numbers. This is kinder for maintenance and allows adding new values without shuffling the values around.
- Migrate the existing database rows to use the columns.
- Give the melu, pöly and tärinä -haitat index values, which might be needed later.
- Rename the melu/pöly/tärinä values to match the current UI design.
- Add a value for "Ei haittaa" for each of melu, pöly and tärinä with an index value of 0.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2463

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
UI will be broken until a matching change has been made.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 