### PR TITLE
HAI-2542 Tighten the user deletion check

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankekayttajaDeleteServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankekayttajaDeleteServiceITest.kt
@@ -260,6 +260,23 @@ class HankekayttajaDeleteServiceITest(
         }
 
         @Test
+        fun `throws an exception if the user is the only identified user with Kaikki Oikeudet privileges`() {
+            val hanke = hankeFactory.builder().save()
+            val founder = hankeKayttajaService.getKayttajaByUserId(hanke.id, USERNAME)!!
+            hankeKayttajaFactory.saveUnidentifiedUser(
+                hanke.id,
+                kayttooikeustaso = Kayttooikeustaso.KAIKKI_OIKEUDET
+            )
+
+            val failure = assertFailure { deleteService.delete(founder.id, USERNAME) }
+
+            failure.all {
+                hasClass(NoAdminRemainingException::class)
+                messageContains(hanke.hankeTunnus)
+            }
+        }
+
+        @Test
         fun `throws an exception if the user is the only yhteyshenkilo for an omistaja`() {
             val hanke = hankeFactory.builder().saveEntity()
             val founder = hankeKayttajaService.getKayttajaByUserId(hanke.id, USERNAME)!!

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankekayttajaDeleteService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankekayttajaDeleteService.kt
@@ -97,10 +97,10 @@ class HankekayttajaDeleteService(
     }
 
     private fun isTheOnlyKaikkiOikeudetKayttaja(kayttaja: HankekayttajaEntity): Boolean {
-        if (kayttaja.deriveKayttooikeustaso() != Kayttooikeustaso.KAIKKI_OIKEUDET) return false
+        if (kayttaja.permission?.kayttooikeustaso != Kayttooikeustaso.KAIKKI_OIKEUDET) return false
         val adminCount =
-            hankekayttajaRepository.findByHankeId(kayttaja.hankeId).count {
-                it.deriveKayttooikeustaso() == Kayttooikeustaso.KAIKKI_OIKEUDET
+            permissionRepository.findAllByHankeId(kayttaja.hankeId).count {
+                it.kayttooikeustaso == Kayttooikeustaso.KAIKKI_OIKEUDET
             }
         return adminCount == 1
     }


### PR DESCRIPTION
# Description

Only allow the user to be deleted if no other identified users have KAIKKI_OIKEUDET permissions. So far, the check has included unidentified users.

The check is tightened to make it less likely the hanke gets stuck without anyone who can manage it.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2542

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [X] Other

# Instructions for testing
1. Create a johtoselvityshakemus (or a hanke in dev).
2. Add a contact person.
3. Give them KAIKKI_OIKEUDET.
4. Try to remove yourself from the project.
5. The backend should refuse.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 