### PR TITLE
HAI-2345 Only allow PDFs for attachments other than MUU

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentServiceITest.kt
@@ -217,7 +217,6 @@ class ApplicationAttachmentServiceITest(
             }
 
             val content = fileClient.download(HAKEMUS_LIITTEET, attachments.first().blobLocation)
-
             assertThat(content)
                 .isNotNull()
                 .prop(DownloadResponse::content)
@@ -340,6 +339,28 @@ class ApplicationAttachmentServiceITest(
             failure.all {
                 hasClass(AttachmentInvalidException::class)
                 hasMessage("Attachment upload exception: File 'hello.html' not supported")
+            }
+            assertThat(attachmentRepository.findAll()).isEmpty()
+        }
+
+        @Test
+        fun `Throws exception when file type is not supported for attachment type`() {
+            val application = applicationFactory.saveApplicationEntity(USERNAME)
+            val invalidFilename = "hello.jpeg"
+
+            val failure = assertFailure {
+                attachmentService.addAttachment(
+                    applicationId = application.id,
+                    attachmentType = VALTAKIRJA,
+                    attachment = testFile(fileName = invalidFilename)
+                )
+            }
+
+            failure.all {
+                hasClass(AttachmentInvalidException::class)
+                messageContains("File extension is not valid for attachment type")
+                messageContains("filename=$invalidFilename")
+                messageContains("attachmentType=$VALTAKIRJA")
             }
             assertThat(attachmentRepository.findAll()).isEmpty()
         }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentController.kt
@@ -14,6 +14,7 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import java.util.UUID
 import mu.KotlinLogging
 import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.DeleteMapping
@@ -85,7 +86,7 @@ class ApplicationAttachmentController(
             .body(content.bytes)
     }
 
-    @PostMapping
+    @PostMapping(consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
     @Operation(
         summary = "Upload attachment for application",
         description =

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentService.kt
@@ -57,6 +57,7 @@ class ApplicationAttachmentService(
                 "content type = ${attachment.contentType}"
         }
         val filename = AttachmentValidator.validFilename(attachment.originalFilename)
+        AttachmentValidator.validateExtensionForType(filename, attachmentType)
         val application = findApplication(applicationId)
 
         if (isInAllu(application)) {

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/common/AttachmentValidator.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/common/AttachmentValidator.kt
@@ -9,9 +9,11 @@ import org.springframework.web.multipart.MultipartFile
 
 private val logger = KotlinLogging.logger {}
 
+private const val pdfExtension = "pdf"
+
 private val supportedFiletypes =
     setOf(
-        "pdf",
+        pdfExtension,
         "jpg",
         "jpeg",
         "png",
@@ -84,6 +86,17 @@ object AttachmentValidator {
             throw AttachmentInvalidException("Invalid content type, $type")
         }
 
+    fun validateExtensionForType(
+        sanitizedFilename: String,
+        attachmentType: ApplicationAttachmentType
+    ) {
+        if (!isValidExtensionForType(sanitizedFilename, attachmentType)) {
+            throw AttachmentInvalidException(
+                "File extension is not valid for attachment type. filename=$sanitizedFilename, attachmentType=$attachmentType"
+            )
+        }
+    }
+
     private fun sanitizeFilename(filename: String?): String? =
         filename?.replace(INVALID_CHARS_PATTERN, "_")
 
@@ -106,7 +119,19 @@ object AttachmentValidator {
     }
 
     private fun supportedType(filename: String): Boolean {
-        val extension = getExtension(filename)
-        return supportedFiletypes.contains(extension.lowercase())
+        val extension = getExtension(filename).lowercase()
+        return supportedFiletypes.contains(extension)
+    }
+
+    private fun isValidExtensionForType(
+        filename: String,
+        attachmentType: ApplicationAttachmentType
+    ): Boolean {
+        val extension = getExtension(filename).lowercase()
+        return when (attachmentType) {
+            ApplicationAttachmentType.MUU -> supportedFiletypes.contains(extension)
+            ApplicationAttachmentType.VALTAKIRJA,
+            ApplicationAttachmentType.LIIKENNEJARJESTELY -> extension == pdfExtension
+        }
     }
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentController.kt
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import java.util.UUID
 import mu.KotlinLogging
+import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.DeleteMapping
@@ -76,7 +77,7 @@ class HankeAttachmentController(
             .body(content.bytes)
     }
 
-    @PostMapping
+    @PostMapping(consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
     @Operation(summary = "Upload an attachment for Hanke")
     @ApiResponses(
         value =

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/attachment/AttachmentValidatorTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/attachment/AttachmentValidatorTest.kt
@@ -6,13 +6,19 @@ import assertk.assertThat
 import assertk.assertions.hasClass
 import assertk.assertions.hasMessage
 import assertk.assertions.isEqualTo
+import assertk.assertions.messageContains
+import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType
 import fi.hel.haitaton.hanke.attachment.common.AttachmentInvalidException
 import fi.hel.haitaton.hanke.attachment.common.AttachmentValidator
 import fi.hel.haitaton.hanke.attachment.common.validNameAndType
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.CsvSource
+import org.junit.jupiter.params.provider.EnumSource
+import org.junit.jupiter.params.provider.MethodSource
 import org.junit.jupiter.params.provider.ValueSource
 import org.springframework.http.MediaType
 import org.springframework.mock.web.MockMultipartFile
@@ -113,6 +119,49 @@ class AttachmentValidatorTest {
                     hasClass(AttachmentInvalidException::class)
                     hasMessage("Attachment upload exception: File '$filename' not supported")
                 }
+        }
+    }
+
+    @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    inner class ValidateExtensionForType {
+        @ParameterizedTest
+        @EnumSource(ApplicationAttachmentType::class)
+        fun `accepts 'pdf' extension for all types`(attachmentType: ApplicationAttachmentType) {
+            AttachmentValidator.validateExtensionForType("file.pdf", attachmentType)
+        }
+
+        @ParameterizedTest
+        @MethodSource("failingExtensions")
+        fun `throws exception when type is other than MUU and extension is not 'pdf'`(
+            attachmentType: ApplicationAttachmentType,
+            extension: String,
+        ) {
+            assertFailure {
+                    AttachmentValidator.validateExtensionForType("file.$extension", attachmentType)
+                }
+                .all {
+                    hasClass(AttachmentInvalidException::class)
+                    messageContains("filename=file.$extension")
+                    messageContains("attachmentType=$attachmentType")
+                }
+        }
+
+        private fun failingExtensions(): List<Arguments> {
+            val extensions = listOf("jpg", "jpeg", "png", "dgn", "dwg", "docx", "txt", "gt")
+
+            return ApplicationAttachmentType.entries
+                .filterNot { it == ApplicationAttachmentType.MUU }
+                .flatMap { type -> extensions.map { Arguments.of(type, it) } }
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = ["jpg", "jpeg", "png", "dgn", "dwg", "docx", "txt", "gt"])
+        fun `accepts other extensions for MUU type attachments`(extension: String) {
+            AttachmentValidator.validateExtensionForType(
+                "file.$extension",
+                ApplicationAttachmentType.MUU
+            )
         }
     }
 


### PR DESCRIPTION
# Description

Only accept PDF attachments for `LIIKENNEJARJESTELY` and `VALTAKIRJA` type attachments. Traffic arrangements need to be PDFs since they are attached to the decision in Allu. The valtakirja needs to be a PDF since it needs to be signed.

Change the consumes parameters for the attachment controllers. This enables attachment uploading in SwaggerUI.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2345

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
http://localhost:3001/api/swagger-ui/index.html#/application-attachment-controller/postAttachment_1

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 