### PR TITLE
HAI-2346 Disallow getting valtakirja content

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentControllerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentControllerITest.kt
@@ -6,6 +6,7 @@ import assertk.assertions.endsWith
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNotNull
 import fi.hel.haitaton.hanke.ControllerTest
+import fi.hel.haitaton.hanke.HankeError
 import fi.hel.haitaton.hanke.HankeError.HAI0001
 import fi.hel.haitaton.hanke.IntegrationTestConfiguration
 import fi.hel.haitaton.hanke.andReturnBody
@@ -21,8 +22,10 @@ import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentMetadataDto
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType.MUU
 import fi.hel.haitaton.hanke.attachment.common.AttachmentContent
+import fi.hel.haitaton.hanke.attachment.common.ValtakirjaForbiddenException
 import fi.hel.haitaton.hanke.attachment.testFile
 import fi.hel.haitaton.hanke.factory.ApplicationAttachmentFactory
+import fi.hel.haitaton.hanke.hankeError
 import fi.hel.haitaton.hanke.permissions.PermissionCode.EDIT_APPLICATIONS
 import fi.hel.haitaton.hanke.permissions.PermissionCode.VIEW
 import fi.hel.haitaton.hanke.test.USERNAME
@@ -154,6 +157,25 @@ class ApplicationAttachmentControllerITest(@Autowired override val mockMvc: Mock
         @WithAnonymousUser
         fun `unauthorized should return error`() {
             getAttachmentContent(resultType = APPLICATION_JSON).andExpectError(HAI0001)
+        }
+
+        @Test
+        fun `returns 403 when asking for valtakirja`() {
+            val attachmentId = UUID.fromString("afc778b1-eb7c-4bad-951c-de70e173a757")
+            every {
+                authorizer.authorizeAttachment(APPLICATION_ID, attachmentId, VIEW.name)
+            } returns true
+            every { applicationAttachmentService.getContent(attachmentId) } throws
+                ValtakirjaForbiddenException(attachmentId)
+
+            get("/hakemukset/$APPLICATION_ID/liitteet/$attachmentId/content")
+                .andExpect(status().isForbidden)
+                .andExpect(hankeError(HankeError.HAI3004))
+
+            verifySequence {
+                authorizer.authorizeAttachment(APPLICATION_ID, attachmentId, VIEW.name)
+                applicationAttachmentService.getContent(attachmentId)
+            }
         }
     }
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeError.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeError.kt
@@ -46,6 +46,7 @@ enum class HankeError(val errorMessage: String) {
     HAI3001("Attachment upload failed"),
     HAI3002("Loading attachment failed"),
     HAI3003("Attachment limit reached"),
+    HAI3004("Valtakirja download forbidden"),
     HAI4001("HankeKayttaja not found"),
     HAI4002("Trying to change own permission"),
     HAI4003("Permission data conflict"),

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentController.kt
@@ -4,6 +4,7 @@ import fi.hel.haitaton.hanke.HankeError
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentMetadataDto
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType
 import fi.hel.haitaton.hanke.attachment.common.HeadersBuilder.buildHeaders
+import fi.hel.haitaton.hanke.attachment.common.ValtakirjaForbiddenException
 import io.swagger.v3.oas.annotations.Hidden
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
@@ -160,5 +161,13 @@ class ApplicationAttachmentController(
     fun alluDataError(ex: ApplicationInAlluException): HankeError {
         logger.warn(ex) { ex.message }
         return HankeError.HAI2009
+    }
+
+    @ExceptionHandler(ValtakirjaForbiddenException::class)
+    @ResponseStatus(HttpStatus.FORBIDDEN)
+    @Hidden
+    fun valtakirjaForbiddenException(ex: ValtakirjaForbiddenException): HankeError {
+        logger.warn(ex) { ex.message }
+        return HankeError.HAI3004
     }
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentService.kt
@@ -12,6 +12,7 @@ import fi.hel.haitaton.hanke.attachment.common.AttachmentInvalidException
 import fi.hel.haitaton.hanke.attachment.common.AttachmentValidator
 import fi.hel.haitaton.hanke.attachment.common.FileScanClient
 import fi.hel.haitaton.hanke.attachment.common.FileScanInput
+import fi.hel.haitaton.hanke.attachment.common.ValtakirjaForbiddenException
 import fi.hel.haitaton.hanke.attachment.common.hasInfected
 import fi.hel.haitaton.hanke.hakemus.HakemusIdentifier
 import java.util.UUID
@@ -37,6 +38,11 @@ class ApplicationAttachmentService(
 
     fun getContent(attachmentId: UUID): AttachmentContent {
         val attachment = metadataService.findAttachment(attachmentId)
+
+        if (attachment.attachmentType == ApplicationAttachmentType.VALTAKIRJA) {
+            throw ValtakirjaForbiddenException(attachmentId)
+        }
+
         val content = attachmentContentService.find(attachment)
 
         return AttachmentContent(attachment.fileName, attachment.contentType, content)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/common/Exceptions.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/common/Exceptions.kt
@@ -9,3 +9,6 @@ class AttachmentInvalidException(str: String) :
     RuntimeException("Attachment upload exception: $str")
 
 class AttachmentNotFoundException(id: UUID?) : RuntimeException("Attachment not found, id=$id")
+
+class ValtakirjaForbiddenException(id: UUID) :
+    RuntimeException("Valtakirja download forbidden, id=$id")


### PR DESCRIPTION
# Description

Disallow requests for attachment content when the attachment is of the `VALTAKIRJA` type. Return 403 Forbidden when such a request is made. This is done because of privacy reasons.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2346

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
Using [Swagger UI](http://localhost:3001/api/swagger-ui/index.html#/), add a valtakirja to hakemus and then try to download the content.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 