### PR TITLE
HAI-2553 Allow deleting the application even when deleting the content of the application attachments fails

### DIFF
--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentService.kt
@@ -120,8 +120,14 @@ class ApplicationAttachmentService(
     fun deleteAllAttachments(hakemus: HakemusIdentifier) {
         logger.info { "Deleting all attachments from application. ${hakemus.logString()}" }
         metadataService.deleteAllAttachments(hakemus)
-        attachmentContentService.deleteAllForApplication(hakemus)
-        logger.info { "Deleted all attachments from application. ${hakemus.logString()}" }
+        try {
+            attachmentContentService.deleteAllForApplication(hakemus)
+            logger.info { "Deleted all attachments from application. ${hakemus.logString()}" }
+        } catch (e: Exception) {
+            logger.error(e) {
+                "Failed to delete all attachment content for application. Continuing with application deletion regardless of error. ${hakemus.logString()}"
+            }
+        }
     }
 
     fun sendInitialAttachments(alluId: Int, applicationId: Long) {

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/attachment/common/MockFileClient.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/attachment/common/MockFileClient.kt
@@ -16,6 +16,9 @@ class MockFileClient : FileClient {
 
     private val subfolderRegex = Regex("/.*/")
 
+    /** Mock client can simulate being connected or disconnected. */
+    var connected = true
+
     fun recreateContainers() {
         Container.entries.forEach { fileMap[it] = mutableMapOf() }
     }
@@ -53,6 +56,7 @@ class MockFileClient : FileClient {
         fileMap[container]!!.remove(path) != null
 
     override fun deleteAllByPrefix(container: Container, prefix: String) {
+        if (!connected) throw IllegalStateException("Not connected")
         val files = fileMap[container]!!
         val paths = files.keys.filter { it.startsWith(prefix) }
         paths

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/attachment/common/MockFileClientExtension.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/attachment/common/MockFileClientExtension.kt
@@ -40,6 +40,7 @@ class MockFileClientExtension : BeforeEachCallback, BeforeAllCallback, AfterAllC
 
     override fun beforeEach(context: ExtensionContext?) {
         client.clearContainers()
+        client.connected = true
     }
 
     override fun beforeAll(context: ExtensionContext) {


### PR DESCRIPTION
# Description

When deleting application, all its attachments are also deleted. If for some reason Azure Blob Storage cannot be reached the deletion of attachment content fails but the application is already cancelled in Allu. This leads to an inconsistency between Haitaton and Allu. 

This PR proposes a fix that allows running the deletion process through even if the content cannot be deleted due to an error in accessing Azure Blob Storage. This leaves the attachment content undeleted in blob storage but the attachment metadata in database is deleted.

This PR does not try to fix the other problem concering the allowance of deleting applications in CANCELLED state. There will be other PR for that fix.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2553

## Type of change

- [x] Bug fix 
- [ ] New feature 
- [ ] Other

# Instructions for testing
Please describe tests how this change or new feature can be tested.

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 

# Other relevant info
Please describe here if there is e.g. some requirements for this change or
 other info that the tester/user needs to know.