### PR TITLE
HAI-2553 Allow deleting a cancelled application

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceITest.kt
@@ -2095,6 +2095,20 @@ class HakemusServiceITest(
             assertThat(hankekayttajaRepository.count())
                 .isEqualTo(5) // Hanke founder + one kayttaja for each role
         }
+
+        @Test
+        fun `deletes application when application is already cancelled`() {
+            val application =
+                hakemusFactory
+                    .builder()
+                    .withStatus(ApplicationStatus.CANCELLED, alluId)
+                    .saveEntity()
+            val hakemus = hakemusService.getById(application.id)
+
+            hakemusService.cancelAndDelete(hakemus, USERNAME)
+
+            assertThat(applicationRepository.findAll()).isEmpty()
+        }
     }
 
     @Nested

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentService.kt
@@ -120,8 +120,14 @@ class ApplicationAttachmentService(
     fun deleteAllAttachments(hakemus: HakemusIdentifier) {
         logger.info { "Deleting all attachments from application. ${hakemus.logString()}" }
         metadataService.deleteAllAttachments(hakemus)
-        attachmentContentService.deleteAllForApplication(hakemus)
-        logger.info { "Deleted all attachments from application. ${hakemus.logString()}" }
+        try {
+            attachmentContentService.deleteAllForApplication(hakemus)
+            logger.info { "Deleted all attachments from application. ${hakemus.logString()}" }
+        } catch (e: Exception) {
+            logger.error(e) {
+                "Failed to delete all attachment content for application. Continuing with application deletion regardless of error. ${hakemus.logString()}"
+            }
+        }
     }
 
     fun sendInitialAttachments(alluId: Int, applicationId: Long) {

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
@@ -896,6 +896,10 @@ class HakemusService(
             alluClient.cancel(alluId)
             alluClient.sendSystemComment(alluId, ALLU_USER_CANCELLATION_MSG)
             logger.info { "Hakemus canceled, proceeding to delete it. id=$id alluid=${alluId}" }
+        } else if (isCancelled(alluStatus)) {
+            logger.info {
+                "Hakemus is already cancelled, proceeding to delete it. id=$id alluid=${alluId}"
+            }
         } else {
             throw ApplicationAlreadyProcessingException(id, alluId)
         }
@@ -926,6 +930,9 @@ class HakemusService(
             else -> false
         }
     }
+
+    private fun isCancelled(alluStatus: ApplicationStatus?) =
+        alluStatus == ApplicationStatus.CANCELLED
 }
 
 class IncompatibleHakemusUpdateRequestException(

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/attachment/common/MockFileClient.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/attachment/common/MockFileClient.kt
@@ -16,6 +16,9 @@ class MockFileClient : FileClient {
 
     private val subfolderRegex = Regex("/.*/")
 
+    /** Mock client can simulate being connected or disconnected. */
+    var connected = true
+
     fun recreateContainers() {
         Container.entries.forEach { fileMap[it] = mutableMapOf() }
     }
@@ -53,6 +56,7 @@ class MockFileClient : FileClient {
         fileMap[container]!!.remove(path) != null
 
     override fun deleteAllByPrefix(container: Container, prefix: String) {
+        if (!connected) throw IllegalStateException("Not connected")
         val files = fileMap[container]!!
         val paths = files.keys.filter { it.startsWith(prefix) }
         paths

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/attachment/common/MockFileClientExtension.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/attachment/common/MockFileClientExtension.kt
@@ -40,6 +40,7 @@ class MockFileClientExtension : BeforeEachCallback, BeforeAllCallback, AfterAllC
 
     override fun beforeEach(context: ExtensionContext?) {
         client.clearContainers()
+        client.connected = true
     }
 
     override fun beforeAll(context: ExtensionContext) {


### PR DESCRIPTION
# Description

When an application is cancelled in Haitaton, it should be able to be deleted. Normally, when application gets cancelled it is automatically deleted but if there is an error in e.g. removing attachment content from Azure Blob Storage, the application might get cancelled (first the application is cancelled in Allu and from there the status will transfer back to Haitaton) but not deleted. This PR will fix this by allowing the deletion of cancelled application.

UI will need changes too in order to show the "Peru hakemus" button when application is already cancelled.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2553

## Type of change

- [x] Bug fix 
- [ ] New feature 
- [ ] Other

# Instructions for testing
This can be tested with [Swagger UI](http://localhost:3001/api/swagger-ui/index.html#/hakemus-controller/delete_1) after manually setting the proper status for an application:
```
update
    applications
set
    alluid=85,
    allustatus='CANCELLED',
    applicationidentifier='JS2400047'
where
    id=2
```

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 

# Other relevant info
Please describe here if there is e.g. some requirements for this change or
 other info that the tester/user needs to know.