### PR TITLE
HAI-2552 Exclude inviter from hakemus emails

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceITest.kt
@@ -914,6 +914,24 @@ class HakemusServiceITest(
             }
 
             @Test
+            fun `doesn't send email when the caller adds themself as contact`() {
+                val hanke = hankeFactory.builder(USERNAME).withHankealue().saveEntity()
+                val hakemus = hakemusFactory.builder(USERNAME, hanke).save()
+                val founder = hankeKayttajaFactory.getFounderFromHakemus(hakemus.id)
+                assertThat(founder.permission?.userId).isNotNull().isEqualTo(USERNAME)
+                val request =
+                    hakemus
+                        .toResponse()
+                        .toUpdateRequest()
+                        .withCustomer(CustomerType.COMPANY, null, founder.id)
+                        .withContractor(CustomerType.COMPANY, null, founder.id)
+
+                hakemusService.updateHakemus(hakemus.id, request, USERNAME)
+
+                assertThat(greenMail.receivedMessages).isEmpty()
+            }
+
+            @Test
             fun `updates project name when application name is changed`() {
                 val entity = hakemusFactory.builderWithGeneratedHanke().saveEntity()
                 val hakemus = hakemusService.hakemusResponse(entity.id)
@@ -1314,6 +1332,27 @@ class HakemusServiceITest(
                     .contains(
                         "laatimassa kaivuilmoitusta hankkeelle \"${hanke.nimi}\" (${hanke.hankeTunnus})"
                     )
+            }
+
+            @Test
+            fun `doesn't send email when the caller adds themself as contact`() {
+                val hanke = hankeFactory.builder(USERNAME).withHankealue().saveEntity()
+                val hakemus =
+                    hakemusFactory
+                        .builder(USERNAME, hanke, ApplicationType.EXCAVATION_NOTIFICATION)
+                        .save()
+                val founder = hankeKayttajaFactory.getFounderFromHakemus(hakemus.id)
+                assertThat(founder.permission?.userId).isNotNull().isEqualTo(USERNAME)
+                val request =
+                    hakemus
+                        .toResponse()
+                        .toUpdateRequest()
+                        .withCustomer(CustomerType.COMPANY, null, founder.id)
+                        .withContractor(CustomerType.COMPANY, null, founder.id)
+
+                hakemusService.updateHakemus(hakemus.id, request, USERNAME)
+
+                assertThat(greenMail.receivedMessages).isEmpty()
             }
 
             @Test


### PR DESCRIPTION
# Description

Don't send application notification emails when the recipient email would be the same as the inviter email. Effectively, this means that the user adding themselves as a new contact to an application won't receive an email about it.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2552

## Type of change

- [X] Bug fix 
- [ ] New feature 
- [ ] Other

# Instructions for testing
Add yourself as a contact on a new application. Check [smtp4dev](http://localhost:3003/) that there are no notifications sent.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 