### PR TITLE
HAI-2553 Allow deleting hanke with cancelled applications

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
@@ -1571,7 +1571,16 @@ class HankeServiceITests(
         }
 
         @Test
-        fun `when hakemus is not pending should throw`() {
+        fun `when hakemus is cancelled should delete hanke`() {
+            val hanke = initHankeWithHakemus(123, ApplicationStatus.CANCELLED)
+
+            hankeService.deleteHanke(hanke.hankeTunnus, USERNAME)
+
+            assertThat(hankeRepository.findByIdOrNull(hanke.id)).isNull()
+        }
+
+        @Test
+        fun `when hakemus is not pending or cancelled should throw`() {
             val hakemusAlluId = 123
             val hanke = initHankeWithHakemus(hakemusAlluId)
             every { cableReportService.getApplicationInformation(hakemusAlluId) } returns
@@ -1757,13 +1766,16 @@ class HankeServiceITests(
         }
     }
 
-    private fun initHankeWithHakemus(alluId: Int): HankeEntity {
+    private fun initHankeWithHakemus(
+        alluId: Int,
+        alluStatus: ApplicationStatus = ApplicationStatus.PENDING
+    ): HankeEntity {
         val hanke = hankeFactory.saveMinimal(hankeTunnus = "HAI23-1")
         val application =
             applicationRepository.save(
                 ApplicationFactory.createApplicationEntity(
                     hanke = hanke,
-                    alluStatus = ApplicationStatus.PENDING,
+                    alluStatus = alluStatus,
                     alluid = alluId,
                     userId = USERNAME
                 )

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
@@ -235,6 +235,14 @@ class HakemusService(
     /**
      * Deletes an application. Cancels the application in Allu if it's still pending. Refuses to
      * delete, if the application is in Allu, and it's beyond the pending status.
+     */
+    @Transactional
+    fun delete(applicationId: Long, userId: String) =
+        with(getById(applicationId)) { cancelAndDelete(this, userId) }
+
+    /**
+     * Deletes an application. Cancels the application in Allu if it's still pending. Refuses to
+     * delete, if the application is in Allu, and it's beyond the pending status.
      *
      * Furthermore, if the owning Hanke is generated and has no more applications, also deletes the
      * Hanke.
@@ -933,8 +941,7 @@ class HakemusService(
         }
     }
 
-    private fun isCancelled(alluStatus: ApplicationStatus?) =
-        alluStatus == ApplicationStatus.CANCELLED
+    fun isCancelled(alluStatus: ApplicationStatus?) = alluStatus == ApplicationStatus.CANCELLED
 }
 
 class IncompatibleHakemusUpdateRequestException(


### PR DESCRIPTION
# Description

Deleting a Hanke that has cancelled applications is allowed.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2553

## Type of change

- [ ] Bug fix 
- [x] New feature 
- [ ] Other

# Instructions for testing
This can be tested in similar manner as deleting cancelled applications: https://github.com/City-of-Helsinki/haitaton-backend/pull/717

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 

# Other relevant info
Please describe here if there is e.g. some requirements for this change or
 other info that the tester/user needs to know.