### PR TITLE
Fixed setting required competence value

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceITest.kt
@@ -78,6 +78,7 @@ import fi.hel.haitaton.hanke.factory.HakemusUpdateRequestFactory.withContractor
 import fi.hel.haitaton.hanke.factory.HakemusUpdateRequestFactory.withCustomer
 import fi.hel.haitaton.hanke.factory.HakemusUpdateRequestFactory.withCustomerWithContactsRequest
 import fi.hel.haitaton.hanke.factory.HakemusUpdateRequestFactory.withName
+import fi.hel.haitaton.hanke.factory.HakemusUpdateRequestFactory.withRequiredCompetence
 import fi.hel.haitaton.hanke.factory.HakemusUpdateRequestFactory.withWorkDescription
 import fi.hel.haitaton.hanke.factory.HakemusyhteystietoFactory
 import fi.hel.haitaton.hanke.factory.HankeFactory
@@ -1195,6 +1196,7 @@ class HakemusServiceITest(
                             newKayttaja.id
                         )
                         .withWorkDescription("New work description")
+                        .withRequiredCompetence(true)
                         .withArea(area)
 
                 val updatedHakemus = hakemusService.updateHakemus(hakemus.id, request, USERNAME)
@@ -1204,6 +1206,7 @@ class HakemusServiceITest(
                     .all {
                         prop(KaivuilmoitusDataResponse::workDescription)
                             .isEqualTo("New work description")
+                        prop(KaivuilmoitusDataResponse::requiredCompetence).isTrue()
                         prop(KaivuilmoitusDataResponse::customerWithContacts)
                             .isNotNull()
                             .prop(CustomerWithContactsResponse::contacts)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationData.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/application/ApplicationData.kt
@@ -198,6 +198,7 @@ data class ExcavationNotificationData(
             rockExcavation = rockExcavation,
             cableReports = cableReports,
             placementContracts = placementContracts,
+            requiredCompetence = requiredCompetence ?: false,
             startTime = startTime,
             endTime = endTime,
             areas = areas,

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusUpdateRequestFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusUpdateRequestFactory.kt
@@ -266,6 +266,12 @@ object HakemusUpdateRequestFactory {
             is KaivuilmoitusUpdateRequest -> this.copy(workDescription = workDescription)
         }
 
+    fun HakemusUpdateRequest.withRequiredCompetence(requiredCompetence: Boolean) =
+        when (this) {
+            is JohtoselvityshakemusUpdateRequest -> this
+            is KaivuilmoitusUpdateRequest -> this.copy(requiredCompetence = requiredCompetence)
+        }
+
     fun HakemusUpdateRequest.withArea(area: ApplicationArea?) = withAreas(area?.let { listOf(it) })
 
     fun HakemusUpdateRequest.withAreas(areas: List<ApplicationArea>?) =


### PR DESCRIPTION
# Description

Fixed bug when kaivuilmoitus application data was loaded and transformed into a domain object. It did not set `requiredCompetence` field.

### Jira Issue: -

## Type of change

- [x] Bug fix 
- [ ] New feature 
- [ ] Other

# Instructions for testing
* With UI: create/open a kaivuilmoitus, check required competence, save and check the result - required competence should be checked
* With Swagger: call PUT /hakemukset/{id} with data that has `requiredComperence: true`. Check the response.

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 

# Other relevant info
Please describe here if there is e.g. some requirements for this change or
 other info that the tester/user needs to know.