### PR TITLE
HAI-1378 Calculate haittaindeksi separately for each hankealue

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeControllerITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeControllerITests.kt
@@ -287,13 +287,15 @@ class HankeControllerITests(@Autowired override val mockMvc: MockMvc) : Controll
                 SavedHankealue(
                     hankeId = hankeIds[0],
                     geometriat = Geometriat(1, FeatureCollection(), version = 1),
-                    nimi = "$HANKEALUE_DEFAULT_NAME 1"
+                    nimi = "$HANKEALUE_DEFAULT_NAME 1",
+                    tormaystarkasteluTulos = null,
                 )
             val alue2 =
                 SavedHankealue(
                     hankeId = hankeIds[1],
                     geometriat = Geometriat(2, FeatureCollection(), version = 1),
-                    nimi = "$HANKEALUE_DEFAULT_NAME 2"
+                    nimi = "$HANKEALUE_DEFAULT_NAME 2",
+                    tormaystarkasteluTulos = null,
                 )
             val hanke1 = HankeFactory.create(id = hankeIds[0], hankeTunnus = HANKE_TUNNUS)
             val hanke2 = HankeFactory.create(id = hankeIds[1], hankeTunnus = "hanketunnus2")
@@ -502,15 +504,20 @@ class HankeControllerITests(@Autowired override val mockMvc: MockMvc) : Controll
             hankeToBeUpdated.tyomaaKatuosoite = "Testikatu 1"
             hankeToBeUpdated.tyomaaTyyppi.add(TyomaaTyyppi.VESI)
             hankeToBeUpdated.tyomaaTyyppi.add(TyomaaTyyppi.KAASUJOHTO)
-            val alue = SavedHankealue(nimi = "$HANKEALUE_DEFAULT_NAME 1")
-            alue.haittaAlkuPvm = DateFactory.getStartDatetime()
-            alue.haittaLoppuPvm = DateFactory.getEndDatetime()
-            alue.kaistaHaitta =
-                VaikutusAutoliikenteenKaistamaariin.VAHENTAA_KAISTAN_YHDELLA_AJOSUUNNALLA
-            alue.kaistaPituusHaitta = AutoliikenteenKaistavaikutustenPituus.PITUUS_100_499_METRIA
-            alue.meluHaitta = Meluhaitta.SATUNNAINEN_MELUHAITTA
-            alue.polyHaitta = Polyhaitta.TOISTUVA_POLYHAITTA
-            alue.tarinaHaitta = Tarinahaitta.JATKUVA_TARINAHAITTA
+            val alue =
+                SavedHankealue(
+                    nimi = "$HANKEALUE_DEFAULT_NAME 1",
+                    haittaAlkuPvm = DateFactory.getStartDatetime(),
+                    haittaLoppuPvm = DateFactory.getEndDatetime(),
+                    kaistaHaitta =
+                        VaikutusAutoliikenteenKaistamaariin.VAHENTAA_KAISTAN_YHDELLA_AJOSUUNNALLA,
+                    kaistaPituusHaitta =
+                        AutoliikenteenKaistavaikutustenPituus.PITUUS_100_499_METRIA,
+                    meluHaitta = Meluhaitta.SATUNNAINEN_MELUHAITTA,
+                    polyHaitta = Polyhaitta.TOISTUVA_POLYHAITTA,
+                    tarinaHaitta = Tarinahaitta.JATKUVA_TARINAHAITTA,
+                    tormaystarkasteluTulos = null,
+                )
             hankeToBeUpdated.alueet.add(alue)
             // Prepare the expected result/return
             // Note, "pvm" values should have become truncated to begin of the day

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
@@ -265,7 +265,6 @@ class HankeServiceITests(
                 prop(Hanke::alkuPvm).isNull()
                 prop(Hanke::loppuPvm).isNull()
                 prop(Hanke::alueet).isEmpty()
-                prop(Hanke::haittaAjanKestoDays).isNull()
                 prop(Hanke::tormaystarkasteluTulos).isNull()
             }
         }

--- a/services/hanke-service/src/integrationTest/resources/fi/hel/haitaton/hanke/logging/expectedHankeWithPolygon.json.mustache
+++ b/services/hanke-service/src/integrationTest/resources/fi/hel/haitaton/hanke/logging/expectedHankeWithPolygon.json.mustache
@@ -91,23 +91,23 @@
       "meluHaitta": "SATUNNAINEN_MELUHAITTA",
       "polyHaitta": "TOISTUVA_POLYHAITTA",
       "tarinaHaitta": "JATKUVA_TARINAHAITTA",
+      {{#tormaystarkasteluTulos}}
+          "tormaystarkasteluTulos": {
+            "autoliikenneindeksi": 1.4,
+            "pyoraliikenneindeksi": 0.0,
+            "linjaautoliikenneindeksi": 0.0,
+            "raitioliikenneindeksi": 0.0,
+            "liikennehaittaindeksi": {
+              "indeksi": 1.4,
+              "tyyppi": "AUTOLIIKENNEINDEKSI"
+            }
+          },
+      {{/tormaystarkasteluTulos}}
+      {{^tormaystarkasteluTulos}}
+          "tormaystarkasteluTulos": null,
+      {{/tormaystarkasteluTulos}}
       "nimi": {{#alueNimi}}"{{alueNimi}}"{{/alueNimi}}{{^alueNimi}}null{{/alueNimi}}
     }
 {{/alueId}}
-  ],
-{{#tormaystarkasteluTulos}}
-  "tormaystarkasteluTulos": {
-    "autoliikenneindeksi": 1.4,
-    "pyoraliikenneindeksi": 0.0,
-    "linjaautoliikenneindeksi": 0.0,
-    "raitioliikenneindeksi": 0.0,
-    "liikennehaittaindeksi": {
-      "indeksi": 1.4,
-      "tyyppi": "AUTOLIIKENNEINDEKSI"
-    }
-  }
-{{/tormaystarkasteluTulos}}
-{{^tormaystarkasteluTulos}}
-  "tormaystarkasteluTulos": null
-{{/tormaystarkasteluTulos}}
+  ]
 }

--- a/services/hanke-service/src/integrationTest/resources/fi/hel/haitaton/hanke/logging/expectedNewHanke.json.mustache
+++ b/services/hanke-service/src/integrationTest/resources/fi/hel/haitaton/hanke/logging/expectedNewHanke.json.mustache
@@ -12,6 +12,5 @@
   "generated": false,
   "tyomaaKatuosoite": null,
   "tyomaaTyyppi": [],
-  "alueet": [],
-  "tormaystarkasteluTulos": null
+  "alueet": []
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeMapper.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeMapper.kt
@@ -53,7 +53,7 @@ object HankeMapper {
 
     private fun alueList(
         hankeTunnus: String?,
-        alueet: MutableList<HankealueEntity>,
+        alueet: List<HankealueEntity>,
         geometriaData: Map<Int, Geometriat?>
     ): MutableList<SavedHankealue> =
         alueet.map { alue(hankeTunnus, it, geometriaData[it.geometriat]) }.toMutableList()
@@ -72,16 +72,21 @@ object HankeMapper {
                 polyHaitta = polyHaitta,
                 tarinaHaitta = tarinaHaitta,
                 nimi = nimi,
+                tormaystarkasteluTulos = entity.tormaystarkasteluTulos?.toDomain()
             )
         }
 
-    private fun tormaystarkasteluTulos(entity: HankeEntity) =
-        entity.tormaystarkasteluTulokset.firstOrNull()?.let {
+    private fun tormaystarkasteluTulos(entity: HankeEntity): TormaystarkasteluTulos? {
+        val tulokset = entity.alueet.mapNotNull { it.tormaystarkasteluTulos }
+        return if (tulokset.isEmpty()) {
+            null
+        } else {
             TormaystarkasteluTulos(
-                it.autoliikenne,
-                it.pyoraliikenne,
-                it.linjaautoliikenne,
-                it.raitioliikenne
+                autoliikenneindeksi = tulokset.maxOf { it.autoliikenne },
+                pyoraliikenneindeksi = tulokset.maxOf { it.pyoraliikenne },
+                linjaautoliikenneindeksi = tulokset.maxOf { it.linjaautoliikenne },
+                raitioliikenneindeksi = tulokset.maxOf { it.raitioliikenne },
             )
         }
+    }
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankealueEntity.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankealueEntity.kt
@@ -5,7 +5,9 @@ import fi.hel.haitaton.hanke.tormaystarkastelu.AutoliikenteenKaistavaikutustenPi
 import fi.hel.haitaton.hanke.tormaystarkastelu.Meluhaitta
 import fi.hel.haitaton.hanke.tormaystarkastelu.Polyhaitta
 import fi.hel.haitaton.hanke.tormaystarkastelu.Tarinahaitta
+import fi.hel.haitaton.hanke.tormaystarkastelu.TormaystarkasteluTulosEntity
 import fi.hel.haitaton.hanke.tormaystarkastelu.VaikutusAutoliikenteenKaistamaariin
+import jakarta.persistence.CascadeType
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
@@ -15,8 +17,10 @@ import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
+import jakarta.persistence.OneToOne
 import jakarta.persistence.Table
 import java.time.LocalDate
+import java.time.temporal.ChronoUnit
 
 @Entity
 @Table(name = "hankealue")
@@ -37,8 +41,22 @@ class HankealueEntity(
     @Enumerated(EnumType.STRING) var meluHaitta: Meluhaitta? = null,
     @Enumerated(EnumType.STRING) var polyHaitta: Polyhaitta? = null,
     @Enumerated(EnumType.STRING) var tarinaHaitta: Tarinahaitta? = null,
-    var nimi: String
+    var nimi: String,
+    // Made bidirectional relation mainly to allow cascaded delete.
+    @OneToOne(
+        fetch = FetchType.LAZY,
+        mappedBy = "hankealue",
+        cascade = [CascadeType.ALL],
+        orphanRemoval = true
+    )
+    var tormaystarkasteluTulos: TormaystarkasteluTulosEntity?,
 ) : HasId<Int> {
+    fun haittaAjanKestoDays(): Int? =
+        if (haittaAlkuPvm != null && haittaLoppuPvm != null) {
+            ChronoUnit.DAYS.between(haittaAlkuPvm, haittaLoppuPvm).toInt() + 1
+        } else {
+            null
+        }
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankealueService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankealueService.kt
@@ -38,7 +38,7 @@ class HankealueService(
         source: Hankealue,
         target: HankealueEntity?
     ): HankealueEntity {
-        val result = target ?: HankealueEntity(nimi = source.nimi)
+        val result = target ?: HankealueEntity(nimi = source.nimi, tormaystarkasteluTulos = null)
 
         // Assuming the incoming date, while being zoned date and time, is in UTC and time value can
         // be simply dropped here.
@@ -71,7 +71,7 @@ class HankealueService(
         hanketunnus: String,
         source: NewHankealue,
     ): HankealueEntity {
-        val result = HankealueEntity(nimi = source.nimi)
+        val result = HankealueEntity(nimi = source.nimi, tormaystarkasteluTulos = null)
 
         // Assuming the incoming date, while being zoned date and time, is in UTC and time value can
         // be simply dropped here.
@@ -93,20 +93,18 @@ class HankealueService(
         return result
     }
 
-    fun calculateTormaystarkastelu(
-        alueet: List<Hankealue>,
-        geometriaIds: Set<Int>,
-        hanke: HankeEntity,
-    ): TormaystarkasteluTulosEntity? =
-        tormaystarkasteluService.calculateTormaystarkastelu(alueet, geometriaIds)?.let {
-            TormaystarkasteluTulosEntity(
-                autoliikenne = it.autoliikenneindeksi,
-                pyoraliikenne = it.pyoraliikenneindeksi,
-                linjaautoliikenne = it.linjaautoliikenneindeksi,
-                raitioliikenne = it.raitioliikenneindeksi,
-                hanke = hanke
-            )
-        }
+    fun updateTormaystarkastelu(alue: HankealueEntity) {
+        alue.tormaystarkasteluTulos =
+            tormaystarkasteluService.calculateTormaystarkastelu(alue)?.let {
+                TormaystarkasteluTulosEntity(
+                    autoliikenne = it.autoliikenneindeksi,
+                    pyoraliikenne = it.pyoraliikenneindeksi,
+                    linjaautoliikenne = it.linjaautoliikenneindeksi,
+                    raitioliikenne = it.raitioliikenneindeksi,
+                    hankealue = alue,
+                )
+            }
+    }
 
     companion object {
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Persistence.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Persistence.kt
@@ -6,7 +6,6 @@ import fi.hel.haitaton.hanke.domain.Hankevaihe
 import fi.hel.haitaton.hanke.domain.HasId
 import fi.hel.haitaton.hanke.domain.TyomaaTyyppi
 import fi.hel.haitaton.hanke.hakemus.HakemusEntity
-import fi.hel.haitaton.hanke.tormaystarkastelu.TormaystarkasteluTulosEntity
 import jakarta.persistence.CascadeType
 import jakarta.persistence.CollectionTable
 import jakarta.persistence.ElementCollection
@@ -82,26 +81,10 @@ class HankeEntity(
     @Enumerated(EnumType.STRING)
     var tyomaaTyyppi: MutableSet<TyomaaTyyppi> = mutableSetOf()
 
-    // Made bidirectional relation mainly to allow cascaded delete.
-    @OneToMany(
-        fetch = FetchType.LAZY,
-        mappedBy = "hanke",
-        cascade = [CascadeType.ALL],
-        orphanRemoval = true
-    )
-    var tormaystarkasteluTulokset: MutableList<TormaystarkasteluTulosEntity> = mutableListOf()
-
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "hanke")
     var hakemukset: MutableSet<HakemusEntity> = mutableSetOf()
 
     // ==================  Helper functions ================
-
-    fun addYhteystieto(yhteystieto: HankeYhteystietoEntity) {
-        // TODO: should check that the given entity is not yet connected to another Hanke, or
-        // if already connected to this hanke (see addTormaystarkasteluTulos())
-        yhteystiedot.add(yhteystieto)
-        yhteystieto.hanke = this
-    }
 
     fun removeYhteystieto(yhteystieto: HankeYhteystietoEntity) {
         yhteystieto.id?.let { id ->

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/Hanke.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/Hanke.kt
@@ -1,6 +1,5 @@
 package fi.hel.haitaton.hanke.domain
 
-import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonView
 import fi.hel.haitaton.hanke.ChangeLogView
 import fi.hel.haitaton.hanke.HankeIdentifier
@@ -122,11 +121,7 @@ data class Hanke(
     )
     var alueet = mutableListOf<SavedHankealue>()
 
-    /** Number of days between haittaAlkuPvm and haittaLoppuPvm (incl. both days) */
-    val haittaAjanKestoDays: Int?
-        @JsonIgnore get() = alueet.haittaAjanKestoDays()
-
-    @JsonView(ChangeLogView::class)
+    @JsonView(NotInChangeLogView::class)
     @field:Schema(description = "Collision review result, set by the service.")
     var tormaystarkasteluTulos: TormaystarkasteluTulos? = null
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/SavedHankealue.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/SavedHankealue.kt
@@ -7,10 +7,10 @@ import fi.hel.haitaton.hanke.tormaystarkastelu.AutoliikenteenKaistavaikutustenPi
 import fi.hel.haitaton.hanke.tormaystarkastelu.Meluhaitta
 import fi.hel.haitaton.hanke.tormaystarkastelu.Polyhaitta
 import fi.hel.haitaton.hanke.tormaystarkastelu.Tarinahaitta
+import fi.hel.haitaton.hanke.tormaystarkastelu.TormaystarkasteluTulos
 import fi.hel.haitaton.hanke.tormaystarkastelu.VaikutusAutoliikenteenKaistamaariin
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.ZonedDateTime
-import java.time.temporal.ChronoUnit
 
 /** NOTE Remember to update PublicHankealue after changes */
 @JsonView(ChangeLogView::class)
@@ -62,29 +62,14 @@ data class SavedHankealue(
         description = "Area name, must not be null or empty",
     )
     override var nimi: String,
+    @field:Schema(
+        description = "Collision review result for this area",
+    )
+    val tormaystarkasteluTulos: TormaystarkasteluTulos?,
 ) : HasId<Int?>, Hankealue
 
 fun List<Hankealue>.alkuPvm(): ZonedDateTime? = mapNotNull { it.haittaAlkuPvm }.minOfOrNull { it }
 
 fun List<Hankealue>.loppuPvm(): ZonedDateTime? = mapNotNull { it.haittaLoppuPvm }.maxOfOrNull { it }
 
-fun List<Hankealue>.vaikutusAutoliikenteenKaistamaariin():
-    Set<VaikutusAutoliikenteenKaistamaariin> {
-    return mapNotNull { it.kaistaHaitta }.toSet()
-}
-
-fun List<Hankealue>.autoliikenteenKaistavaikutustenPituus():
-    Set<AutoliikenteenKaistavaikutustenPituus> {
-    return mapNotNull { it.kaistaPituusHaitta }.toSet()
-}
-
 fun List<SavedHankealue>.geometriat(): List<Geometriat> = mapNotNull { it.geometriat }
-
-fun List<SavedHankealue>.geometriaIds(): Set<Int> = mapNotNull { it.geometriat?.id }.toSet()
-
-fun List<Hankealue>.haittaAjanKestoDays(): Int? =
-    if (alkuPvm() != null && loppuPvm() != null) {
-        ChronoUnit.DAYS.between(alkuPvm(), loppuPvm()).toInt() + 1
-    } else {
-        null
-    }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluTulos.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluTulos.kt
@@ -3,7 +3,7 @@ package fi.hel.haitaton.hanke.tormaystarkastelu
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonView
 import fi.hel.haitaton.hanke.ChangeLogView
-import fi.hel.haitaton.hanke.HankeEntity
+import fi.hel.haitaton.hanke.HankealueEntity
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.persistence.Entity
 import jakarta.persistence.FetchType
@@ -11,7 +11,7 @@ import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
-import jakarta.persistence.ManyToOne
+import jakarta.persistence.OneToOne
 import jakarta.persistence.Table
 
 @Schema(description = "Collision review result")
@@ -74,7 +74,15 @@ class TormaystarkasteluTulosEntity(
     val pyoraliikenne: Float,
     val linjaautoliikenne: Float,
     val raitioliikenne: Float,
-    @ManyToOne(optional = false, fetch = FetchType.LAZY)
-    @JoinColumn(name = "hankeid")
-    val hanke: HankeEntity,
-)
+    @OneToOne(optional = false, fetch = FetchType.LAZY)
+    @JoinColumn(name = "hankealue_id")
+    val hankealue: HankealueEntity,
+) {
+    fun toDomain(): TormaystarkasteluTulos =
+        TormaystarkasteluTulos(
+            autoliikenne,
+            pyoraliikenne,
+            linjaautoliikenne,
+            raitioliikenne,
+        )
+}

--- a/services/hanke-service/src/main/resources/db/changelog/changesets/075-change-tormaystarkastelutulos-to-refer-to-hankealue.sql
+++ b/services/hanke-service/src/main/resources/db/changelog/changesets/075-change-tormaystarkastelutulos-to-refer-to-hankealue.sql
@@ -1,6 +1,6 @@
 --liquibase formatted sql
---changeset Topias Heinonen:075-remove-old-cycle-tormays-tables
---comment: Remove the old cycle tormays tables.
+--changeset Topias Heinonen:075-change-tormaystarkastelutulos-to-refer-to-hankealue
+--comment: Change Tormaystarkastelutulos to refer to hankealue instead of hanke. Change the individual results to numeric type instead of float.
 
 DELETE
 FROM tormaystarkastelutulos;
@@ -9,3 +9,9 @@ ALTER TABLE tormaystarkastelutulos
     DROP COLUMN hankeid,
     ADD COLUMN hankealue_id bigint NOT NULL,
     ADD CONSTRAINT fk_tormaystarkastelutulos_hankealue FOREIGN KEY (hankealue_id) REFERENCES hankealue (id);
+
+ALTER TABLE tormaystarkastelutulos
+    ALTER COLUMN autoliikenne TYPE numeric(2, 1),
+    ALTER COLUMN pyoraliikenne TYPE numeric(2, 1),
+    ALTER COLUMN linjaautoliikenne TYPE numeric(2, 1),
+    ALTER COLUMN raitioliikenne TYPE numeric(2, 1);

--- a/services/hanke-service/src/main/resources/db/changelog/changesets/075-change-tormaystarkastelutulos-to-refer-to-hankealue.sql
+++ b/services/hanke-service/src/main/resources/db/changelog/changesets/075-change-tormaystarkastelutulos-to-refer-to-hankealue.sql
@@ -1,0 +1,11 @@
+--liquibase formatted sql
+--changeset Topias Heinonen:075-remove-old-cycle-tormays-tables
+--comment: Remove the old cycle tormays tables.
+
+DELETE
+FROM tormaystarkastelutulos;
+
+ALTER TABLE tormaystarkastelutulos
+    DROP COLUMN hankeid,
+    ADD COLUMN hankealue_id bigint NOT NULL,
+    ADD CONSTRAINT fk_tormaystarkastelutulos_hankealue FOREIGN KEY (hankealue_id) REFERENCES hankealue (id);

--- a/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -177,3 +177,5 @@ databaseChangeLog:
       file: db/changelog/changesets/073-change-haitat-to-enum-names.sql
   - include:
       file: db/changelog/changesets/074-remove-old-cycle-tormays-tables.sql
+  - include:
+      file: db/changelog/changesets/075-change-tormaystarkastelutulos-to-refer-to-hankealue.sql

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/domain/HankeTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/domain/HankeTest.kt
@@ -2,8 +2,6 @@ package fi.hel.haitaton.hanke.domain
 
 import assertk.assertThat
 import assertk.assertions.isEqualTo
-import fi.hel.haitaton.hanke.HANKEALUE_DEFAULT_NAME
-import fi.hel.haitaton.hanke.TZ_UTC
 import fi.hel.haitaton.hanke.factory.DateFactory
 import fi.hel.haitaton.hanke.factory.HankeFactory
 import fi.hel.haitaton.hanke.factory.HankeFactory.Companion.withHankealue
@@ -13,28 +11,10 @@ import fi.hel.haitaton.hanke.tormaystarkastelu.Meluhaitta
 import fi.hel.haitaton.hanke.tormaystarkastelu.Polyhaitta
 import fi.hel.haitaton.hanke.tormaystarkastelu.Tarinahaitta
 import fi.hel.haitaton.hanke.tormaystarkastelu.VaikutusAutoliikenteenKaistamaariin
-import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.CsvSource
 
 internal class HankeTest {
-
-    @ParameterizedTest(name = "There are {0} days between {1} and {2}")
-    @CsvSource("1,2021-03-02,2021-03-02", "214,2021-03-01,2021-09-30")
-    fun haittaAjanKesto(expectedNumberOfDays: Int, startDate: LocalDate, endDate: LocalDate) {
-        val hanke = HankeFactory.create(id = 1, hankeTunnus = "HAI21-1")
-        hanke.alueet.add(
-            SavedHankealue(
-                haittaAlkuPvm = startDate.atStartOfDay(TZ_UTC),
-                haittaLoppuPvm = endDate.atStartOfDay(TZ_UTC),
-                nimi = "$HANKEALUE_DEFAULT_NAME 1"
-            )
-        )
-        val haittaAjanKesto = hanke.haittaAjanKestoDays
-        assertThat(haittaAjanKesto!!).isEqualTo(expectedNumberOfDays)
-    }
 
     @Test
     fun `Hanke alku and loppu calculated from alueet`() {

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeFactory.kt
@@ -24,7 +24,6 @@ import fi.hel.haitaton.hanke.factory.ProfiiliFactory.DEFAULT_NAMES
 import fi.hel.haitaton.hanke.profiili.ProfiiliClient
 import fi.hel.haitaton.hanke.test.USERNAME
 import fi.hel.haitaton.hanke.tormaystarkastelu.TormaystarkasteluTulos
-import fi.hel.haitaton.hanke.tormaystarkastelu.TormaystarkasteluTulosEntity
 import java.time.ZonedDateTime
 import org.springframework.stereotype.Component
 
@@ -196,7 +195,6 @@ class HankeFactory(
                                 createdByUser = defaultUser
                             )
                         )
-                    tormaystarkasteluTulokset = mutableListOf(tormaysTarkastelu(hankeEntity = this))
                 }
 
         fun createRequest(
@@ -323,18 +321,5 @@ class HankeFactory(
             muut.add(HankeYhteystietoFactory.createDifferentiated(i, id, yhteyshenkilo.toList()))
             return this
         }
-
-        private fun tormaysTarkastelu(
-            id: Int = 1,
-            hankeEntity: HankeEntity
-        ): TormaystarkasteluTulosEntity =
-            TormaystarkasteluTulosEntity(
-                id = id,
-                autoliikenne = 1.25f,
-                pyoraliikenne = 2.5f,
-                linjaautoliikenne = 3.75f,
-                raitioliikenne = 3.75f,
-                hanke = hankeEntity,
-            )
     }
 }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankealueFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankealueFactory.kt
@@ -9,6 +9,8 @@ import fi.hel.haitaton.hanke.tormaystarkastelu.AutoliikenteenKaistavaikutustenPi
 import fi.hel.haitaton.hanke.tormaystarkastelu.Meluhaitta
 import fi.hel.haitaton.hanke.tormaystarkastelu.Polyhaitta
 import fi.hel.haitaton.hanke.tormaystarkastelu.Tarinahaitta
+import fi.hel.haitaton.hanke.tormaystarkastelu.TormaystarkasteluTulos
+import fi.hel.haitaton.hanke.tormaystarkastelu.TormaystarkasteluTulosEntity
 import fi.hel.haitaton.hanke.tormaystarkastelu.VaikutusAutoliikenteenKaistamaariin
 import java.time.ZonedDateTime
 
@@ -28,6 +30,7 @@ object HankealueFactory {
         polyHaitta: Polyhaitta? = Polyhaitta.TOISTUVA_POLYHAITTA,
         tarinaHaitta: Tarinahaitta? = Tarinahaitta.JATKUVA_TARINAHAITTA,
         nimi: String = "$HANKEALUE_DEFAULT_NAME 1",
+        tormaystarkasteluTulos: TormaystarkasteluTulos? = tormaystarkasteluTulos(),
     ): SavedHankealue {
         return SavedHankealue(
             id,
@@ -41,6 +44,7 @@ object HankealueFactory {
             polyHaitta,
             tarinaHaitta,
             nimi,
+            tormaystarkasteluTulos,
         )
     }
 
@@ -69,23 +73,47 @@ object HankealueFactory {
             polyHaitta,
             tarinaHaitta,
             nimi,
+            null
         )
     }
 
     fun createHankeAlueEntity(mockId: Int = 1, hankeEntity: HankeEntity): HankealueEntity {
         val alue = create(id = mockId).apply { geometriat?.id = mockId }
         return HankealueEntity(
-            id = alue.id!!,
-            hanke = hankeEntity,
-            geometriat = alue.geometriat?.id,
-            haittaAlkuPvm = DateFactory.getStartDatetime().toLocalDate(),
-            haittaLoppuPvm = DateFactory.getEndDatetime().toLocalDate(),
-            kaistaHaitta = alue.kaistaHaitta,
-            kaistaPituusHaitta = alue.kaistaPituusHaitta,
-            meluHaitta = alue.meluHaitta,
-            polyHaitta = alue.polyHaitta,
-            tarinaHaitta = alue.tarinaHaitta,
-            nimi = alue.nimi
-        )
+                id = alue.id!!,
+                hanke = hankeEntity,
+                geometriat = alue.geometriat?.id,
+                haittaAlkuPvm = DateFactory.getStartDatetime().toLocalDate(),
+                haittaLoppuPvm = DateFactory.getEndDatetime().toLocalDate(),
+                kaistaHaitta = alue.kaistaHaitta,
+                kaistaPituusHaitta = alue.kaistaPituusHaitta,
+                meluHaitta = alue.meluHaitta,
+                polyHaitta = alue.polyHaitta,
+                tarinaHaitta = alue.tarinaHaitta,
+                nimi = alue.nimi,
+                tormaystarkasteluTulos = null,
+            )
+            .apply { tormaystarkasteluTulos = tormaystarkasteluTulosEntity(hankealueEntity = this) }
     }
+
+    private fun tormaystarkasteluTulos() =
+        TormaystarkasteluTulos(
+            autoliikenneindeksi = 1.25f,
+            pyoraliikenneindeksi = 2.5f,
+            linjaautoliikenneindeksi = 3.75f,
+            raitioliikenneindeksi = 3.75f,
+        )
+
+    private fun tormaystarkasteluTulosEntity(
+        id: Int = 1,
+        hankealueEntity: HankealueEntity,
+    ): TormaystarkasteluTulosEntity =
+        TormaystarkasteluTulosEntity(
+            id = id,
+            autoliikenne = 1.25f,
+            pyoraliikenne = 2.5f,
+            linjaautoliikenne = 3.75f,
+            raitioliikenne = 3.75f,
+            hankealue = hankealueEntity,
+        )
 }


### PR DESCRIPTION
# Description

The calculated tormaystarkastelu results are saved and returned with each hankealue. One tormaystarkastelu is also returned for the whole hanke, for backwards compatibility. That's calculated by taking the worst cases from all of the areas.

Wipe all existing tormaystarkastelu, because they're not used in production and they can't be converted.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1378

## Type of change

- [X] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
1. Add several hankealue to a hanke.
2. Check the response from the browser's network tab to see that there are tormaystarkastelu under the hankealueet.
3. Check that the tormaystarkastelu are saved in DB.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 