### PR TITLE
HAI-1383 Add nuisance management plan for project area

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres
     ports:
-      - 5432:5432
+      - "5432:5432"
     volumes:
       - ${DB_VOLUME}:/var/lib/postgresql/data
     networks:
@@ -92,7 +92,7 @@ services:
     image: services/hanke-service
     container_name: haitaton-hanke
     ports:
-      - 3000:8080
+      - "3000:8080"
     hostname: haitaton-hanke
     environment:
       HAITATON_HOST: db
@@ -142,7 +142,7 @@ services:
       REACT_APP_FEATURE_HANKE: 1
       REACT_APP_FEATURE_ACCESS_RIGHTS: 1
     ports:
-      - 8000:8000
+      - "8000:8000"
     volumes:
       - ${BUILD_ROOT}/haitaton-ui:/app
       - '/app/node_modules'
@@ -158,7 +158,7 @@ services:
     volumes:
       - ${BUILD_ROOT}/haitaton-backend/scripts/nginx/${NGINX_CONF}:/etc/nginx/conf.d/default.conf
     ports:
-      - 3001:80
+      - "3001:80"
     depends_on:
       - haitaton-hanke
       - haitaton-ui

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeControllerITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeControllerITests.kt
@@ -2,6 +2,7 @@ package fi.hel.haitaton.hanke
 
 import assertk.assertThat
 import assertk.assertions.isTrue
+import fi.hel.haitaton.hanke.domain.Haittojenhallintatyyppi
 import fi.hel.haitaton.hanke.domain.HankeStatus
 import fi.hel.haitaton.hanke.domain.SavedHankealue
 import fi.hel.haitaton.hanke.domain.TyomaaTyyppi
@@ -14,6 +15,7 @@ import fi.hel.haitaton.hanke.factory.HankeFactory.Companion.withRakennuttaja
 import fi.hel.haitaton.hanke.factory.HankeFactory.Companion.withTormaystarkasteluTulos
 import fi.hel.haitaton.hanke.factory.HankeFactory.Companion.withToteuttaja
 import fi.hel.haitaton.hanke.factory.HankeYhteyshenkiloFactory
+import fi.hel.haitaton.hanke.factory.HankealueFactory.createHaittojenhallintasuunnitelma
 import fi.hel.haitaton.hanke.geometria.Geometriat
 import fi.hel.haitaton.hanke.logging.DisclosureLogService
 import fi.hel.haitaton.hanke.permissions.PermissionCode
@@ -517,6 +519,7 @@ class HankeControllerITests(@Autowired override val mockMvc: MockMvc) : Controll
                     polyHaitta = Polyhaitta.TOISTUVA_POLYHAITTA,
                     tarinaHaitta = Tarinahaitta.JATKUVA_TARINAHAITTA,
                     tormaystarkasteluTulos = null,
+                    haittojenhallintasuunnitelma = createHaittojenhallintasuunnitelma(),
                 )
             hankeToBeUpdated.alueet.add(alue)
             // Prepare the expected result/return
@@ -553,6 +556,13 @@ class HankeControllerITests(@Autowired override val mockMvc: MockMvc) : Controll
                                 .name
                         )
                 ) // Note, here as string, not the enum.
+                .andExpect(
+                    jsonPath("$.alueet[0].haittojenhallintasuunnitelma.YLEINEN")
+                        .value(
+                            hankeToBeUpdated.alueet[0].haittojenhallintasuunnitelma!![
+                                Haittojenhallintatyyppi.YLEINEN]
+                        )
+                )
 
             verifySequence {
                 authorizer.authorizeHankeTunnus(HANKE_TUNNUS, PermissionCode.EDIT.name)

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
@@ -382,8 +382,6 @@ class HankeServiceITests(
         }
     }
 
-    @Nested inner class UpdateHanke {}
-
     @Test
     fun `test personal data logging`() {
         // Create hanke with two yhteystietos, save and check logs. There should be two rows and the
@@ -700,7 +698,11 @@ class HankeServiceITests(
     inner class DeleteHanke {
         @Test
         fun `creates audit log entry for deleted hanke`() {
-            val hanke = hankeFactory.builder(USERNAME).withHankealue().save()
+            val hanke =
+                hankeFactory
+                    .builder(USERNAME)
+                    .withHankealue(haittojenhallintasuunnitelma = true)
+                    .save()
             auditLogRepository.deleteAll()
             assertEquals(0, auditLogRepository.count())
             TestUtils.addMockedRequestIp()
@@ -730,6 +732,7 @@ class HankeServiceITests(
                     hanke.alueet[0],
                     hankeVersion = 1,
                     tormaystarkasteluTulos = true,
+                    haittojenhallintasuunnitelma = true
                 )
             JSONAssert.assertEquals(
                 expectedObject,
@@ -983,6 +986,7 @@ object ExpectedHankeLogObject {
         tormaystarkasteluTulos: Boolean = false,
         alkuPvm: String? = "${nextYear()}-02-20T00:00:00Z",
         loppuPvm: String? = "${nextYear()}-02-21T00:00:00Z",
+        haittojenhallintasuunnitelma: Boolean = false,
     ): String {
         val templateData =
             TemplateData(
@@ -997,6 +1001,7 @@ object ExpectedHankeLogObject {
                 alue?.nimi,
                 alkuPvm,
                 loppuPvm,
+                haittojenhallintasuunnitelma,
             )
         return expectedHankeWithPolygon.processToString(templateData)
     }
@@ -1013,5 +1018,6 @@ object ExpectedHankeLogObject {
         val alueNimi: String? = null,
         val alkuPvm: String? = null,
         val loppuPvm: String? = null,
+        val haittojenhallintasuunnitelma: Boolean = false,
     )
 }

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
@@ -41,6 +41,7 @@ import fi.hel.haitaton.hanke.factory.HankeFactory
 import fi.hel.haitaton.hanke.factory.HankeFactory.Companion.DEFAULT_HANKE_PERUSTAJA
 import fi.hel.haitaton.hanke.factory.HankeKayttajaFactory
 import fi.hel.haitaton.hanke.factory.HankeYhteystietoFactory
+import fi.hel.haitaton.hanke.factory.HankealueFactory.createHaittojenhallintasuunnitelma
 import fi.hel.haitaton.hanke.factory.ProfiiliFactory
 import fi.hel.haitaton.hanke.factory.ProfiiliFactory.DEFAULT_GIVEN_NAME
 import fi.hel.haitaton.hanke.factory.ProfiiliFactory.DEFAULT_LAST_NAME
@@ -701,7 +702,9 @@ class HankeServiceITests(
             val hanke =
                 hankeFactory
                     .builder(USERNAME)
-                    .withHankealue(haittojenhallintasuunnitelma = true)
+                    .withHankealue(
+                        haittojenhallintasuunnitelma = createHaittojenhallintasuunnitelma()
+                    )
                     .save()
             auditLogRepository.deleteAll()
             assertEquals(0, auditLogRepository.count())

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/UpdateHankeITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/UpdateHankeITests.kt
@@ -636,7 +636,7 @@ class UpdateHankeITests(
     }
 
     @Test
-    fun `removes hankealue and geometriat and nuisance management plan when saved alue missing from request`() {
+    fun `removes hankealue and geometriat and nuisance control plan when saved alue missing from request`() {
         val alkuPvm = DateFactory.getStartDatetime()
         val loppuPvm = DateFactory.getStartDatetime()
         val hankealue =
@@ -822,7 +822,7 @@ class UpdateHankeITests(
     }
 
     @Test
-    fun `creates audit log entry when nuisance management plan is updated in hankealue`() {
+    fun `creates audit log entry when nuisance control plan is updated in hankealue`() {
         val hanke = hankeFactory.builder(USERNAME).withHankealue().save()
         auditLogRepository.deleteAll()
         assertEquals(0, auditLogRepository.count())

--- a/services/hanke-service/src/integrationTest/resources/clear-db.sql
+++ b/services/hanke-service/src/integrationTest/resources/clear-db.sql
@@ -16,5 +16,6 @@ TRUNCATE TABLE
     int_lock,
     kayttajakutsu,
     permissions,
-    tormaystarkastelutulos;
+    tormaystarkastelutulos,
+    hankkeen_haittojenhallintasuunnitelma;
 UPDATE allu_status SET history_last_updated = '2017-01-01T00:00:00Z';

--- a/services/hanke-service/src/integrationTest/resources/fi/hel/haitaton/hanke/logging/expectedHankeWithPolygon.json.mustache
+++ b/services/hanke-service/src/integrationTest/resources/fi/hel/haitaton/hanke/logging/expectedHankeWithPolygon.json.mustache
@@ -91,30 +91,26 @@
       "meluHaitta": "SATUNNAINEN_MELUHAITTA",
       "polyHaitta": "TOISTUVA_POLYHAITTA",
       "tarinaHaitta": "JATKUVA_TARINAHAITTA",
-      {{#tormaystarkasteluTulos}}
-          "tormaystarkasteluTulos": {
-            "autoliikenneindeksi": 1.4,
-            "pyoraliikenneindeksi": 0.0,
-            "linjaautoliikenneindeksi": 0.0,
-            "raitioliikenneindeksi": 0.0,
-            "liikennehaittaindeksi": {
-              "indeksi": 1.4,
-              "tyyppi": "AUTOLIIKENNEINDEKSI"
-            }
-          },
-      {{/tormaystarkasteluTulos}}
-      {{^tormaystarkasteluTulos}}
-          "tormaystarkasteluTulos": null,
-      {{/tormaystarkasteluTulos}}
       "nimi": {{#alueNimi}}"{{alueNimi}}"{{/alueNimi}}{{^alueNimi}}null{{/alueNimi}},
-      "haittojenhallintasuunnitelma": {{#haittojenhallintasuunnitelma}}{
-        "AUTOLIIKENNE":"Autoliikenteelle koituvien haittojen hallintasuunnitelma",
+      {{#tormaystarkasteluTulos}}"tormaystarkasteluTulos": {
+        "autoliikenneindeksi": 1.4,
+        "pyoraliikenneindeksi": 0.0,
+        "linjaautoliikenneindeksi": 0.0,
+        "raitioliikenneindeksi": 0.0,
+        "liikennehaittaindeksi": {
+          "indeksi": 1.4,
+          "tyyppi": "AUTOLIIKENNEINDEKSI"
+        }
+      },{{/tormaystarkasteluTulos}}
+      "haittojenhallintasuunnitelma": {
+        {{#haittojenhallintasuunnitelma}}"AUTOLIIKENNE":"Autoliikenteelle koituvien haittojen hallintasuunnitelma",
         "LINJAAUTOLIIKENNE":"Linja-autoliikenteelle koituvien haittojen hallintasuunnitelma",
         "YLEINEN":"Yleisten haittojen hallintasuunnitelma",
         "PYORALIIKENNE":"Pyöräliikenteelle koituvien haittojen hallintasuunnitelma",
         "RAITIOLIIKENNE":"Raitioliikenteelle koituvien haittojen hallintasuunnitelma",
         "MUUT":"Muiden haittojen hallintasuunnitelma"
-      }{{/haittojenhallintasuunnitelma}}{{^haittojenhallintasuunnitelma}}null{{/haittojenhallintasuunnitelma}}
+        {{/haittojenhallintasuunnitelma}}
+      }
     }
 {{/alueId}}
   ]

--- a/services/hanke-service/src/integrationTest/resources/fi/hel/haitaton/hanke/logging/expectedHankeWithPolygon.json.mustache
+++ b/services/hanke-service/src/integrationTest/resources/fi/hel/haitaton/hanke/logging/expectedHankeWithPolygon.json.mustache
@@ -106,7 +106,15 @@
       {{^tormaystarkasteluTulos}}
           "tormaystarkasteluTulos": null,
       {{/tormaystarkasteluTulos}}
-      "nimi": {{#alueNimi}}"{{alueNimi}}"{{/alueNimi}}{{^alueNimi}}null{{/alueNimi}}
+      "nimi": {{#alueNimi}}"{{alueNimi}}"{{/alueNimi}}{{^alueNimi}}null{{/alueNimi}},
+      "haittojenhallintasuunnitelma": {{#haittojenhallintasuunnitelma}}{
+        "AUTOLIIKENNE":"Autoliikenteelle koituvien haittojen hallintasuunnitelma",
+        "LINJAAUTOLIIKENNE":"Linja-autoliikenteelle koituvien haittojen hallintasuunnitelma",
+        "YLEINEN":"Yleisten haittojen hallintasuunnitelma",
+        "PYORALIIKENNE":"Pyöräliikenteelle koituvien haittojen hallintasuunnitelma",
+        "RAITIOLIIKENNE":"Raitioliikenteelle koituvien haittojen hallintasuunnitelma",
+        "MUUT":"Muiden haittojen hallintasuunnitelma"
+      }{{/haittojenhallintasuunnitelma}}{{^haittojenhallintasuunnitelma}}null{{/haittojenhallintasuunnitelma}}
     }
 {{/alueId}}
   ]

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeMapper.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeMapper.kt
@@ -73,8 +73,7 @@ object HankeMapper {
                 tarinaHaitta = tarinaHaitta,
                 nimi = nimi,
                 tormaystarkasteluTulos = entity.tormaystarkasteluTulos?.toDomain(),
-                haittojenhallintasuunnitelma =
-                    haittojenhallintasuunnitelma?.let { it.ifEmpty { null } }
+                haittojenhallintasuunnitelma = haittojenhallintasuunnitelma.toMap(),
             )
         }
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeMapper.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeMapper.kt
@@ -72,7 +72,9 @@ object HankeMapper {
                 polyHaitta = polyHaitta,
                 tarinaHaitta = tarinaHaitta,
                 nimi = nimi,
-                tormaystarkasteluTulos = entity.tormaystarkasteluTulos?.toDomain()
+                tormaystarkasteluTulos = entity.tormaystarkasteluTulos?.toDomain(),
+                haittojenhallintasuunnitelma =
+                    haittojenhallintasuunnitelma?.let { it.ifEmpty { null } }
             )
         }
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankealueEntity.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankealueEntity.kt
@@ -64,7 +64,7 @@ class HankealueEntity(
     @MapKeyColumn(name = "tyyppi")
     @Column(name = "sisalto")
     @MapKeyEnumerated(EnumType.STRING)
-    var haittojenhallintasuunnitelma: Map<Haittojenhallintatyyppi, String>? = null
+    var haittojenhallintasuunnitelma: MutableMap<Haittojenhallintatyyppi, String> = mutableMapOf(),
 ) : HasId<Int> {
     fun haittaAjanKestoDays(): Int? =
         if (haittaAlkuPvm != null && haittaLoppuPvm != null) {
@@ -107,5 +107,3 @@ class HankealueEntity(
         return result
     }
 }
-
-fun List<HankealueEntity>.geometriaIds(): Set<Int> = mapNotNull { it.geometriat }.toSet()

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankealueEntity.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankealueEntity.kt
@@ -1,5 +1,6 @@
 package fi.hel.haitaton.hanke
 
+import fi.hel.haitaton.hanke.domain.Haittojenhallintatyyppi
 import fi.hel.haitaton.hanke.domain.HasId
 import fi.hel.haitaton.hanke.tormaystarkastelu.AutoliikenteenKaistavaikutustenPituus
 import fi.hel.haitaton.hanke.tormaystarkastelu.Meluhaitta
@@ -8,6 +9,9 @@ import fi.hel.haitaton.hanke.tormaystarkastelu.Tarinahaitta
 import fi.hel.haitaton.hanke.tormaystarkastelu.TormaystarkasteluTulosEntity
 import fi.hel.haitaton.hanke.tormaystarkastelu.VaikutusAutoliikenteenKaistamaariin
 import jakarta.persistence.CascadeType
+import jakarta.persistence.CollectionTable
+import jakarta.persistence.Column
+import jakarta.persistence.ElementCollection
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
@@ -17,6 +21,8 @@ import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
+import jakarta.persistence.MapKeyColumn
+import jakarta.persistence.MapKeyEnumerated
 import jakarta.persistence.OneToOne
 import jakarta.persistence.Table
 import java.time.LocalDate
@@ -50,6 +56,15 @@ class HankealueEntity(
         orphanRemoval = true
     )
     var tormaystarkasteluTulos: TormaystarkasteluTulosEntity?,
+    @ElementCollection(fetch = FetchType.LAZY)
+    @CollectionTable(
+        name = "hankkeen_haittojenhallintasuunnitelma",
+        joinColumns = [JoinColumn(name = "hankealue_id", referencedColumnName = "id")]
+    )
+    @MapKeyColumn(name = "tyyppi")
+    @Column(name = "sisalto")
+    @MapKeyEnumerated(EnumType.STRING)
+    var haittojenhallintasuunnitelma: Map<Haittojenhallintatyyppi, String>? = null
 ) : HasId<Int> {
     fun haittaAjanKestoDays(): Int? =
         if (haittaAlkuPvm != null && haittaLoppuPvm != null) {

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankealueService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankealueService.kt
@@ -57,7 +57,10 @@ class HankealueService(
             result.geometriat = saved?.id
         }
         result.nimi = source.nimi
-        source.haittojenhallintasuunnitelma?.let { result.haittojenhallintasuunnitelma = it }
+        source.haittojenhallintasuunnitelma?.let {
+            result.haittojenhallintasuunnitelma.clear()
+            result.haittojenhallintasuunnitelma.putAll(it)
+        }
 
         return result
     }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankealueService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankealueService.kt
@@ -57,6 +57,7 @@ class HankealueService(
             result.geometriat = saved?.id
         }
         result.nimi = source.nimi
+        source.haittojenhallintasuunnitelma?.let { result.haittojenhallintasuunnitelma = it }
 
         return result
     }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/BaseHanke.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/BaseHanke.kt
@@ -102,5 +102,5 @@ enum class Haittojenhallintatyyppi {
     AUTOLIIKENNE,
     RAITIOLIIKENNE,
     LINJAAUTOLIIKENNE,
-    MUUT
+    MUUT,
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/BaseHanke.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/BaseHanke.kt
@@ -75,6 +75,7 @@ interface Hankealue {
     val polyHaitta: Polyhaitta?
     val tarinaHaitta: Tarinahaitta?
     val nimi: String
+    val haittojenhallintasuunnitelma: Map<Haittojenhallintatyyppi, String>?
 }
 
 fun List<Hankealue>.geometriat(): List<HasFeatures> = mapNotNull { it.geometriat }
@@ -93,4 +94,13 @@ interface HasFeatures {
     fun hasFeatures(): Boolean {
         return !featureCollection?.features.isNullOrEmpty()
     }
+}
+
+enum class Haittojenhallintatyyppi {
+    YLEINEN,
+    PYORALIIKENNE,
+    AUTOLIIKENNE,
+    RAITIOLIIKENNE,
+    LINJAAUTOLIIKENNE,
+    MUUT
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/CreateHankeRequest.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/CreateHankeRequest.kt
@@ -74,7 +74,7 @@ data class NewHankealue(
     )
     override val nimi: String,
     @field:Schema(
-        description = "Nuisance management plans for this area",
+        description = "Nuisance control plans for this area",
     )
     override val haittojenhallintasuunnitelma: Map<Haittojenhallintatyyppi, String>? = null
 ) : Hankealue

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/CreateHankeRequest.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/CreateHankeRequest.kt
@@ -73,6 +73,10 @@ data class NewHankealue(
         description = "Area name, must not be null or empty",
     )
     override val nimi: String,
+    @field:Schema(
+        description = "Nuisance management plans for this area",
+    )
+    override val haittojenhallintasuunnitelma: Map<Haittojenhallintatyyppi, String>? = null
 ) : Hankealue
 
 data class NewGeometriat(

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/CreateHankeRequest.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/CreateHankeRequest.kt
@@ -76,7 +76,7 @@ data class NewHankealue(
     @field:Schema(
         description = "Nuisance control plans for this area",
     )
-    override val haittojenhallintasuunnitelma: Map<Haittojenhallintatyyppi, String>? = null
+    override val haittojenhallintasuunnitelma: Map<Haittojenhallintatyyppi, String>? = null,
 ) : Hankealue
 
 data class NewGeometriat(

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/ModifyHankealueRequest.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/ModifyHankealueRequest.kt
@@ -52,7 +52,7 @@ data class ModifyHankealueRequest(
     @field:Schema(
         description = "Nuisance control plan for this area",
     )
-    override val haittojenhallintasuunnitelma: Map<Haittojenhallintatyyppi, String>?
+    override val haittojenhallintasuunnitelma: Map<Haittojenhallintatyyppi, String>?,
 ) : HasId<Int?>, Hankealue
 
 data class ModifyGeometriaRequest(

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/ModifyHankealueRequest.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/ModifyHankealueRequest.kt
@@ -50,7 +50,7 @@ data class ModifyHankealueRequest(
     )
     override val tarinaHaitta: Tarinahaitta?,
     @field:Schema(
-        description = "Nuisance management plan for this area",
+        description = "Nuisance control plan for this area",
     )
     override val haittojenhallintasuunnitelma: Map<Haittojenhallintatyyppi, String>?
 ) : HasId<Int?>, Hankealue

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/ModifyHankealueRequest.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/ModifyHankealueRequest.kt
@@ -49,6 +49,10 @@ data class ModifyHankealueRequest(
         description = "Vibration nuisance",
     )
     override val tarinaHaitta: Tarinahaitta?,
+    @field:Schema(
+        description = "Nuisance management plan for this area",
+    )
+    override val haittojenhallintasuunnitelma: Map<Haittojenhallintatyyppi, String>?
 ) : HasId<Int?>, Hankealue
 
 data class ModifyGeometriaRequest(

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/SavedHankealue.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/SavedHankealue.kt
@@ -67,7 +67,7 @@ data class SavedHankealue(
     )
     val tormaystarkasteluTulos: TormaystarkasteluTulos?,
     @field:Schema(
-        description = "Nuisance management plan for this area",
+        description = "Nuisance control plan for this area",
     )
     override var haittojenhallintasuunnitelma: Map<Haittojenhallintatyyppi, String>? = null,
 ) : HasId<Int?>, Hankealue

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/SavedHankealue.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/SavedHankealue.kt
@@ -66,6 +66,10 @@ data class SavedHankealue(
         description = "Collision review result for this area",
     )
     val tormaystarkasteluTulos: TormaystarkasteluTulos?,
+    @field:Schema(
+        description = "Nuisance management plan for this area",
+    )
+    override var haittojenhallintasuunnitelma: Map<Haittojenhallintatyyppi, String>? = null,
 ) : HasId<Int?>, Hankealue
 
 fun List<Hankealue>.alkuPvm(): ZonedDateTime? = mapNotNull { it.haittaAlkuPvm }.minOfOrNull { it }

--- a/services/hanke-service/src/main/resources/db/changelog/changesets/076-create-hankkeen-haittojenhallintasuunnitelma-table.sql
+++ b/services/hanke-service/src/main/resources/db/changelog/changesets/076-create-hankkeen-haittojenhallintasuunnitelma-table.sql
@@ -1,0 +1,20 @@
+--liquibase formatted sql
+--changeset Teemu Hiltunen:076-create-hankkeen-haittojenhallintasuunnitelma-table
+--comment: Create a table for project's nuisance management plan
+
+CREATE TABLE hankkeen_haittojenhallintasuunnitelma
+(
+    hankealue_id        bigint                   NOT NULL,
+    tyyppi              varchar(255)             NOT NULL,
+    sisalto             text                     NOT NULL,
+    CONSTRAINT fk_hanke
+        FOREIGN KEY (hankealue_id)
+            REFERENCES hankealue (id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_hankealue ON hankkeen_haittojenhallintasuunnitelma (hankealue_id);
+
+COMMENT ON TABLE hankkeen_haittojenhallintasuunnitelma IS 'Table for project nuisance management plan.';
+COMMENT ON COLUMN hankkeen_haittojenhallintasuunnitelma.hankealue_id IS 'The project area of which nuisance management plan this is.';
+COMMENT ON COLUMN hankkeen_haittojenhallintasuunnitelma.tyyppi IS 'Type of nuisance.';
+COMMENT ON COLUMN hankkeen_haittojenhallintasuunnitelma.sisalto IS 'Content of the nuisance management plan.';

--- a/services/hanke-service/src/main/resources/db/changelog/changesets/076-create-hankkeen-haittojenhallintasuunnitelma-table.sql
+++ b/services/hanke-service/src/main/resources/db/changelog/changesets/076-create-hankkeen-haittojenhallintasuunnitelma-table.sql
@@ -1,12 +1,13 @@
 --liquibase formatted sql
 --changeset Teemu Hiltunen:076-create-hankkeen-haittojenhallintasuunnitelma-table
---comment: Create a table for project's nuisance management plan
+--comment: Create a table for project's nuisance control plan
 
 CREATE TABLE hankkeen_haittojenhallintasuunnitelma
 (
     hankealue_id        bigint                   NOT NULL,
     tyyppi              varchar(255)             NOT NULL,
     sisalto             text                     NOT NULL,
+    PRIMARY KEY (hankealue_id, tyyppi),
     CONSTRAINT fk_hanke
         FOREIGN KEY (hankealue_id)
             REFERENCES hankealue (id) ON DELETE CASCADE
@@ -14,7 +15,7 @@ CREATE TABLE hankkeen_haittojenhallintasuunnitelma
 
 CREATE INDEX idx_hankealue ON hankkeen_haittojenhallintasuunnitelma (hankealue_id);
 
-COMMENT ON TABLE hankkeen_haittojenhallintasuunnitelma IS 'Table for project nuisance management plan.';
-COMMENT ON COLUMN hankkeen_haittojenhallintasuunnitelma.hankealue_id IS 'The project area of which nuisance management plan this is.';
+COMMENT ON TABLE hankkeen_haittojenhallintasuunnitelma IS 'Table for project nuisance control plan.';
+COMMENT ON COLUMN hankkeen_haittojenhallintasuunnitelma.hankealue_id IS 'The project area of which nuisance control plan this is.';
 COMMENT ON COLUMN hankkeen_haittojenhallintasuunnitelma.tyyppi IS 'Type of nuisance.';
-COMMENT ON COLUMN hankkeen_haittojenhallintasuunnitelma.sisalto IS 'Content of the nuisance management plan.';
+COMMENT ON COLUMN hankkeen_haittojenhallintasuunnitelma.sisalto IS 'Content of the nuisance control plan.';

--- a/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -179,3 +179,5 @@ databaseChangeLog:
       file: db/changelog/changesets/074-remove-old-cycle-tormays-tables.sql
   - include:
       file: db/changelog/changesets/075-change-tormaystarkastelutulos-to-refer-to-hankealue.sql
+  - include:
+      file: db/changelog/changesets/076-create-hankkeen-haittojenhallintasuunnitelma-table.sql

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/HankeMapperTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/HankeMapperTest.kt
@@ -90,6 +90,7 @@ class HankeMapperTest {
                 haittaLoppuPvm = DateFactory.getEndDatetime().toLocalDate().atStartOfDay(TZ_UTC),
                 geometriat =
                     GeometriaFactory.create().apply { resetFeatureProperties(hankeTunnus) },
+                haittojenhallintasuunnitelma = emptyMap(),
             )
         )
 }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeBuilder.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeBuilder.kt
@@ -18,6 +18,7 @@ import fi.hel.haitaton.hanke.domain.ModifyHankeYhteystietoRequest
 import fi.hel.haitaton.hanke.domain.ModifyHankealueRequest
 import fi.hel.haitaton.hanke.domain.SavedHankealue
 import fi.hel.haitaton.hanke.domain.TyomaaTyyppi
+import fi.hel.haitaton.hanke.factory.HankealueFactory.createHaittojenhallintasuunnitelma
 import fi.hel.haitaton.hanke.factory.ProfiiliFactory.DEFAULT_NAMES
 import fi.hel.haitaton.hanke.permissions.HankekayttajaEntity
 import fi.hel.haitaton.hanke.permissions.HankekayttajaInput
@@ -116,10 +117,16 @@ data class HankeBuilder(
         rakennuttajat = mutableListOf(HankeYhteystietoFactory.createDifferentiated(i, id = null))
     }
 
-    fun withHankealue(alue: SavedHankealue = HankealueFactory.create()) = applyToHanke {
+    fun withHankealue(
+        alue: SavedHankealue = HankealueFactory.create(),
+        haittojenhallintasuunnitelma: Boolean = false
+    ) = applyToHanke {
         alueet.add(alue)
         tyomaaKatuosoite = "Testikatu 1"
         tyomaaTyyppi = mutableSetOf(TyomaaTyyppi.VESI, TyomaaTyyppi.MUU)
+        if (haittojenhallintasuunnitelma) {
+            alue.haittojenhallintasuunnitelma = createHaittojenhallintasuunnitelma()
+        }
     }
 
     fun withPerustaja(perustaja: HankekayttajaInput): HankeBuilder =
@@ -193,7 +200,8 @@ data class HankeBuilder(
                 kaistaPituusHaitta = kaistaPituusHaitta,
                 meluHaitta = meluHaitta,
                 polyHaitta = polyHaitta,
-                tarinaHaitta = tarinaHaitta
+                tarinaHaitta = tarinaHaitta,
+                haittojenhallintasuunnitelma = haittojenhallintasuunnitelma
             )
     }
 }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeBuilder.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeBuilder.kt
@@ -9,6 +9,7 @@ import fi.hel.haitaton.hanke.HankeYhteyshenkiloRepository
 import fi.hel.haitaton.hanke.HankeYhteystietoEntity
 import fi.hel.haitaton.hanke.HankeYhteystietoRepository
 import fi.hel.haitaton.hanke.domain.CreateHankeRequest
+import fi.hel.haitaton.hanke.domain.Haittojenhallintatyyppi
 import fi.hel.haitaton.hanke.domain.Hanke
 import fi.hel.haitaton.hanke.domain.HankePerustaja
 import fi.hel.haitaton.hanke.domain.HankeYhteystieto
@@ -18,7 +19,6 @@ import fi.hel.haitaton.hanke.domain.ModifyHankeYhteystietoRequest
 import fi.hel.haitaton.hanke.domain.ModifyHankealueRequest
 import fi.hel.haitaton.hanke.domain.SavedHankealue
 import fi.hel.haitaton.hanke.domain.TyomaaTyyppi
-import fi.hel.haitaton.hanke.factory.HankealueFactory.createHaittojenhallintasuunnitelma
 import fi.hel.haitaton.hanke.factory.ProfiiliFactory.DEFAULT_NAMES
 import fi.hel.haitaton.hanke.permissions.HankekayttajaEntity
 import fi.hel.haitaton.hanke.permissions.HankekayttajaInput
@@ -119,14 +119,12 @@ data class HankeBuilder(
 
     fun withHankealue(
         alue: SavedHankealue = HankealueFactory.create(),
-        haittojenhallintasuunnitelma: Boolean = false
+        haittojenhallintasuunnitelma: Map<Haittojenhallintatyyppi, String>? = null,
     ) = applyToHanke {
         alueet.add(alue)
         tyomaaKatuosoite = "Testikatu 1"
         tyomaaTyyppi = mutableSetOf(TyomaaTyyppi.VESI, TyomaaTyyppi.MUU)
-        if (haittojenhallintasuunnitelma) {
-            alue.haittojenhallintasuunnitelma = createHaittojenhallintasuunnitelma()
-        }
+        haittojenhallintasuunnitelma?.let { alue.haittojenhallintasuunnitelma = it }
     }
 
     fun withPerustaja(perustaja: HankekayttajaInput): HankeBuilder =

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankealueFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankealueFactory.kt
@@ -51,19 +51,22 @@ object HankealueFactory {
         )
     }
 
-    fun createHaittojenhallintasuunnitelma(): Map<Haittojenhallintatyyppi, String> {
-        return mapOf(
-            Haittojenhallintatyyppi.YLEINEN to "Yleisten haittojen hallintasuunnitelma",
-            Haittojenhallintatyyppi.PYORALIIKENNE to
-                "Pyöräliikenteelle koituvien haittojen hallintasuunnitelma",
-            Haittojenhallintatyyppi.AUTOLIIKENNE to
-                "Autoliikenteelle koituvien haittojen hallintasuunnitelma",
-            Haittojenhallintatyyppi.LINJAAUTOLIIKENNE to
-                "Linja-autoliikenteelle koituvien haittojen hallintasuunnitelma",
-            Haittojenhallintatyyppi.RAITIOLIIKENNE to
-                "Raitioliikenteelle koituvien haittojen hallintasuunnitelma",
-            Haittojenhallintatyyppi.MUUT to "Muiden haittojen hallintasuunnitelma"
-        )
+    fun createHaittojenhallintasuunnitelma(
+        vararg pairs: Pair<Haittojenhallintatyyppi, String> =
+            arrayOf(
+                Haittojenhallintatyyppi.YLEINEN to "Yleisten haittojen hallintasuunnitelma",
+                Haittojenhallintatyyppi.PYORALIIKENNE to
+                    "Pyöräliikenteelle koituvien haittojen hallintasuunnitelma",
+                Haittojenhallintatyyppi.AUTOLIIKENNE to
+                    "Autoliikenteelle koituvien haittojen hallintasuunnitelma",
+                Haittojenhallintatyyppi.LINJAAUTOLIIKENNE to
+                    "Linja-autoliikenteelle koituvien haittojen hallintasuunnitelma",
+                Haittojenhallintatyyppi.RAITIOLIIKENNE to
+                    "Raitioliikenteelle koituvien haittojen hallintasuunnitelma",
+                Haittojenhallintatyyppi.MUUT to "Muiden haittojen hallintasuunnitelma"
+            )
+    ): MutableMap<Haittojenhallintatyyppi, String> {
+        return mutableMapOf(*pairs)
     }
 
     fun createMinimal(
@@ -110,9 +113,11 @@ object HankealueFactory {
                 tarinaHaitta = alue.tarinaHaitta,
                 nimi = alue.nimi,
                 tormaystarkasteluTulos = null,
-                haittojenhallintasuunnitelma = alue.haittojenhallintasuunnitelma,
             )
-            .apply { tormaystarkasteluTulos = tormaystarkasteluTulosEntity(hankealueEntity = this) }
+            .apply {
+                tormaystarkasteluTulos = tormaystarkasteluTulosEntity(hankealueEntity = this)
+                alue.haittojenhallintasuunnitelma?.let { haittojenhallintasuunnitelma.putAll(it) }
+            }
     }
 
     private fun tormaystarkasteluTulos() =

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankealueFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankealueFactory.kt
@@ -3,6 +3,7 @@ package fi.hel.haitaton.hanke.factory
 import fi.hel.haitaton.hanke.HANKEALUE_DEFAULT_NAME
 import fi.hel.haitaton.hanke.HankeEntity
 import fi.hel.haitaton.hanke.HankealueEntity
+import fi.hel.haitaton.hanke.domain.Haittojenhallintatyyppi
 import fi.hel.haitaton.hanke.domain.SavedHankealue
 import fi.hel.haitaton.hanke.geometria.Geometriat
 import fi.hel.haitaton.hanke.tormaystarkastelu.AutoliikenteenKaistavaikutustenPituus
@@ -31,6 +32,7 @@ object HankealueFactory {
         tarinaHaitta: Tarinahaitta? = Tarinahaitta.JATKUVA_TARINAHAITTA,
         nimi: String = "$HANKEALUE_DEFAULT_NAME 1",
         tormaystarkasteluTulos: TormaystarkasteluTulos? = tormaystarkasteluTulos(),
+        haittojenhallintasuunnitelma: Map<Haittojenhallintatyyppi, String>? = null,
     ): SavedHankealue {
         return SavedHankealue(
             id,
@@ -45,6 +47,22 @@ object HankealueFactory {
             tarinaHaitta,
             nimi,
             tormaystarkasteluTulos,
+            haittojenhallintasuunnitelma,
+        )
+    }
+
+    fun createHaittojenhallintasuunnitelma(): Map<Haittojenhallintatyyppi, String> {
+        return mapOf(
+            Haittojenhallintatyyppi.YLEINEN to "Yleisten haittojen hallintasuunnitelma",
+            Haittojenhallintatyyppi.PYORALIIKENNE to
+                "Pyöräliikenteelle koituvien haittojen hallintasuunnitelma",
+            Haittojenhallintatyyppi.AUTOLIIKENNE to
+                "Autoliikenteelle koituvien haittojen hallintasuunnitelma",
+            Haittojenhallintatyyppi.LINJAAUTOLIIKENNE to
+                "Linja-autoliikenteelle koituvien haittojen hallintasuunnitelma",
+            Haittojenhallintatyyppi.RAITIOLIIKENNE to
+                "Raitioliikenteelle koituvien haittojen hallintasuunnitelma",
+            Haittojenhallintatyyppi.MUUT to "Muiden haittojen hallintasuunnitelma"
         )
     }
 
@@ -92,6 +110,7 @@ object HankealueFactory {
                 tarinaHaitta = alue.tarinaHaitta,
                 nimi = alue.nimi,
                 tormaystarkasteluTulos = null,
+                haittojenhallintasuunnitelma = alue.haittojenhallintasuunnitelma,
             )
             .apply { tormaystarkasteluTulos = tormaystarkasteluTulosEntity(hankealueEntity = this) }
     }


### PR DESCRIPTION
# Description

Project areas can have nuisance management plans for different nuisance types.

Also, unrelated, added quotes in port definitions in `docker-compose.yml`.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1383

## Type of change

- [ ] Bug fix 
- [x] New feature 
- [ ] Other

# Instructions for testing
1. Start the backend
2. Create a new project or use an existing one and update its data via API: http://localhost:3001/api/swagger-ui/index.html#/hanke-controller/updateHanke. Add nuisance management plan in the data:
```
{
    "id": 10,
    "hankeTunnus": "HAI24-10",
...
    "alueet": [
        {
            "id": 56,
            "hankeId": 10,
...
            "haittojenhallintasuunnitelma": {
                "YLEINEN": "Yleinen haittojenhallinta",
                "PYORALIIKENNE": "Pyöräliikenteelle koituvien haittojen hallinta",
                "AUTOLIIKENNE": "Autoliikenteelle koituvien haittojen hallinta",
                "RAITIOLIIKENNE": "Raitioliikenteelle koituvien haittojen hallinta",
                "LINJAAUTOLIIKENNE": "Linja-autoliikenteelle koituvien haittojen hallinta",
                "MUUT": "Muiden haittojen hallinta" 
            }
        }
    ],
...
}
```
3. Update should work without errors and the database should have new values
4. Try also GET and DELETE endpoints, they should work as well

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 

# Other relevant info
Please describe here if there is e.g. some requirements for this change or
 other info that the tester/user needs to know.