### PR TITLE
HAI-2389 Add API for calculating nuisance indexes

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluControllerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluControllerITest.kt
@@ -67,7 +67,9 @@ class TormaystarkasteluControllerITest(
         @Test
         fun `returns 400 when request has wrong CRS`() {
             val request = createRequest()
-            request.geometriat.crs?.properties?.set("name", "urn:ogc:def:crs:EPSG::0000")
+            request.geometriat.featureCollection.crs
+                ?.properties
+                ?.set("name", "urn:ogc:def:crs:EPSG::0000")
 
             post(url, request)
                 .andExpect(status().isBadRequest)
@@ -77,7 +79,7 @@ class TormaystarkasteluControllerITest(
         @Test
         fun `returns 400 when request has no CRS`() {
             val request = createRequest()
-            request.geometriat.crs = null
+            request.geometriat.featureCollection.crs = null
 
             post(url, request)
                 .andExpect(status().isBadRequest)
@@ -87,7 +89,7 @@ class TormaystarkasteluControllerITest(
         @Test
         fun `returns 400 when request has no CRS properties`() {
             val request = createRequest()
-            request.geometriat.crs.properties = null
+            request.geometriat.featureCollection.crs.properties = null
 
             post(url, request)
                 .andExpect(status().isBadRequest)
@@ -170,14 +172,17 @@ class TormaystarkasteluControllerITest(
                 VaikutusAutoliikenteenKaistamaariin.VAHENTAA_KAISTAN_YHDELLA_AJOSUUNNALLA,
             kaistaPituusHaitta: AutoliikenteenKaistavaikutustenPituus =
                 AutoliikenteenKaistavaikutustenPituus.PITUUS_10_99_METRIA,
-        ) =
-            TormaystarkasteluRequest(
-                geometriat = GeometriaFactory.createNew().featureCollection!!,
+        ): TormaystarkasteluRequest {
+            val featureCollection = GeometriaFactory.createNew().featureCollection!!
+
+            return TormaystarkasteluRequest(
+                geometriat = TormaystarkasteluRequest.Geometriat(featureCollection),
                 haittaAlkuPvm = haittaAlkuPvm,
                 haittaLoppuPvm = haittaLoppuPvm,
                 kaistaHaitta = kaistaHaitta,
                 kaistaPituusHaitta = kaistaPituusHaitta,
             )
+        }
 
         private fun createTulos() = TormaystarkasteluTulos(1.5f, 2.4f, 7.1f, 5.0f)
     }

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluControllerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluControllerITest.kt
@@ -56,8 +56,6 @@ class TormaystarkasteluControllerITest(
     inner class Calculate {
         val url = "/haittaindeksit"
 
-        val featureCollection = GeometriaFactory.createNew().featureCollection!!
-
         @Test
         @WithAnonymousUser
         fun `returns 401 when not authenticated`() {
@@ -174,7 +172,7 @@ class TormaystarkasteluControllerITest(
                 AutoliikenteenKaistavaikutustenPituus.PITUUS_10_99_METRIA,
         ) =
             TormaystarkasteluRequest(
-                geometriat = featureCollection,
+                geometriat = GeometriaFactory.createNew().featureCollection!!,
                 haittaAlkuPvm = haittaAlkuPvm,
                 haittaLoppuPvm = haittaLoppuPvm,
                 kaistaHaitta = kaistaHaitta,

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluControllerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluControllerITest.kt
@@ -1,0 +1,186 @@
+package fi.hel.haitaton.hanke.tormaystarkastelu
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import fi.hel.haitaton.hanke.ControllerTest
+import fi.hel.haitaton.hanke.HankeError
+import fi.hel.haitaton.hanke.IntegrationTestConfiguration
+import fi.hel.haitaton.hanke.andReturnBody
+import fi.hel.haitaton.hanke.factory.DateFactory
+import fi.hel.haitaton.hanke.factory.GeometriaFactory
+import fi.hel.haitaton.hanke.hankeError
+import fi.hel.haitaton.hanke.test.USERNAME
+import io.mockk.Called
+import io.mockk.checkUnnecessaryStub
+import io.mockk.clearAllMocks
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.verifySequence
+import java.time.ZonedDateTime
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.context.annotation.Import
+import org.springframework.security.test.context.support.WithAnonymousUser
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+@WebMvcTest(controllers = [TormaystarkasteluController::class])
+@Import(IntegrationTestConfiguration::class)
+@ActiveProfiles("test")
+@WithMockUser(USERNAME)
+class TormaystarkasteluControllerITest(
+    @Autowired override val mockMvc: MockMvc,
+    @Autowired val laskentaService: TormaystarkasteluLaskentaService,
+) : ControllerTest {
+
+    @BeforeEach
+    fun clearMocks() {
+        clearAllMocks()
+    }
+
+    @AfterEach
+    fun checkMocks() {
+        checkUnnecessaryStub()
+        confirmVerified(laskentaService)
+    }
+
+    @Nested
+    inner class Calculate {
+        val url = "/haittaindeksit"
+
+        val featureCollection = GeometriaFactory.createNew().featureCollection!!
+
+        @Test
+        @WithAnonymousUser
+        fun `returns 401 when not authenticated`() {
+            post(url).andExpect(status().isUnauthorized)
+
+            verifySequence { laskentaService wasNot Called }
+        }
+
+        @Test
+        fun `returns 400 when request has wrong CRS`() {
+            val request = createRequest()
+            request.geometriat.crs?.properties?.set("name", "urn:ogc:def:crs:EPSG::0000")
+
+            post(url, request)
+                .andExpect(status().isBadRequest)
+                .andExpect(hankeError(HankeError.HAI1013))
+        }
+
+        @Test
+        fun `returns 400 when request has no CRS`() {
+            val request = createRequest()
+            request.geometriat.crs = null
+
+            post(url, request)
+                .andExpect(status().isBadRequest)
+                .andExpect(hankeError(HankeError.HAI1011))
+        }
+
+        @Test
+        fun `returns 400 when request has no CRS properties`() {
+            val request = createRequest()
+            request.geometriat.crs.properties = null
+
+            post(url, request)
+                .andExpect(status().isBadRequest)
+                .andExpect(hankeError(HankeError.HAI1011))
+        }
+
+        @ParameterizedTest
+        @CsvSource(
+            value =
+                [
+                    "2025-02-20T23:45:56Z,2025-02-20T23:45:55Z",
+                    "2025-02-20T23:45:56Z,2025-02-19T23:47:56Z",
+                ]
+        )
+        fun `returns 400 when start time is after end time`(
+            startDate: ZonedDateTime,
+            endDate: ZonedDateTime
+        ) {
+            val request = createRequest(startDate, endDate)
+
+            post(url, request)
+                .andExpect(status().isBadRequest)
+                .andExpect(hankeError(HankeError.HAI0003))
+        }
+
+        @ParameterizedTest
+        @CsvSource(
+            value =
+                [
+                    "2025-02-20T23:45:56Z,2025-02-21T00:12:34Z,1",
+                    "2025-02-20T23:45:56Z,2025-02-20T23:45:56Z,1",
+                    "2025-02-20T00:45:56Z,2025-02-20T23:12:34Z,1",
+                    "2025-02-20T23:45:56Z,2025-02-21T23:45:56Z,2",
+                ]
+        )
+        fun `calls the service with the right length in days`(
+            startDate: ZonedDateTime,
+            endDate: ZonedDateTime,
+            days: Int,
+        ) {
+            val request = createRequest(startDate, endDate)
+            every {
+                laskentaService.calculateTormaystarkastelu(
+                    any(),
+                    days,
+                    VaikutusAutoliikenteenKaistamaariin.VAHENTAA_KAISTAN_YHDELLA_AJOSUUNNALLA,
+                    AutoliikenteenKaistavaikutustenPituus.PITUUS_10_99_METRIA
+                )
+            } returns createTulos()
+
+            post(url, request).andExpect(status().isOk)
+
+            verifySequence {
+                laskentaService.calculateTormaystarkastelu(
+                    any(),
+                    days,
+                    VaikutusAutoliikenteenKaistamaariin.VAHENTAA_KAISTAN_YHDELLA_AJOSUUNNALLA,
+                    AutoliikenteenKaistavaikutustenPituus.PITUUS_10_99_METRIA
+                )
+            }
+        }
+
+        @Test
+        fun `returns the calculation results`() {
+            val request = createRequest()
+            every { laskentaService.calculateTormaystarkastelu(any(), 1, any(), any()) } returns
+                createTulos()
+
+            val result: TormaystarkasteluTulos =
+                post(url, request).andExpect(status().isOk).andReturnBody()
+
+            assertThat(result).isEqualTo(createTulos())
+            verifySequence { laskentaService.calculateTormaystarkastelu(any(), 1, any(), any()) }
+        }
+
+        private fun createRequest(
+            haittaAlkuPvm: ZonedDateTime = DateFactory.getStartDatetime(),
+            haittaLoppuPvm: ZonedDateTime = DateFactory.getEndDatetime(),
+            kaistaHaitta: VaikutusAutoliikenteenKaistamaariin =
+                VaikutusAutoliikenteenKaistamaariin.VAHENTAA_KAISTAN_YHDELLA_AJOSUUNNALLA,
+            kaistaPituusHaitta: AutoliikenteenKaistavaikutustenPituus =
+                AutoliikenteenKaistavaikutustenPituus.PITUUS_10_99_METRIA,
+        ) =
+            TormaystarkasteluRequest(
+                geometriat = featureCollection,
+                haittaAlkuPvm = haittaAlkuPvm,
+                haittaLoppuPvm = haittaLoppuPvm,
+                kaistaHaitta = kaistaHaitta,
+                kaistaPituusHaitta = kaistaPituusHaitta,
+            )
+
+        private fun createTulos() = TormaystarkasteluTulos(1.5f, 2.4f, 7.1f, 5.0f)
+    }
+}

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluTormaysServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluTormaysServiceITest.kt
@@ -5,9 +5,13 @@ import assertk.assertions.containsExactlyInAnyOrder
 import assertk.assertions.isEmpty
 import assertk.assertions.isEqualTo
 import fi.hel.haitaton.hanke.IntegrationTest
+import fi.hel.haitaton.hanke.SRID
 import fi.hel.haitaton.hanke.asJsonResource
 import fi.hel.haitaton.hanke.geometria.Geometriat
 import fi.hel.haitaton.hanke.geometria.GeometriatDao
+import org.geojson.Crs
+import org.geojson.GeometryCollection
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
 import org.springframework.beans.factory.annotation.Autowired
@@ -103,7 +107,9 @@ internal class TormaystarkasteluTormaysServiceITest : IntegrationTest() {
     @CsvSource("Kaivokatu,3,1023N;1023N;1016", "Mustikkamaa,0,")
     fun `bus routes`(location: String, resultCount: Int, resultRoutes: String?) {
         val geometriaIds = createHankeGeometriat(location)
+
         val bussit = tormaysService.getIntersectingBusRoutes(geometriaIds)
+
         assertThat(bussit.size).isEqualTo(resultCount)
         if (resultRoutes != null) {
             assertThat(bussit.map { it.reittiId })
@@ -142,5 +148,123 @@ internal class TormaystarkasteluTormaysServiceITest : IntegrationTest() {
             "/fi/hel/haitaton/hanke/tormaystarkastelu/hankeGeometriat-$location.json"
                 .asJsonResource(Geometriat::class.java)
         return setOf(geometriatDao.createGeometriat(geometriat).id!!)
+    }
+
+    @Nested
+    inner class WithGeometry {
+
+        @ParameterizedTest
+        @CsvSource("Kaivokatu,true", "Mustikkamaa,false")
+        fun `general street area`(location: String, result: Boolean) {
+            val geometry = createGeometryCollection(location)
+
+            assertThat(tormaysService.anyIntersectsYleinenKatuosa(geometry)).isEqualTo(result)
+        }
+
+        @ParameterizedTest
+        @CsvSource("Kaivokatu,4", "Mustikkamaa,")
+        fun `general street classes`(location: String, result: Int?) {
+            val geometry = createGeometryCollection(location)
+
+            assertThat(tormaysService.maxIntersectingYleinenkatualueKatuluokka(geometry))
+                .isEqualTo(result)
+        }
+
+        @ParameterizedTest
+        @CsvSource("Kaivokatu,4", "Mustikkamaa,")
+        fun `street classes`(location: String, result: Int?) {
+            val geometry = createGeometryCollection(location)
+
+            assertThat(tormaysService.maxIntersectingLiikenteellinenKatuluokka(geometry))
+                .isEqualTo(result)
+        }
+
+        @ParameterizedTest
+        @CsvSource("Kaivokatu,17566", "Mustikkamaa,")
+        fun `traffic counts with radius of 15m`(location: String, result: Int?) {
+            val geometry = createGeometryCollection(location)
+
+            assertThat(
+                    tormaysService.maxLiikennemaara(
+                        geometry,
+                        TormaystarkasteluLiikennemaaranEtaisyys.RADIUS_15
+                    )
+                )
+                .isEqualTo(result)
+        }
+
+        @ParameterizedTest
+        @CsvSource("Kaivokatu,17566", "Mustikkamaa,")
+        fun `traffic counts with radius of 30m`(location: String, result: Int?) {
+            val geometry = createGeometryCollection(location)
+
+            assertThat(
+                    tormaysService.maxLiikennemaara(
+                        geometry,
+                        TormaystarkasteluLiikennemaaranEtaisyys.RADIUS_30
+                    )
+                )
+                .isEqualTo(result)
+        }
+
+        @ParameterizedTest
+        @CsvSource("Kaivokatu,false", "Mustikkamaa,false")
+        fun `critical bus routes`(location: String, result: Boolean) {
+            val geometry = createGeometryCollection(location)
+
+            assertThat(tormaysService.anyIntersectsCriticalBusRoutes(geometry)).isEqualTo(result)
+        }
+
+        @ParameterizedTest
+        @CsvSource("Kaivokatu,3,1023N;1023N;1016", "Mustikkamaa,0,")
+        fun `bus routes`(location: String, resultCount: Int, resultRoutes: String?) {
+            val geometry = createGeometryCollection(location)
+
+            val bussit = tormaysService.getIntersectingBusRoutes(geometry)
+
+            assertThat(bussit.size).isEqualTo(resultCount)
+            if (resultRoutes != null) {
+                assertThat(bussit.map { it.reittiId })
+                    .containsExactlyInAnyOrder(*resultRoutes.split(';').toTypedArray())
+            } else {
+                assertThat(bussit).isEmpty()
+            }
+        }
+
+        @ParameterizedTest
+        @CsvSource("Kaivokatu,true", "Mustikkamaa,false")
+        fun `tram infra`(location: String, result: Boolean) {
+            val geometry = createGeometryCollection(location)
+
+            assertThat(tormaysService.anyIntersectsWithTramInfra(geometry)).isEqualTo(result)
+        }
+
+        @ParameterizedTest
+        @CsvSource("Kaivokatu,true", "Mustikkamaa,false")
+        fun `tram lines`(location: String, result: Boolean) {
+            val geometry = createGeometryCollection(location)
+
+            assertThat(tormaysService.anyIntersectsWithTramLines(geometry)).isEqualTo(result)
+        }
+
+        @ParameterizedTest
+        @CsvSource("Kaivokatu,3", "Mustikkamaa,")
+        fun `cycleways hierarkia`(location: String, result: Int?) {
+            val geometry = createGeometryCollection(location)
+
+            assertThat(tormaysService.maxIntersectingPyoraliikenneHierarkia(geometry))
+                .isEqualTo(result)
+        }
+
+        private fun createGeometryCollection(location: String): GeometryCollection {
+            val geometriat =
+                "/fi/hel/haitaton/hanke/tormaystarkastelu/hankeGeometriat-$location.json"
+                    .asJsonResource(Geometriat::class.java)
+            val geoColl = GeometryCollection()
+            geoColl.crs = Crs()
+            geoColl.crs.properties["name"] = "EPSG:$SRID"
+            geoColl.geometries = geometriat.featureCollection!!.features.map { it.geometry }
+            return geoColl
+        }
     }
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/geometria/GeometriatDao.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/geometria/GeometriatDao.kt
@@ -190,7 +190,7 @@ class GeometriatDao(private val jdbcOperations: JdbcOperations) {
         }
     }
 
-    fun validateGeometria(geometria: GeoJsonObject): GeometriatDao.InvalidDetail? {
+    fun validateGeometria(geometria: GeoJsonObject): InvalidDetail? {
         val detailQuery =
             "select valid, reason, ST_AsGeoJSON(location) as location from ST_IsValidDetail(ST_GeomFromGeoJSON(?))"
 
@@ -199,7 +199,7 @@ class GeometriatDao(private val jdbcOperations: JdbcOperations) {
                 detailQuery,
                 { rs, _ ->
                     if (!rs.getBoolean("valid")) {
-                        GeometriatDao.InvalidDetail(
+                        InvalidDetail(
                             rs.getString("reason"),
                             rs.getString("location"),
                         )
@@ -222,7 +222,7 @@ class GeometriatDao(private val jdbcOperations: JdbcOperations) {
      *
      * @return List of indexes in the feature collection where the validation failed.
      */
-    fun validateGeometriat(geometriat: List<GeoJsonObject>): GeometriatDao.InvalidDetail? =
+    fun validateGeometriat(geometriat: List<GeoJsonObject>): InvalidDetail? =
         geometriat.firstNotNullOfOrNull { validateGeometria(it) }
 
     /** Check if the given geometry is inside any hankealue of the given hanke. */

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/geometria/GeometriatValidator.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/geometria/GeometriatValidator.kt
@@ -2,12 +2,17 @@ package fi.hel.haitaton.hanke.geometria
 
 import fi.hel.haitaton.hanke.COORDINATE_SYSTEM_URN
 import fi.hel.haitaton.hanke.domain.HasFeatures
+import org.geojson.FeatureCollection
 
 class GeometriatValidator {
     companion object {
         fun expectValid(value: HasFeatures?) {
             val featureCollection =
                 value?.featureCollection ?: throw GeometriaValidationException("featureCollection")
+            expectValid(featureCollection)
+        }
+
+        fun expectValid(featureCollection: FeatureCollection) {
             when {
                 featureCollection.crs == null ->
                     throw GeometriaValidationException("featureCollection.crs")

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluController.kt
@@ -52,7 +52,7 @@ class TormaystarkasteluController(
             ]
     )
     fun calculate(@RequestBody request: TormaystarkasteluRequest): TormaystarkasteluTulos {
-        GeometriatValidator.expectValid(request.geometriat)
+        GeometriatValidator.expectValid(request.geometriat.featureCollection)
 
         if (request.haittaAlkuPvm.isAfter(request.haittaLoppuPvm)) {
             throw EndBeforeStartException(request.haittaAlkuPvm, request.haittaLoppuPvm)
@@ -62,7 +62,7 @@ class TormaystarkasteluController(
             ChronoUnit.DAYS.between(request.haittaAlkuPvm, request.haittaLoppuPvm).toInt() + 1
 
         return tormaystarkasteluLaskentaService.calculateTormaystarkastelu(
-            request.geometriat,
+            request.geometriat.featureCollection,
             haittaajanKestoDays,
             request.kaistaHaitta,
             request.kaistaPituusHaitta

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluController.kt
@@ -1,0 +1,83 @@
+package fi.hel.haitaton.hanke.tormaystarkastelu
+
+import fi.hel.haitaton.hanke.HankeError
+import fi.hel.haitaton.hanke.geometria.GeometriatValidator
+import io.sentry.Sentry
+import io.swagger.v3.oas.annotations.Hidden
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
+import java.time.ZonedDateTime
+import java.time.temporal.ChronoUnit
+import mu.KotlinLogging
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+
+private val logger = KotlinLogging.logger {}
+
+@RestController
+@RequestMapping("/haittaindeksit")
+@SecurityRequirement(name = "bearerAuth")
+class TormaystarkasteluController(
+    private val tormaystarkasteluLaskentaService: TormaystarkasteluLaskentaService,
+) {
+
+    @PostMapping
+    @Operation(
+        summary = "Calculate nuisance indices",
+        description =
+            "Calculate nuisance indices with the given geometry and other information. The calculated indices will not be saved anywhere."
+    )
+    @ApiResponses(
+        value =
+            [
+                ApiResponse(
+                    description =
+                        "The calculated nuisance indices for the given geometry and other information.",
+                    responseCode = "200"
+                ),
+                ApiResponse(
+                    description = "The given information was not valid.",
+                    responseCode = "400",
+                    content = [Content(schema = Schema(implementation = HankeError::class))]
+                ),
+            ]
+    )
+    fun calculate(@RequestBody request: TormaystarkasteluRequest): TormaystarkasteluTulos {
+        GeometriatValidator.expectValid(request.geometriat)
+
+        if (request.haittaAlkuPvm.isAfter(request.haittaLoppuPvm)) {
+            throw EndBeforeStartException(request.haittaAlkuPvm, request.haittaLoppuPvm)
+        }
+
+        val haittaajanKestoDays =
+            ChronoUnit.DAYS.between(request.haittaAlkuPvm, request.haittaLoppuPvm).toInt() + 1
+
+        return tormaystarkasteluLaskentaService.calculateTormaystarkastelu(
+            request.geometriat,
+            haittaajanKestoDays,
+            request.kaistaHaitta,
+            request.kaistaPituusHaitta
+        )
+    }
+
+    class EndBeforeStartException(start: ZonedDateTime, end: ZonedDateTime) :
+        RuntimeException("Start date is after the end date. start=$start, end=$end")
+
+    @ExceptionHandler(EndBeforeStartException::class)
+    @Hidden
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    fun endBeforeStartException(ex: EndBeforeStartException): HankeError {
+        logger.warn { ex.message }
+        Sentry.captureException(ex)
+        return HankeError.HAI0003
+    }
+}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluLaskentaService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluLaskentaService.kt
@@ -1,8 +1,13 @@
 package fi.hel.haitaton.hanke.tormaystarkastelu
 
 import fi.hel.haitaton.hanke.HankealueEntity
+import fi.hel.haitaton.hanke.SRID
 import fi.hel.haitaton.hanke.roundToOneDecimal
 import kotlin.math.max
+import org.geojson.Crs
+import org.geojson.FeatureCollection
+import org.geojson.GeoJsonObject
+import org.geojson.GeometryCollection
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
 
@@ -17,15 +22,41 @@ class TormaystarkasteluLaskentaService(
         }
 
         val autoliikenneindeksi = calculateAutoliikenneindeksi(alue)
-        val pyoraliikenneindeksi = calculatePyoraliikenneindeksi(alue.geometriat!!)
-        val linjaautoliikenneindeksi = calculateLinjaautoliikenneindeksi(alue.geometriat!!)
-        val raitioliikenneindeksi = calculateRaitioliikenneindeksi(alue.geometriat!!)
+        val pyoraliikenneindeksi = calculatePyoraliikenneindeksi(setOf(alue.geometriat!!))
+        val linjaautoliikenneindeksi =
+            calculateLinjaautoliikenneindeksi(setOf(alue.geometriat!!)).toFloat()
+        val raitioliikenneindeksi = calculateRaitioliikenneindeksi(setOf(alue.geometriat!!))
 
         return TormaystarkasteluTulos(
             autoliikenneindeksi,
             pyoraliikenneindeksi,
             linjaautoliikenneindeksi,
             raitioliikenneindeksi,
+        )
+    }
+
+    fun calculateTormaystarkastelu(
+        geometriat: FeatureCollection,
+        haittaajanKestoDays: Int,
+        kaistahaitta: VaikutusAutoliikenteenKaistamaariin,
+        kaistapituushaitta: AutoliikenteenKaistavaikutustenPituus,
+    ): TormaystarkasteluTulos {
+
+        val geometryCollection = GeometryCollection()
+        geometryCollection.crs = Crs()
+        geometryCollection.crs.properties["name"] = "EPSG:$SRID"
+        geometryCollection.geometries = geometriat.features.map { it.geometry }
+
+        return TormaystarkasteluTulos(
+            calculateAutoliikenneindeksi(
+                geometryCollection,
+                haittaajanKestoDays,
+                kaistahaitta,
+                kaistapituushaitta,
+            ),
+            calculatePyoraliikenneindeksi(geometryCollection),
+            calculateLinjaautoliikenneindeksi(geometryCollection).toFloat(),
+            calculateRaitioliikenneindeksi(geometryCollection),
         )
     }
 
@@ -55,28 +86,77 @@ class TormaystarkasteluLaskentaService(
         return calculateAutoliikenneindeksiFromLuokittelu(luokittelu)
     }
 
-    internal fun katuluokkaluokittelu(geometriaIds: Set<Int>): Int {
-        return if (tormaysService.anyIntersectsYleinenKatuosa(geometriaIds)) {
-            // ON ylre_parts => street_classes?
-            tormaysService.maxIntersectingLiikenteellinenKatuluokka(geometriaIds)
-                // EI street_classes => ylre_classes?
-                ?: tormaysService.maxIntersectingYleinenkatualueKatuluokka(geometriaIds)
-                // EI ylre_classes
-                ?: 0
-        } else {
-            // EI ylre_parts => ylre_classes?
-            val max =
-                tormaysService.maxIntersectingYleinenkatualueKatuluokka(geometriaIds)
-                    // EI ylre_classes
-                    ?: return 0
-            // ON ylre_classes => street_classes?
-            tormaysService.maxIntersectingLiikenteellinenKatuluokka(geometriaIds)
-                // JOS EI LÖYDY => Valitse ylre_classes
-                ?: max
-        }
+    private fun calculateAutoliikenneindeksi(
+        geometria: GeoJsonObject,
+        haittaajanKestoDays: Int,
+        kaistahaitta: VaikutusAutoliikenteenKaistamaariin,
+        kaistapituushaitta: AutoliikenteenKaistavaikutustenPituus,
+    ): Float {
+        val luokittelu = mutableMapOf<LuokitteluType, Int>()
+
+        luokittelu[LuokitteluType.HAITTA_AJAN_KESTO] =
+            RajaArvoLuokittelija.haittaajankestoluokka(haittaajanKestoDays)
+        luokittelu[LuokitteluType.VAIKUTUS_AUTOLIIKENTEEN_KAISTAMAARIIN] = kaistahaitta.value
+        luokittelu[LuokitteluType.AUTOLIIKENTEEN_KAISTAVAIKUTUSTEN_PITUUS] =
+            kaistapituushaitta.value
+
+        val katuluokkaLuokittelu = katuluokkaluokittelu(geometria)
+        luokittelu[LuokitteluType.KATULUOKKA] = katuluokkaLuokittelu
+        luokittelu[LuokitteluType.AUTOLIIKENTEEN_MAARA] =
+            liikennemaaraluokittelu(geometria, katuluokkaLuokittelu)
+
+        return calculateAutoliikenneindeksiFromLuokittelu(luokittelu)
     }
 
-    internal fun liikennemaaraluokittelu(geometriaIds: Set<Int>, katuluokkaluokittelu: Int): Int {
+    internal fun katuluokkaluokittelu(geometriaIds: Set<Int>): Int =
+        katuluokkaluokittelu(
+            { tormaysService.anyIntersectsYleinenKatuosa(geometriaIds) },
+            { tormaysService.maxIntersectingLiikenteellinenKatuluokka(geometriaIds) },
+            { tormaysService.maxIntersectingYleinenkatualueKatuluokka(geometriaIds) },
+        )
+
+    internal fun katuluokkaluokittelu(geometry: GeoJsonObject): Int =
+        katuluokkaluokittelu(
+            { tormaysService.anyIntersectsYleinenKatuosa(geometry) },
+            { tormaysService.maxIntersectingLiikenteellinenKatuluokka(geometry) },
+            { tormaysService.maxIntersectingYleinenkatualueKatuluokka(geometry) },
+        )
+
+    private fun katuluokkaluokittelu(
+        ylreParts: () -> Boolean,
+        streetClasses: () -> Int?,
+        ylreClasses: () -> Int?,
+    ): Int =
+        if (ylreParts()) {
+            // Use street classes if they are available.
+            // Otherwise, default to ylre classes.
+            streetClasses() ?: ylreClasses() ?: 0
+        } else {
+            val max = ylreClasses()
+            if (max == null) {
+                // If there are no ylre parts or classes, return 0
+                0
+            } else {
+                // Use street classes if they are available.
+                // Otherwise default to ylre classes.
+                streetClasses() ?: max
+            }
+        }
+
+    internal fun liikennemaaraluokittelu(geometriaIds: Set<Int>, katuluokkaluokittelu: Int): Int =
+        liikennemaaraluokittelu(katuluokkaluokittelu) { radius ->
+            tormaysService.maxLiikennemaara(geometriaIds, radius)
+        }
+
+    internal fun liikennemaaraluokittelu(geometry: GeoJsonObject, katuluokkaluokittelu: Int): Int =
+        liikennemaaraluokittelu(katuluokkaluokittelu) { radius ->
+            tormaysService.maxLiikennemaara(geometry, radius)
+        }
+
+    private fun liikennemaaraluokittelu(
+        katuluokkaluokittelu: Int,
+        maxLiikennemaara: (TormaystarkasteluLiikennemaaranEtaisyys) -> Int?
+    ): Int {
         if (katuluokkaluokittelu == 0) {
             return 0
         }
@@ -88,30 +168,45 @@ class TormaystarkasteluLaskentaService(
             } else {
                 TormaystarkasteluLiikennemaaranEtaisyys.RADIUS_15
             }
-        val maxVolume = tormaysService.maxLiikennemaara(geometriaIds, radius) ?: 0
+        val maxVolume = maxLiikennemaara(radius) ?: 0
         return RajaArvoLuokittelija.liikennemaaraluokka(maxVolume)
     }
 
     internal fun calculateAutoliikenneindeksiFromLuokittelu(
         luokitteluByType: Map<LuokitteluType, Int>
     ): Float =
-        autoliikenneindeksipainot
-            .map { (type, weight) -> luokitteluByType[type]?.times(weight) ?: 0f }
+        luokitteluByType
+            .map { (type, index) -> autoliikenneindeksipainot(type).times(index) }
             .sum()
             .roundToOneDecimal()
 
-    internal fun calculatePyoraliikenneindeksi(geometriaId: Int): Float =
-        tormaysService.maxIntersectingPyoraliikenneHierarkia(setOf(geometriaId))?.toFloat() ?: 0f
+    internal fun calculatePyoraliikenneindeksi(geometriaIds: Set<Int>): Float =
+        tormaysService.maxIntersectingPyoraliikenneHierarkia(geometriaIds)?.toFloat() ?: 0f
 
-    internal fun calculateLinjaautoliikenneindeksi(geometriaId: Int): Float =
-        linjaautoliikenneluokittelu(setOf(geometriaId)).toFloat()
+    internal fun calculatePyoraliikenneindeksi(geometry: GeoJsonObject): Float =
+        tormaysService.maxIntersectingPyoraliikenneHierarkia(geometry)?.toFloat() ?: 0f
 
-    internal fun linjaautoliikenneluokittelu(geometriaIds: Set<Int>): Int {
-        if (tormaysService.anyIntersectsCriticalBusRoutes(geometriaIds)) {
+    internal fun calculateLinjaautoliikenneindeksi(geometriaIds: Set<Int>): Int =
+        calculateLinjaautoliikenneindeksi(
+            { tormaysService.anyIntersectsCriticalBusRoutes(geometriaIds) },
+            { tormaysService.getIntersectingBusRoutes(geometriaIds) },
+        )
+
+    internal fun calculateLinjaautoliikenneindeksi(geometria: GeoJsonObject): Int =
+        calculateLinjaautoliikenneindeksi(
+            { tormaysService.anyIntersectsCriticalBusRoutes(geometria) },
+            { tormaysService.getIntersectingBusRoutes(geometria) },
+        )
+
+    private fun calculateLinjaautoliikenneindeksi(
+        intersectsWithCriticalRoutes: () -> Boolean,
+        intersectingRoutes: () -> Set<TormaystarkasteluBussireitti>
+    ): Int {
+        if (intersectsWithCriticalRoutes()) {
             return Linjaautoliikenneluokittelu.TARKEIMMAT_JOUKKOLIIKENNEKADUT.value
         }
 
-        val bussireitit = tormaysService.getIntersectingBusRoutes(geometriaIds)
+        val bussireitit = intersectingRoutes()
 
         val valueByRunkolinja =
             bussireitit.maxOfOrNull { it.runkolinja.toLinjaautoliikenneluokittelu().value }
@@ -125,27 +220,42 @@ class TormaystarkasteluLaskentaService(
         return max(valueByRajaArvo, valueByRunkolinja)
     }
 
-    internal fun calculateRaitioliikenneindeksi(geometriaId: Int): Float =
-        raitioliikenneluokittelu(setOf(geometriaId)).toFloat()
+    internal fun calculateRaitioliikenneindeksi(geometriaIds: Set<Int>): Float =
+        calculateRaitioliikenneindeksi(
+            { tormaysService.anyIntersectsWithTramLines(geometriaIds) },
+            { tormaysService.anyIntersectsWithTramInfra(geometriaIds) },
+        )
 
-    internal fun raitioliikenneluokittelu(geometriaIds: Set<Int>): Int =
+    internal fun calculateRaitioliikenneindeksi(geometria: GeoJsonObject): Float =
+        calculateRaitioliikenneindeksi(
+            { tormaysService.anyIntersectsWithTramLines(geometria) },
+            { tormaysService.anyIntersectsWithTramInfra(geometria) },
+        )
+
+    private fun calculateRaitioliikenneindeksi(
+        intersectsWithLines: () -> Boolean,
+        intersectsWithInfra: () -> Boolean,
+    ): Float =
         when {
-            tormaysService.anyIntersectsWithTramLines(geometriaIds) ->
-                Raitioliikenneluokittelu.RAITIOTIEVERKON_RATAOSA_JOLLA_SAANNOLLISTA_LINJALIIKENNETTA
-            tormaysService.anyIntersectsWithTramInfra(geometriaIds) ->
-                Raitioliikenneluokittelu
-                    .RAITIOTIEVERKON_RATAOSA_JOLLA_EI_SAANNOLLISTA_LINJALIIKENNETTA
-            else -> Raitioliikenneluokittelu.EI_TUNNISTETTUJA_RAITIOTIEKISKOJA
-        }.value
+                intersectsWithLines() ->
+                    Raitioliikenneluokittelu
+                        .RAITIOTIEVERKON_RATAOSA_JOLLA_SAANNOLLISTA_LINJALIIKENNETTA
+                intersectsWithInfra() ->
+                    Raitioliikenneluokittelu
+                        .RAITIOTIEVERKON_RATAOSA_JOLLA_EI_SAANNOLLISTA_LINJALIIKENNETTA
+                else -> Raitioliikenneluokittelu.EI_TUNNISTETTUJA_RAITIOTIEKISKOJA
+            }
+            .value
+            .toFloat()
 
     companion object {
-        val autoliikenneindeksipainot =
-            mapOf(
-                Pair(LuokitteluType.HAITTA_AJAN_KESTO, 0.1f),
-                Pair(LuokitteluType.VAIKUTUS_AUTOLIIKENTEEN_KAISTAMAARIIN, 0.25f),
-                Pair(LuokitteluType.AUTOLIIKENTEEN_KAISTAVAIKUTUSTEN_PITUUS, 0.2f),
-                Pair(LuokitteluType.KATULUOKKA, 0.2f),
-                Pair(LuokitteluType.AUTOLIIKENTEEN_MAARA, 0.25f)
-            )
+        fun autoliikenneindeksipainot(luokittelu: LuokitteluType) =
+            when (luokittelu) {
+                LuokitteluType.HAITTA_AJAN_KESTO -> 0.1f
+                LuokitteluType.VAIKUTUS_AUTOLIIKENTEEN_KAISTAMAARIIN -> 0.25f
+                LuokitteluType.AUTOLIIKENTEEN_KAISTAVAIKUTUSTEN_PITUUS -> 0.2f
+                LuokitteluType.KATULUOKKA -> 0.2f
+                LuokitteluType.AUTOLIIKENTEEN_MAARA -> 0.25f
+            }
     }
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluRequest.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluRequest.kt
@@ -1,12 +1,34 @@
 package fi.hel.haitaton.hanke.tormaystarkastelu
 
+import io.swagger.v3.oas.annotations.media.Schema
 import java.time.ZonedDateTime
 import org.geojson.FeatureCollection
 
 data class TormaystarkasteluRequest(
-    val geometriat: FeatureCollection,
+    @field:Schema(
+        description = "Geometry data",
+    )
+    val geometriat: Geometriat,
+    @field:Schema(
+        description = "Nuisance start date",
+        maximum = "2099-12-31T23:59:59.99Z",
+    )
     val haittaAlkuPvm: ZonedDateTime,
+    @field:Schema(
+        description = "Nuisance end date, must not be before haittaAlkuPvm",
+        maximum = "2099-12-31T23:59:59.99Z",
+    )
     val haittaLoppuPvm: ZonedDateTime,
+    @field:Schema(
+        description = "Street lane hindrance value",
+    )
     val kaistaHaitta: VaikutusAutoliikenteenKaistamaariin,
+    @field:Schema(
+        description = "Street lane hindrance length",
+    )
     val kaistaPituusHaitta: AutoliikenteenKaistavaikutustenPituus,
-)
+) {
+    data class Geometriat(
+        @field:Schema(description = "The geometry data") val featureCollection: FeatureCollection
+    )
+}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluRequest.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluRequest.kt
@@ -1,0 +1,12 @@
+package fi.hel.haitaton.hanke.tormaystarkastelu
+
+import java.time.ZonedDateTime
+import org.geojson.FeatureCollection
+
+data class TormaystarkasteluRequest(
+    val geometriat: FeatureCollection,
+    val haittaAlkuPvm: ZonedDateTime,
+    val haittaLoppuPvm: ZonedDateTime,
+    val kaistaHaitta: VaikutusAutoliikenteenKaistamaariin,
+    val kaistaPituusHaitta: AutoliikenteenKaistavaikutustenPituus,
+)

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluLaskentaServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluLaskentaServiceTest.kt
@@ -283,8 +283,7 @@ internal class TormaystarkasteluLaskentaServiceTest {
     @Nested
     inner class CalculatePyoraliikenneindeksi {
         // The parameter is only used to call mocks
-        val geometria = 6
-        val geometriat = setOf(geometria)
+        val geometriat = setOf(6)
 
         @ParameterizedTest
         @ValueSource(ints = [2, 3, 5])
@@ -294,7 +293,7 @@ internal class TormaystarkasteluLaskentaServiceTest {
             every { tormaysService.maxIntersectingPyoraliikenneHierarkia(geometriat) } returns
                 hierarkiaValue
 
-            val result = laskentaService.calculatePyoraliikenneindeksi(geometria)
+            val result = laskentaService.calculatePyoraliikenneindeksi(geometriat)
 
             assertThat(result).isEqualTo(hierarkiaValue.toFloat())
             verifySequence { tormaysService.maxIntersectingPyoraliikenneHierarkia(geometriat) }
@@ -304,7 +303,7 @@ internal class TormaystarkasteluLaskentaServiceTest {
         fun `returns 0 when the geometries don't intersect with any cycle routes`() {
             every { tormaysService.maxIntersectingPyoraliikenneHierarkia(geometriat) } returns null
 
-            val result = laskentaService.calculatePyoraliikenneindeksi(geometria)
+            val result = laskentaService.calculatePyoraliikenneindeksi(geometriat)
 
             assertThat(result).isEqualTo(0f)
             verifySequence { tormaysService.maxIntersectingPyoraliikenneHierarkia(geometriat) }
@@ -320,9 +319,9 @@ internal class TormaystarkasteluLaskentaServiceTest {
         fun `returns 5 when intersects with a tram line`() {
             every { tormaysService.anyIntersectsWithTramLines(geometriat) } returns true
 
-            val result = laskentaService.raitioliikenneluokittelu(geometriat)
+            val result = laskentaService.calculateRaitioliikenneindeksi(geometriat)
 
-            assertThat(result).isEqualTo(5)
+            assertThat(result).isEqualTo(5f)
             verify { tormaysService.anyIntersectsWithTramLines(geometriat) }
             verify(exactly = 0) { tormaysService.anyIntersectsWithTramInfra(geometriat) }
         }
@@ -332,9 +331,9 @@ internal class TormaystarkasteluLaskentaServiceTest {
             every { tormaysService.anyIntersectsWithTramLines(geometriat) } returns false
             every { tormaysService.anyIntersectsWithTramInfra(geometriat) } returns true
 
-            val result = laskentaService.raitioliikenneluokittelu(geometriat)
+            val result = laskentaService.calculateRaitioliikenneindeksi(geometriat)
 
-            assertThat(result).isEqualTo(3)
+            assertThat(result).isEqualTo(3f)
             verifyAll {
                 tormaysService.anyIntersectsWithTramLines(geometriat)
                 tormaysService.anyIntersectsWithTramInfra(geometriat)
@@ -346,9 +345,9 @@ internal class TormaystarkasteluLaskentaServiceTest {
             every { tormaysService.anyIntersectsWithTramLines(geometriat) } returns false
             every { tormaysService.anyIntersectsWithTramInfra(geometriat) } returns false
 
-            val result = laskentaService.raitioliikenneluokittelu(geometriat)
+            val result = laskentaService.calculateRaitioliikenneindeksi(geometriat)
 
-            assertThat(result).isEqualTo(0)
+            assertThat(result).isEqualTo(0f)
             verifyAll {
                 tormaysService.anyIntersectsWithTramLines(geometriat)
                 tormaysService.anyIntersectsWithTramInfra(geometriat)
@@ -365,7 +364,7 @@ internal class TormaystarkasteluLaskentaServiceTest {
         fun `returns 5 when intersects with critical bus routes`() {
             every { tormaysService.anyIntersectsCriticalBusRoutes(geometriat) } returns true
 
-            val result = laskentaService.linjaautoliikenneluokittelu(geometriat)
+            val result = laskentaService.calculateLinjaautoliikenneindeksi(geometriat)
 
             assertThat(result).isEqualTo(5)
             verify { tormaysService.anyIntersectsCriticalBusRoutes(geometriat) }
@@ -376,7 +375,7 @@ internal class TormaystarkasteluLaskentaServiceTest {
             every { tormaysService.anyIntersectsCriticalBusRoutes(geometriat) } returns false
             every { tormaysService.getIntersectingBusRoutes(geometriat) } returns setOf()
 
-            val result = laskentaService.linjaautoliikenneluokittelu(geometriat)
+            val result = laskentaService.calculateLinjaautoliikenneindeksi(geometriat)
 
             assertThat(result).isEqualTo(0)
             verifyAll {
@@ -411,7 +410,7 @@ internal class TormaystarkasteluLaskentaServiceTest {
             every { tormaysService.anyIntersectsCriticalBusRoutes(geometriat) } returns false
             every { tormaysService.getIntersectingBusRoutes(geometriat) } returns busLines
 
-            val result = laskentaService.linjaautoliikenneluokittelu(geometriat)
+            val result = laskentaService.calculateLinjaautoliikenneindeksi(geometriat)
 
             assertThat(result).isEqualTo(expectedResult)
             verifyAll {
@@ -433,7 +432,7 @@ internal class TormaystarkasteluLaskentaServiceTest {
             every { tormaysService.anyIntersectsCriticalBusRoutes(geometriat) } returns false
             every { tormaysService.getIntersectingBusRoutes(geometriat) } returns busLines
 
-            val result = laskentaService.linjaautoliikenneluokittelu(geometriat)
+            val result = laskentaService.calculateLinjaautoliikenneindeksi(geometriat)
 
             assertThat(result).isEqualTo(expectedResult)
             verifyAll {
@@ -451,7 +450,11 @@ internal class TormaystarkasteluLaskentaServiceTest {
 
         assertThat(tulos).isNotNull()
         assertThat(tulos!!.liikennehaittaindeksi).isNotNull()
-        assertThat(tulos.liikennehaittaindeksi.indeksi).isNotNull().isEqualTo(5.0f)
+        assertThat(tulos.liikennehaittaindeksi.indeksi).isEqualTo(5.0f)
+        assertThat(tulos.liikennehaittaindeksi.tyyppi)
+            .isEqualTo(IndeksiType.LINJAAUTOLIIKENNEINDEKSI)
+        assertThat(tulos.autoliikenneindeksi).isEqualTo(2.7f)
+        assertThat(tulos.linjaautoliikenneindeksi).isEqualTo(5.0f)
         assertThat(tulos.raitioliikenneindeksi).isEqualTo(3.0f)
         assertThat(tulos.pyoraliikenneindeksi).isEqualTo(3.0f)
 

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluLaskentaServiceWithGeometryTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluLaskentaServiceWithGeometryTest.kt
@@ -1,0 +1,450 @@
+package fi.hel.haitaton.hanke.tormaystarkastelu
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import fi.hel.haitaton.hanke.SRID
+import fi.hel.haitaton.hanke.tormaystarkastelu.TormaystarkasteluLiikennemaaranEtaisyys.RADIUS_15
+import fi.hel.haitaton.hanke.tormaystarkastelu.TormaystarkasteluLiikennemaaranEtaisyys.RADIUS_30
+import io.mockk.checkUnnecessaryStub
+import io.mockk.clearAllMocks
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import io.mockk.verifyAll
+import io.mockk.verifySequence
+import org.geojson.Crs
+import org.geojson.FeatureCollection
+import org.geojson.GeometryCollection
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+import org.junit.jupiter.params.provider.EnumSource
+import org.junit.jupiter.params.provider.ValueSource
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+internal class TormaystarkasteluLaskentaServiceWithGeometryTest {
+
+    private val tormaysService: TormaystarkasteluTormaysService = mockk()
+    private val laskentaService = TormaystarkasteluLaskentaService(tormaysService)
+
+    // The parameter is only used to call mocks
+    val geometry =
+        GeometryCollection().apply {
+            crs = Crs()
+            crs.properties["name"] = "EPSG:$SRID"
+        }
+
+    @BeforeEach
+    fun clearMocks() {
+        clearAllMocks()
+    }
+
+    @AfterEach
+    fun checkMocks() {
+        checkUnnecessaryStub()
+        confirmVerified(tormaysService)
+    }
+
+    @Nested
+    inner class Katuluokkaluokittelu {
+        @Nested
+        inner class WithYlreParts {
+            @BeforeEach
+            fun mockYlreParts() {
+                every { tormaysService.anyIntersectsYleinenKatuosa(geometry) } returns true
+            }
+
+            @AfterEach
+            fun verifyYlreParts() {
+                verify { tormaysService.anyIntersectsYleinenKatuosa(geometry) }
+            }
+
+            @Nested
+            inner class WithoutStreetClasses {
+                @BeforeEach
+                fun mockStreetClasses() {
+                    every {
+                        tormaysService.maxIntersectingLiikenteellinenKatuluokka(geometry)
+                    } returns null
+                }
+
+                @AfterEach
+                fun verifyYlreParts() {
+                    verify { tormaysService.maxIntersectingLiikenteellinenKatuluokka(geometry) }
+                }
+
+                @Test
+                fun `returns 0 when there are no ylre classes`() {
+                    every {
+                        tormaysService.maxIntersectingYleinenkatualueKatuluokka(geometry)
+                    } returns null
+
+                    val result = laskentaService.katuluokkaluokittelu(geometry)
+
+                    assertThat(result).isEqualTo(0)
+                    verify { tormaysService.maxIntersectingYleinenkatualueKatuluokka(geometry) }
+                }
+
+                @ParameterizedTest
+                @EnumSource(TormaystarkasteluKatuluokka::class)
+                fun `returns ylre class value when it exists`(
+                    ylreClass: TormaystarkasteluKatuluokka
+                ) {
+                    every {
+                        tormaysService.maxIntersectingYleinenkatualueKatuluokka(geometry)
+                    } returns ylreClass.value
+
+                    val result = laskentaService.katuluokkaluokittelu(geometry)
+
+                    assertThat(result).isEqualTo(ylreClass.value)
+                    verify { tormaysService.maxIntersectingYleinenkatualueKatuluokka(geometry) }
+                }
+            }
+
+            @ParameterizedTest
+            @EnumSource(TormaystarkasteluKatuluokka::class)
+            fun `returns street class value when it exists`(
+                streetClass: TormaystarkasteluKatuluokka
+            ) {
+                every { tormaysService.maxIntersectingLiikenteellinenKatuluokka(geometry) } returns
+                    streetClass.value
+
+                val result = laskentaService.katuluokkaluokittelu(geometry)
+
+                assertThat(result).isEqualTo(streetClass.value)
+                verify { tormaysService.maxIntersectingLiikenteellinenKatuluokka(geometry) }
+            }
+        }
+
+        @Nested
+        inner class WithoutYlreParts {
+            @BeforeEach
+            fun mockYlreParts() {
+                every { tormaysService.anyIntersectsYleinenKatuosa(geometry) } returns false
+            }
+
+            @AfterEach
+            fun verifyYlreParts() {
+                verify { tormaysService.anyIntersectsYleinenKatuosa(geometry) }
+            }
+
+            @Test
+            fun `returns 0 without ylre classes`() {
+                every { tormaysService.maxIntersectingYleinenkatualueKatuluokka(geometry) } returns
+                    null
+
+                val result = laskentaService.katuluokkaluokittelu(geometry)
+
+                assertThat(result).isEqualTo(0)
+                verify { tormaysService.maxIntersectingYleinenkatualueKatuluokka(geometry) }
+            }
+
+            @ParameterizedTest
+            @EnumSource(TormaystarkasteluKatuluokka::class)
+            fun `returns ylre classes when it exists and street classes doesn't`(
+                ylreClass: TormaystarkasteluKatuluokka
+            ) {
+                every { tormaysService.maxIntersectingYleinenkatualueKatuluokka(geometry) } returns
+                    ylreClass.value
+                every { tormaysService.maxIntersectingLiikenteellinenKatuluokka(geometry) } returns
+                    null
+
+                val result = laskentaService.katuluokkaluokittelu(geometry)
+
+                assertThat(result).isEqualTo(ylreClass.value)
+                verify {
+                    tormaysService.maxIntersectingYleinenkatualueKatuluokka(geometry)
+                    tormaysService.maxIntersectingLiikenteellinenKatuluokka(geometry)
+                }
+            }
+
+            @ParameterizedTest
+            @EnumSource(TormaystarkasteluKatuluokka::class)
+            fun `returns street classes when both it and ylre classes exist`(
+                streetClass: TormaystarkasteluKatuluokka
+            ) {
+                every { tormaysService.maxIntersectingYleinenkatualueKatuluokka(geometry) } returns
+                    2
+                every { tormaysService.maxIntersectingLiikenteellinenKatuluokka(geometry) } returns
+                    streetClass.value
+
+                val result = laskentaService.katuluokkaluokittelu(geometry)
+
+                assertThat(result).isEqualTo(streetClass.value)
+                verify {
+                    tormaysService.maxIntersectingYleinenkatualueKatuluokka(geometry)
+                    tormaysService.maxIntersectingLiikenteellinenKatuluokka(geometry)
+                }
+            }
+        }
+    }
+
+    @Nested
+    inner class Liikennemaaraluokittelu {
+        @Test
+        fun `returns 0 when street class is 0`() {
+            val result = laskentaService.liikennemaaraluokittelu(geometry, 0)
+
+            assertThat(result).isEqualTo(0)
+        }
+
+        @Test
+        fun `uses small radius for traffic amounts when street class is 3`() {
+            every { tormaysService.maxLiikennemaara(geometry, RADIUS_15) } returns 1500
+
+            val result = laskentaService.liikennemaaraluokittelu(geometry, 3)
+
+            assertThat(result).isEqualTo(3)
+            verify { tormaysService.maxLiikennemaara(geometry, RADIUS_15) }
+        }
+
+        @Test
+        fun `uses large radius for traffic amounts when street class is 4`() {
+            every { tormaysService.maxLiikennemaara(geometry, RADIUS_30) } returns 1500
+
+            val result = laskentaService.liikennemaaraluokittelu(geometry, 4)
+
+            assertThat(result).isEqualTo(3)
+            verify { tormaysService.maxLiikennemaara(geometry, RADIUS_30) }
+        }
+
+        @Test
+        fun `returns 0 if there is no traffic`() {
+            every { tormaysService.maxLiikennemaara(geometry, RADIUS_15) } returns null
+
+            val result = laskentaService.liikennemaaraluokittelu(geometry, 1)
+
+            assertThat(result).isEqualTo(0)
+            verify { tormaysService.maxLiikennemaara(geometry, RADIUS_15) }
+        }
+
+        @ParameterizedTest
+        @CsvSource(
+            "-140,0",
+            "0,0",
+            "1,1",
+            "499,1",
+            "500,2",
+            "1499,2",
+            "1500,3",
+            "4999,3",
+            "5000,4",
+            "9999,4",
+            "10000,5",
+            "18000,5",
+        )
+        fun `returns matching classification when there is traffic`(
+            volume: Int,
+            expectedResult: Int
+        ) {
+            every { tormaysService.maxLiikennemaara(geometry, RADIUS_15) } returns volume
+
+            val result = laskentaService.liikennemaaraluokittelu(geometry, 1)
+
+            assertThat(result).isEqualTo(expectedResult)
+            verify { tormaysService.maxLiikennemaara(geometry, RADIUS_15) }
+        }
+    }
+
+    @Nested
+    inner class CalculatePyoraliikenneindeksi {
+        @ParameterizedTest
+        @ValueSource(ints = [2, 3, 5])
+        fun `returns the matching float when the geometries intersect with cycle routes`(
+            hierarkiaValue: Int
+        ) {
+            every { tormaysService.maxIntersectingPyoraliikenneHierarkia(geometry) } returns
+                hierarkiaValue
+
+            val result = laskentaService.calculatePyoraliikenneindeksi(geometry)
+
+            assertThat(result).isEqualTo(hierarkiaValue.toFloat())
+            verifySequence { tormaysService.maxIntersectingPyoraliikenneHierarkia(geometry) }
+        }
+
+        @Test
+        fun `returns 0 when the geometries don't intersect with any cycle routes`() {
+            every { tormaysService.maxIntersectingPyoraliikenneHierarkia(geometry) } returns null
+
+            val result = laskentaService.calculatePyoraliikenneindeksi(geometry)
+
+            assertThat(result).isEqualTo(0f)
+            verifySequence { tormaysService.maxIntersectingPyoraliikenneHierarkia(geometry) }
+        }
+    }
+
+    @Nested
+    inner class Raitioliikenneluokittelu {
+        @Test
+        fun `returns 5 when intersects with a tram line`() {
+            every { tormaysService.anyIntersectsWithTramLines(geometry) } returns true
+
+            val result = laskentaService.calculateRaitioliikenneindeksi(geometry)
+
+            assertThat(result).isEqualTo(5f)
+            verify { tormaysService.anyIntersectsWithTramLines(geometry) }
+            verify(exactly = 0) { tormaysService.anyIntersectsWithTramInfra(geometry) }
+        }
+
+        @Test
+        fun `returns 3 when intersects with tram infra`() {
+            every { tormaysService.anyIntersectsWithTramLines(geometry) } returns false
+            every { tormaysService.anyIntersectsWithTramInfra(geometry) } returns true
+
+            val result = laskentaService.calculateRaitioliikenneindeksi(geometry)
+
+            assertThat(result).isEqualTo(3f)
+            verifyAll {
+                tormaysService.anyIntersectsWithTramLines(geometry)
+                tormaysService.anyIntersectsWithTramInfra(geometry)
+            }
+        }
+
+        @Test
+        fun `returns 0 when doesn't intersect with any tram line or infra`() {
+            every { tormaysService.anyIntersectsWithTramLines(geometry) } returns false
+            every { tormaysService.anyIntersectsWithTramInfra(geometry) } returns false
+
+            val result = laskentaService.calculateRaitioliikenneindeksi(geometry)
+
+            assertThat(result).isEqualTo(0f)
+            verifyAll {
+                tormaysService.anyIntersectsWithTramLines(geometry)
+                tormaysService.anyIntersectsWithTramInfra(geometry)
+            }
+        }
+    }
+
+    @Nested
+    inner class Linjaautoliikenneluokittelu {
+        @Test
+        fun `returns 5 when intersects with critical bus routes`() {
+            every { tormaysService.anyIntersectsCriticalBusRoutes(geometry) } returns true
+
+            val result = laskentaService.calculateLinjaautoliikenneindeksi(geometry)
+
+            assertThat(result).isEqualTo(5)
+            verify { tormaysService.anyIntersectsCriticalBusRoutes(geometry) }
+        }
+
+        @Test
+        fun `returns 0 when doesn't intersect with any bus lines`() {
+            every { tormaysService.anyIntersectsCriticalBusRoutes(geometry) } returns false
+            every { tormaysService.getIntersectingBusRoutes(geometry) } returns setOf()
+
+            val result = laskentaService.calculateLinjaautoliikenneindeksi(geometry)
+
+            assertThat(result).isEqualTo(0)
+            verifyAll {
+                tormaysService.anyIntersectsCriticalBusRoutes(geometry)
+                tormaysService.getIntersectingBusRoutes(geometry)
+            }
+        }
+
+        @ParameterizedTest
+        @CsvSource(
+            "0,2",
+            "1,3",
+            "10,3",
+            "11,4",
+            "20,4",
+            "21,5",
+            "100,5",
+        )
+        fun `returns classification based on rush hour buses when there's no trunk line`(
+            rushHourBuses: Int,
+            expectedResult: Int,
+        ) {
+            val busLines =
+                setOf(
+                    TormaystarkasteluBussireitti(
+                        "",
+                        0,
+                        rushHourBuses,
+                        TormaystarkasteluBussiRunkolinja.EI
+                    )
+                )
+            every { tormaysService.anyIntersectsCriticalBusRoutes(geometry) } returns false
+            every { tormaysService.getIntersectingBusRoutes(geometry) } returns busLines
+
+            val result = laskentaService.calculateLinjaautoliikenneindeksi(geometry)
+
+            assertThat(result).isEqualTo(expectedResult)
+            verifyAll {
+                tormaysService.anyIntersectsCriticalBusRoutes(geometry)
+                tormaysService.getIntersectingBusRoutes(geometry)
+            }
+        }
+
+        @ParameterizedTest
+        @CsvSource(
+            "ON,4",
+            "EI,2",
+        )
+        fun `returns classification based on trunk lines when there are zero rush hour buses`(
+            runkolinja: TormaystarkasteluBussiRunkolinja,
+            expectedResult: Int
+        ) {
+            val busLines = setOf(TormaystarkasteluBussireitti("", 0, 0, runkolinja))
+            every { tormaysService.anyIntersectsCriticalBusRoutes(geometry) } returns false
+            every { tormaysService.getIntersectingBusRoutes(geometry) } returns busLines
+
+            val result = laskentaService.calculateLinjaautoliikenneindeksi(geometry)
+
+            assertThat(result).isEqualTo(expectedResult)
+            verifyAll {
+                tormaysService.anyIntersectsCriticalBusRoutes(geometry)
+                tormaysService.getIntersectingBusRoutes(geometry)
+            }
+        }
+    }
+
+    @Test
+    fun `calculateTormaystarkastelu happy case`() {
+        setupHappyCase()
+        val featureCollection = FeatureCollection()
+
+        val tulos =
+            laskentaService.calculateTormaystarkastelu(
+                featureCollection,
+                5,
+                VaikutusAutoliikenteenKaistamaariin.VAHENTAA_KAISTAN_YHDELLA_AJOSUUNNALLA,
+                AutoliikenteenKaistavaikutustenPituus.PITUUS_100_499_METRIA
+            )
+
+        assertThat(tulos.liikennehaittaindeksi.indeksi).isEqualTo(5.0f)
+        assertThat(tulos.liikennehaittaindeksi.tyyppi)
+            .isEqualTo(IndeksiType.LINJAAUTOLIIKENNEINDEKSI)
+        assertThat(tulos.autoliikenneindeksi).isEqualTo(2.7f)
+        assertThat(tulos.linjaautoliikenneindeksi).isEqualTo(5.0f)
+        assertThat(tulos.raitioliikenneindeksi).isEqualTo(3.0f)
+        assertThat(tulos.pyoraliikenneindeksi).isEqualTo(3.0f)
+
+        verifySequence {
+            tormaysService.anyIntersectsYleinenKatuosa(geometry)
+            tormaysService.maxIntersectingLiikenteellinenKatuluokka(geometry)
+            tormaysService.maxLiikennemaara(geometry, RADIUS_30)
+            tormaysService.maxIntersectingPyoraliikenneHierarkia(geometry)
+            tormaysService.anyIntersectsCriticalBusRoutes(geometry)
+            tormaysService.anyIntersectsWithTramLines(geometry)
+            tormaysService.anyIntersectsWithTramInfra(geometry)
+        }
+    }
+
+    private fun setupHappyCase() {
+        every { tormaysService.anyIntersectsYleinenKatuosa(geometry) } returns true
+        every { tormaysService.maxIntersectingLiikenteellinenKatuluokka(geometry) } returns
+            TormaystarkasteluKatuluokka.ALUEELLINEN_KOKOOJAKATU.value
+        every { tormaysService.maxLiikennemaara(geometry, RADIUS_30) } returns 1000
+        every { tormaysService.maxIntersectingPyoraliikenneHierarkia(geometry) } returns
+            PyoraliikenteenHierarkia.MUU_PYORAREITTI.value
+        every { tormaysService.anyIntersectsWithTramInfra(geometry) } returns true
+        every { tormaysService.anyIntersectsWithTramLines(geometry) } returns false
+        every { tormaysService.anyIntersectsCriticalBusRoutes(geometry) } returns true
+    }
+}


### PR DESCRIPTION
# Description

The API takes the hankealue geometry, start date, end date and lane obstruction information. This is intended to be used with the hanke form, so the geometry is read as a FeatureCollection.

The underlying calculation needed to be duplicated down to the database level, since the existing calculations expect the geometries to be stored in the hankegeometria table. The transient geometries are not, of course.

The new calculations use GeoJsonObject as geometries after the first call, so it should be easy to adapt these for applications.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2389

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
http://localhost:3001/api/swagger-ui/index.html#/tormaystarkastelu-controller/calculate

The body can be copied from a hankealue response JSON.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: