### PR TITLE
HAI-2356 Set GDPR API active by default

### DIFF
--- a/services/hanke-service/src/main/resources/application.yml
+++ b/services/hanke-service/src/main/resources/application.yml
@@ -41,7 +41,7 @@ haitaton:
     audience: ${HAITATON_GDPR_AUDIENCE:http://localhost:8080/haitaton}
     authorization-field: ${HAITATON_GDPR_AUTHORIZATION_FIELD:http://localhost:8080}
     delete-scope: ${HAITATON_GDPR_DELETE_SCOPE:haitaton.gdprdelete}
-    disabled: ${HAITATON_GDPR_DISABLED:true}
+    disabled: ${HAITATON_GDPR_DISABLED:false}
     issuer: ${HAITATON_GDPR_ISSUER:http://gdpr-api-tester:8888/}
     query-scope: ${HAITATON_GDPR_QUERY_SCOPE:haitaton.gdprquery}
   profiili-api:

--- a/services/hanke-service/src/test/resources/application-test.yml
+++ b/services/hanke-service/src/test/resources/application-test.yml
@@ -12,6 +12,8 @@ haitaton:
     from: no-reply@hel.fi
   features:
     hanke-editing: true
+  gdpr:
+    disabled: true
   profiili-api:
     api-tokens-url: http://localhost:14678/api-tokens/
     graph-ql-url: http://localhost:14678/graphql/


### PR DESCRIPTION
# Description

Set GDPR API active by default. It has been active in all cloud environments for over a year now.

Removing the option of disabling the API was considered, but tests broke down when attempting it. Spring Security tries to contact the issuer at startup, but the value is filled with a placeholder. We don't want it to contact any actual cloud service, because that would make the tests very unreliable.

It might be possible to solve this by starting a correct test container that runs some kind of OAuth authenticator. It didn't feel worth the effort at this point. We might need to return to this in the fall when we move to a JWT-based authentication.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2356

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [X] Other