### PR TITLE
HAI-2589 Reject attachments without content

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentServiceITest.kt
@@ -270,6 +270,24 @@ class ApplicationAttachmentServiceITest(
         }
 
         @Test
+        fun `Throws exception without content`() {
+            val application = applicationFactory.saveApplicationEntity(USERNAME)
+
+            val failure = assertFailure {
+                attachmentService.addAttachment(
+                    applicationId = application.id,
+                    attachmentType = VALTAKIRJA,
+                    attachment = testFile(data = byteArrayOf())
+                )
+            }
+
+            failure.all {
+                hasClass(AttachmentInvalidException::class)
+                messageContains("Attachment has no content")
+            }
+        }
+
+        @Test
         fun `Throws exception without content type`() {
             val application = applicationFactory.saveApplicationEntity(USERNAME)
 

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentServiceITest.kt
@@ -137,6 +137,20 @@ class HankeAttachmentServiceITest(
                     )
                 }
         }
+
+        @Test
+        fun `throws an exception when the attachment has no content`() {
+            val hanke = hankeFactory.builder(USERNAME).save()
+            val testfile = testFile(data = byteArrayOf())
+
+            assertFailure {
+                    hankeAttachmentService.uploadHankeAttachment(hanke.hankeTunnus, testfile)
+                }
+                .all {
+                    hasClass(AttachmentInvalidException::class)
+                    messageContains("Attachment has no content")
+                }
+        }
     }
 
     @Nested

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentService.kt
@@ -56,6 +56,7 @@ class ApplicationAttachmentService(
                 "attachment name = ${attachment.originalFilename}, size = ${attachment.bytes.size}, " +
                 "content type = ${attachment.contentType}"
         }
+        AttachmentValidator.validateSize(attachment.bytes.size)
         val filename = AttachmentValidator.validFilename(attachment.originalFilename)
         AttachmentValidator.validateExtensionForType(filename, attachmentType)
         val hakemus = findHakemus(applicationId)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/common/AttachmentValidator.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/common/AttachmentValidator.kt
@@ -63,6 +63,10 @@ object AttachmentValidator {
             "LPT9",
         )
 
+    fun validateSize(size: Int) {
+        if (size == 0) throw AttachmentInvalidException("Attachment has no content.")
+    }
+
     fun validFilename(filename: String?): String {
         logger.info { "Validating file name $filename" }
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentService.kt
@@ -3,6 +3,7 @@ package fi.hel.haitaton.hanke.attachment.hanke
 import fi.hel.haitaton.hanke.HankeIdentifier
 import fi.hel.haitaton.hanke.attachment.common.AttachmentContent
 import fi.hel.haitaton.hanke.attachment.common.AttachmentInvalidException
+import fi.hel.haitaton.hanke.attachment.common.AttachmentValidator
 import fi.hel.haitaton.hanke.attachment.common.FileScanClient
 import fi.hel.haitaton.hanke.attachment.common.FileScanInput
 import fi.hel.haitaton.hanke.attachment.common.HankeAttachmentMetadataDto
@@ -35,6 +36,7 @@ class HankeAttachmentService(
     ): HankeAttachmentMetadataDto {
         val hanke = metadataService.hankeWithRoomForAttachment(hankeTunnus)
 
+        AttachmentValidator.validateSize(attachment.bytes.size)
         val (filename, mediatype) = attachment.validNameAndType()
 
         scanAttachment(filename, attachment.bytes)

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/attachment/AttachmentValidatorTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/attachment/AttachmentValidatorTest.kt
@@ -26,6 +26,24 @@ import org.springframework.mock.web.MockMultipartFile
 class AttachmentValidatorTest {
 
     @Nested
+    inner class ValidateSize {
+        @Test
+        fun `throws exception if the attachment has no content`() {
+            assertFailure { AttachmentValidator.validateSize(0) }
+                .all {
+                    hasClass(AttachmentInvalidException::class.java)
+                    messageContains("Attachment has no content.")
+                }
+        }
+
+        @ParameterizedTest
+        @ValueSource(ints = [1, 2, 100, 1000000])
+        fun `passes without errors when the size is positive`(size: Int) {
+            AttachmentValidator.validateSize(size)
+        }
+    }
+
+    @Nested
     inner class ValidFilename {
         @Test
         fun `Normal filename should be valid`() {


### PR DESCRIPTION
# Description

Reject attachments that have no content. Allu will not accept such attachments, so adding them to applications causes an error when sending the application to Allu. Attachments without content are very dubious anyways, so we can block them for hanke attachments as well.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2589

## Type of change

- [X] Bug fix 
- [ ] New feature 
- [ ] Other

# Instructions for testing
Try to upload a file without content.

A file without content can be created from the shell with `touch test.txt`.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 