### PR TITLE
HAI-2385 Require nuisance control plan for public hanke

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   db:
     build:

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/UpdateHankeITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/UpdateHankeITests.kt
@@ -147,13 +147,12 @@ class UpdateHankeITests(
     fun `updates hanke status when given full data`() {
         val hanke = hankeFactory.builder(USERNAME).withHankealue().save()
         assertThat(hanke.status).isEqualTo(HankeStatus.DRAFT)
-        hanke.tyomaaKatuosoite = "Testikatu 1 A 1"
         hanke.withYhteystiedot { id = null }
-        val request = hanke.toModifyRequest().copy(tyomaaKatuosoite = "Testikatu 1 A 1")
+        val request = hanke.toModifyRequest()
 
-        val returnedHanke2 = hankeService.updateHanke(hanke.hankeTunnus, request)
+        val returnedHanke = hankeService.updateHanke(hanke.hankeTunnus, request)
 
-        assertThat(returnedHanke2.status).isEqualTo(HankeStatus.PUBLIC)
+        assertThat(returnedHanke.status).isEqualTo(HankeStatus.PUBLIC)
     }
 
     @Test


### PR DESCRIPTION
# Description

The nuisance control plan is always required for the YLEINEN and MUUT categories. For the transport categories (AUTOLIIKENNE, LINJAAUTOLIIKENNE, RAITIOLIIKENNE and PYORAILYLIIKENNE) it's required if the matching nuisance index in tormaystarkastelu is higher than zero. Currently, the car traffic index is always higher than zero if the index has been calculated, but it's checked the same way regardless.

If the tormaystarkastelu is not yet calculated, the transport categories are not checked because we don't know which categories are required. It's always calculated when all necessary information has been given, so either the validation will fail somewhere else or the tormaystarkastelu will be calculated.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2385

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
Check that the project is not public until the nuisance control plan has been filled out.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 