### PR TITLE
HAI-2583 Changed invitation emails - translations pending

### DIFF
--- a/email/johtoselvitys-valmis.mjml
+++ b/email/johtoselvitys-valmis.mjml
@@ -13,9 +13,7 @@
                 </a> ja tutustu sen sisältöön huolellisesti.
                 </mj-text>
                 <mj-text mj-class="basic-txt">
-                    Miten onnistuimme? Kerro mielipiteesi <a
-                        href="https://ecv.microsoft.com/zepZlZSdnT">
-                    täällä</a>.
+                    Miten onnistuimme? Kerro mielipiteesi <a href="https://ecv.microsoft.com/zepZlZSdnT">täällä</a>.
                 </mj-text>
                 <mj-text mj-class="basic-txt">
                     Ystävällisin terveisin,

--- a/email/kayttaja-lisatty-hakemus.mjml
+++ b/email/kayttaja-lisatty-hakemus.mjml
@@ -35,6 +35,11 @@
                     <a href="{{baseUrl}}">{{baseUrl}}</a>
                 </mj-text>
                 <mj-text mj-class="basic-txt">
+                    Observera att du för att kunna se ansökan måste ha aktiverat den identifieringslänk
+                    du fått för det projekt som ansökan gäller.
+                    Du hittar identifieringslänken i ett separat e-postmeddelande.
+                </mj-text>
+                <mj-text mj-class="basic-txt">
                     Du hittar din ansökan genom att gå från startsidan till Egna projekt och välja rätt projekt.
                     Öppna projektets uppgifter i listvyn och välj ”Visa projektets ansökningar”.
                 </mj-text>
@@ -47,6 +52,11 @@
                     for project <b>{{hankeNimi}} ({{hankeTunnus}})</b>. You have been added to the application.
                     View the application in the Haitaton system:
                     <a href="{{baseUrl}}">{{baseUrl}}</a>
+                </mj-text>
+                <mj-text mj-class="basic-txt">
+                    Please note that in order to see the application, you must have activated
+                    the identification link that you have received for the project for which
+                    the application was submitted. You can find the identification link in a separate email message.
                 </mj-text>
                 <mj-text mj-class="basic-txt">
                     You can find your application by selecting ‘Own projects’ on the front page and then selecting the project in question.

--- a/email/kayttaja-lisatty-hakemus.mjml
+++ b/email/kayttaja-lisatty-hakemus.mjml
@@ -16,6 +16,10 @@
                     <a href="{{baseUrl}}">{{baseUrl}}</a>
                 </mj-text>
                 <mj-text mj-class="basic-txt">
+                    Huomioithan, että nähdäksesi hakemuksen tulee sinun olla aktivoinut saamasi tunnistautumislinkki
+                    hankkeelle, jolle hakemus on tehty. Löydät tunnistautumislinkin erillisestä sähköpostiviestistä.
+                </mj-text>
+                <mj-text mj-class="basic-txt">
                     Löydät hakemuksesi siirtymällä etusivulta Omiin hankkeisiin ja valitsemalla sieltä oikean
                     hankkeen.
                     Avaa listanäkymässä hankkeen tiedot ja valitse "Näytä hankkeen hakemukset".

--- a/email/kayttaja-lisatty-hanke.mjml
+++ b/email/kayttaja-lisatty-hanke.mjml
@@ -7,12 +7,12 @@
         <mj-section>
             <mj-column>
                 <mj-text mj-class="header-txt">
-                    Sinut on lisätty hankkeelle {{hankeTunnus}} / Du har lagts till i projektet {{hankeTunnus}} / You
-                    have been added to project {{hankeTunnus}}
+                    Sinut on kutsuttu hankkeelle {{hankeTunnus}} / Du har blivit inbjuden till projektet {{hankeTunnus}} / You
+                    have been invited to project {{hankeTunnus}}
                 </mj-text>
                 <mj-text mj-class="basic-txt">
-                    {{inviterName}} ({{inviterEmail}}) lisäsi sinut hankkeelle <b>{{hankeNimi}} ({{hankeTunnus}})</b>.
-                    Tunnistaudu Haitattomaan alla olevan linkin kautta.
+                    {{inviterName}} ({{inviterEmail}}) on kutsunut sinut hankkeelle <b>{{hankeNimi}} ({{hankeTunnus}})</b>.
+                    Nähdäksesi hankkeen, sinun tulee tunnistautua alla olevan linkin kautta. Huomioithan, että linkki on kertakäyttöinen.
                 </mj-text>
                 <mj-text mj-class="basic-txt">
                     <a href="{{baseUrl}}/fi/kutsu?id={{invitationToken}}">{{baseUrl}}/fi/kutsu?id={{invitationToken}}

--- a/email/kayttaja-lisatty-hanke.mjml
+++ b/email/kayttaja-lisatty-hanke.mjml
@@ -26,8 +26,8 @@
                 <mj-divider mj-class="language-separator" />
 
                 <mj-text mj-class="basic-txt">
-                    {{inviterName}} ({{inviterEmail}}) lade till dig i projektet <b>{{hankeNimi}} ({{hankeTunnus}})</b>.
-                    Identifiera dig i Haitaton via länken nedan.
+                    {{inviterName}} ({{inviterEmail}}) har bjudit in dig till projektet <b>{{hankeNimi}} ({{hankeTunnus}})</b>.
+                    För att kunna se projektet måste du identifiera dig via nedanstående länk. Observera att länken bara kan användas en gång.
                 </mj-text>
                 <mj-text mj-class="basic-txt">
                     <a href="{{baseUrl}}/sv/inbjudan?id={{invitationToken}}">
@@ -42,9 +42,9 @@
                 <mj-divider mj-class="language-separator" />
 
                 <mj-text mj-class="basic-txt">
-                    {{inviterName}} ({{inviterEmail}}) has added you to the project <b>‘{{hankeNimi}}’
+                    {{inviterName}} ({{inviterEmail}}) has invited you to the project <b>‘{{hankeNimi}}’
                     ({{hankeTunnus}})</b>.
-                    Please log in to Haitaton via the link below.
+                    In order to see the project, you must identify yourself via the link below. Please note that the link is one-use.
                 </mj-text>
                 <mj-text mj-class="basic-txt">
                     <a href="{{baseUrl}}/en/invitation?id={{invitationToken}}">

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/email/EmailSenderServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/email/EmailSenderServiceITest.kt
@@ -147,9 +147,9 @@ class EmailSenderServiceITest : IntegrationTest() {
             val email = greenMail.firstReceivedMessage()
             assertThat(email.subject)
                 .isEqualTo(
-                    "Haitaton: Sinut on lisätty hankkeelle HAI24-1 " +
-                        "/ Du har lagts till i projektet HAI24-1 " +
-                        "/ You have been added to project HAI24-1"
+                    "Haitaton: Sinut on kutsuttu hankkeelle HAI24-1 " +
+                        "/ Du har blivit inbjuden till projektet HAI24-1 " +
+                        "/ You have been invited to project HAI24-1"
                 )
         }
 
@@ -160,7 +160,9 @@ class EmailSenderServiceITest : IntegrationTest() {
             val email = greenMail.firstReceivedMessage()
             val (textBody, htmlBody) = email.bodies()
             assertThat(textBody).all {
-                contains("${notification.inviterName} (${notification.inviterEmail}) lisäsi sinut")
+                contains(
+                    "${notification.inviterName} (${notification.inviterEmail}) on kutsunut sinut"
+                )
                 contains("hankkeelle ${notification.hankeNimi} (${notification.hankeTunnus}).")
                 contains("http://localhost:3001/fi/kutsu?id=${notification.invitationToken}")
             }

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaServiceITest.kt
@@ -39,7 +39,6 @@ import fi.hel.haitaton.hanke.factory.ProfiiliFactory
 import fi.hel.haitaton.hanke.factory.ProfiiliFactory.DEFAULT_GIVEN_NAME
 import fi.hel.haitaton.hanke.factory.ProfiiliFactory.DEFAULT_LAST_NAME
 import fi.hel.haitaton.hanke.factory.identifier
-import fi.hel.haitaton.hanke.hakemus.HakemusRepository
 import fi.hel.haitaton.hanke.logging.AuditLogEvent
 import fi.hel.haitaton.hanke.logging.AuditLogRepository
 import fi.hel.haitaton.hanke.logging.AuditLogTarget
@@ -84,7 +83,6 @@ class HankeKayttajaServiceITest : IntegrationTest() {
     @Autowired private lateinit var hankeKayttajaRepository: HankekayttajaRepository
     @Autowired private lateinit var permissionRepository: PermissionRepository
     @Autowired private lateinit var auditLogRepository: AuditLogRepository
-    @Autowired private lateinit var hakemusRepository: HakemusRepository
 
     @Autowired private lateinit var profiiliClient: ProfiiliClient
 
@@ -1377,7 +1375,7 @@ class HankeKayttajaServiceITest : IntegrationTest() {
         hankeTunnus: String,
     ) {
         prop(MimeMessage::textBody).all {
-            contains("$inviterName ($inviterEmail) lisäsi sinut")
+            contains("$inviterName ($inviterEmail) on kutsunut sinut")
             containsMatch("kutsu\\?id=$kayttajaTunnistePattern".toRegex())
             contains("hankkeelle $hankeNimi ($hankeTunnus)")
         }

--- a/services/hanke-service/src/main/resources/email/template/johtoselvitys-valmis.html.mustache
+++ b/services/hanke-service/src/main/resources/email/template/johtoselvitys-valmis.html.mustache
@@ -78,7 +78,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0;padding:16px 24px 0 24px;word-break:break-word">
-                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">Miten onnistuimme? Kerro mielipiteesi <a href="https://ecv.microsoft.com/zepZlZSdnT"> täällä</a>.</div>
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">Miten onnistuimme? Kerro mielipiteesi <a href="https://ecv.microsoft.com/zepZlZSdnT">täällä</a>.</div>
                       </td>
                     </tr>
                     <tr>

--- a/services/hanke-service/src/main/resources/email/template/kayttaja-lisatty-hakemus.html.mustache
+++ b/services/hanke-service/src/main/resources/email/template/kayttaja-lisatty-hakemus.html.mustache
@@ -77,6 +77,11 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0;padding:16px 24px 0 24px;word-break:break-word">
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">Huomioithan, että nähdäksesi hakemuksen tulee sinun olla aktivoinut saamasi tunnistautumislinkki hankkeelle, jolle hakemus on tehty. Löydät tunnistautumislinkin erillisestä sähköpostiviestistä.</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="left" style="font-size:0;padding:16px 24px 0 24px;word-break:break-word">
                         <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">Löydät hakemuksesi siirtymällä etusivulta Omiin hankkeisiin ja valitsemalla sieltä oikean hankkeen. Avaa listanäkymässä hankkeen tiedot ja valitse "Näytä hankkeen hakemukset".</div>
                       </td>
                     </tr>

--- a/services/hanke-service/src/main/resources/email/template/kayttaja-lisatty-hakemus.html.mustache
+++ b/services/hanke-service/src/main/resources/email/template/kayttaja-lisatty-hakemus.html.mustache
@@ -120,6 +120,11 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0;padding:16px 24px 0 24px;word-break:break-word">
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">Observera att du för att kunna se ansökan måste ha aktiverat den identifieringslänk du fått för det projekt som ansökan gäller. Du hittar identifieringslänken i ett separat e-postmeddelande.</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="left" style="font-size:0;padding:16px 24px 0 24px;word-break:break-word">
                         <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">Du hittar din ansökan genom att gå från startsidan till Egna projekt och välja rätt projekt. Öppna projektets uppgifter i listvyn och välj ”Visa projektets ansökningar”.</div>
                       </td>
                     </tr>
@@ -154,6 +159,11 @@
                     <tr>
                       <td align="left" style="font-size:0;padding:16px 24px 0 24px;word-break:break-word">
                         <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">{{senderName}} ({{senderEmail}}) is preparing {{applicationType.en}} for project <b>{{hankeNimi}} ({{hankeTunnus}})</b>. You have been added to the application. View the application in the Haitaton system: <a href="{{baseUrl}}">{{baseUrl}}</a></div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="left" style="font-size:0;padding:16px 24px 0 24px;word-break:break-word">
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">Please note that in order to see the application, you must have activated the identification link that you have received for the project for which the application was submitted. You can find the identification link in a separate email message.</div>
                       </td>
                     </tr>
                     <tr>

--- a/services/hanke-service/src/main/resources/email/template/kayttaja-lisatty-hakemus.text.mustache
+++ b/services/hanke-service/src/main/resources/email/template/kayttaja-lisatty-hakemus.text.mustache
@@ -2,6 +2,8 @@ Sinut on lisätty hakemukselle / Du har lagts till i en ansökan / You have been
 
 {{{senderName}}} ({{{senderEmail}}}) on laatimassa {{applicationType.fi}} hankkeelle "{{{hankeNimi}}}" ({{hankeTunnus}}). Sinut on lisätty hakemukselle. Tarkastele hakemusta Haitattomassa: {{baseUrl}}
 
+Huomioithan, että nähdäksesi hakemuksen tulee sinun olla aktivoinut saamasi tunnistautumislinkki hankkeelle, jolle hakemus on tehty. Löydät tunnistautumislinkin erillisestä sähköpostiviestistä.
+
 Löydät hakemuksesi siirtymällä etusivulta Omiin hankkeisiin ja valitsemalla sieltä oikean hankkeen. Avaa listanäkymässä hankkeen tiedot ja valitse “Näytä hankkeen hakemukset”.
 
 {{{signatures.fi}}}

--- a/services/hanke-service/src/main/resources/email/template/kayttaja-lisatty-hakemus.text.mustache
+++ b/services/hanke-service/src/main/resources/email/template/kayttaja-lisatty-hakemus.text.mustache
@@ -11,12 +11,16 @@ Löydät hakemuksesi siirtymällä etusivulta Omiin hankkeisiin ja valitsemalla 
 
 {{{senderName}}} ({{{senderEmail}}}) gör {{applicationType.sv}} till projektet "{{{hankeNimi}}}" ({{hankeTunnus}}). Du har lagts till i ansökan. Kontrollera ansökan i Haitaton: {{baseUrl}}
 
+Observera att du för att kunna se ansökan måste ha aktiverat den identifieringslänk du fått för det projekt som ansökan gäller. Du hittar identifieringslänken i ett separat e-postmeddelande.
+
 Du hittar din ansökan genom att gå från startsidan till Egna projekt och välja rätt projekt. Öppna projektets uppgifter i listvyn och välj ”Visa projektets ansökningar”.
 
 {{{signatures.sv}}}
 
 
 {{{senderName}}} ({{{senderEmail}}}) is preparing {{applicationType.en}} for project "{{{hankeNimi}}}" ({{hankeTunnus}}). You have been added to the application. View the application in the Haitaton system: {{baseUrl}}
+
+Please note that in order to see the application, you must have activated the identification link that you have received for the project for which the application was submitted. You can find the identification link in a separate email message.
 
 You can find your application by selecting ‘Own projects’ on the front page and then selecting the project in question. Open the project information in the list view and select ‘Show project applications’.
 

--- a/services/hanke-service/src/main/resources/email/template/kayttaja-lisatty-hanke.html.mustache
+++ b/services/hanke-service/src/main/resources/email/template/kayttaja-lisatty-hanke.html.mustache
@@ -116,7 +116,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0;padding:16px 24px 0 24px;word-break:break-word">
-                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">{{inviterName}} ({{inviterEmail}}) lade till dig i projektet <b>{{hankeNimi}} ({{hankeTunnus}})</b>. Identifiera dig i Haitaton via länken nedan.</div>
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">{{inviterName}} ({{inviterEmail}}) har bjudit in dig till projektet <b>{{hankeNimi}} ({{hankeTunnus}})</b>. För att kunna se projektet måste du identifiera dig via nedanstående länk. Observera att länken bara kan användas en gång.</div>
                       </td>
                     </tr>
                     <tr>
@@ -161,7 +161,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0;padding:16px 24px 0 24px;word-break:break-word">
-                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">{{inviterName}} ({{inviterEmail}}) has added you to the project <b>‘{{hankeNimi}}’ ({{hankeTunnus}})</b>. Please log in to Haitaton via the link below.</div>
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">{{inviterName}} ({{inviterEmail}}) has invited you to the project <b>‘{{hankeNimi}}’ ({{hankeTunnus}})</b>. In order to see the project, you must identify yourself via the link below. Please note that the link is one-use.</div>
                       </td>
                     </tr>
                     <tr>

--- a/services/hanke-service/src/main/resources/email/template/kayttaja-lisatty-hanke.html.mustache
+++ b/services/hanke-service/src/main/resources/email/template/kayttaja-lisatty-hanke.html.mustache
@@ -67,12 +67,12 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0;padding:16px 24px 16px 24px;word-break:break-word">
-                        <div style="font-family:Arial;font-size:36px;line-height:43px;text-align:left;color:#000">Sinut on lisätty hankkeelle {{hankeTunnus}} / Du har lagts till i projektet {{hankeTunnus}} / You have been added to project {{hankeTunnus}}</div>
+                        <div style="font-family:Arial;font-size:36px;line-height:43px;text-align:left;color:#000">Sinut on kutsuttu hankkeelle {{hankeTunnus}} / Du har blivit inbjuden till projektet {{hankeTunnus}} / You have been invited to project {{hankeTunnus}}</div>
                       </td>
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0;padding:16px 24px 0 24px;word-break:break-word">
-                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">{{inviterName}} ({{inviterEmail}}) lisäsi sinut hankkeelle <b>{{hankeNimi}} ({{hankeTunnus}})</b>. Tunnistaudu Haitattomaan alla olevan linkin kautta.</div>
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">{{inviterName}} ({{inviterEmail}}) on kutsunut sinut hankkeelle <b>{{hankeNimi}} ({{hankeTunnus}})</b>. Nähdäksesi hankkeen, sinun tulee tunnistautua alla olevan linkin kautta. Huomioithan, että linkki on kertakäyttöinen.</div>
                       </td>
                     </tr>
                     <tr>

--- a/services/hanke-service/src/main/resources/email/template/kayttaja-lisatty-hanke.subject.mustache
+++ b/services/hanke-service/src/main/resources/email/template/kayttaja-lisatty-hanke.subject.mustache
@@ -1,1 +1,1 @@
-Haitaton: Sinut on lisätty hankkeelle {{hankeTunnus}} / Du har lagts till i projektet {{hankeTunnus}} / You have been added to project {{hankeTunnus}}
+Haitaton: Sinut on kutsuttu hankkeelle {{hankeTunnus}} / Du har blivit inbjuden till projektet {{hankeTunnus}} / You have been invited to project {{hankeTunnus}}

--- a/services/hanke-service/src/main/resources/email/template/kayttaja-lisatty-hanke.text.mustache
+++ b/services/hanke-service/src/main/resources/email/template/kayttaja-lisatty-hanke.text.mustache
@@ -8,7 +8,7 @@ Löydät hankkeesi Haitattoman etusivun Omat hankkeet -osion alta hankkeen nimel
 {{{signatures.fi}}}
 
 
-{{{inviterName}}} ({{{inviterEmail}}}) lade till dig i projektet {{{hankeNimi}}} ({{hankeTunnus}}). Identifiera dig i Haitaton via länken nedan.
+{{{inviterName}}} ({{{inviterEmail}}}) har bjudit in dig till projektet {{{hankeNimi}}} ({{hankeTunnus}}). För att kunna se projektet måste du identifiera dig via nedanstående länk. Observera att länken bara kan användas en gång.
 {{baseUrl}}/sv/inbjudan?id={{invitationToken}}
 
 Du hittar ditt projekt under dess namn under Egna projekt på Haitatons startsida.
@@ -16,7 +16,7 @@ Du hittar ditt projekt under dess namn under Egna projekt på Haitatons startsid
 {{{signatures.sv}}}
 
 
-{{{inviterName}}} ({{{inviterEmail}}}) has added you to the project ‘{{{hankeNimi}}}’ ({{hankeTunnus}}). Please log in to Haitaton via the link below.
+{{{inviterName}}} ({{{inviterEmail}}}) has invited you to the project ‘{{{hankeNimi}}}’ ({{hankeTunnus}}). In order to see the project, you must identify yourself via the link below. Please note that the link is one-use.
 {{baseUrl}}/en/invitation?id={{invitationToken}}
 
 You will find your project in the ‘Own projects’ section of the Haitaton front page under the name of the project.

--- a/services/hanke-service/src/main/resources/email/template/kayttaja-lisatty-hanke.text.mustache
+++ b/services/hanke-service/src/main/resources/email/template/kayttaja-lisatty-hanke.text.mustache
@@ -1,6 +1,6 @@
-Sinut on lisätty hankkeelle {{hankeTunnus}} / Du har lagts till i projektet {{hankeTunnus}} / You have been added to project {{hankeTunnus}}
+Sinut on kutsuttu hankkeelle {{hankeTunnus}} / Du har blivit inbjuden till projektet {{hankeTunnus}} / You have been invited to project {{hankeTunnus}}
 
-{{{inviterName}}} ({{{inviterEmail}}}) lisäsi sinut hankkeelle {{{hankeNimi}}} ({{hankeTunnus}}). Tunnistaudu Haitattomaan alla olevan linkin kautta.
+{{{inviterName}}} ({{{inviterEmail}}}) on kutsunut sinut hankkeelle {{{hankeNimi}}} ({{hankeTunnus}}). Nähdäksesi hankkeen, sinun tulee tunnistautua alla olevan linkin kautta. Huomioithan, että linkki on kertakäyttöinen.
 {{baseUrl}}/fi/kutsu?id={{invitationToken}}
 
 Löydät hankkeesi Haitattoman etusivun Omat hankkeet -osion alta hankkeen nimellä.

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/email/EmailSenderServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/email/EmailSenderServiceTest.kt
@@ -164,9 +164,9 @@ class EmailSenderServiceTest {
                 )
 
             override fun inviterInformation(name: String, email: String) =
-                "$name ($email) lade till dig i projektet"
+                "$name ($email) har bjudit in dig till projektet"
 
-            override val hankeInformation = "i projektet <b>$HANKE_NIMI ($HANKE_TUNNUS)</b>."
+            override val hankeInformation = "projektet <b>$HANKE_NIMI ($HANKE_TUNNUS)</b>."
         }
 
         @Nested
@@ -183,7 +183,7 @@ class EmailSenderServiceTest {
                 )
 
             override fun inviterInformation(name: String, email: String) =
-                "$name ($email) has added you to the project"
+                "$name ($email) has invited you to the project"
 
             override val hankeInformation = "to the project <b>‘$HANKE_NIMI’ ($HANKE_TUNNUS)</b>."
         }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/email/EmailSenderServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/email/EmailSenderServiceTest.kt
@@ -77,9 +77,9 @@ class EmailSenderServiceTest {
 
             assertThat(email.subject)
                 .isEqualTo(
-                    "Haitaton: Sinut on lisätty hankkeelle HAI24-1 " +
-                        "/ Du har lagts till i projektet HAI24-1 " +
-                        "/ You have been added to project HAI24-1"
+                    "Haitaton: Sinut on kutsuttu hankkeelle HAI24-1 " +
+                        "/ Du har blivit inbjuden till projektet HAI24-1 " +
+                        "/ You have been invited to project HAI24-1"
                 )
         }
 
@@ -88,9 +88,9 @@ class EmailSenderServiceTest {
             val (textBody, htmlBody) = sendAndCapture().bodies()
 
             val expectedHeader =
-                "Sinut on lisätty hankkeelle HAI24-1 " +
-                    "/ Du har lagts till i projektet HAI24-1 " +
-                    "/ You have been added to project HAI24-1"
+                "Sinut on kutsuttu hankkeelle HAI24-1 " +
+                    "/ Du har blivit inbjuden till projektet HAI24-1 " +
+                    "/ You have been invited to project HAI24-1"
             assertThat(textBody).contains(expectedHeader)
             assertThat(htmlBody).contains(expectedHeader)
         }
@@ -109,7 +109,7 @@ class EmailSenderServiceTest {
                 )
 
             open fun inviterInformation(name: String, email: String) =
-                "$name ($email) lisäsi sinut hankkeelle"
+                "$name ($email) on kutsunut sinut hankkeelle"
 
             open val hankeInformation = "hankkeelle <b>$HANKE_NIMI ($HANKE_TUNNUS)</b>."
 


### PR DESCRIPTION
# Description

Changed invitation email texts.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2583

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [x] Other

# Instructions for testing
* Add a new contact person to a project and see that he/she gets a correct email according to specs (see below)
* Add a new contact person to an application and see that he/she gets correct emails (one for inviting to the project, another for adding to the application)
* Resend an invitation email to a contact person and see that he/she gets a correct email

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [x] I have made necessary changes to the documentation, link to confluence
 or other location: https://helsinkisolutionoffice.atlassian.net/wiki/spaces/HAI/pages/8189902867/S+hk+posti-ilmoitukset+k+ytt+j+lle
