### PR TITLE
HAI Refactor TormaysService and remove unused test methods

### DIFF
--- a/services/hanke-service/build.gradle.kts
+++ b/services/hanke-service/build.gradle.kts
@@ -122,7 +122,7 @@ dependencies {
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
 }
 
-tasks.withType<KotlinCompile> { kotlinOptions { freeCompilerArgs = listOf("-Xjsr305=strict") } }
+tasks.withType<KotlinCompile> { compilerOptions { freeCompilerArgs = listOf("-Xjsr305=strict") } }
 
 kotlin { jvmToolchain { languageVersion.set(JavaLanguageVersion.of(17)) } }
 

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaServiceITest.kt
@@ -7,7 +7,6 @@ import assertk.assertThat
 import assertk.assertions.contains
 import assertk.assertions.containsExactlyInAnyOrder
 import assertk.assertions.containsMatch
-import assertk.assertions.each
 import assertk.assertions.hasClass
 import assertk.assertions.hasSize
 import assertk.assertions.isEmpty
@@ -26,7 +25,6 @@ import com.icegreen.greenmail.util.ServerSetupTest
 import fi.hel.haitaton.hanke.ContactType
 import fi.hel.haitaton.hanke.HankeNotFoundException
 import fi.hel.haitaton.hanke.IntegrationTest
-import fi.hel.haitaton.hanke.domain.Hanke
 import fi.hel.haitaton.hanke.email.textBody
 import fi.hel.haitaton.hanke.factory.HankeFactory
 import fi.hel.haitaton.hanke.factory.HankeFactory.Companion.DEFAULT_HANKE_PERUSTAJA
@@ -1366,30 +1364,11 @@ class HankeKayttajaServiceITest : IntegrationTest() {
         }
     }
 
-    private fun findKayttaja(hankeId: Int, email: String) =
-        hankeKayttajaRepository.findByHankeIdAndSahkopostiIn(hankeId, listOf(email)).first()
-
     private fun Assert<KayttajakutsuEntity>.hasKayttajaWithId(kayttajaId: UUID) =
         prop(KayttajakutsuEntity::hankekayttaja)
             .isNotNull()
             .prop(HankekayttajaEntity::id)
             .isEqualTo(kayttajaId)
-
-    private fun Assert<List<KayttajakutsuEntity>>.areValid() = each { t ->
-        t.prop(KayttajakutsuEntity::id).isNotNull()
-        t.prop(KayttajakutsuEntity::kayttooikeustaso).isEqualTo(Kayttooikeustaso.KATSELUOIKEUS)
-        t.prop(KayttajakutsuEntity::createdAt).isRecent()
-        t.prop(KayttajakutsuEntity::tunniste).matches(Regex(kayttajaTunnistePattern))
-        t.prop(KayttajakutsuEntity::hankekayttaja).isNotNull()
-    }
-
-    private fun Assert<Array<MimeMessage>>.areValidHankeInvitations(
-        inviterName: String,
-        inviterEmail: String,
-        hanke: Hanke
-    ) {
-        each { it.isValidHankeInvitation(inviterName, inviterEmail, hanke.nimi, hanke.hankeTunnus) }
-    }
 
     private fun Assert<MimeMessage>.isValidHankeInvitation(
         inviterName: String,


### PR DESCRIPTION
# Description

- Restyle the older methods in TormaystarkasteluTormaysService.kt to match the newer ones.
- For `getIntersectingBusRoutes`
  - Implement the DISTINCT ON (route_id, direction_id)
  - Select only the columns that are used in the row mapper.
  - Share the row mapper with the GeoJSON version
- Remove unused methods from `HankeKayttajaServiceITest`.
- In the build script, replace the deprecated `kotlinOptions` with the newer `compilerOptions`.

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [X] Other