### PR TITLE
HAI-2601 Accept filename that ends in a dot

### DIFF
--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/attachment/AttachmentValidatorTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/attachment/AttachmentValidatorTest.kt
@@ -65,6 +65,15 @@ class AttachmentValidatorTest {
 
         @Test
         fun `Missing filename should cause exception`() {
+            assertFailure { AttachmentValidator.validFilename(null) }
+                .all {
+                    hasClass(AttachmentInvalidException::class)
+                    hasMessage("Attachment upload exception: Null filename not supported")
+                }
+        }
+
+        @Test
+        fun `Blank filename should cause exception`() {
             assertFailure { AttachmentValidator.validFilename("") }
                 .all {
                     hasClass(AttachmentInvalidException::class)
@@ -97,6 +106,8 @@ class AttachmentValidatorTest {
             "exa%22mple,exa_mple",
             "exa*|%22:<>mple,exa______mple",
             "exa-mple,exa-mple",
+            "../example,___example",
+            "example.,example_",
         )
         fun `Invalid characters should be sanitized`(given: String, expected: String) {
             val filename = "$given.txt"
@@ -114,17 +125,6 @@ class AttachmentValidatorTest {
                 .all {
                     hasClass(AttachmentInvalidException::class)
                     hasMessage("Attachment upload exception: File '$filename' not supported")
-                }
-        }
-
-        @Test
-        fun `PathTraversal should cause an exception`() {
-            val filename = "../example.txt"
-
-            assertFailure { AttachmentValidator.validFilename(filename) }
-                .all {
-                    hasClass(AttachmentInvalidException::class)
-                    hasMessage("Attachment upload exception: File '.._example.txt' not supported")
                 }
         }
 


### PR DESCRIPTION
# Description

Change the file name sanitazion to split the filename to base and extension and sanitize those separately. Then rejoin them and add a dot if extension is not empty.

This way, dot can be added as an invalid character and all other dots except the extension separator will be replaced with the underscore `_`. File names with path traversal will have their `../` segments changed to `___`.

Handle null filenames separately to make this process easier.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2601

## Type of change

- [X] Bug fix 
- [ ] New feature 
- [ ] Other

# Instructions for testing
1. Create a file with a name like `testi luon..txt`.
2. Add it to a hanke or hakemus.
3. After saving its filename should be shown as `testi luon_.txt`.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 