### PR TITLE
HAI-2346 Disallow getting valtakirja content

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentServiceITest.kt
@@ -36,6 +36,7 @@ import fi.hel.haitaton.hanke.attachment.common.AttachmentLimitReachedException
 import fi.hel.haitaton.hanke.attachment.common.AttachmentNotFoundException
 import fi.hel.haitaton.hanke.attachment.common.DownloadResponse
 import fi.hel.haitaton.hanke.attachment.common.MockFileClient
+import fi.hel.haitaton.hanke.attachment.common.ValtakirjaForbiddenException
 import fi.hel.haitaton.hanke.attachment.failResult
 import fi.hel.haitaton.hanke.attachment.response
 import fi.hel.haitaton.hanke.attachment.successResult
@@ -146,31 +147,28 @@ class ApplicationAttachmentServiceITest(
             }
         }
 
-        @Nested
-        inner class FromDb {
-            @Test
-            fun `Returns the attachment content, filename and type`() {
-                val attachment = attachmentFactory.save().withContent().value
+        @Test
+        fun `Returns the attachment content, filename and type`() {
+            val attachment = attachmentFactory.save().withContent().value
 
-                val result = attachmentService.getContent(attachmentId = attachment.id!!)
+            val result = attachmentService.getContent(attachmentId = attachment.id!!)
 
-                assertThat(result.fileName).isEqualTo(FILE_NAME_PDF)
-                assertThat(result.contentType).isEqualTo(APPLICATION_PDF_VALUE)
-                assertThat(result.bytes).isEqualTo(DEFAULT_DATA)
-            }
+            assertThat(result.fileName).isEqualTo(FILE_NAME_PDF)
+            assertThat(result.contentType).isEqualTo(APPLICATION_PDF_VALUE)
+            assertThat(result.bytes).isEqualTo(DEFAULT_DATA)
         }
 
-        @Nested
-        inner class FromCloud {
-            @Test
-            fun `Returns the attachment content, filename and type`() {
-                val attachment = attachmentFactory.save().withContent().value
+        @Test
+        fun `Throws exception when trying to get valtakirja content`() {
+            val attachment = attachmentFactory.save(attachmentType = VALTAKIRJA).withContent().value
 
-                val result = attachmentService.getContent(attachmentId = attachment.id!!)
+            val failure = assertFailure {
+                attachmentService.getContent(attachmentId = attachment.id!!)
+            }
 
-                assertThat(result.fileName).isEqualTo(FILE_NAME_PDF)
-                assertThat(result.contentType).isEqualTo(APPLICATION_PDF_VALUE)
-                assertThat(result.bytes).isEqualTo(DEFAULT_DATA)
+            failure.all {
+                hasClass(ValtakirjaForbiddenException::class)
+                messageContains("id=${attachment.id}")
             }
         }
     }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeError.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeError.kt
@@ -46,6 +46,7 @@ enum class HankeError(val errorMessage: String) {
     HAI3001("Attachment upload failed"),
     HAI3002("Loading attachment failed"),
     HAI3003("Attachment limit reached"),
+    HAI3004("Valtakirja download forbidden"),
     HAI4001("HankeKayttaja not found"),
     HAI4002("Trying to change own permission"),
     HAI4003("Permission data conflict"),

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentController.kt
@@ -4,6 +4,7 @@ import fi.hel.haitaton.hanke.HankeError
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentMetadataDto
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType
 import fi.hel.haitaton.hanke.attachment.common.HeadersBuilder.buildHeaders
+import fi.hel.haitaton.hanke.attachment.common.ValtakirjaForbiddenException
 import io.swagger.v3.oas.annotations.Hidden
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
@@ -156,5 +157,13 @@ class ApplicationAttachmentController(
     fun alluDataError(ex: ApplicationInAlluException): HankeError {
         logger.warn(ex) { ex.message }
         return HankeError.HAI2009
+    }
+
+    @ExceptionHandler(ValtakirjaForbiddenException::class)
+    @ResponseStatus(HttpStatus.FORBIDDEN)
+    @Hidden
+    fun valtakirjaForbiddenException(ex: ValtakirjaForbiddenException): HankeError {
+        logger.warn(ex) { ex.message }
+        return HankeError.HAI3004
     }
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentService.kt
@@ -9,6 +9,7 @@ import fi.hel.haitaton.hanke.attachment.common.AttachmentInvalidException
 import fi.hel.haitaton.hanke.attachment.common.AttachmentValidator
 import fi.hel.haitaton.hanke.attachment.common.FileScanClient
 import fi.hel.haitaton.hanke.attachment.common.FileScanInput
+import fi.hel.haitaton.hanke.attachment.common.ValtakirjaForbiddenException
 import fi.hel.haitaton.hanke.attachment.common.hasInfected
 import fi.hel.haitaton.hanke.hakemus.HakemusIdentifier
 import fi.hel.haitaton.hanke.hakemus.HakemusMetaData
@@ -37,6 +38,11 @@ class ApplicationAttachmentService(
 
     fun getContent(attachmentId: UUID): AttachmentContent {
         val attachment = metadataService.findAttachment(attachmentId)
+
+        if (attachment.attachmentType == ApplicationAttachmentType.VALTAKIRJA) {
+            throw ValtakirjaForbiddenException(attachmentId)
+        }
+
         val content = attachmentContentService.find(attachment)
 
         return AttachmentContent(attachment.fileName, attachment.contentType, content)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/common/Exceptions.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/common/Exceptions.kt
@@ -9,3 +9,6 @@ class AttachmentInvalidException(str: String) :
     RuntimeException("Attachment upload exception: $str")
 
 class AttachmentNotFoundException(id: UUID?) : RuntimeException("Attachment not found, id=$id")
+
+class ValtakirjaForbiddenException(id: UUID) :
+    RuntimeException("Valtakirja download forbidden, id=$id")


### PR DESCRIPTION
# Description

Disallow requests for attachment content when the attachment is of the `VALTAKIRJA` type. Return 403 Forbidden when such a request is made. This is done because of privacy reasons.

A new PR after the old one (#714) was merged to the wrong branch and somehow got lost.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2346

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
Using [Swagger UI](http://localhost:3001/api/swagger-ui/index.html#/), add a valtakirja to hakemus and then try to download the content.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 