### PR TITLE
HAI-2417 Refactor cable report service

### DIFF
--- a/services/hanke-service/build.gradle.kts
+++ b/services/hanke-service/build.gradle.kts
@@ -84,6 +84,7 @@ dependencies {
     implementation("com.github.librepdf:openpdf:2.0.2")
     implementation("net.pwall.mustache:kotlin-mustache:0.12")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.1")
+    implementation("com.auth0:java-jwt:4.4.0")
 
     implementation("org.postgresql:postgresql")
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0")

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/allu/CableReportServiceITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/allu/CableReportServiceITests.kt
@@ -7,6 +7,7 @@ import assertk.assertions.containsExactly
 import assertk.assertions.hasClass
 import assertk.assertions.hasMessage
 import assertk.assertions.isEqualTo
+import assertk.assertions.isGreaterThan
 import assertk.assertions.isNull
 import assertk.assertions.isTrue
 import assertk.assertions.isZero
@@ -103,11 +104,12 @@ class CableReportServiceITests {
 
         @Test
         fun `renews token when it's expired`() {
-            service.authExpiration = Instant.now().minusSeconds(6 * 60)
+            service.authExpiration = Instant.now().minusSeconds(1)
             val mockToken = addStubbedLoginResponse()
 
             val token = service.getToken()
 
+            assertThat(mockWebServer.requestCount).isGreaterThan(0)
             assertThat(mockWebServer.takeRequest()).isValidLoginRequest()
             assertThat(token).isEqualTo(mockToken)
             assertThat(service.authToken).isEqualTo(mockToken)
@@ -116,7 +118,7 @@ class CableReportServiceITests {
 
         @Test
         fun `renews token when it's about to expire, but has not expired yet`() {
-            service.authExpiration = Instant.now().plusSeconds(4 * 60)
+            service.authExpiration = Instant.now().plusSeconds(AUTH_TOKEN_SAFETY_MARGIN_SECONDS - 1)
             val mockToken = addStubbedLoginResponse()
 
             val token = service.getToken()


### PR DESCRIPTION
# Description

Refactor cable report service to reuse query code. Extract common parts of query building to separate functions to reuse those.

Add Allu login token reuse. Reuse the Allu login token until it expires. Renew it 5 minutes before expiration, so it doesn't expire while e.g. uploading a set of attachments.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2417

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [X] Other

# Instructions for testing
The login token reuse can be checked by searching the logs for the phrase `Renewed Allu login token with expiration date`. It should happen only once every two hours.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 

# Other relevant info
The actual tests for sending a kaivuilmoitus will be added later in a separate PR.