### PR TITLE
HAI-1373 Rename cable report service

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/allu/AlluClientITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/allu/AlluClientITests.kt
@@ -46,10 +46,10 @@ import org.springframework.http.MediaType.IMAGE_PNG
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.WebClientResponseException
 
-class CableReportServiceITests {
+class AlluClientITests {
 
     private lateinit var mockWebServer: MockWebServer
-    private lateinit var service: CableReportService
+    private lateinit var service: AlluClient
 
     private lateinit var authToken: String
 
@@ -61,7 +61,7 @@ class CableReportServiceITests {
         val properties = AlluProperties(baseUrl, "fake_username", "any_password", 2)
         val webClient = webClientWithLargeBuffer(WebClient.builder())
         authToken = createMockToken()
-        service = CableReportService(webClient, properties)
+        service = AlluClient(webClient, properties)
         service.authToken = authToken
         service.authExpiration = Instant.now().plusSeconds(3600)
     }

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentServiceITest.kt
@@ -19,7 +19,7 @@ import assertk.assertions.single
 import assertk.assertions.startsWith
 import fi.hel.haitaton.hanke.ALLOWED_ATTACHMENT_COUNT
 import fi.hel.haitaton.hanke.IntegrationTest
-import fi.hel.haitaton.hanke.allu.CableReportService
+import fi.hel.haitaton.hanke.allu.AlluClient
 import fi.hel.haitaton.hanke.attachment.DEFAULT_DATA
 import fi.hel.haitaton.hanke.attachment.DEFAULT_SIZE
 import fi.hel.haitaton.hanke.attachment.FILE_NAME_PDF
@@ -66,7 +66,7 @@ import org.springframework.http.MediaType.APPLICATION_PDF_VALUE
 private const val ALLU_ID = 42
 
 class ApplicationAttachmentServiceITest(
-    @Autowired private val cableReportService: CableReportService,
+    @Autowired private val alluClient: AlluClient,
     @Autowired private val attachmentService: ApplicationAttachmentService,
     @Autowired private val attachmentRepository: ApplicationAttachmentRepository,
     @Autowired private val applicationFactory: ApplicationFactory,
@@ -87,7 +87,7 @@ class ApplicationAttachmentServiceITest(
     fun tearDown() {
         mockClamAv.shutdown()
         checkUnnecessaryStub()
-        confirmVerified(cableReportService)
+        confirmVerified(alluClient)
     }
 
     @Nested
@@ -221,7 +221,7 @@ class ApplicationAttachmentServiceITest(
                 .transform { it.toBytes() }
                 .isEqualTo(DEFAULT_DATA)
 
-            verify { cableReportService wasNot Called }
+            verify { alluClient wasNot Called }
         }
 
         @Test
@@ -439,7 +439,7 @@ class ApplicationAttachmentServiceITest(
                     )
                 }
                 assertThat(attachmentRepository.findById(attachment.id!!)).isPresent()
-                verify { cableReportService wasNot Called }
+                verify { alluClient wasNot Called }
             }
 
             @Test

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/configuration/MockAlluClient.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/configuration/MockAlluClient.kt
@@ -1,11 +1,11 @@
 package fi.hel.haitaton.hanke.configuration
 
-import fi.hel.haitaton.hanke.allu.CableReportService
+import fi.hel.haitaton.hanke.allu.AlluClient
 import io.mockk.mockk
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
 @Configuration
-class MockCableReportService {
-    @Bean fun cableReportService(): CableReportService = mockk()
+class MockAlluClient {
+    @Bean fun alluClient(): AlluClient = mockk()
 }

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceITest.kt
@@ -30,9 +30,9 @@ import fi.hel.haitaton.hanke.HankeNotFoundException
 import fi.hel.haitaton.hanke.HankeRepository
 import fi.hel.haitaton.hanke.HankeService
 import fi.hel.haitaton.hanke.IntegrationTest
+import fi.hel.haitaton.hanke.allu.AlluClient
 import fi.hel.haitaton.hanke.allu.AlluStatusRepository
 import fi.hel.haitaton.hanke.allu.ApplicationStatus
-import fi.hel.haitaton.hanke.allu.CableReportService
 import fi.hel.haitaton.hanke.allu.Contact
 import fi.hel.haitaton.hanke.allu.Customer
 import fi.hel.haitaton.hanke.allu.CustomerType
@@ -133,7 +133,7 @@ class HakemusServiceITest(
     @Autowired private val hankeKayttajaFactory: HankeKayttajaFactory,
     @Autowired private val attachmentFactory: ApplicationAttachmentFactory,
     @Autowired private val fileClient: MockFileClient,
-    @Autowired private val alluClient: CableReportService,
+    @Autowired private val alluClient: AlluClient,
     @Autowired private val alluStatusRepository: AlluStatusRepository,
     @Autowired private val hankeService: HankeService,
 ) : IntegrationTest() {

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/AlluClient.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/AlluClient.kt
@@ -30,7 +30,7 @@ private val logger = KotlinLogging.logger {}
 const val HAITATON_SYSTEM = "Haitaton järjestelmä"
 const val AUTH_TOKEN_SAFETY_MARGIN_SECONDS = 5L * 60L
 
-class CableReportService(
+class AlluClient(
     private val webClient: WebClient,
     private val properties: AlluProperties,
     private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentService.kt
@@ -1,6 +1,6 @@
 package fi.hel.haitaton.hanke.attachment.application
 
-import fi.hel.haitaton.hanke.allu.CableReportService
+import fi.hel.haitaton.hanke.allu.AlluClient
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentMetadata
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentMetadataDto
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType
@@ -26,7 +26,7 @@ private val logger = KotlinLogging.logger {}
 
 @Service
 class ApplicationAttachmentService(
-    private val cableReportService: CableReportService,
+    private val alluClient: AlluClient,
     private val metadataService: ApplicationAttachmentMetadataService,
     private val hakemusRepository: HakemusRepository,
     private val attachmentContentService: ApplicationAttachmentContentService,
@@ -146,7 +146,7 @@ class ApplicationAttachmentService(
             return
         }
 
-        cableReportService.addAttachments(alluId, attachments) { attachmentContentService.find(it) }
+        alluClient.addAttachments(alluId, attachments) { attachmentContentService.find(it) }
     }
 
     private fun findHakemus(applicationId: Long): HakemusMetaData =

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/configuration/Configuration.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/configuration/Configuration.kt
@@ -1,7 +1,7 @@
 package fi.hel.haitaton.hanke.configuration
 
+import fi.hel.haitaton.hanke.allu.AlluClient
 import fi.hel.haitaton.hanke.allu.AlluProperties
-import fi.hel.haitaton.hanke.allu.CableReportService
 import fi.hel.haitaton.hanke.attachment.azure.Containers
 import fi.hel.haitaton.hanke.email.EmailProperties
 import fi.hel.haitaton.hanke.gdpr.GdprProperties
@@ -37,13 +37,13 @@ class Configuration {
 
     @Bean
     @Profile("!test")
-    fun cableReportService(webClientBuilder: WebClient.Builder): CableReportService {
+    fun alluClient(webClientBuilder: WebClient.Builder): AlluClient {
         val webClient =
             webClientWithLargeBuffer(
                 if (alluTrustInsecure) createInsecureTrustingWebClient(webClientBuilder)
                 else webClientBuilder
             )
-        return CableReportService(webClient, alluProperties)
+        return AlluClient(webClient, alluProperties)
     }
 
     private fun createInsecureTrustingWebClient(

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/AlluUpdateService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/AlluUpdateService.kt
@@ -1,7 +1,7 @@
 package fi.hel.haitaton.hanke.hakemus
 
+import fi.hel.haitaton.hanke.allu.AlluClient
 import fi.hel.haitaton.hanke.allu.AlluStatusRepository
-import fi.hel.haitaton.hanke.allu.CableReportService
 import fi.hel.haitaton.hanke.configuration.LockService
 import java.time.OffsetDateTime
 import mu.KotlinLogging
@@ -14,7 +14,7 @@ private val logger = KotlinLogging.logger {}
 class AlluUpdateService(
     private val hakemusRepository: HakemusRepository,
     private val alluStatusRepository: AlluStatusRepository,
-    private val cableReportService: CableReportService,
+    private val alluClient: AlluClient,
     private val hakemusService: HakemusService,
     private val lockService: LockService,
 ) {
@@ -44,7 +44,7 @@ class AlluUpdateService(
             "Updating application histories with date $lastUpdate and ${ids.size} Allu IDs"
         }
         val applicationHistories =
-            cableReportService.getApplicationStatusHistories(ids, lastUpdate.toZonedDateTime())
+            alluClient.getApplicationStatusHistories(ids, lastUpdate.toZonedDateTime())
 
         hakemusService.handleHakemusUpdates(applicationHistories, currentUpdate)
     }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
@@ -7,6 +7,7 @@ import fi.hel.haitaton.hanke.HankeRepository
 import fi.hel.haitaton.hanke.HankealueService
 import fi.hel.haitaton.hanke.allu.AlluApplicationData
 import fi.hel.haitaton.hanke.allu.AlluApplicationResponse
+import fi.hel.haitaton.hanke.allu.AlluClient
 import fi.hel.haitaton.hanke.allu.AlluLoginException
 import fi.hel.haitaton.hanke.allu.AlluStatusRepository
 import fi.hel.haitaton.hanke.allu.ApplicationHistory
@@ -14,7 +15,6 @@ import fi.hel.haitaton.hanke.allu.ApplicationStatus
 import fi.hel.haitaton.hanke.allu.ApplicationStatusEvent
 import fi.hel.haitaton.hanke.allu.Attachment
 import fi.hel.haitaton.hanke.allu.AttachmentMetadata
-import fi.hel.haitaton.hanke.allu.CableReportService
 import fi.hel.haitaton.hanke.attachment.application.ApplicationAttachmentService
 import fi.hel.haitaton.hanke.email.ApplicationNotificationData
 import fi.hel.haitaton.hanke.email.EmailSenderService
@@ -55,7 +55,7 @@ class HakemusService(
     private val disclosureLogService: DisclosureLogService,
     private val hankeKayttajaService: HankeKayttajaService,
     private val attachmentService: ApplicationAttachmentService,
-    private val alluClient: CableReportService,
+    private val alluClient: AlluClient,
     private val alluStatusRepository: AlluStatusRepository,
     private val emailSenderService: EmailSenderService,
 ) {

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/AlluUpdateServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/AlluUpdateServiceTest.kt
@@ -1,8 +1,8 @@
 package fi.hel.haitaton.hanke.hakemus
 
 import assertk.assertThat
+import fi.hel.haitaton.hanke.allu.AlluClient
 import fi.hel.haitaton.hanke.allu.AlluStatusRepository
-import fi.hel.haitaton.hanke.allu.CableReportService
 import fi.hel.haitaton.hanke.configuration.LockService
 import fi.hel.haitaton.hanke.factory.ApplicationHistoryFactory
 import fi.hel.haitaton.hanke.test.Asserts.isRecent
@@ -27,7 +27,7 @@ import org.springframework.web.reactive.function.client.WebClientResponseExcepti
 class AlluUpdateServiceTest {
     private val hakemusRepository: HakemusRepository = mockk()
     private val alluStatusRepository: AlluStatusRepository = mockk()
-    private val cableReportService: CableReportService = mockk()
+    private val alluClient: AlluClient = mockk()
     private val hakemusService: HakemusService = mockk()
     private val jdbcLockRegistry: JdbcLockRegistry = mockk()
     private val lockService = LockService(jdbcLockRegistry)
@@ -36,7 +36,7 @@ class AlluUpdateServiceTest {
         AlluUpdateService(
             hakemusRepository,
             alluStatusRepository,
-            cableReportService,
+            alluClient,
             hakemusService,
             lockService,
         )
@@ -52,7 +52,7 @@ class AlluUpdateServiceTest {
         confirmVerified(
             alluStatusRepository,
             hakemusRepository,
-            cableReportService,
+            alluClient,
             hakemusService,
             jdbcLockRegistry,
         )
@@ -75,7 +75,7 @@ class AlluUpdateServiceTest {
                 jdbcLockRegistry.obtain(alluUpdateService.lockName)
                 hakemusRepository.getAllAlluIds()
                 alluStatusRepository wasNot Called
-                cableReportService wasNot Called
+                alluClient wasNot Called
                 hakemusService wasNot Called
             }
         }
@@ -86,7 +86,7 @@ class AlluUpdateServiceTest {
             val alluids = listOf(23, 24)
             every { hakemusRepository.getAllAlluIds() } returns alluids
             every { alluStatusRepository.getLastUpdateTime() } returns lastUpdated
-            every { cableReportService.getApplicationStatusHistories(alluids, eventsAfter) } returns
+            every { alluClient.getApplicationStatusHistories(alluids, eventsAfter) } returns
                 listOf()
             justRun { hakemusService.handleHakemusUpdates(listOf(), any()) }
 
@@ -96,7 +96,7 @@ class AlluUpdateServiceTest {
                 jdbcLockRegistry.obtain(alluUpdateService.lockName)
                 hakemusRepository.getAllAlluIds()
                 alluStatusRepository.getLastUpdateTime()
-                cableReportService.getApplicationStatusHistories(alluids, eventsAfter)
+                alluClient.getApplicationStatusHistories(alluids, eventsAfter)
                 hakemusService.handleHakemusUpdates(listOf(), any())
             }
         }
@@ -108,7 +108,7 @@ class AlluUpdateServiceTest {
             val histories = listOf(ApplicationHistoryFactory.create(applicationId = 24))
             every { hakemusRepository.getAllAlluIds() } returns alluids
             every { alluStatusRepository.getLastUpdateTime() } returns lastUpdated
-            every { cableReportService.getApplicationStatusHistories(alluids, eventsAfter) } returns
+            every { alluClient.getApplicationStatusHistories(alluids, eventsAfter) } returns
                 histories
             justRun { hakemusService.handleHakemusUpdates(histories, any()) }
 
@@ -118,7 +118,7 @@ class AlluUpdateServiceTest {
                 jdbcLockRegistry.obtain(alluUpdateService.lockName)
                 hakemusRepository.getAllAlluIds()
                 alluStatusRepository.getLastUpdateTime()
-                cableReportService.getApplicationStatusHistories(alluids, eventsAfter)
+                alluClient.getApplicationStatusHistories(alluids, eventsAfter)
                 hakemusService.handleHakemusUpdates(histories, any())
             }
         }
@@ -129,7 +129,7 @@ class AlluUpdateServiceTest {
             val alluids = listOf(23, 24)
             every { hakemusRepository.getAllAlluIds() } returns alluids
             every { alluStatusRepository.getLastUpdateTime() } returns lastUpdated
-            every { cableReportService.getApplicationStatusHistories(alluids, eventsAfter) } returns
+            every { alluClient.getApplicationStatusHistories(alluids, eventsAfter) } returns
                 listOf()
             justRun { hakemusService.handleHakemusUpdates(listOf(), any()) }
 
@@ -139,7 +139,7 @@ class AlluUpdateServiceTest {
                 jdbcLockRegistry.obtain(alluUpdateService.lockName)
                 hakemusRepository.getAllAlluIds()
                 alluStatusRepository.getLastUpdateTime()
-                cableReportService.getApplicationStatusHistories(alluids, eventsAfter)
+                alluClient.getApplicationStatusHistories(alluids, eventsAfter)
                 hakemusService.handleHakemusUpdates(listOf(), withArg { assertThat(it).isRecent() })
             }
         }
@@ -154,7 +154,7 @@ class AlluUpdateServiceTest {
                 jdbcLockRegistry.obtain(alluUpdateService.lockName)
                 hakemusRepository wasNot Called
                 alluStatusRepository wasNot Called
-                cableReportService wasNot Called
+                alluClient wasNot Called
                 hakemusService wasNot Called
             }
         }
@@ -165,7 +165,7 @@ class AlluUpdateServiceTest {
             val alluids = listOf(23, 24)
             every { hakemusRepository.getAllAlluIds() } returns alluids
             every { alluStatusRepository.getLastUpdateTime() } returns lastUpdated
-            every { cableReportService.getApplicationStatusHistories(alluids, eventsAfter) } throws
+            every { alluClient.getApplicationStatusHistories(alluids, eventsAfter) } throws
                 WebClientResponseException(500, "Internal server error", null, null, null)
 
             alluUpdateService.checkApplicationStatuses()
@@ -175,7 +175,7 @@ class AlluUpdateServiceTest {
                 lock.tryLock()
                 hakemusRepository.getAllAlluIds()
                 alluStatusRepository.getLastUpdateTime()
-                cableReportService.getApplicationStatusHistories(alluids, eventsAfter)
+                alluClient.getApplicationStatusHistories(alluids, eventsAfter)
                 lock.unlock()
                 hakemusService wasNot Called
             }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceTest.kt
@@ -15,11 +15,11 @@ import assertk.assertions.single
 import fi.hel.haitaton.hanke.HankeRepository
 import fi.hel.haitaton.hanke.HankealueService
 import fi.hel.haitaton.hanke.allu.AlluCableReportApplicationData
+import fi.hel.haitaton.hanke.allu.AlluClient
 import fi.hel.haitaton.hanke.allu.AlluLoginException
 import fi.hel.haitaton.hanke.allu.AlluStatus
 import fi.hel.haitaton.hanke.allu.AlluStatusRepository
 import fi.hel.haitaton.hanke.allu.ApplicationStatus
-import fi.hel.haitaton.hanke.allu.CableReportService
 import fi.hel.haitaton.hanke.allu.Contact
 import fi.hel.haitaton.hanke.allu.Customer
 import fi.hel.haitaton.hanke.allu.CustomerWithContacts
@@ -78,7 +78,7 @@ class HakemusServiceTest {
     private val disclosureLogService: DisclosureLogService = mockk(relaxUnitFun = true)
     private val hankeKayttajaService: HankeKayttajaService = mockk(relaxUnitFun = true)
     private val attachmentService: ApplicationAttachmentService = mockk()
-    private val alluClient: CableReportService = mockk()
+    private val alluClient: AlluClient = mockk()
     private val alluStatusRepository: AlluStatusRepository = mockk()
     private val emailSenderService: EmailSenderService = mockk()
 


### PR DESCRIPTION
# Description

CablereportService now handles other applications as well, not just cable reports. Rename it to AlluClient so it's more accurate.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1373

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [X] Other