### PR TITLE
HAI-2606 Save the decision when an excavation notification gets one

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentContentServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentContentServiceITest.kt
@@ -9,8 +9,8 @@ import assertk.assertions.hasMessage
 import assertk.assertions.isEmpty
 import assertk.assertions.isEqualTo
 import fi.hel.haitaton.hanke.IntegrationTest
-import fi.hel.haitaton.hanke.attachment.DEFAULT_DATA
 import fi.hel.haitaton.hanke.attachment.FILE_NAME_PDF
+import fi.hel.haitaton.hanke.attachment.PDF_BYTES
 import fi.hel.haitaton.hanke.attachment.azure.Container
 import fi.hel.haitaton.hanke.attachment.common.AttachmentNotFoundException
 import fi.hel.haitaton.hanke.attachment.common.MockFileClient
@@ -66,7 +66,7 @@ class ApplicationAttachmentContentServiceITest(
                 attachmentContentService.upload(
                     FILE_NAME_PDF,
                     MediaType.APPLICATION_PDF,
-                    DEFAULT_DATA,
+                    PDF_BYTES,
                     applicationId
                 )
 

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentServiceITest.kt
@@ -20,9 +20,9 @@ import assertk.assertions.startsWith
 import fi.hel.haitaton.hanke.ALLOWED_ATTACHMENT_COUNT
 import fi.hel.haitaton.hanke.IntegrationTest
 import fi.hel.haitaton.hanke.allu.AlluClient
-import fi.hel.haitaton.hanke.attachment.DEFAULT_DATA
 import fi.hel.haitaton.hanke.attachment.DEFAULT_SIZE
 import fi.hel.haitaton.hanke.attachment.FILE_NAME_PDF
+import fi.hel.haitaton.hanke.attachment.PDF_BYTES
 import fi.hel.haitaton.hanke.attachment.azure.Container.HAKEMUS_LIITTEET
 import fi.hel.haitaton.hanke.attachment.body
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentEntity
@@ -155,7 +155,7 @@ class ApplicationAttachmentServiceITest(
 
             assertThat(result.fileName).isEqualTo(FILE_NAME_PDF)
             assertThat(result.contentType).isEqualTo(APPLICATION_PDF_VALUE)
-            assertThat(result.bytes).isEqualTo(DEFAULT_DATA)
+            assertThat(result.bytes).isEqualTo(PDF_BYTES)
         }
 
         @Test
@@ -219,7 +219,7 @@ class ApplicationAttachmentServiceITest(
                 .isNotNull()
                 .prop(DownloadResponse::content)
                 .transform { it.toBytes() }
-                .isEqualTo(DEFAULT_DATA)
+                .isEqualTo(PDF_BYTES)
 
             verify { alluClient wasNot Called }
         }

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentContentServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentContentServiceITest.kt
@@ -9,8 +9,8 @@ import assertk.assertions.hasMessage
 import assertk.assertions.isEmpty
 import assertk.assertions.isEqualTo
 import fi.hel.haitaton.hanke.IntegrationTest
-import fi.hel.haitaton.hanke.attachment.DEFAULT_DATA
 import fi.hel.haitaton.hanke.attachment.FILE_NAME_PDF
+import fi.hel.haitaton.hanke.attachment.PDF_BYTES
 import fi.hel.haitaton.hanke.attachment.azure.Container.HANKE_LIITTEET
 import fi.hel.haitaton.hanke.attachment.common.AttachmentNotFoundException
 import fi.hel.haitaton.hanke.attachment.common.MockFileClient
@@ -62,12 +62,7 @@ class HankeAttachmentContentServiceITest(
         @Test
         fun `Should return location of uploaded blob`() {
             val blobLocation =
-                attachmentContentService.upload(
-                    FILE_NAME_PDF,
-                    APPLICATION_PDF,
-                    DEFAULT_DATA,
-                    hankeId
-                )
+                attachmentContentService.upload(FILE_NAME_PDF, APPLICATION_PDF, PDF_BYTES, hankeId)
 
             assertThat(blobLocation).isValidBlobLocation(id = hankeId)
         }

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentServiceITest.kt
@@ -15,9 +15,9 @@ import assertk.assertions.isNotNull
 import assertk.assertions.messageContains
 import assertk.assertions.prop
 import fi.hel.haitaton.hanke.IntegrationTest
-import fi.hel.haitaton.hanke.attachment.DEFAULT_DATA
 import fi.hel.haitaton.hanke.attachment.DEFAULT_SIZE
 import fi.hel.haitaton.hanke.attachment.FILE_NAME_PDF
+import fi.hel.haitaton.hanke.attachment.PDF_BYTES
 import fi.hel.haitaton.hanke.attachment.azure.Container
 import fi.hel.haitaton.hanke.attachment.body
 import fi.hel.haitaton.hanke.attachment.common.AttachmentInvalidException
@@ -177,7 +177,7 @@ class HankeAttachmentServiceITest(
 
             assertThat(result.fileName).isEqualTo(FILE_NAME_PDF)
             assertThat(result.contentType).isEqualTo(APPLICATION_PDF_VALUE)
-            assertThat(result.bytes).isEqualTo(DEFAULT_DATA)
+            assertThat(result.bytes).isEqualTo(PDF_BYTES)
         }
     }
 

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusControllerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusControllerITest.kt
@@ -862,14 +862,14 @@ class HakemusControllerITest(@Autowired override val mockMvc: MockMvc) : Control
         @Test
         fun `when application has no decision should return 404`() {
             every { authorizer.authorizeHakemusId(id, PermissionCode.VIEW.name) } returns true
-            every { hakemusService.downloadDecision(id, USERNAME) } throws
+            every { hakemusService.downloadDecision(id) } throws
                 HakemusDecisionNotFoundException("Decision not found in Allu. alluid=23")
 
             get(url).andExpect(status().isNotFound).andExpect(hankeError(HankeError.HAI2006))
 
             verifySequence {
                 authorizer.authorizeHakemusId(id, PermissionCode.VIEW.name)
-                hakemusService.downloadDecision(id, USERNAME)
+                hakemusService.downloadDecision(id)
             }
         }
 
@@ -878,7 +878,7 @@ class HakemusControllerITest(@Autowired override val mockMvc: MockMvc) : Control
             val applicationIdentifier = "JS230001"
             val pdfBytes = "/fi/hel/haitaton/hanke/decision/fake-decision.pdf".getResourceAsBytes()
             every { authorizer.authorizeHakemusId(id, PermissionCode.VIEW.name) } returns true
-            every { hakemusService.downloadDecision(id, USERNAME) } returns
+            every { hakemusService.downloadDecision(id) } returns
                 Pair(applicationIdentifier, pdfBytes)
             every { hakemusService.getById(id) } returns
                 HakemusFactory.create(applicationIdentifier = applicationIdentifier)
@@ -893,7 +893,7 @@ class HakemusControllerITest(@Autowired override val mockMvc: MockMvc) : Control
 
             verifySequence {
                 authorizer.authorizeHakemusId(id, PermissionCode.VIEW.name)
-                hakemusService.downloadDecision(id, USERNAME)
+                hakemusService.downloadDecision(id)
                 hakemusService.getById(id)
             }
         }
@@ -904,7 +904,7 @@ class HakemusControllerITest(@Autowired override val mockMvc: MockMvc) : Control
             val hakemus = HakemusFactory.create(applicationIdentifier = applicationIdentifier)
             val pdfBytes = "/fi/hel/haitaton/hanke/decision/fake-decision.pdf".getResourceAsBytes()
             every { authorizer.authorizeHakemusId(id, PermissionCode.VIEW.name) } returns true
-            every { hakemusService.downloadDecision(id, USERNAME) } returns
+            every { hakemusService.downloadDecision(id) } returns
                 Pair(applicationIdentifier, pdfBytes)
             every { hakemusService.getById(id) } returns hakemus
 
@@ -912,7 +912,7 @@ class HakemusControllerITest(@Autowired override val mockMvc: MockMvc) : Control
 
             verifySequence {
                 authorizer.authorizeHakemusId(id, PermissionCode.VIEW.name)
-                hakemusService.downloadDecision(id, USERNAME)
+                hakemusService.downloadDecision(id)
                 hakemusService.getById(id)
                 disclosureLogService.saveDisclosureLogsForCableReport(
                     hakemus.toMetadata(),

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/paatos/PaatosServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/paatos/PaatosServiceITest.kt
@@ -1,11 +1,26 @@
 package fi.hel.haitaton.hanke.paatos
 
+import assertk.all
+import assertk.assertFailure
 import assertk.assertThat
 import assertk.assertions.containsExactly
 import assertk.assertions.extracting
 import assertk.assertions.hasSize
 import assertk.assertions.isEmpty
+import assertk.assertions.isEqualTo
+import assertk.assertions.isInstanceOf
+import assertk.assertions.prop
+import assertk.assertions.single
+import assertk.assertions.startsWith
 import fi.hel.haitaton.hanke.IntegrationTest
+import fi.hel.haitaton.hanke.allu.AlluClient
+import fi.hel.haitaton.hanke.allu.ApplicationStatus
+import fi.hel.haitaton.hanke.allu.ApplicationStatusEvent
+import fi.hel.haitaton.hanke.attachment.PDF_BYTES
+import fi.hel.haitaton.hanke.attachment.azure.Container
+import fi.hel.haitaton.hanke.attachment.common.MockFileClient
+import fi.hel.haitaton.hanke.attachment.common.TestFile
+import fi.hel.haitaton.hanke.factory.AlluFactory
 import fi.hel.haitaton.hanke.factory.HakemusFactory
 import fi.hel.haitaton.hanke.factory.PaatosFactory
 import fi.hel.haitaton.hanke.hakemus.ApplicationType
@@ -14,16 +29,39 @@ import fi.hel.haitaton.hanke.paatos.PaatosTila.NYKYINEN
 import fi.hel.haitaton.hanke.paatos.PaatosTyyppi.PAATOS
 import fi.hel.haitaton.hanke.paatos.PaatosTyyppi.TOIMINNALLINEN_KUNTO
 import fi.hel.haitaton.hanke.paatos.PaatosTyyppi.TYO_VALMIS
-import fi.hel.haitaton.hanke.test.USERNAME
+import fi.hel.haitaton.hanke.test.AlluException
+import io.mockk.checkUnnecessaryStub
+import io.mockk.clearAllMocks
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.verifySequence
+import java.time.ZonedDateTime
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.MediaType
 
 class PaatosServiceITest(
     @Autowired private val paatosService: PaatosService,
     @Autowired private val hakemusFactory: HakemusFactory,
     @Autowired private val paatosFactory: PaatosFactory,
+    @Autowired private val alluClient: AlluClient,
+    @Autowired private val fileClient: MockFileClient,
+    @Autowired private val paatosRepository: PaatosRepository,
 ) : IntegrationTest() {
+
+    @BeforeEach
+    fun clearMocks() {
+        clearAllMocks()
+    }
+
+    @AfterEach
+    fun checkMocks() {
+        checkUnnecessaryStub()
+        confirmVerified(alluClient)
+    }
 
     @Nested
     inner class FindByHakemusId {
@@ -39,7 +77,7 @@ class PaatosServiceITest(
         fun `returns list of all decisions when they exist`() {
             val hakemus =
                 hakemusFactory
-                    .builder(USERNAME, applicationType = ApplicationType.EXCAVATION_NOTIFICATION)
+                    .builder(ApplicationType.EXCAVATION_NOTIFICATION)
                     .withMandatoryFields()
                     .save()
             paatosFactory.save(hakemus, "KP2400001", PAATOS, KORVATTU)
@@ -72,21 +110,21 @@ class PaatosServiceITest(
         fun `returns decisions only for the requested application when they exist for several`() {
             val hakemus1 =
                 hakemusFactory
-                    .builder(USERNAME, applicationType = ApplicationType.EXCAVATION_NOTIFICATION)
+                    .builder(ApplicationType.EXCAVATION_NOTIFICATION)
                     .withMandatoryFields()
                     .withStatus(alluId = 11)
                     .withName("First")
                     .save()
             val hakemus2 =
                 hakemusFactory
-                    .builder(USERNAME, applicationType = ApplicationType.EXCAVATION_NOTIFICATION)
+                    .builder(ApplicationType.EXCAVATION_NOTIFICATION)
                     .withMandatoryFields()
                     .withStatus(alluId = 12)
                     .withName("Second")
                     .save()
             val hakemus3 =
                 hakemusFactory
-                    .builder(USERNAME, applicationType = ApplicationType.EXCAVATION_NOTIFICATION)
+                    .builder(ApplicationType.EXCAVATION_NOTIFICATION)
                     .withMandatoryFields()
                     .withStatus(alluId = 13)
                     .withName("Third")
@@ -98,6 +136,150 @@ class PaatosServiceITest(
             val result = paatosService.findByHakemusId(hakemus2.id)
 
             assertThat(result).extracting { it.hakemusId }.containsExactly(hakemus2.id)
+        }
+    }
+
+    @Nested
+    inner class SaveKaivuilmoituksenPaatos {
+        private val eventTime = ZonedDateTime.parse("2024-07-21T15:23:12Z")
+        private val alluId = 631
+        private val hakemustunnus = "KP2400414"
+        private val nameFromAllu = "Name from Allu"
+        private val startDateFromAllu = ZonedDateTime.parse("2024-07-24T15:23:12Z")
+        private val endDateFromAllu = ZonedDateTime.parse("2024-07-25T15:23:12Z")
+        private val event =
+            ApplicationStatusEvent(
+                eventTime = eventTime,
+                applicationIdentifier = hakemustunnus,
+                newStatus = ApplicationStatus.DECISION,
+                targetStatus = null,
+            )
+
+        private fun setupAlluMocks() {
+            every { alluClient.getDecisionPdf(alluId) } returns PDF_BYTES
+            every { alluClient.getApplicationInformation(alluId) } returns
+                AlluFactory.createAlluApplicationResponse(
+                    id = alluId,
+                    name = nameFromAllu,
+                    startTime = startDateFromAllu,
+                    endTime = endDateFromAllu,
+                )
+        }
+
+        @Test
+        fun `saves decision PDF to blob storage`() {
+            val hakemus =
+                hakemusFactory
+                    .builder(ApplicationType.EXCAVATION_NOTIFICATION)
+                    .withMandatoryFields()
+                    .withStatus(ApplicationStatus.DECISION, alluId, hakemustunnus)
+                    .saveEntity()
+            setupAlluMocks()
+
+            paatosService.saveKaivuilmoituksenPaatos(hakemus, event)
+
+            val decisions = fileClient.listBlobs(Container.PAATOKSET)
+            assertThat(decisions).single().all {
+                prop(TestFile::path).startsWith("${hakemus.id}/")
+                prop(TestFile::contentType).isEqualTo(MediaType.APPLICATION_PDF)
+                prop(TestFile::contentLength).isEqualTo(PDF_BYTES.size)
+                prop(TestFile::contentDisposition)
+                    .isEqualTo("attachment; filename*=UTF-8''$hakemustunnus-paatos.pdf")
+                prop(TestFile::content).transform { it.toBytes() }.isEqualTo(PDF_BYTES)
+            }
+            verifySequence {
+                alluClient.getDecisionPdf(alluId)
+                alluClient.getApplicationInformation(alluId)
+            }
+        }
+
+        @Test
+        fun `writes the decision data to database`() {
+            val hakemus =
+                hakemusFactory
+                    .builder(ApplicationType.EXCAVATION_NOTIFICATION)
+                    .withMandatoryFields()
+                    .withStatus(ApplicationStatus.DECISION, alluId, hakemustunnus)
+                    .saveEntity()
+            setupAlluMocks()
+
+            paatosService.saveKaivuilmoituksenPaatos(hakemus, event)
+
+            assertThat(paatosRepository.findAll()).single().all {
+                prop(PaatosEntity::hakemusId).isEqualTo(hakemus.id)
+                prop(PaatosEntity::hakemustunnus).isEqualTo(hakemustunnus)
+                prop(PaatosEntity::tyyppi).isEqualTo(PAATOS)
+                prop(PaatosEntity::tila).isEqualTo(NYKYINEN)
+            }
+            verifySequence {
+                alluClient.getDecisionPdf(alluId)
+                alluClient.getApplicationInformation(alluId)
+            }
+        }
+
+        @Test
+        fun `reads name and dates from Allu`() {
+            val hakemus =
+                hakemusFactory
+                    .builder(ApplicationType.EXCAVATION_NOTIFICATION)
+                    .withMandatoryFields()
+                    .withStatus(ApplicationStatus.DECISION, alluId, hakemustunnus)
+                    .withName("Old name")
+                    .withStartTime(ZonedDateTime.parse("2023-07-24T15:23:12Z"))
+                    .withEndTime(ZonedDateTime.parse("2023-07-24T15:23:12Z"))
+                    .saveEntity()
+            setupAlluMocks()
+
+            paatosService.saveKaivuilmoituksenPaatos(hakemus, event)
+
+            assertThat(paatosRepository.findAll()).single().all {
+                prop(PaatosEntity::nimi).isEqualTo(nameFromAllu)
+                prop(PaatosEntity::alkupaiva).isEqualTo(startDateFromAllu.toLocalDate())
+                prop(PaatosEntity::loppupaiva).isEqualTo(endDateFromAllu.toLocalDate())
+            }
+            verifySequence {
+                alluClient.getDecisionPdf(alluId)
+                alluClient.getApplicationInformation(alluId)
+            }
+        }
+
+        @Test
+        fun `throws exception when getting the PDF from Allu throws an exception`() {
+            val hakemus =
+                hakemusFactory
+                    .builder(ApplicationType.EXCAVATION_NOTIFICATION)
+                    .withMandatoryFields()
+                    .withStatus(ApplicationStatus.DECISION, alluId, hakemustunnus)
+                    .saveEntity()
+            every { alluClient.getDecisionPdf(alluId) } throws AlluException()
+
+            val failure = assertFailure { paatosService.saveKaivuilmoituksenPaatos(hakemus, event) }
+
+            failure.isInstanceOf(AlluException::class.java)
+            assertThat(paatosRepository.findAll()).isEmpty()
+            verifySequence { alluClient.getDecisionPdf(alluId) }
+        }
+
+        @Test
+        fun `doesn't save the decision when getting application information fails`() {
+            val hakemus =
+                hakemusFactory
+                    .builder(ApplicationType.EXCAVATION_NOTIFICATION)
+                    .withMandatoryFields()
+                    .withStatus(ApplicationStatus.DECISION, alluId, hakemustunnus)
+                    .saveEntity()
+            every { alluClient.getDecisionPdf(alluId) } returns PDF_BYTES
+            every { alluClient.getApplicationInformation(alluId) } throws AlluException()
+
+            val failure = assertFailure { paatosService.saveKaivuilmoituksenPaatos(hakemus, event) }
+
+            failure.isInstanceOf(AlluException::class.java)
+            assertThat(paatosRepository.findAll()).isEmpty()
+            assertThat(fileClient.listBlobs(Container.PAATOKSET)).isEmpty()
+            verifySequence {
+                alluClient.getDecisionPdf(alluId)
+                alluClient.getApplicationInformation(alluId)
+            }
         }
     }
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusController.kt
@@ -314,7 +314,7 @@ class HakemusController(
     @PreAuthorize("@hakemusAuthorizer.authorizeHakemusId(#id, 'VIEW')")
     fun downloadDecision(@PathVariable(name = "id") id: Long): ResponseEntity<ByteArray> {
         val userId = currentUserId()
-        val (filename, pdfBytes) = hakemusService.downloadDecision(id, userId)
+        val (filename, pdfBytes) = hakemusService.downloadDecision(id)
         val application = hakemusService.getById(id)
         disclosureLogService.saveDisclosureLogsForCableReport(application.toMetadata(), userId)
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/paatos/PaatosService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/paatos/PaatosService.kt
@@ -1,11 +1,50 @@
 package fi.hel.haitaton.hanke.paatos
 
+import fi.hel.haitaton.hanke.allu.AlluClient
+import fi.hel.haitaton.hanke.allu.ApplicationStatusEvent
+import fi.hel.haitaton.hanke.attachment.application.ApplicationAttachmentContentService
+import fi.hel.haitaton.hanke.attachment.azure.Container
+import fi.hel.haitaton.hanke.attachment.common.FileClient
+import fi.hel.haitaton.hanke.hakemus.HakemusEntity
+import org.springframework.http.MediaType
 import org.springframework.stereotype.Service
 
 @Service
 class PaatosService(
     private val paatosRepository: PaatosRepository,
+    private val alluClient: AlluClient,
+    private val fileClient: FileClient,
 ) {
     fun findByHakemusId(hakemusId: Long): List<Paatos> =
         paatosRepository.findByHakemusId(hakemusId).map { it.toDomain() }
+
+    fun saveKaivuilmoituksenPaatos(hakemus: HakemusEntity, event: ApplicationStatusEvent) {
+        val alluId = hakemus.alluid!!
+        val pdfData = alluClient.getDecisionPdf(alluId)
+
+        val applicationResponse = alluClient.getApplicationInformation(alluId)
+
+        val filename = "${event.applicationIdentifier}-paatos.pdf"
+        val path = uploadPaatos(pdfData, filename, hakemus.id)
+
+        paatosRepository.save(
+            PaatosEntity(
+                hakemusId = hakemus.id,
+                hakemustunnus = event.applicationIdentifier,
+                tyyppi = PaatosTyyppi.PAATOS,
+                tila = PaatosTila.NYKYINEN,
+                nimi = applicationResponse.name,
+                alkupaiva = applicationResponse.startTime.toLocalDate(),
+                loppupaiva = applicationResponse.endTime.toLocalDate(),
+                blobLocation = path,
+                size = pdfData.size,
+            )
+        )
+    }
+
+    private fun uploadPaatos(pdfData: ByteArray, filename: String, hakemusId: Long): String {
+        val path = ApplicationAttachmentContentService.generateBlobPath(hakemusId)
+        fileClient.upload(Container.PAATOKSET, path, filename, MediaType.APPLICATION_PDF, pdfData)
+        return path
+    }
 }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/attachment/AttachmentTestUtil.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/attachment/AttachmentTestUtil.kt
@@ -22,16 +22,14 @@ const val APPLICATION_ID = 1L
 const val CONTENT_TYPE_HEADER = "Content-Type"
 
 val DUMMY_DATA = "ABC".toByteArray()
-val DEFAULT_DATA by lazy {
-    "/fi/hel/haitaton/hanke/decision/fake-decision.pdf".getResourceAsBytes()
-}
-val DEFAULT_SIZE by lazy { DEFAULT_DATA.size.toLong() }
+val PDF_BYTES by lazy { "/fi/hel/haitaton/hanke/decision/fake-decision.pdf".getResourceAsBytes() }
+val DEFAULT_SIZE by lazy { PDF_BYTES.size.toLong() }
 
 fun testFile(
     fileParam: String = FILE_PARAM,
     fileName: String = FILE_NAME_PDF,
     contentType: String? = APPLICATION_PDF_VALUE,
-    data: ByteArray = DEFAULT_DATA,
+    data: ByteArray = PDF_BYTES,
 ) = MockMultipartFile(fileParam, fileName, contentType, data)
 
 fun ResultActions.andExpectError(error: HankeError): ResultActions =

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/AlluFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/AlluFactory.kt
@@ -8,21 +8,25 @@ import fi.hel.haitaton.hanke.allu.Contact
 import fi.hel.haitaton.hanke.allu.Customer
 import fi.hel.haitaton.hanke.allu.CustomerType
 import fi.hel.haitaton.hanke.allu.CustomerWithContacts
+import java.time.ZonedDateTime
 import org.geojson.GeometryCollection
 import org.springframework.http.MediaType
 
 object AlluFactory {
     fun createAlluApplicationResponse(
         id: Int = 42,
-        status: ApplicationStatus = ApplicationStatus.PENDING
+        status: ApplicationStatus = ApplicationStatus.PENDING,
+        name: String = ApplicationFactory.DEFAULT_APPLICATION_NAME,
+        startTime: ZonedDateTime = DateFactory.getStartDatetime(),
+        endTime: ZonedDateTime = DateFactory.getEndDatetime(),
     ) =
         AlluApplicationResponse(
             id = id,
-            name = ApplicationFactory.DEFAULT_APPLICATION_NAME,
+            name = name,
             applicationId = ApplicationFactory.DEFAULT_APPLICATION_IDENTIFIER,
             status = status,
-            startTime = DateFactory.getStartDatetime(),
-            endTime = DateFactory.getEndDatetime(),
+            startTime = startTime,
+            endTime = endTime,
             owner = null,
             kindsWithSpecifiers = mapOf(),
             terms = null,

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/ApplicationAttachmentBuilder.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/ApplicationAttachmentBuilder.kt
@@ -1,7 +1,7 @@
 package fi.hel.haitaton.hanke.factory
 
-import fi.hel.haitaton.hanke.attachment.DEFAULT_DATA
 import fi.hel.haitaton.hanke.attachment.FILE_NAME_PDF
+import fi.hel.haitaton.hanke.attachment.PDF_BYTES
 import fi.hel.haitaton.hanke.attachment.application.ApplicationAttachmentContentService.Companion.generateBlobPath
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentEntity
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentRepository
@@ -16,7 +16,7 @@ data class ApplicationAttachmentBuilder(
         path: String = generateBlobPath(value.applicationId),
         filename: String = FILE_NAME_PDF,
         mediaType: MediaType = MediaType.APPLICATION_PDF,
-        bytes: ByteArray = DEFAULT_DATA
+        bytes: ByteArray = PDF_BYTES
     ): ApplicationAttachmentBuilder {
         this.value.blobLocation = path
         this.value.size = bytes.size.toLong()

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/ApplicationAttachmentFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/ApplicationAttachmentFactory.kt
@@ -1,8 +1,8 @@
 package fi.hel.haitaton.hanke.factory
 
-import fi.hel.haitaton.hanke.attachment.DEFAULT_DATA
 import fi.hel.haitaton.hanke.attachment.DEFAULT_SIZE
 import fi.hel.haitaton.hanke.attachment.FILE_NAME_PDF
+import fi.hel.haitaton.hanke.attachment.PDF_BYTES
 import fi.hel.haitaton.hanke.attachment.application.ApplicationAttachmentContentService.Companion.generateBlobPath
 import fi.hel.haitaton.hanke.attachment.azure.Container.HAKEMUS_LIITTEET
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentEntity
@@ -57,7 +57,7 @@ class ApplicationAttachmentFactory(
         path: String,
         filename: String = FILE_NAME_PDF,
         mediaType: MediaType = MEDIA_TYPE,
-        bytes: ByteArray = DEFAULT_DATA
+        bytes: ByteArray = PDF_BYTES
     ) {
         fileClient.upload(HAKEMUS_LIITTEET, path, filename, mediaType, bytes)
     }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusFactory.kt
@@ -51,6 +51,13 @@ class HakemusFactory(
         hankeEntity: HankeEntity = hankeFactory.builder(USERNAME).withHankealue().saveEntity()
     ) = builder(USERNAME, hankeEntity)
 
+    fun builder(applicationType: ApplicationType) =
+        builder(
+            USERNAME,
+            hankeFactory.builder(USERNAME).withHankealue().saveEntity(),
+            applicationType
+        )
+
     private fun builder(
         userId: String,
         hakemusEntity: HakemusEntity,

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeAttachmentBuilder.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeAttachmentBuilder.kt
@@ -1,7 +1,7 @@
 package fi.hel.haitaton.hanke.factory
 
-import fi.hel.haitaton.hanke.attachment.DEFAULT_DATA
 import fi.hel.haitaton.hanke.attachment.FILE_NAME_PDF
+import fi.hel.haitaton.hanke.attachment.PDF_BYTES
 import fi.hel.haitaton.hanke.attachment.common.HankeAttachmentEntity
 import fi.hel.haitaton.hanke.attachment.common.HankeAttachmentRepository
 import fi.hel.haitaton.hanke.attachment.hanke.HankeAttachmentContentService.Companion.generateBlobPath
@@ -16,7 +16,7 @@ data class HankeAttachmentBuilder(
         path: String = generateBlobPath(value.hanke.id),
         filename: String = FILE_NAME_PDF,
         mediaType: MediaType = MediaType.APPLICATION_PDF,
-        bytes: ByteArray = DEFAULT_DATA
+        bytes: ByteArray = PDF_BYTES
     ): HankeAttachmentBuilder {
         this.value.blobLocation = path
         this.value.size = bytes.size.toLong()

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeAttachmentFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeAttachmentFactory.kt
@@ -1,9 +1,9 @@
 package fi.hel.haitaton.hanke.factory
 
 import fi.hel.haitaton.hanke.HankeEntity
-import fi.hel.haitaton.hanke.attachment.DEFAULT_DATA
 import fi.hel.haitaton.hanke.attachment.DEFAULT_SIZE
 import fi.hel.haitaton.hanke.attachment.FILE_NAME_PDF
+import fi.hel.haitaton.hanke.attachment.PDF_BYTES
 import fi.hel.haitaton.hanke.attachment.azure.Container.HANKE_LIITTEET
 import fi.hel.haitaton.hanke.attachment.common.FileClient
 import fi.hel.haitaton.hanke.attachment.common.HankeAttachmentEntity
@@ -44,7 +44,7 @@ class HankeAttachmentFactory(
         path: String,
         filename: String = FILE_NAME_PDF,
         mediaType: MediaType = MEDIA_TYPE,
-        bytes: ByteArray = DEFAULT_DATA
+        bytes: ByteArray = PDF_BYTES
     ) {
         fileClient.upload(HANKE_LIITTEET, path, filename, mediaType, bytes)
     }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceTest.kt
@@ -39,6 +39,7 @@ import fi.hel.haitaton.hanke.logging.DisclosureLogService
 import fi.hel.haitaton.hanke.logging.HakemusLoggingService
 import fi.hel.haitaton.hanke.logging.HankeLoggingService
 import fi.hel.haitaton.hanke.logging.Status
+import fi.hel.haitaton.hanke.paatos.PaatosService
 import fi.hel.haitaton.hanke.permissions.HankeKayttajaService
 import fi.hel.haitaton.hanke.test.AlluException
 import fi.hel.haitaton.hanke.test.USERNAME
@@ -81,6 +82,7 @@ class HakemusServiceTest {
     private val alluClient: AlluClient = mockk()
     private val alluStatusRepository: AlluStatusRepository = mockk()
     private val emailSenderService: EmailSenderService = mockk()
+    private val paatosService: PaatosService = mockk()
 
     private val hakemusService =
         HakemusService(
@@ -96,6 +98,7 @@ class HakemusServiceTest {
             alluClient,
             alluStatusRepository,
             emailSenderService,
+            paatosService,
         )
 
     @BeforeEach


### PR DESCRIPTION
# Description

When an excavation notification gets a status update to DECISION:
- Download the decision PDF
- Upload the PDF to blob storage
- Read the name and start/end dates from Allu
- Save a new Paatos row to DB with information on the uploaded PDF and the current application information from Allu.

Also, drop the unused username parameter from
`HakemusService.downloadDecision`. This enables it to be reused in the background updates.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2606

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
1. Create an excavation notification and send it to Allu.
2. In Allu, create a decision for it.
3. After a minute, the decision should be downloaded:
  - The decision has been saved to the local blob storage (can be checked with Azure Storage Explorer)
  - The information on the decision has been saved to the `paatos` database table.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 