### PR TITLE
HAI-2607 Save decisions for operational condition

### DIFF
--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
@@ -356,6 +356,16 @@ class HakemusService(
                     paatosService.saveKaivuilmoituksenPaatos(application, event)
             }
         }
+        if (event.newStatus == ApplicationStatus.OPERATIONAL_CONDITION) {
+            when (application.applicationType) {
+                ApplicationType.CABLE_REPORT ->
+                    logger.error {
+                        "Got operational condition update for a cable report. ${application.logString()}"
+                    }
+                ApplicationType.EXCAVATION_NOTIFICATION ->
+                    paatosService.saveKaivuilmoituksenToiminnallinenKunto(application, event)
+            }
+        }
     }
 
     private fun sendDecisionReadyEmails(application: HakemusEntity, applicationIdentifier: String) {

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/paatos/PaatosService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/paatos/PaatosService.kt
@@ -22,16 +22,52 @@ class PaatosService(
         val alluId = hakemus.alluid!!
         val pdfData = alluClient.getDecisionPdf(alluId)
 
+        val filename = "${event.applicationIdentifier}-paatos.pdf"
+        createPaatos(
+            pdfData,
+            filename,
+            hakemus.id,
+            alluId,
+            event.applicationIdentifier,
+            PaatosTyyppi.PAATOS,
+        )
+    }
+
+    fun saveKaivuilmoituksenToiminnallinenKunto(
+        hakemus: HakemusEntity,
+        event: ApplicationStatusEvent
+    ) {
+        val alluId = hakemus.alluid!!
+        val pdfData = alluClient.getOperationalConditionPdf(alluId)
+
+        val filename = "${event.applicationIdentifier}-toiminnallinen-kunto.pdf"
+        createPaatos(
+            pdfData,
+            filename,
+            hakemus.id,
+            alluId,
+            event.applicationIdentifier,
+            PaatosTyyppi.TOIMINNALLINEN_KUNTO,
+        )
+    }
+
+    private fun createPaatos(
+        pdfData: ByteArray,
+        filename: String,
+        hakemusId: Long,
+        alluId: Int,
+        hakemustunnus: String,
+        tyyppi: PaatosTyyppi,
+    ) {
         val applicationResponse = alluClient.getApplicationInformation(alluId)
 
-        val filename = "${event.applicationIdentifier}-paatos.pdf"
-        val path = uploadPaatos(pdfData, filename, hakemus.id)
+        val path = uploadPaatos(pdfData, filename, hakemusId)
 
         paatosRepository.save(
             PaatosEntity(
-                hakemusId = hakemus.id,
-                hakemustunnus = event.applicationIdentifier,
-                tyyppi = PaatosTyyppi.PAATOS,
+                hakemusId = hakemusId,
+                hakemustunnus = hakemustunnus,
+                tyyppi = tyyppi,
                 tila = PaatosTila.NYKYINEN,
                 nimi = applicationResponse.name,
                 alkupaiva = applicationResponse.startTime.toLocalDate(),


### PR DESCRIPTION
# Description

When an excavation notification gets a status update to OPERATIONAL_CONDITION:

- Download the operational condition PDF
- Upload the PDF to blob storage
- Read the name and start/end dates from Allu
- Save a new Paatos row to DB with information on the uploaded PDF and the current application information from Allu.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2607

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
1. Create an excavation notification and send it to Allu.
    - The excavation notification (and the hanke) needs to be in the past to make this work. It's easier if the dates are in the winter before 15.4., so Allu will suggest adding the operational condition date to it.
2. In Allu, create a decision for it and set it to operational condition.
    - Before making a decision, edit the application in Allu and click on the warning sign under `Kaivuilmoituksen voimassaolo
`. This will set the operational condition date to the end date and the end date to 15.4.
    - After making a decision, go to Valvonta and accept the task for operational condition. This will set the application to operational condition.
3. After a minute, the decision should be downloaded:
    - The decision has been saved to the local blob storage (can be checked with Azure Storage Explorer) 
    - The information on the decision has been saved to the paatos database table.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 