### PR TITLE
HAI-2608 Save decisions for work finished

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceITest.kt
@@ -2247,7 +2247,7 @@ class HakemusServiceITest(
         private val placeholderUpdateTime = OffsetDateTime.parse("2017-01-01T00:00:00Z")
         private val updateTime = OffsetDateTime.parse("2022-10-09T06:36:51Z")
         private val alluId = 42
-        private val identifier = ApplicationHistoryFactory.defaultApplicationIdentifier
+        private val identifier = ApplicationHistoryFactory.DEFAULT_APPLICATION_IDENTIFIER
 
         @Test
         fun `updates the last updated time with empty histories`() {
@@ -2363,6 +2363,8 @@ class HakemusServiceITest(
                     every { alluClient.getDecisionPdf(alluId) } returns PDF_BYTES
                 ApplicationStatus.OPERATIONAL_CONDITION ->
                     every { alluClient.getOperationalConditionPdf(alluId) } returns PDF_BYTES
+                ApplicationStatus.FINISHED ->
+                    every { alluClient.getWorkFinishedPdf(alluId) } returns PDF_BYTES
                 else -> throw IllegalArgumentException()
             }
 
@@ -2371,11 +2373,15 @@ class HakemusServiceITest(
                 ApplicationStatus.DECISION -> verify { alluClient.getDecisionPdf(alluId) }
                 ApplicationStatus.OPERATIONAL_CONDITION ->
                     verify { alluClient.getOperationalConditionPdf(alluId) }
+                ApplicationStatus.FINISHED -> verify { alluClient.getWorkFinishedPdf(alluId) }
                 else -> throw IllegalArgumentException()
             }
 
         @ParameterizedTest
-        @EnumSource(ApplicationStatus::class, names = ["DECISION", "OPERATIONAL_CONDITION"])
+        @EnumSource(
+            ApplicationStatus::class,
+            names = ["DECISION", "OPERATIONAL_CONDITION", "FINISHED"]
+        )
         fun `downloads the document when a kaivuilmoitus gets a decision`(
             status: ApplicationStatus
         ) {

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/AlluClient.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/AlluClient.kt
@@ -247,6 +247,12 @@ class AlluClient(
         return getPdf(alluApplicationId, requestPath)
     }
 
+    fun getWorkFinishedPdf(alluApplicationId: Int): ByteArray {
+        logger.info { "Fetching work finished pdf for application $alluApplicationId." }
+        val requestPath = "excavationannouncements/$alluApplicationId/approval/workfinished"
+        return getPdf(alluApplicationId, requestPath)
+    }
+
     private fun getPdf(alluApplicationId: Int, path: String): ByteArray {
         val response =
             get(path, MediaType.APPLICATION_PDF)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
@@ -360,10 +360,20 @@ class HakemusService(
             when (application.applicationType) {
                 ApplicationType.CABLE_REPORT ->
                     logger.error {
-                        "Got operational condition update for a cable report. ${application.logString()}"
+                        "Got ${event.newStatus} update for a cable report. ${application.logString()}"
                     }
                 ApplicationType.EXCAVATION_NOTIFICATION ->
                     paatosService.saveKaivuilmoituksenToiminnallinenKunto(application, event)
+            }
+        }
+        if (event.newStatus == ApplicationStatus.FINISHED) {
+            when (application.applicationType) {
+                ApplicationType.CABLE_REPORT ->
+                    logger.error {
+                        "Got ${event.newStatus} update for a cable report. ${application.logString()}"
+                    }
+                ApplicationType.EXCAVATION_NOTIFICATION ->
+                    paatosService.saveKaivuilmoituksenTyoValmis(application, event)
             }
         }
     }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/ApplicationHistoryFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/ApplicationHistoryFactory.kt
@@ -7,19 +7,19 @@ import java.time.ZonedDateTime
 
 object ApplicationHistoryFactory {
 
-    val defaultApplicationId = 1
-    val defaultApplicationIdentifier = "JS2300001"
-    val defaultEventTime = ZonedDateTime.parse("2022-10-12T15:25:34.981654Z")
-    val defaultStatus = ApplicationStatus.PENDING
-    val defaultTargetStatus: ApplicationStatus? = null
+    const val DEFAULT_APPLICATION_ID: Int = 1
+    const val DEFAULT_APPLICATION_IDENTIFIER: String = "JS2300001"
+    val DEFAULT_EVENT_TIME: ZonedDateTime = ZonedDateTime.parse("2022-10-12T15:25:34.981654Z")
+    val DEFAULT_STATUS: ApplicationStatus = ApplicationStatus.PENDING
+    val DEFAULT_TARGET_STATUS: ApplicationStatus? = null
 
     /**
      * Create a history for an application with two events at different times. Supervision events
      * are not included.
      */
     fun create(
-        applicationId: Int = defaultApplicationId,
-        applicationIdentifier: String = defaultApplicationIdentifier,
+        applicationId: Int = DEFAULT_APPLICATION_ID,
+        applicationIdentifier: String = DEFAULT_APPLICATION_IDENTIFIER,
     ): ApplicationHistory =
         ApplicationHistory(
             applicationId,
@@ -40,17 +40,17 @@ object ApplicationHistoryFactory {
         )
 
     fun create(
-        applicationId: Int = defaultApplicationId,
+        applicationId: Int = DEFAULT_APPLICATION_ID,
         vararg events: ApplicationStatusEvent,
     ): ApplicationHistory =
         ApplicationHistory(applicationId, events = events.toList(), supervisionEvents = listOf())
 
     /** Create a status event for an application. */
     fun createEvent(
-        eventTime: ZonedDateTime = defaultEventTime,
-        newStatus: ApplicationStatus = defaultStatus,
-        applicationIdentifier: String = defaultApplicationIdentifier,
-        targetStatus: ApplicationStatus? = defaultTargetStatus,
+        eventTime: ZonedDateTime = DEFAULT_EVENT_TIME,
+        newStatus: ApplicationStatus = DEFAULT_STATUS,
+        applicationIdentifier: String = DEFAULT_APPLICATION_IDENTIFIER,
+        targetStatus: ApplicationStatus? = DEFAULT_TARGET_STATUS,
     ) =
         ApplicationStatusEvent(
             eventTime = eventTime,


### PR DESCRIPTION
# Description

When an excavation notification gets a status update to FINISHED:

- Download the work finished PDF
- Upload the PDF to blob storage
- Read the name and start/end dates from Allu
- Save a new Paatos row to DB with information on the uploaded PDF and the current application information from Allu.

Also, refactor PaatosServiceITest to reduce duplication.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2608

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
After following the instructions in #777, accept the "Loppuvalvonta" task for the application in Allu. This will move the application to finished status.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 