### PR TITLE
HAI-2609 Mark replaced decisions as `KORVATTU`

### DIFF
--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/paatos/PaatosRepository.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/paatos/PaatosRepository.kt
@@ -2,9 +2,15 @@ package fi.hel.haitaton.hanke.paatos
 
 import java.util.UUID
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 
 @Repository
 interface PaatosRepository : JpaRepository<PaatosEntity, UUID> {
     fun findByHakemusId(hakemusId: Long): List<PaatosEntity>
+
+    @Modifying
+    @Query("UPDATE PaatosEntity SET tila = :tila WHERE hakemustunnus = :hakemustunnus")
+    fun markReplacedByHakemustunnus(hakemustunnus: String, tila: PaatosTila = PaatosTila.KORVATTU)
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/paatos/PaatosService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/paatos/PaatosService.kt
@@ -9,6 +9,7 @@ import fi.hel.haitaton.hanke.hakemus.HakemusIdentifier
 import mu.KotlinLogging
 import org.springframework.http.MediaType
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 
 private val logger = KotlinLogging.logger {}
 
@@ -18,9 +19,16 @@ class PaatosService(
     private val alluClient: AlluClient,
     private val fileClient: FileClient,
 ) {
+    @Transactional(readOnly = true)
     fun findByHakemusId(hakemusId: Long): List<Paatos> =
         paatosRepository.findByHakemusId(hakemusId).map { it.toDomain() }
 
+    @Transactional
+    fun markReplaced(hakemustunnus: String) {
+        paatosRepository.markReplacedByHakemustunnus(hakemustunnus)
+    }
+
+    @Transactional
     fun saveKaivuilmoituksenPaatos(hakemus: HakemusIdentifier, event: ApplicationStatusEvent) {
         val alluId = hakemus.alluid!!
         val pdfData = alluClient.getDecisionPdf(alluId)
@@ -34,6 +42,7 @@ class PaatosService(
         )
     }
 
+    @Transactional
     fun saveKaivuilmoituksenToiminnallinenKunto(
         hakemus: HakemusIdentifier,
         event: ApplicationStatusEvent
@@ -50,6 +59,7 @@ class PaatosService(
         )
     }
 
+    @Transactional
     fun saveKaivuilmoituksenTyoValmis(hakemus: HakemusIdentifier, event: ApplicationStatusEvent) {
         val alluId = hakemus.alluid!!
         val pdfData = alluClient.getWorkFinishedPdf(alluId)

--- a/services/hanke-service/src/main/resources/db/changelog/changesets/079-add-hakemustunnus-index-to-paatos.sql
+++ b/services/hanke-service/src/main/resources/db/changelog/changesets/079-add-hakemustunnus-index-to-paatos.sql
@@ -1,0 +1,5 @@
+--liquibase formatted sql
+--changeset Topias Heinonen:079-add-hakemustunnus-index-to-paatos
+--comment: Add an index to paatos, to make finding decisions by application identifier efficient.
+
+CREATE INDEX idx_paatos_hakemustunnus on paatos (hakemustunnus);

--- a/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -185,3 +185,5 @@ databaseChangeLog:
       file: db/changelog/changesets/077-add-car-traffic-classification.yml
   - include:
       file: db/changelog/changesets/078-create-paatos-table.sql
+  - include:
+      file: db/changelog/changesets/079-add-hakemustunnus-index-to-paatos.sql


### PR DESCRIPTION
# Description

Add handling of `REPLACED` status updates. Don't update the application status or identifier when we receive one. Instead, update all decisions in the `paatos` table with the same hakemustunnus as the update and set their status to `KORVATTU`.

Whenever Allu marks a decision as `REPLACED`, there should be a matching `DECISION` update with a new identifier.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2609

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
1. Create an application and create a decision for it in Allu. You can also add an operational condition decision if you want.
2. Create a korvaava päätös in Allu and accept it.
3. Check that the `paatos` table has rows for both the replaced and the new decision and that their statuses are `KORVATTU` and `NYKYINEN`, respectively.
4. Check that Azure Storage Explorer shows files for both decisions.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 