### PR TITLE
HAI-1549 Move PDF stuff to separate package

### DIFF
--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
@@ -25,6 +25,7 @@ import fi.hel.haitaton.hanke.logging.HakemusLoggingService
 import fi.hel.haitaton.hanke.logging.HankeLoggingService
 import fi.hel.haitaton.hanke.logging.Status
 import fi.hel.haitaton.hanke.paatos.PaatosService
+import fi.hel.haitaton.hanke.pdf.JohtoselvityshakemusPdfEncoder
 import fi.hel.haitaton.hanke.permissions.CurrentUserWithoutKayttajaException
 import fi.hel.haitaton.hanke.permissions.HankeKayttajaService
 import fi.hel.haitaton.hanke.toJsonString
@@ -545,7 +546,7 @@ class HakemusService(
             geometriatDao.calculateCombinedArea(data.areas?.map { it.geometry } ?: listOf())
         val areas = data.areas?.map { geometriatDao.calculateArea(it.geometry) } ?: listOf()
         val attachments = attachmentService.getMetadataList(applicationId)
-        val pdfData = HakemusPdfService.createPdf(data, totalArea, areas, attachments)
+        val pdfData = JohtoselvityshakemusPdfEncoder.createPdf(data, totalArea, areas, attachments)
         val attachmentMetadata =
             AttachmentMetadata(
                 id = null,

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/pdf/Formatters.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/pdf/Formatters.kt
@@ -1,0 +1,27 @@
+package fi.hel.haitaton.hanke.pdf
+
+import fi.hel.haitaton.hanke.hakemus.Hakemusyhteyshenkilo
+import fi.hel.haitaton.hanke.hakemus.Hakemusyhteystieto
+import fi.hel.haitaton.hanke.hakemus.PostalAddress
+import java.time.ZoneId
+import java.time.ZonedDateTime
+
+fun PostalAddress.format(): String =
+    "${this.streetAddress.streetName}\n${this.postalCode} ${this.city}"
+
+fun Hakemusyhteyshenkilo.format(): String =
+    listOfNotNull(kokoNimi(), sahkoposti, puhelin).filter { it.isNotBlank() }.joinToString("\n")
+
+fun Hakemusyhteystieto.format(): String =
+    listOfNotNull(
+            nimi + "\n",
+            ytunnus,
+            sahkoposti,
+            puhelinnumero,
+            "\nYhteyshenkilöt\n",
+        )
+        .filter { it.isNotBlank() }
+        .joinToString("\n") + this.yhteyshenkilot.joinToString("\n") { "\n" + it.format() }
+
+fun ZonedDateTime?.format(): String? =
+    this?.withZoneSameInstant(ZoneId.of("Europe/Helsinki"))?.format(finnishDateFormat)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/pdf/JohtoselvityshakemusPdfEncoder.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/pdf/JohtoselvityshakemusPdfEncoder.kt
@@ -1,91 +1,19 @@
-package fi.hel.haitaton.hanke.hakemus
+package fi.hel.haitaton.hanke.pdf
 
-import com.lowagie.text.Chunk
 import com.lowagie.text.Document
-import com.lowagie.text.Element
-import com.lowagie.text.Font
 import com.lowagie.text.PageSize
-import com.lowagie.text.Paragraph
-import com.lowagie.text.Phrase
-import com.lowagie.text.Rectangle
-import com.lowagie.text.pdf.PdfPTable
 import com.lowagie.text.pdf.PdfWriter
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentMetadata
+import fi.hel.haitaton.hanke.hakemus.Hakemusyhteyshenkilo
+import fi.hel.haitaton.hanke.hakemus.JohtoselvityshakemusData
 import java.io.ByteArrayOutputStream
-import java.time.ZoneId
-import java.time.ZonedDateTime
-import java.time.format.DateTimeFormatter
 
 /**
  * Transform an application to a PDF. The PDF is added as an attachment when sending the application
  * to Allu. It will be archived along the application and decision to show how the user inputted the
  * application in Haitaton, as the data models of Haitaton and Allu differ slightly.
  */
-object HakemusPdfService {
-    private val titleFont = Font(Font.HELVETICA, 18f, Font.BOLD)
-    private val sectionFont = Font(Font.HELVETICA, 15f, Font.BOLD)
-
-    private val headerFont = Font(Font.HELVETICA, 10f, Font.BOLD)
-    private val textFont = Font(Font.HELVETICA, 10f, Font.NORMAL)
-
-    private val finnishDateFormat: DateTimeFormatter = DateTimeFormatter.ofPattern("d.M.uuuu")
-
-    private fun Document.newline() {
-        this.add(Paragraph(Chunk.NEWLINE))
-    }
-
-    private fun Document.title(title: String) {
-        val paragraph = Paragraph(title, titleFont)
-        paragraph.alignment = Element.ALIGN_CENTER
-        this.add(paragraph)
-        this.newline()
-    }
-
-    private fun Document.sectionTitle(sectionTitle: String) {
-        val paragraph = Paragraph(sectionTitle, sectionFont)
-        this.add(paragraph)
-        this.newline()
-    }
-
-    fun PdfPTable.row(key: String, value: Any?) {
-        this.addCell(Phrase("$key ", headerFont))
-        this.addCell(Phrase(value?.toString() ?: "<Tyhjä>", textFont))
-    }
-
-    private fun Document.section(sectionTitle: String, addRows: (table: PdfPTable) -> Unit) {
-        this.sectionTitle(sectionTitle)
-
-        val table = PdfPTable(2)
-        table.widthPercentage = 100f
-        table.setWidths(floatArrayOf(1.5f, 3.5f))
-        table.setSpacingBefore(10f)
-        table.defaultCell.border = Rectangle.NO_BORDER
-        table.defaultCell.paddingBottom = 15f
-
-        addRows(table)
-
-        this.add(table)
-    }
-
-    private fun PostalAddress.format(): String =
-        "${this.streetAddress.streetName}\n${this.postalCode} ${this.city}"
-
-    private fun Hakemusyhteyshenkilo.format(): String =
-        listOfNotNull(kokoNimi(), sahkoposti, puhelin).filter { it.isNotBlank() }.joinToString("\n")
-
-    private fun Hakemusyhteystieto.format(): String =
-        listOfNotNull(
-                nimi + "\n",
-                ytunnus,
-                sahkoposti,
-                puhelinnumero,
-                "\nYhteyshenkilöt\n",
-            )
-            .filter { it.isNotBlank() }
-            .joinToString("\n") + this.yhteyshenkilot.joinToString("\n") { "\n" + it.format() }
-
-    private fun ZonedDateTime?.format(): String? =
-        this?.withZoneSameInstant(ZoneId.of("Europe/Helsinki"))?.format(finnishDateFormat)
+object JohtoselvityshakemusPdfEncoder {
 
     fun createPdf(
         data: JohtoselvityshakemusData,

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/pdf/PdfHelpers.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/pdf/PdfHelpers.kt
@@ -1,0 +1,56 @@
+package fi.hel.haitaton.hanke.pdf
+
+import com.lowagie.text.Chunk
+import com.lowagie.text.Document
+import com.lowagie.text.Element
+import com.lowagie.text.Font
+import com.lowagie.text.Paragraph
+import com.lowagie.text.Phrase
+import com.lowagie.text.Rectangle
+import com.lowagie.text.pdf.PdfPTable
+import java.time.format.DateTimeFormatter
+
+val titleFont = Font(Font.HELVETICA, 18f, Font.BOLD)
+val sectionFont = Font(Font.HELVETICA, 15f, Font.BOLD)
+
+val headerFont = Font(Font.HELVETICA, 10f, Font.BOLD)
+val textFont = Font(Font.HELVETICA, 10f, Font.NORMAL)
+
+val finnishDateFormat: DateTimeFormatter = DateTimeFormatter.ofPattern("d.M.uuuu")
+
+fun Document.newline() {
+    this.add(Paragraph(Chunk.NEWLINE))
+}
+
+fun Document.title(title: String) {
+    val paragraph = Paragraph(title, titleFont)
+    paragraph.alignment = Element.ALIGN_CENTER
+    this.add(paragraph)
+    this.newline()
+}
+
+fun Document.sectionTitle(sectionTitle: String) {
+    val paragraph = Paragraph(sectionTitle, sectionFont)
+    this.add(paragraph)
+    this.newline()
+}
+
+fun PdfPTable.row(key: String, value: Any?) {
+    this.addCell(Phrase("$key ", headerFont))
+    this.addCell(Phrase(value?.toString() ?: "<Tyhjä>", textFont))
+}
+
+fun Document.section(sectionTitle: String, addRows: (table: PdfPTable) -> Unit) {
+    this.sectionTitle(sectionTitle)
+
+    val table = PdfPTable(2)
+    table.widthPercentage = 100f
+    table.setWidths(floatArrayOf(1.5f, 3.5f))
+    table.setSpacingBefore(10f)
+    table.defaultCell.border = Rectangle.NO_BORDER
+    table.defaultCell.paddingBottom = 15f
+
+    addRows(table)
+
+    this.add(table)
+}

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/pdf/JohtoselvityshakemusPdfEncoderTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/pdf/JohtoselvityshakemusPdfEncoderTest.kt
@@ -1,4 +1,4 @@
-package fi.hel.haitaton.hanke.hakemus
+package fi.hel.haitaton.hanke.pdf
 
 import assertk.all
 import assertk.assertThat
@@ -8,17 +8,17 @@ import com.lowagie.text.pdf.PdfReader
 import com.lowagie.text.pdf.parser.PdfTextExtractor
 import fi.hel.haitaton.hanke.factory.ApplicationAttachmentFactory
 import fi.hel.haitaton.hanke.factory.ApplicationFactory
-import fi.hel.haitaton.hanke.factory.ApplicationFactory.Companion.createPostalAddress
 import fi.hel.haitaton.hanke.factory.HakemusFactory
 import fi.hel.haitaton.hanke.factory.HakemusyhteyshenkiloFactory
 import fi.hel.haitaton.hanke.factory.HakemusyhteystietoFactory
 import fi.hel.haitaton.hanke.factory.HakemusyhteystietoFactory.withYhteyshenkilo
+import fi.hel.haitaton.hanke.hakemus.JohtoselvitysHakemusalue
 import java.time.ZonedDateTime
 import org.geojson.Polygon
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
-class HakemusPdfServiceTest {
+class JohtoselvityshakemusPdfEncoderTest {
 
     @Nested
     inner class CreatePdf {
@@ -26,7 +26,8 @@ class HakemusPdfServiceTest {
         fun `created PDF contains title and section headers`() {
             val hakemusData = HakemusFactory.createJohtoselvityshakemusData()
 
-            val pdfData = HakemusPdfService.createPdf(hakemusData, 1f, listOf(), listOf())
+            val pdfData =
+                JohtoselvityshakemusPdfEncoder.createPdf(hakemusData, 1f, listOf(), listOf())
 
             assertThat(getPdfAsText(pdfData))
                 .contains("Johtoselvityshakemus", "Perustiedot", "Alueet", "Yhteystiedot")
@@ -36,7 +37,8 @@ class HakemusPdfServiceTest {
         fun `created PDF contains headers for basic information`() {
             val hakemusData = HakemusFactory.createJohtoselvityshakemusData()
 
-            val pdfData = HakemusPdfService.createPdf(hakemusData, 614f, listOf(), listOf())
+            val pdfData =
+                JohtoselvityshakemusPdfEncoder.createPdf(hakemusData, 614f, listOf(), listOf())
 
             assertThat(getPdfAsText(pdfData)).all {
                 contains("Työn nimi")
@@ -51,7 +53,7 @@ class HakemusPdfServiceTest {
         fun `created PDF contains basic information`() {
             val applicationData =
                 HakemusFactory.createJohtoselvityshakemusData(
-                    postalAddress = createPostalAddress(),
+                    postalAddress = ApplicationFactory.createPostalAddress(),
                     customerWithContacts = HakemusyhteystietoFactory.create().withYhteyshenkilo(),
                     constructionWork = true,
                     maintenanceWork = true,
@@ -59,7 +61,8 @@ class HakemusPdfServiceTest {
                     propertyConnectivity = true,
                 )
 
-            val pdfData = HakemusPdfService.createPdf(applicationData, 1f, listOf(), listOf())
+            val pdfData =
+                JohtoselvityshakemusPdfEncoder.createPdf(applicationData, 1f, listOf(), listOf())
 
             val pdfText = getPdfAsText(pdfData)
             assertThat(pdfText).all {
@@ -102,7 +105,8 @@ class HakemusPdfServiceTest {
                     propertyConnectivity = false,
                 )
 
-            val pdfData = HakemusPdfService.createPdf(hakemusData, 1f, listOf(), listOf())
+            val pdfData =
+                JohtoselvityshakemusPdfEncoder.createPdf(hakemusData, 1f, listOf(), listOf())
 
             assertThat(getPdfAsText(pdfData)).all {
                 doesNotContain("Uuden rakenteen tai johdon rakentamisesta")
@@ -116,7 +120,8 @@ class HakemusPdfServiceTest {
         fun `created PDF contains headers for area information`() {
             val hakemusData = HakemusFactory.createJohtoselvityshakemusData()
 
-            val pdfData = HakemusPdfService.createPdf(hakemusData, 614f, listOf(), listOf())
+            val pdfData =
+                JohtoselvityshakemusPdfEncoder.createPdf(hakemusData, 614f, listOf(), listOf())
 
             assertThat(getPdfAsText(pdfData)).all {
                 contains("Työn arvioitu alkupäivä")
@@ -141,7 +146,12 @@ class HakemusPdfServiceTest {
                 )
 
             val pdfData =
-                HakemusPdfService.createPdf(hakemusData, 614f, listOf(185f, 231f, 198f), listOf())
+                JohtoselvityshakemusPdfEncoder.createPdf(
+                    hakemusData,
+                    614f,
+                    listOf(185f, 231f, 198f),
+                    listOf()
+                )
 
             assertThat(getPdfAsText(pdfData)).all {
                 contains("18.11.2022")
@@ -168,7 +178,8 @@ class HakemusPdfServiceTest {
                         HakemusyhteystietoFactory.create().withYhteyshenkilo()
                 )
 
-            val pdfData = HakemusPdfService.createPdf(hakemusData, 1f, listOf(), listOf())
+            val pdfData =
+                JohtoselvityshakemusPdfEncoder.createPdf(hakemusData, 1f, listOf(), listOf())
 
             assertThat(getPdfAsText(pdfData)).all {
                 contains("Työstä vastaavat")
@@ -189,7 +200,8 @@ class HakemusPdfServiceTest {
                     propertyDeveloperWithContacts = null,
                 )
 
-            val pdfData = HakemusPdfService.createPdf(hakemusData, 614f, listOf(), listOf())
+            val pdfData =
+                JohtoselvityshakemusPdfEncoder.createPdf(hakemusData, 614f, listOf(), listOf())
 
             assertThat(getPdfAsText(pdfData)).all {
                 contains("Työstä vastaavat")
@@ -263,7 +275,8 @@ class HakemusPdfServiceTest {
                     propertyDeveloperWithContacts = rakennuttaja,
                 )
 
-            val pdfData = HakemusPdfService.createPdf(hakemusData, 614f, listOf(), listOf())
+            val pdfData =
+                JohtoselvityshakemusPdfEncoder.createPdf(hakemusData, 614f, listOf(), listOf())
 
             assertThat(getPdfAsText(pdfData)).all {
                 contains("Company Ltd")
@@ -312,7 +325,8 @@ class HakemusPdfServiceTest {
                     ApplicationAttachmentFactory.create(fileName = "third.gt"),
                 )
 
-            val pdfData = HakemusPdfService.createPdf(hakemusData, 614f, listOf(), attachments)
+            val pdfData =
+                JohtoselvityshakemusPdfEncoder.createPdf(hakemusData, 614f, listOf(), attachments)
 
             assertThat(getPdfAsText(pdfData)).all {
                 contains("first.pdf")


### PR DESCRIPTION
# Description

- Move HakemusPdfService to a separate package for managing PDF stuff.
- Rename it to JohtoselvityshakemusPdfEncoder
- Split the reusable functions to separate files

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1549

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [X] Other