### PR TITLE
HAI Use AWS ECR Docker images

### DIFF
--- a/services/hanke-service/Dockerfile-local
+++ b/services/hanke-service/Dockerfile-local
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17 as build
+FROM public.ecr.aws/docker/library/eclipse-temurin:17 as build
 WORKDIR /workspace/app
 
 COPY gradlew settings.gradle.kts ./
@@ -10,7 +10,7 @@ RUN --mount=type=cache,target=/root/.gradle ./gradlew --no-daemon :services:hank
 RUN mkdir -p services/hanke-service/build/dependency && \
     (cd services/hanke-service/build/dependency; jar -xf ../libs/*SNAPSHOT.jar)
 
-FROM eclipse-temurin:17
+FROM public.ecr.aws/docker/library/eclipse-temurin:17
 VOLUME /tmp
 
 ARG DEPENDENCY=/workspace/app/services/hanke-service/build/dependency

--- a/services/hanke-service/Dockerfile-platta
+++ b/services/hanke-service/Dockerfile-platta
@@ -1,7 +1,7 @@
 # Uses different base images for build and run. RedHat Ubi stronger security policies prevent gradle builds.
 
 # Stage 1: Build application
-FROM eclipse-temurin:17 as build
+FROM public.ecr.aws/docker/library/eclipse-temurin:17 as build
 
 # Set the working directory, copy gradle and source code
 WORKDIR /app


### PR DESCRIPTION
# Description

The official Docker registry is declining pull requests for images because of rate limits.

As a temporary workaround, use AWS ECR images, which have a limit of one per second.

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [X] Other