### PR TITLE
HAI-1549 Add PDF creation and uploading for kaivuilmoitus

### DIFF
--- a/services/hanke-service/build.gradle.kts
+++ b/services/hanke-service/build.gradle.kts
@@ -42,7 +42,7 @@ spotless {
     ratchetFrom("origin/dev") // only format files which have changed since origin/dev
 
     kotlin {
-        ktfmt("0.46").kotlinlangStyle()
+        ktfmt("0.51").kotlinlangStyle()
         toggleOffOn()
     }
 }

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceITest.kt
@@ -574,14 +574,11 @@ class HakemusServiceITest(
                     name = "area",
                     geometry =
                         "/fi/hel/haitaton/hanke/geometria/intersecting-polygon.json"
-                            .asJsonResource()
-                )
+                            .asJsonResource())
 
             private val notInHankeArea =
                 ApplicationFactory.createCableReportApplicationArea(
-                    name = "area",
-                    geometry = GeometriaFactory.polygon()
-                )
+                    name = "area", geometry = GeometriaFactory.polygon())
 
             @Test
             fun `throws exception when the application does not exist`() {
@@ -645,8 +642,7 @@ class HakemusServiceITest(
                     messageContains("id=${hakemus.id}")
                     messageContains("reason=Self-intersection")
                     messageContains(
-                        "location={\"type\":\"Point\",\"coordinates\":[25494009.65639264,6679886.142116806]}"
-                    )
+                        "location={\"type\":\"Point\",\"coordinates\":[25494009.65639264,6679886.142116806]}")
                 }
             }
 
@@ -756,11 +752,7 @@ class HakemusServiceITest(
                     hakemus
                         .toUpdateRequest()
                         .withCustomer(
-                            CustomerType.COMPANY,
-                            yhteystieto.id,
-                            kayttaja.id,
-                            newKayttaja.id
-                        )
+                            CustomerType.COMPANY, yhteystieto.id, kayttaja.id, newKayttaja.id)
                         .withWorkDescription("New work description")
 
                 val updatedHakemus = hakemusService.updateHakemus(hakemus.id, request, USERNAME)
@@ -811,10 +803,7 @@ class HakemusServiceITest(
                     hakemus
                         .toUpdateRequest()
                         .withContractor(
-                            CustomerType.COMPANY,
-                            tyonSuorittaja.id,
-                            hankekayttajaIds = arrayOf()
-                        )
+                            CustomerType.COMPANY, tyonSuorittaja.id, hankekayttajaIds = arrayOf())
 
                 val updatedHakemus = hakemusService.updateHakemus(hakemus.id, request, USERNAME)
 
@@ -851,8 +840,7 @@ class HakemusServiceITest(
                         .withCustomer(
                             CustomerType.COMPANY,
                             yhteystietoId = null,
-                            hankekayttajaIds = arrayOf(newKayttaja.id)
-                        )
+                            hankekayttajaIds = arrayOf(newKayttaja.id))
 
                 val updatedHakemus = hakemusService.updateHakemus(hakemus.id, request, USERNAME)
 
@@ -894,12 +882,10 @@ class HakemusServiceITest(
                     .isEqualTo(newKayttaja.sahkoposti)
                 assertThat(email.subject)
                     .isEqualTo(
-                        "Haitaton: Sinut on lisätty hakemukselle / Du har lagts till i en ansökan / You have been added to an application"
-                    )
+                        "Haitaton: Sinut on lisätty hakemukselle / Du har lagts till i en ansökan / You have been added to an application")
                 assertThat(email.textBody())
                     .contains(
-                        "laatimassa johtoselvityshakemusta hankkeelle \"${hanke.nimi}\" (${hanke.hankeTunnus})"
-                    )
+                        "laatimassa johtoselvityshakemusta hankkeelle \"${hanke.nimi}\" (${hanke.hankeTunnus})")
             }
 
             @Test
@@ -944,9 +930,7 @@ class HakemusServiceITest(
                         listOf(
                             createTyoalue(
                                 "/fi/hel/haitaton/hanke/geometria/intersecting-polygon.json"
-                                    .asJsonResource()
-                            )
-                        ),
+                                    .asJsonResource())),
                 )
 
             private val notInHankeArea =
@@ -973,8 +957,7 @@ class HakemusServiceITest(
                     hakemusFactory
                         .builder(
                             userId = USERNAME,
-                            applicationType = ApplicationType.EXCAVATION_NOTIFICATION
-                        )
+                            applicationType = ApplicationType.EXCAVATION_NOTIFICATION)
                         .withStatus(alluId = 21)
                         .saveEntity()
                 val hakemus = hakemusService.hakemusResponse(entity.id)
@@ -997,8 +980,7 @@ class HakemusServiceITest(
                     hakemusFactory
                         .builder(
                             userId = USERNAME,
-                            applicationType = ApplicationType.EXCAVATION_NOTIFICATION
-                        )
+                            applicationType = ApplicationType.EXCAVATION_NOTIFICATION)
                         .saveEntity()
                 val hakemus = hakemusService.hakemusResponse(entity.id)
                 val originalAuditLogSize =
@@ -1020,8 +1002,7 @@ class HakemusServiceITest(
                     hakemusFactory
                         .builder(
                             userId = USERNAME,
-                            applicationType = ApplicationType.EXCAVATION_NOTIFICATION
-                        )
+                            applicationType = ApplicationType.EXCAVATION_NOTIFICATION)
                         .saveEntity()
                 val hakemus = hakemusService.hakemusResponse(entity.id)
                 val request = hakemus.toUpdateRequest().withAreas(listOf(intersectingArea))
@@ -1035,8 +1016,7 @@ class HakemusServiceITest(
                     messageContains("id=${hakemus.id}")
                     messageContains("reason=Self-intersection")
                     messageContains(
-                        "location={\"type\":\"Point\",\"coordinates\":[25494009.65639264,6679886.142116806]}"
-                    )
+                        "location={\"type\":\"Point\",\"coordinates\":[25494009.65639264,6679886.142116806]}")
                 }
             }
 
@@ -1046,8 +1026,7 @@ class HakemusServiceITest(
                     hakemusFactory
                         .builder(
                             userId = USERNAME,
-                            applicationType = ApplicationType.EXCAVATION_NOTIFICATION
-                        )
+                            applicationType = ApplicationType.EXCAVATION_NOTIFICATION)
                         .saveEntity()
                 val hakemus = hakemusService.hakemusResponse(entity.id)
                 val requestYhteystietoId = UUID.randomUUID()
@@ -1075,8 +1054,7 @@ class HakemusServiceITest(
                     hakemusFactory
                         .builder(
                             userId = USERNAME,
-                            applicationType = ApplicationType.EXCAVATION_NOTIFICATION
-                        )
+                            applicationType = ApplicationType.EXCAVATION_NOTIFICATION)
                         .hakija()
                         .saveEntity()
                 val hakemus = hakemusService.hakemusResponse(entity.id)
@@ -1106,8 +1084,7 @@ class HakemusServiceITest(
                     hakemusFactory
                         .builder(
                             userId = USERNAME,
-                            applicationType = ApplicationType.EXCAVATION_NOTIFICATION
-                        )
+                            applicationType = ApplicationType.EXCAVATION_NOTIFICATION)
                         .hakija()
                         .saveEntity()
                 val hakemus = hakemusService.hakemusResponse(entity.id)
@@ -1117,10 +1094,7 @@ class HakemusServiceITest(
                     hakemus
                         .toUpdateRequest()
                         .withCustomerWithContactsRequest(
-                            CustomerType.COMPANY,
-                            yhteystieto.id,
-                            requestHankekayttajaId
-                        )
+                            CustomerType.COMPANY, yhteystieto.id, requestHankekayttajaId)
 
                 val exception = assertFailure {
                     hakemusService.updateHakemus(hakemus.id, request, USERNAME)
@@ -1152,8 +1126,7 @@ class HakemusServiceITest(
                     messageContains("id=${hakemus.id}")
                     messageContains(hanke.logString())
                     messageContains(
-                        "geometry=${notInHankeArea.tyoalueet.single().geometry.toJsonString()}"
-                    )
+                        "geometry=${notInHankeArea.tyoalueet.single().geometry.toJsonString()}")
                 }
             }
 
@@ -1178,11 +1151,7 @@ class HakemusServiceITest(
                     hakemus
                         .toUpdateRequest()
                         .withCustomerWithContactsRequest(
-                            CustomerType.COMPANY,
-                            yhteystieto.id,
-                            kayttaja.id,
-                            newKayttaja.id
-                        )
+                            CustomerType.COMPANY, yhteystieto.id, kayttaja.id, newKayttaja.id)
                         .withWorkDescription("New work description")
                         .withRequiredCompetence(true)
                         .withArea(area)
@@ -1238,10 +1207,7 @@ class HakemusServiceITest(
                     hakemus
                         .toUpdateRequest()
                         .withContractor(
-                            CustomerType.COMPANY,
-                            tyonSuorittaja.id,
-                            hankekayttajaIds = arrayOf()
-                        )
+                            CustomerType.COMPANY, tyonSuorittaja.id, hankekayttajaIds = arrayOf())
 
                 val updatedHakemus = hakemusService.updateHakemus(hakemus.id, request, USERNAME)
 
@@ -1270,8 +1236,7 @@ class HakemusServiceITest(
                         .withCustomer(
                             CustomerType.COMPANY,
                             yhteystietoId = null,
-                            hankekayttajaIds = arrayOf(newKayttaja.id)
-                        )
+                            hankekayttajaIds = arrayOf(newKayttaja.id))
 
                 val updatedHakemus = hakemusService.updateHakemus(hakemus.id, request, USERNAME)
 
@@ -1317,12 +1282,10 @@ class HakemusServiceITest(
                     .isEqualTo(newKayttaja.sahkoposti)
                 assertThat(email.subject)
                     .isEqualTo(
-                        "Haitaton: Sinut on lisätty hakemukselle / Du har lagts till i en ansökan / You have been added to an application"
-                    )
+                        "Haitaton: Sinut on lisätty hakemukselle / Du har lagts till i en ansökan / You have been added to an application")
                 assertThat(email.textBody())
                     .contains(
-                        "laatimassa kaivuilmoitusta hankkeelle \"${hanke.nimi}\" (${hanke.hankeTunnus})"
-                    )
+                        "laatimassa kaivuilmoitusta hankkeelle \"${hanke.nimi}\" (${hanke.hankeTunnus})")
             }
 
             @Test
@@ -1370,8 +1333,7 @@ class HakemusServiceITest(
 
         private val areaOutsideDefaultHanke: JohtoselvitysHakemusalue =
             ApplicationFactory.createCableReportApplicationArea(
-                geometry = GeometriaFactory.thirdPolygon()
-            )
+                geometry = GeometriaFactory.thirdPolygon())
 
         @Test
         fun `throws exception when the application doesn't exist`() {
@@ -1419,10 +1381,7 @@ class HakemusServiceITest(
             hankeRepository.save(hanke.apply { alueet = mutableListOf() })
             assertThat(
                     geometriatDao.isInsideHankeAlueet(
-                        hanke.id,
-                        areas.single().geometries().single()
-                    )
-                )
+                        hanke.id, areas.single().geometries().single()))
                 .isFalse()
             every { alluClient.create(any()) } returns alluId
             justRun { alluClient.addAttachment(alluId, any()) }
@@ -1542,8 +1501,7 @@ class HakemusServiceITest(
                 messageContains(hakemus.logString())
                 messageContains(hanke.logString())
                 messageContains(
-                    "hakemus geometry=${areaOutsideDefaultHanke.geometry.toJsonString()}"
-                )
+                    "hakemus geometry=${areaOutsideDefaultHanke.geometry.toJsonString()}")
             }
         }
 
@@ -1704,8 +1662,7 @@ class HakemusServiceITest(
                 hakijaYhteystieto.copy(
                     nimi = "Tytti Työläinen",
                     sahkoposti = "tytti@hakeus.info",
-                    puhelinnumero = "999888777"
-                )
+                    puhelinnumero = "999888777")
             val hakemus =
                 hakemusFactory
                     .builder(userId = "Other user")
@@ -1776,9 +1733,7 @@ class HakemusServiceITest(
                     AlluCustomerWithRole(TYON_SUORITTAJA, expectedAsianhoitajaCustomer),
                     AlluContactWithRole(HAKIJA, expectedPerustajaContact),
                     AlluContactWithRole(
-                        TYON_SUORITTAJA,
-                        expectedPerustajaContact.copy(orderer = false)
-                    ),
+                        TYON_SUORITTAJA, expectedPerustajaContact.copy(orderer = false)),
                     AlluContactWithRole(ASIANHOITAJA, expectedAsianhoitajaContact),
                 )
             assertThat(yhteystietoEntries.map { it.message.auditEvent.target.objectBefore })
@@ -1808,6 +1763,7 @@ class HakemusServiceITest(
             val expectedAlluRequest =
                 expectedDataAfterSend.toAlluExcavationNotificationData(hakemus.hankeTunnus)
             every { alluClient.create(expectedAlluRequest) } returns alluId
+            justRun { alluClient.addAttachment(alluId, any()) }
             justRun { alluClient.addAttachments(alluId, any(), any()) }
             every { alluClient.getApplicationInformation(alluId) } returns
                 AlluFactory.createAlluApplicationResponse(alluId)
@@ -1829,6 +1785,7 @@ class HakemusServiceITest(
             }
             verifySequence {
                 alluClient.create(expectedAlluRequest)
+                alluClient.addAttachment(alluId, any())
                 alluClient.addAttachments(alluId, any(), any())
                 alluClient.getApplicationInformation(alluId)
             }
@@ -1862,9 +1819,7 @@ class HakemusServiceITest(
             assertThat(
                     fileClient.list(
                         Container.HAKEMUS_LIITTEET,
-                        ApplicationAttachmentContentService.prefix(hakemus.id)
-                    )
-                )
+                        ApplicationAttachmentContentService.prefix(hakemus.id)))
                 .hasSize(2)
 
             val result = hakemusService.deleteWithOrphanGeneratedHankeRemoval(hakemus.id, USERNAME)
@@ -1875,9 +1830,7 @@ class HakemusServiceITest(
             assertThat(
                     fileClient.list(
                         Container.HAKEMUS_LIITTEET,
-                        ApplicationAttachmentContentService.prefix(hakemus.id)
-                    )
-                )
+                        ApplicationAttachmentContentService.prefix(hakemus.id)))
                 .isEmpty()
             assertThat(applicationAttachmentRepository.findByApplicationId(hakemus.id)).isEmpty()
         }
@@ -1891,9 +1844,7 @@ class HakemusServiceITest(
             assertThat(
                     fileClient.list(
                         Container.HAKEMUS_LIITTEET,
-                        ApplicationAttachmentContentService.prefix(hakemus.id)
-                    )
-                )
+                        ApplicationAttachmentContentService.prefix(hakemus.id)))
                 .hasSize(2)
             fileClient.connected = false
 
@@ -1906,9 +1857,7 @@ class HakemusServiceITest(
             assertThat(
                     fileClient.list(
                         Container.HAKEMUS_LIITTEET,
-                        ApplicationAttachmentContentService.prefix(hakemus.id)
-                    )
-                )
+                        ApplicationAttachmentContentService.prefix(hakemus.id)))
                 .hasSize(2)
             assertThat(applicationAttachmentRepository.findByApplicationId(hakemus.id)).isEmpty()
         }
@@ -2042,9 +1991,7 @@ class HakemusServiceITest(
             assertThat(
                     fileClient.list(
                         Container.HAKEMUS_LIITTEET,
-                        ApplicationAttachmentContentService.prefix(application.id)
-                    )
-                )
+                        ApplicationAttachmentContentService.prefix(application.id)))
                 .hasSize(2)
             assertThat(applicationAttachmentRepository.findByApplicationId(application.id))
                 .hasSize(2)
@@ -2055,9 +2002,7 @@ class HakemusServiceITest(
             assertThat(
                     fileClient.list(
                         Container.HAKEMUS_LIITTEET,
-                        ApplicationAttachmentContentService.prefix(application.id)
-                    )
-                )
+                        ApplicationAttachmentContentService.prefix(application.id)))
                 .isEmpty()
             assertThat(applicationAttachmentRepository.findByApplicationId(application.id))
                 .isEmpty()
@@ -2072,9 +2017,7 @@ class HakemusServiceITest(
             assertThat(
                     fileClient.list(
                         Container.HAKEMUS_LIITTEET,
-                        ApplicationAttachmentContentService.prefix(application.id)
-                    )
-                )
+                        ApplicationAttachmentContentService.prefix(application.id)))
                 .hasSize(2)
             assertThat(applicationAttachmentRepository.findByApplicationId(application.id))
                 .hasSize(2)
@@ -2086,9 +2029,7 @@ class HakemusServiceITest(
             assertThat(
                     fileClient.list(
                         Container.HAKEMUS_LIITTEET,
-                        ApplicationAttachmentContentService.prefix(application.id)
-                    )
-                )
+                        ApplicationAttachmentContentService.prefix(application.id)))
                 .hasSize(2)
             assertThat(applicationAttachmentRepository.findByApplicationId(application.id))
                 .isEmpty()
@@ -2205,8 +2146,7 @@ class HakemusServiceITest(
         fun `returns true when status is pending and allu confirms it`(status: ApplicationStatus?) {
             every { alluClient.getApplicationInformation(alluId) } returns
                 AlluFactory.createAlluApplicationResponse(
-                    status = status ?: ApplicationStatus.PENDING
-                )
+                    status = status ?: ApplicationStatus.PENDING)
 
             assertThat(hakemusService.isStillPending(alluId, status)).isTrue()
 
@@ -2231,8 +2171,7 @@ class HakemusServiceITest(
         @EnumSource(
             value = ApplicationStatus::class,
             mode = EnumSource.Mode.EXCLUDE,
-            names = ["PENDING", "PENDING_CLIENT"]
-        )
+            names = ["PENDING", "PENDING_CLIENT"])
         fun `returns false when status is not pending`(status: ApplicationStatus) {
             assertThat(hakemusService.isStillPending(alluId, status)).isFalse()
 
@@ -2268,17 +2207,11 @@ class HakemusServiceITest(
                 ApplicationHistoryFactory.create(
                     alluId,
                     ApplicationHistoryFactory.createEvent(
-                        firstEventTime.plusDays(5),
-                        ApplicationStatus.PENDING
-                    ),
+                        firstEventTime.plusDays(5), ApplicationStatus.PENDING),
                     ApplicationHistoryFactory.createEvent(
-                        firstEventTime.plusDays(10),
-                        ApplicationStatus.HANDLING
-                    ),
+                        firstEventTime.plusDays(10), ApplicationStatus.HANDLING),
                     ApplicationHistoryFactory.createEvent(
-                        firstEventTime,
-                        ApplicationStatus.PENDING
-                    ),
+                        firstEventTime, ApplicationStatus.PENDING),
                 )
 
             hakemusService.handleHakemusUpdates(listOf(history), updateTime)
@@ -2343,9 +2276,7 @@ class HakemusServiceITest(
             assertThat(applications.map { it.alluid }).containsExactlyInAnyOrder(alluId, alluId + 2)
             assertThat(applications.map { it.alluStatus })
                 .containsExactlyInAnyOrder(
-                    ApplicationStatus.PENDING_CLIENT,
-                    ApplicationStatus.PENDING_CLIENT
-                )
+                    ApplicationStatus.PENDING_CLIENT, ApplicationStatus.PENDING_CLIENT)
             assertThat(applications.map { it.applicationIdentifier })
                 .containsExactlyInAnyOrder("JS2300082", "JS2300084")
         }
@@ -2365,9 +2296,7 @@ class HakemusServiceITest(
                         alluId,
                         ApplicationHistoryFactory.createEvent(
                             applicationIdentifier = identifier,
-                            newStatus = ApplicationStatus.DECISION
-                        )
-                    ),
+                            newStatus = ApplicationStatus.DECISION)),
                 )
 
             hakemusService.handleHakemusUpdates(histories, updateTime)
@@ -2377,8 +2306,7 @@ class HakemusServiceITest(
             assertThat(email.allRecipients[0].toString()).isEqualTo(hakija.sahkoposti)
             assertThat(email.subject)
                 .isEqualTo(
-                    "Haitaton: Johtoselvitys $identifier / Ledningsutredning $identifier / Cable report $identifier"
-                )
+                    "Haitaton: Johtoselvitys $identifier / Ledningsutredning $identifier / Cable report $identifier")
         }
 
         private fun mockAlluDownload(status: ApplicationStatus) =
@@ -2403,9 +2331,7 @@ class HakemusServiceITest(
 
         @ParameterizedTest
         @EnumSource(
-            ApplicationStatus::class,
-            names = ["DECISION", "OPERATIONAL_CONDITION", "FINISHED"]
-        )
+            ApplicationStatus::class, names = ["DECISION", "OPERATIONAL_CONDITION", "FINISHED"])
         fun `downloads the document when a kaivuilmoitus gets a decision`(
             status: ApplicationStatus
         ) {
@@ -2421,8 +2347,7 @@ class HakemusServiceITest(
                         ApplicationHistoryFactory.createEvent(
                             applicationIdentifier = identifier,
                             newStatus = status,
-                        )
-                    ),
+                        )),
                 )
             mockAlluDownload(status)
             every { alluClient.getApplicationInformation(alluId) } returns

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
@@ -25,14 +25,18 @@ import fi.hel.haitaton.hanke.logging.HakemusLoggingService
 import fi.hel.haitaton.hanke.logging.HankeLoggingService
 import fi.hel.haitaton.hanke.logging.Status
 import fi.hel.haitaton.hanke.paatos.PaatosService
+import fi.hel.haitaton.hanke.pdf.EnrichedKaivuilmoitusalue
 import fi.hel.haitaton.hanke.pdf.JohtoselvityshakemusPdfEncoder
+import fi.hel.haitaton.hanke.pdf.KaivuilmoitusPdfEncoder
 import fi.hel.haitaton.hanke.permissions.CurrentUserWithoutKayttajaException
 import fi.hel.haitaton.hanke.permissions.HankeKayttajaService
 import fi.hel.haitaton.hanke.toJsonString
+import java.io.File
 import java.time.LocalDateTime
 import java.time.OffsetDateTime
 import java.util.UUID
 import kotlin.reflect.KClass
+import kotlin.system.exitProcess
 import mu.KotlinLogging
 import org.geojson.Polygon
 import org.springframework.http.MediaType
@@ -63,6 +67,22 @@ class HakemusService(
     private val paatosService: PaatosService,
 ) {
 
+    // @EventListener(ApplicationReadyEvent::class)
+    @Transactional
+    fun testPdf() {
+        logger.info { "Finding application with hardcoded id..." }
+        val hakemus = getById(14L)
+
+        logger.info { "Creating PDF..." }
+        val attachment = getApplicationDataAsPdf(hakemus.id, "HAI24-12", hakemus.applicationData)
+
+        logger.info { "Writing PDF to file ${attachment.metadata.name}..." }
+        File(attachment.metadata.name).writeBytes(attachment.file)
+
+        logger.info { "PDF test complete." }
+        exitProcess(0)
+    }
+
     @Transactional(readOnly = true)
     fun getById(applicationId: Long): Hakemus = getEntityById(applicationId).toHakemus()
 
@@ -75,8 +95,7 @@ class HakemusService(
             hankeRepository.findByHankeTunnus(hankeTunnus)
                 ?: throw HankeNotFoundException(hankeTunnus)
         return HankkeenHakemuksetResponse(
-            hanke.hakemukset.map { hakemus -> HankkeenHakemusResponse(hakemus) }
-        )
+            hanke.hakemukset.map { hakemus -> HankkeenHakemusResponse(hakemus) })
     }
 
     @Transactional
@@ -94,9 +113,7 @@ class HakemusService(
                     userId = userId,
                     applicationType = createHakemusRequest.applicationType,
                     hakemusEntityData = newApplicationData(createHakemusRequest),
-                    hanke = hanke
-                )
-            )
+                    hanke = hanke))
         val hakemus = entity.toHakemus()
         hakemusLoggingService.logCreate(hakemus, userId)
         return hakemus
@@ -126,8 +143,7 @@ class HakemusService(
                 applicationType = ApplicationType.CABLE_REPORT,
                 hakemusEntityData = data,
                 hanke = hanke,
-                yhteystiedot = mutableMapOf()
-            )
+                yhteystiedot = mutableMapOf())
 
         val hakemus = hakemusRepository.save(entity).toHakemus()
         hakemusLoggingService.logCreate(hakemus, currentUserId)
@@ -262,8 +278,7 @@ class HakemusService(
         val alluid =
             hakemus.alluid
                 ?: throw HakemusDecisionNotFoundException(
-                    "Hakemus not in Allu, so it doesn't have a decision. ${hakemus.logString()}"
-                )
+                    "Hakemus not in Allu, so it doesn't have a decision. ${hakemus.logString()}")
         val filename = hakemus.applicationIdentifier ?: "paatos"
         val pdfBytes = alluClient.getDecisionPdf(alluid)
         return Pair(filename, pdfBytes)
@@ -418,10 +433,7 @@ class HakemusService(
         applicationId: Long?,
     ) {
         emailSenderService.sendJohtoselvitysCompleteEmail(
-            email,
-            applicationId,
-            applicationIdentifier
-        )
+            email, applicationId, applicationIdentifier)
     }
 
     /** Find the application entity or throw an exception. */
@@ -434,8 +446,7 @@ class HakemusService(
                     ApplicationContactType.HAKIJA,
                     ApplicationContactType.TYON_SUORITTAJA,
                     ApplicationContactType.RAKENNUTTAJA,
-                    ApplicationContactType.ASIANHOITAJA
-                )
+                    ApplicationContactType.ASIANHOITAJA)
                 .asSequence()
                 .mapNotNull { hakemus.yhteystiedot[it] }
                 .flatMap { it.yhteyshenkilot }
@@ -448,10 +459,7 @@ class HakemusService(
     private fun assertNotSent(hakemusEntity: HakemusEntity) {
         if (hakemusEntity.alluid != null) {
             throw HakemusAlreadySentException(
-                hakemusEntity.id,
-                hakemusEntity.alluid,
-                hakemusEntity.alluStatus
-            )
+                hakemusEntity.id, hakemusEntity.alluid, hakemusEntity.alluStatus)
         }
     }
 
@@ -490,7 +498,7 @@ class HakemusService(
     ): Int {
         val alluData = hakemusData.toAlluData(hankeTunnus)
 
-        return withFormDataPdfUploading(applicationId, hakemusData) {
+        return withFormDataPdfUploading(applicationId, hankeTunnus, hakemusData) {
             withDisclosureLogging(applicationId, alluData) { alluClient.create(alluData) }
         }
     }
@@ -510,19 +518,11 @@ class HakemusService(
      */
     private fun withFormDataPdfUploading(
         applicationId: Long,
-        cableReport: HakemusData,
+        hankeTunnus: String,
+        hakemusData: HakemusData,
         alluAction: () -> Int,
     ): Int {
-        val formAttachment =
-            when (cableReport) {
-                is JohtoselvityshakemusData -> getApplicationDataAsPdf(applicationId, cableReport)
-                else -> {
-                    logger.warn(
-                        "No PDF created for hakemus with type ${cableReport.applicationType}."
-                    )
-                    return alluAction()
-                }
-            }
+        val formAttachment = getApplicationDataAsPdf(applicationId, hankeTunnus, hakemusData)
 
         val alluId = alluAction()
 
@@ -539,14 +539,41 @@ class HakemusService(
 
     private fun getApplicationDataAsPdf(
         applicationId: Long,
-        data: JohtoselvityshakemusData,
+        hankeTunnus: String,
+        data: HakemusData,
     ): Attachment {
         logger.info { "Creating a PDF from the hakemus data for data attachment." }
         val totalArea =
-            geometriatDao.calculateCombinedArea(data.areas?.map { it.geometry } ?: listOf())
-        val areas = data.areas?.map { geometriatDao.calculateArea(it.geometry) } ?: listOf()
+            geometriatDao.calculateCombinedArea(data.areas?.flatMap { it.geometries() } ?: listOf())
+
         val attachments = attachmentService.getMetadataList(applicationId)
-        val pdfData = JohtoselvityshakemusPdfEncoder.createPdf(data, totalArea, areas, attachments)
+        val pdfData =
+            when (data) {
+                is JohtoselvityshakemusData -> {
+                    val areas =
+                        data.areas?.map { geometriatDao.calculateArea(it.geometry) } ?: listOf()
+                    JohtoselvityshakemusPdfEncoder.createPdf(data, totalArea, areas, attachments)
+                }
+                is KaivuilmoitusData -> {
+                    val areas =
+                        data.areas?.associate {
+                            it.hankealueId to
+                                geometriatDao.calculateCombinedArea(
+                                    it.tyoalueet.map { alue -> alue.geometry })
+                        } ?: mapOf()
+                    val hankealueet = hankeRepository.findByHankeTunnus(hankeTunnus)?.alueet
+                    val hankealueNames = hankealueet?.associate { it.id to it.nimi } ?: mapOf()
+                    val alueet =
+                        data.areas?.map {
+                            EnrichedKaivuilmoitusalue(
+                                areas[it.hankealueId],
+                                hankealueNames[it.hankealueId] ?: "Nimetön hankealue",
+                                it)
+                        }
+                    KaivuilmoitusPdfEncoder.createPdf(data, totalArea, attachments, alueet)
+                }
+            }
+
         val attachmentMetadata =
             AttachmentMetadata(
                 id = null,
@@ -571,10 +598,7 @@ class HakemusService(
         try {
             val result = f()
             disclosureLogService.saveDisclosureLogsForAllu(
-                applicationId,
-                alluApplicationData,
-                Status.SUCCESS
-            )
+                applicationId, alluApplicationData, Status.SUCCESS)
             return result
         } catch (e: AlluLoginException) {
             // Since the login failed we didn't send the application itself, so logging not needed.
@@ -584,11 +608,7 @@ class HakemusService(
             // application to Allu. Allu might have read it and rejected it, so we should log this
             // as a disclosure event.
             disclosureLogService.saveDisclosureLogsForAllu(
-                applicationId,
-                alluApplicationData,
-                Status.FAILED,
-                ALLU_APPLICATION_ERROR_MSG
-            )
+                applicationId, alluApplicationData, Status.FAILED, ALLU_APPLICATION_ERROR_MSG)
             throw e
         }
     }
@@ -602,10 +622,7 @@ class HakemusService(
             }
         if (!expected) {
             throw IncompatibleHakemusUpdateRequestException(
-                hakemusEntity,
-                hakemusEntity.hakemusEntityData::class,
-                request::class
-            )
+                hakemusEntity, hakemusEntity.hakemusEntityData::class, request::class)
         }
     }
 
@@ -632,11 +649,7 @@ class HakemusService(
         val customersWithContacts = updateRequest.customersByRole()
         ApplicationContactType.entries.forEach {
             assertYhteystietoValidity(
-                hakemusEntity,
-                it,
-                hakemusEntity.yhteystiedot[it],
-                customersWithContacts[it]
-            )
+                hakemusEntity, it, hakemusEntity.yhteystiedot[it], customersWithContacts[it])
         }
 
         assertYhteyshenkilotValidity(
@@ -644,10 +657,9 @@ class HakemusService(
             customersWithContacts.values
                 .filterNotNull()
                 .flatMap { it.contacts.map { contact -> contact.hankekayttajaId } }
-                .toSet()
-        ) {
-            "Invalid hanke user/users received when updating hakemus ${hakemusEntity.logString()}, invalidHankeKayttajaIds=$it"
-        }
+                .toSet()) {
+                "Invalid hanke user/users received when updating hakemus ${hakemusEntity.logString()}, invalidHankeKayttajaIds=$it"
+            }
     }
 
     /**
@@ -663,19 +675,16 @@ class HakemusService(
         hakemusyhteystietoEntity: HakemusyhteystietoEntity?,
         customerWithContacts: CustomerWithContactsRequest?
     ) {
-        if (
-            customerWithContacts == null ||
-                customerWithContacts.customer.yhteystietoId == null ||
-                customerWithContacts.customer.yhteystietoId == hakemusyhteystietoEntity?.id
-        ) {
+        if (customerWithContacts == null ||
+            customerWithContacts.customer.yhteystietoId == null ||
+            customerWithContacts.customer.yhteystietoId == hakemusyhteystietoEntity?.id) {
             return
         }
         throw InvalidHakemusyhteystietoException(
             application,
             rooli,
             hakemusyhteystietoEntity?.id,
-            customerWithContacts.customer.yhteystietoId
-        )
+            customerWithContacts.customer.yhteystietoId)
     }
 
     /** Assert that the contacts are users of the hanke. */
@@ -689,8 +698,7 @@ class HakemusService(
         val newInvalidHankekayttajaIds = newHankekayttajaIds.minus(currentHankekayttajaIds)
         if (newInvalidHankekayttajaIds.isNotEmpty()) {
             throw InvalidHakemusyhteyshenkiloException(
-                customMessageOnFailure(newInvalidHankekayttajaIds)
-            )
+                customMessageOnFailure(newInvalidHankekayttajaIds))
         }
     }
 
@@ -706,8 +714,7 @@ class HakemusService(
                 is JohtoselvitysHakemusalue -> {
                     if (!geometriatDao.isInsideHankeAlueet(hankeId, area.geometry))
                         throw HakemusGeometryNotInsideHankeException(
-                            customMessageOnFailure(area.geometry)
-                        )
+                            customMessageOnFailure(area.geometry))
                 }
                 // for excavation notification we check that all the tyoalue geometries are inside
                 // the same hanke area
@@ -715,8 +722,7 @@ class HakemusService(
                     area.tyoalueet.forEach { tyoalue ->
                         if (!geometriatDao.isInsideHankeAlue(area.hankealueId, tyoalue.geometry))
                             throw HakemusGeometryNotInsideHankeException(
-                                customMessageOnFailure(tyoalue.geometry)
-                            )
+                                customMessageOnFailure(tyoalue.geometry))
                     }
                 }
             }
@@ -730,14 +736,10 @@ class HakemusService(
     ) {
         val hankealueet =
             HankealueService.createHankealueetFromApplicationAreas(
-                updateRequest.areas,
-                updateRequest.startTime,
-                updateRequest.endTime
-            )
+                updateRequest.areas, updateRequest.startTime, updateRequest.endTime)
         hankeEntity.alueet.clear()
         hankeEntity.alueet.addAll(
-            hankealueService.createAlueetFromCreateRequest(hankealueet, hankeEntity)
-        )
+            hankealueService.createAlueetFromCreateRequest(hankealueet, hankeEntity))
     }
 
     /** Creates a new [HakemusEntity] based on the given [request] and saves it. */
@@ -752,11 +754,7 @@ class HakemusService(
                 hakemusEntityData = request.toEntityData(hakemusEntity.hakemusEntityData),
                 yhteystiedot =
                     updateYhteystiedot(
-                        hakemusEntity,
-                        hakemusEntity.yhteystiedot,
-                        request.customersByRole()
-                    )
-            )
+                        hakemusEntity, hakemusEntity.yhteystiedot, request.customersByRole()))
         if (updatedApplicationEntity.hanke.generated) {
             updatedApplicationEntity.hanke.nimi = request.name
         }
@@ -772,11 +770,7 @@ class HakemusService(
         val updatedYhteystiedot = mutableMapOf<ApplicationContactType, HakemusyhteystietoEntity>()
         ApplicationContactType.entries.forEach { rooli ->
             updateYhteystieto(
-                    rooli,
-                    hakemusEntity,
-                    currentYhteystiedot[rooli],
-                    newYhteystiedot[rooli]
-                )
+                    rooli, hakemusEntity, currentYhteystiedot[rooli], newYhteystiedot[rooli])
                 ?.let { updatedYhteystiedot[rooli] = it }
         }
         return updatedYhteystiedot
@@ -798,8 +792,7 @@ class HakemusService(
         }
         // update existing customer
         return customerWithContactsRequest.toExistingHakemusyhteystietoEntity(
-            hakemusyhteystietoEntity
-        )
+            hakemusyhteystietoEntity)
     }
 
     private fun CustomerWithContactsRequest.toNewHakemusyhteystietoEntity(
@@ -826,11 +819,8 @@ class HakemusService(
             hakemusyhteystieto = hakemusyhteystietoEntity,
             hankekayttaja =
                 hankeKayttajaService.getKayttajaForHanke(
-                    hankekayttajaId,
-                    hakemusyhteystietoEntity.application.hanke.id
-                ),
-            tilaaja = false
-        )
+                    hankekayttajaId, hakemusyhteystietoEntity.application.hanke.id),
+            tilaaja = false)
 
     private fun CustomerWithContactsRequest.toExistingHakemusyhteystietoEntity(
         hakemusyhteystietoEntity: HakemusyhteystietoEntity
@@ -856,8 +846,7 @@ class HakemusService(
         this.addAll(
             toAdd.map {
                 ContactRequest(it).toNewHakemusyhteyshenkiloEntity(hakemusyhteystietoEntity)
-            }
-        )
+            })
     }
 
     private fun sendApplicationNotifications(
@@ -960,8 +949,7 @@ class IncompatibleHakemusUpdateRequestException(
     requestClass: KClass<out HakemusUpdateRequest>,
 ) :
     RuntimeException(
-        "Invalid update request for hakemus. ${application.logString()}, type=$oldApplicationClass, requestType=$requestClass"
-    )
+        "Invalid update request for hakemus. ${application.logString()}, type=$oldApplicationClass, requestType=$requestClass")
 
 class InvalidHakemusyhteystietoException(
     application: HakemusIdentifier,
@@ -970,8 +958,7 @@ class InvalidHakemusyhteystietoException(
     newId: UUID?,
 ) :
     RuntimeException(
-        "Invalid hakemusyhteystieto received when updating hakemus. ${application.logString()}, role=$rooli, yhteystietoId=$yhteystietoId, newId=$newId"
-    )
+        "Invalid hakemusyhteystieto received when updating hakemus. ${application.logString()}, role=$rooli, yhteystietoId=$yhteystietoId, newId=$newId")
 
 class InvalidHakemusyhteyshenkiloException(message: String) : RuntimeException(message)
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
@@ -31,12 +31,10 @@ import fi.hel.haitaton.hanke.pdf.KaivuilmoitusPdfEncoder
 import fi.hel.haitaton.hanke.permissions.CurrentUserWithoutKayttajaException
 import fi.hel.haitaton.hanke.permissions.HankeKayttajaService
 import fi.hel.haitaton.hanke.toJsonString
-import java.io.File
 import java.time.LocalDateTime
 import java.time.OffsetDateTime
 import java.util.UUID
 import kotlin.reflect.KClass
-import kotlin.system.exitProcess
 import mu.KotlinLogging
 import org.geojson.Polygon
 import org.springframework.http.MediaType
@@ -66,22 +64,6 @@ class HakemusService(
     private val emailSenderService: EmailSenderService,
     private val paatosService: PaatosService,
 ) {
-
-    // @EventListener(ApplicationReadyEvent::class)
-    @Transactional
-    fun testPdf() {
-        logger.info { "Finding application with hardcoded id..." }
-        val hakemus = getById(14L)
-
-        logger.info { "Creating PDF..." }
-        val attachment = getApplicationDataAsPdf(hakemus.id, "HAI24-12", hakemus.applicationData)
-
-        logger.info { "Writing PDF to file ${attachment.metadata.name}..." }
-        File(attachment.metadata.name).writeBytes(attachment.file)
-
-        logger.info { "PDF test complete." }
-        exitProcess(0)
-    }
 
     @Transactional(readOnly = true)
     fun getById(applicationId: Long): Hakemus = getEntityById(applicationId).toHakemus()

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/pdf/EnrichedKaivuilmoitusalue.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/pdf/EnrichedKaivuilmoitusalue.kt
@@ -1,0 +1,9 @@
+package fi.hel.haitaton.hanke.pdf
+
+import fi.hel.haitaton.hanke.hakemus.KaivuilmoitusAlue
+
+data class EnrichedKaivuilmoitusalue(
+    val totalArea: Float?,
+    val hankealueName: String,
+    val alue: KaivuilmoitusAlue
+)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/pdf/Formatters.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/pdf/Formatters.kt
@@ -13,15 +13,19 @@ fun Hakemusyhteyshenkilo.format(): String =
     listOfNotNull(kokoNimi(), sahkoposti, puhelin).filter { it.isNotBlank() }.joinToString("\n")
 
 fun Hakemusyhteystieto.format(): String =
-    listOfNotNull(
-            nimi + "\n",
-            ytunnus,
-            sahkoposti,
-            puhelinnumero,
-            "\nYhteyshenkilöt\n",
-        )
+    listOfNotNull("$nimi\n", ytunnus, sahkoposti, puhelinnumero, "\nYhteyshenkilöt\n")
         .filter { it.isNotBlank() }
         .joinToString("\n") + this.yhteyshenkilot.joinToString("\n") { "\n" + it.format() }
 
 fun ZonedDateTime?.format(): String? =
     this?.withZoneSameInstant(ZoneId.of("Europe/Helsinki"))?.format(finnishDateFormat)
+
+fun Boolean?.format(): String = this?.let { if (it) "Kyllä" else "Ei" } ?: "-"
+
+fun Float?.format(): String = "%.2f".format(this)
+
+fun Double?.format(): String = "%.2f".format(this)
+
+fun List<String>?.format(): String = if (this.isNullOrEmpty()) "-" else this.joinToString(", ")
+
+fun String?.orDash() = if (this.isNullOrEmpty()) "-" else this

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/pdf/Formatters.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/pdf/Formatters.kt
@@ -5,6 +5,11 @@ import fi.hel.haitaton.hanke.hakemus.Hakemusyhteystieto
 import fi.hel.haitaton.hanke.hakemus.PostalAddress
 import java.time.ZoneId
 import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+
+private val LOCALE = Locale("fi", "FI")
+private val FINNISH_DATE_FORMAT: DateTimeFormatter = DateTimeFormatter.ofPattern("d.M.uuuu")
 
 fun PostalAddress.format(): String =
     "${this.streetAddress.streetName}\n${this.postalCode} ${this.city}"
@@ -18,13 +23,13 @@ fun Hakemusyhteystieto.format(): String =
         .joinToString("\n") + this.yhteyshenkilot.joinToString("\n") { "\n" + it.format() }
 
 fun ZonedDateTime?.format(): String? =
-    this?.withZoneSameInstant(ZoneId.of("Europe/Helsinki"))?.format(finnishDateFormat)
+    this?.withZoneSameInstant(ZoneId.of("Europe/Helsinki"))?.format(FINNISH_DATE_FORMAT)
 
 fun Boolean?.format(): String = this?.let { if (it) "Kyllä" else "Ei" } ?: "-"
 
-fun Float?.format(): String = "%.2f".format(this)
+fun Float?.format(): String = "%.2f".format(LOCALE, this)
 
-fun Double?.format(): String = "%.2f".format(this)
+fun Double?.format(): String = "%.2f".format(LOCALE, this)
 
 fun List<String>?.format(): String = if (this.isNullOrEmpty()) "-" else this.joinToString(", ")
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/pdf/JohtoselvityshakemusPdfEncoder.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/pdf/JohtoselvityshakemusPdfEncoder.kt
@@ -62,12 +62,6 @@ object JohtoselvityshakemusPdfEncoder {
 
             row("Työn arvioitu alkupäivä", data.startTime.format())
             row("Työn arvioitu loppupäivä", data.endTime.format())
-            row("Alueiden kokonaispinta-ala", totalArea.toString() + " m²")
-            row(
-                "Alueet",
-                areas
-                    .mapIndexed { i, area -> "${areaNames[i]}\n\nPinta-ala: $area m²" }
-                    .joinToString("\n\n"))
             row("Alueiden kokonaispinta-ala", totalArea.format() + " m²")
             row(
                 "Alueet",

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/pdf/KaivuilmoitusPdfEncoder.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/pdf/KaivuilmoitusPdfEncoder.kt
@@ -1,0 +1,166 @@
+package fi.hel.haitaton.hanke.pdf
+
+import com.lowagie.text.Document
+import com.lowagie.text.PageSize
+import com.lowagie.text.pdf.PdfWriter
+import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentMetadata
+import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType
+import fi.hel.haitaton.hanke.hakemus.Hakemusyhteyshenkilo
+import fi.hel.haitaton.hanke.hakemus.JohtoselvityshakemusData
+import fi.hel.haitaton.hanke.hakemus.KaivuilmoitusData
+import java.io.ByteArrayOutputStream
+
+object KaivuilmoitusPdfEncoder {
+
+    fun createPdf(
+        data: KaivuilmoitusData,
+        totalArea: Float?,
+        attachments: List<ApplicationAttachmentMetadata>,
+        areas: List<EnrichedKaivuilmoitusalue>?,
+    ): ByteArray {
+        val outputStream = ByteArrayOutputStream()
+        val document = Document(PageSize.A4)
+        PdfWriter.getInstance(document, outputStream)
+        formatKaivuilmoitusPdf(
+            document,
+            data,
+            totalArea,
+            attachments,
+            areas,
+        )
+        return outputStream.toByteArray()
+    }
+
+    private fun formatKaivuilmoitusPdf(
+        document: Document,
+        data: KaivuilmoitusData,
+        totalArea: Float?,
+        attachments: List<ApplicationAttachmentMetadata>,
+        areas: List<EnrichedKaivuilmoitusalue>?,
+    ) {
+        document.open()
+
+        document.title("Kaivuilmoitus")
+
+        document.section("Perustiedot") {
+            row("Työn nimi", data.name)
+            row("Työn kuvaus", data.workDescription)
+            row("Työssä on kyse", data.getWorkTargets())
+            row("Tehtyjen johtoselvitysten tunnukset", data.cableReports.format())
+            if (!data.cableReportDone) {
+                row(
+                    "Uusi johtoselvitys",
+                    "Louhitaanko työn yhteydessä, esimerkiksi maaperää? ${data.rockExcavation.format()}")
+            }
+            row("Sijoitussopimustunnukset", data.placementContracts.format())
+            row("Työhön vaadittavat pätevyydet", data.requiredCompetence.format())
+            row("Tilaaja", data.getOrderer()?.format() ?: "-")
+        }
+
+        document.newPage()
+
+        document.section("Alueet") {
+            row("Alueiden kokonaispinta-ala", totalArea.format() + " m²")
+            row("Työn arvioitu alkupäivä", data.startTime.format())
+            row("Työn arvioitu loppupäivä", data.endTime.format())
+            row("Alueet", areas?.joinToString("\n\n") { it.format() })
+        }
+
+        document.newPage()
+
+        document.section("Yhteystiedot") {
+            data.customerWithContacts?.let { row("Työstä vastaava", it.format()) }
+            data.contractorWithContacts?.let { row("Työn suorittaja", it.format()) }
+            data.propertyDeveloperWithContacts?.let { row("Rakennuttaja", it.format()) }
+            data.representativeWithContacts?.let { row("Asianhoitaja", it.format()) }
+        }
+        document.newPage()
+
+        document.section("Laskutustiedot") {
+            data.invoicingCustomer?.let {
+                row("Nimi", it.nimi)
+                rowIfNotBlank("Y-tunnus", it.ytunnus)
+
+                if (!it.katuosoite.isNullOrBlank()) {
+                    row(
+                        "Osoite",
+                        "${it.katuosoite}\n${it.postinumero.orDash()} ${it.postitoimipaikka.orDash()}")
+                }
+
+                row("OVT-tunnus", it.ovttunnus.orDash())
+                row("Välittäjän tunnus", it.valittajanTunnus.orDash())
+                row("Puhelinnumero", it.puhelinnumero.orDash())
+                row("Sähköposti", it.sahkoposti.orDash())
+                row("Asiakkaan viite", it.asiakkaanViite.orDash())
+            }
+        }
+        document.newPage()
+
+        document.section("Liitteet ja lisätiedot") {
+            val attachmentsByType = attachments.groupBy { it.attachmentType }
+            row(
+                "Tilapäisiä liikennejärjestelyitä koskevat suunnitelmat",
+                attachmentsByType[ApplicationAttachmentType.LIIKENNEJARJESTELY]?.joinToString(
+                    "\n") {
+                        it.fileName
+                    } ?: "")
+            row(
+                "Valtakirjat",
+                attachmentsByType[ApplicationAttachmentType.VALTAKIRJA]?.joinToString("\n") {
+                    it.fileName
+                } ?: "")
+            row(
+                "Muut liitteet",
+                attachmentsByType[ApplicationAttachmentType.MUU]?.joinToString("\n") { it.fileName }
+                    ?: "")
+            row("Lisätietoja hakemuksesta", data.additionalInfo.orDash())
+        }
+
+        document.close()
+    }
+
+    private fun KaivuilmoitusData.getOrderer(): Hakemusyhteyshenkilo? =
+        listOfNotNull(
+            customerWithContacts,
+            contractorWithContacts,
+            representativeWithContacts,
+            propertyDeveloperWithContacts)
+            .flatMap { it.yhteyshenkilot }
+            .find { it.tilaaja }
+
+    private fun KaivuilmoitusData.getWorkTargets(): String =
+        listOf(
+                constructionWork to "Uuden rakenteen tai johdon rakentamisesta",
+                maintenanceWork to "Olemassaolevan rakenteen kunnossapitotyöstä",
+                emergencyWork to
+                    "Kaivutyö on aloitettu ennen kaivuilmoituksen tekemistä merkittävien vahinkojen välttämiseksi",
+            )
+            .filter { (active, _) -> active }
+            .joinToString("\n") { (_, description) -> description }
+
+    private fun EnrichedKaivuilmoitusalue.format(): String {
+        val builder = StringBuilder()
+        builder.append("Työalueet ($hankealueName)\n")
+        builder.append("\n")
+        alue.tyoalueet.forEachIndexed { i, tyoalue ->
+            builder.append("Työalue ${i+1}: (${tyoalue.area.format()} m²)\n")
+        }
+        builder.append("\n")
+
+        builder.append("Pinta-ala: ${totalArea.format()} m²\n")
+        builder.append("Katuosoite: ${alue.katuosoite}\n")
+        builder.append(
+            "Työn tarkoitus: ${alue.tyonTarkoitukset.map { it.format() }.joinToString ( ", " )}\n")
+        builder.append("\n")
+
+        builder.append("Meluhaitta: ${alue.meluhaitta.format()}\n")
+        builder.append("Pölyhaitta: ${alue.polyhaitta.format()}\n")
+        builder.append("Tärinähaitta: ${alue.tarinahaitta.format()}\n")
+        builder.append("Autoliikenteen kaistahaitta: ${alue.kaistahaitta.format()}\n")
+        builder.append("Kaistahaittojen pituus: ${alue.kaistahaittojenPituus.format()}\n")
+        builder.append("\n")
+
+        builder.append("Lisätietoja alueesta: ${alue.lisatiedot.orDash()}\n")
+        return builder.toString()
+    }
+}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/pdf/KaivuilmoitusPdfEncoder.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/pdf/KaivuilmoitusPdfEncoder.kt
@@ -6,7 +6,6 @@ import com.lowagie.text.pdf.PdfWriter
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentMetadata
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType
 import fi.hel.haitaton.hanke.hakemus.Hakemusyhteyshenkilo
-import fi.hel.haitaton.hanke.hakemus.JohtoselvityshakemusData
 import fi.hel.haitaton.hanke.hakemus.KaivuilmoitusData
 import java.io.ByteArrayOutputStream
 
@@ -121,10 +120,10 @@ object KaivuilmoitusPdfEncoder {
 
     private fun KaivuilmoitusData.getOrderer(): Hakemusyhteyshenkilo? =
         listOfNotNull(
-            customerWithContacts,
-            contractorWithContacts,
-            representativeWithContacts,
-            propertyDeveloperWithContacts)
+                customerWithContacts,
+                contractorWithContacts,
+                representativeWithContacts,
+                propertyDeveloperWithContacts)
             .flatMap { it.yhteyshenkilot }
             .find { it.tilaaja }
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/pdf/PdfHelpers.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/pdf/PdfHelpers.kt
@@ -8,15 +8,12 @@ import com.lowagie.text.Paragraph
 import com.lowagie.text.Phrase
 import com.lowagie.text.Rectangle
 import com.lowagie.text.pdf.PdfPTable
-import java.time.format.DateTimeFormatter
 
 val titleFont = Font(Font.HELVETICA, 18f, Font.BOLD)
 val sectionFont = Font(Font.HELVETICA, 15f, Font.BOLD)
 
 val headerFont = Font(Font.HELVETICA, 10f, Font.BOLD)
 val textFont = Font(Font.HELVETICA, 10f, Font.NORMAL)
-
-val finnishDateFormat: DateTimeFormatter = DateTimeFormatter.ofPattern("d.M.uuuu")
 
 fun Document.newline() {
     this.add(Paragraph(Chunk.NEWLINE))

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/pdf/PdfHelpers.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/pdf/PdfHelpers.kt
@@ -40,7 +40,13 @@ fun PdfPTable.row(key: String, value: Any?) {
     this.addCell(Phrase(value?.toString() ?: "<Tyhjä>", textFont))
 }
 
-fun Document.section(sectionTitle: String, addRows: (table: PdfPTable) -> Unit) {
+fun PdfPTable.rowIfNotBlank(title: String, content: String?) {
+    if (!content.isNullOrBlank()) {
+        row(title, content)
+    }
+}
+
+fun Document.section(sectionTitle: String, addRows: PdfPTable.() -> Unit) {
     this.sectionTitle(sectionTitle)
 
     val table = PdfPTable(2)
@@ -50,7 +56,7 @@ fun Document.section(sectionTitle: String, addRows: (table: PdfPTable) -> Unit) 
     table.defaultCell.border = Rectangle.NO_BORDER
     table.defaultCell.paddingBottom = 15f
 
-    addRows(table)
+    table.addRows()
 
     this.add(table)
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/pdf/Translations.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/pdf/Translations.kt
@@ -1,0 +1,95 @@
+package fi.hel.haitaton.hanke.pdf
+
+import fi.hel.haitaton.hanke.domain.TyomaaTyyppi
+import fi.hel.haitaton.hanke.tormaystarkastelu.AutoliikenteenKaistavaikutustenPituus
+import fi.hel.haitaton.hanke.tormaystarkastelu.Meluhaitta
+import fi.hel.haitaton.hanke.tormaystarkastelu.Polyhaitta
+import fi.hel.haitaton.hanke.tormaystarkastelu.Tarinahaitta
+import fi.hel.haitaton.hanke.tormaystarkastelu.VaikutusAutoliikenteenKaistamaariin
+
+fun Meluhaitta.format(): String =
+    when (this) {
+        Meluhaitta.JATKUVA_MELUHAITTA -> "Jatkuva meluhaitta"
+        Meluhaitta.TOISTUVA_MELUHAITTA -> "Toistuva meluhaitta"
+        Meluhaitta.SATUNNAINEN_MELUHAITTA -> "Satunnainen meluhaitta"
+        Meluhaitta.EI_MELUHAITTAA -> "Ei meluhaittaa"
+    }
+
+fun Polyhaitta.format(): String =
+    when (this) {
+        Polyhaitta.JATKUVA_POLYHAITTA -> "Jatkuva pölyhaitta"
+        Polyhaitta.TOISTUVA_POLYHAITTA -> "Toistuva pölyhaitta"
+        Polyhaitta.SATUNNAINEN_POLYHAITTA -> "Satunnainen pölyhaitta"
+        Polyhaitta.EI_POLYHAITTAA -> "Ei pölyhaittaa"
+    }
+
+fun Tarinahaitta.format(): String =
+    when (this) {
+        Tarinahaitta.JATKUVA_TARINAHAITTA -> "Jatkuva tärinähaitta"
+        Tarinahaitta.TOISTUVA_TARINAHAITTA -> "Toistuva tärinähaitta"
+        Tarinahaitta.SATUNNAINEN_TARINAHAITTA -> "Satunnainen tärinähaitta"
+        Tarinahaitta.EI_TARINAHAITTAA -> "Ei tärinähaittaa"
+    }
+
+fun VaikutusAutoliikenteenKaistamaariin.format(): String =
+    when (this) {
+        VaikutusAutoliikenteenKaistamaariin.EI_VAIKUTA -> "Ei vaikuta"
+        VaikutusAutoliikenteenKaistamaariin.VAHENTAA_KAISTAN_YHDELLA_AJOSUUNNALLA ->
+            "Vähentää kaistan yhdellä ajosuunnalla"
+
+        VaikutusAutoliikenteenKaistamaariin
+            .VAHENTAA_SAMANAIKAISESTI_KAISTAN_KAHDELLA_AJOSUUNNALLA ->
+            "Vähentää samanaikaisesti kaistan kahdella ajosuunnalla"
+
+        VaikutusAutoliikenteenKaistamaariin
+            .VAHENTAA_SAMANAIKAISESTI_USEITA_KAISTOJA_KAHDELLA_AJOSUUNNALLA ->
+            "Vähentää samanaikaisesti useita kaistoja kahdella ajosuunnalla"
+
+        VaikutusAutoliikenteenKaistamaariin
+            .VAHENTAA_SAMANAIKAISESTI_USEITA_KAISTOJA_LIITTYMIEN_ERI_SUUNNILLA ->
+            "Vähentää samanaikaisesti useita kaistoja liittymän eri suunnilla"
+    }
+
+fun AutoliikenteenKaistavaikutustenPituus.format(): String =
+    when (this) {
+        AutoliikenteenKaistavaikutustenPituus.EI_VAIKUTA_KAISTAJARJESTELYIHIN -> "Ei vaikuta"
+        AutoliikenteenKaistavaikutustenPituus.PITUUS_ALLE_10_METRIA -> "Alle 10 m"
+        AutoliikenteenKaistavaikutustenPituus.PITUUS_10_99_METRIA -> "10-99 m"
+        AutoliikenteenKaistavaikutustenPituus.PITUUS_100_499_METRIA -> "100-499 m"
+        AutoliikenteenKaistavaikutustenPituus.PITUUS_500_METRIA_TAI_ENEMMAN -> "500 m tai enemmän"
+    }
+
+fun TyomaaTyyppi.format(): String =
+    when (this) {
+        TyomaaTyyppi.VESI -> "Vesi"
+        TyomaaTyyppi.VIEMARI -> "Viemäri"
+        TyomaaTyyppi.SADEVESI -> "Sadevesi"
+        TyomaaTyyppi.SAHKO -> "Sähkö"
+        TyomaaTyyppi.TIETOLIIKENNE -> "Tietoliikenne"
+        TyomaaTyyppi.LIIKENNEVALO -> "Liikennevalo"
+        TyomaaTyyppi.ULKOVALAISTUS -> "Ulkovalaistus"
+        TyomaaTyyppi.KAAPPITYO -> "Kaappityö"
+        TyomaaTyyppi.KAUKOLAMPO -> "Kaukolämpö"
+        TyomaaTyyppi.KAUKOKYLMA -> "Kaukokylmä"
+        TyomaaTyyppi.KAASUJOHTO -> "Kaasujohto"
+        TyomaaTyyppi.KISKOTYO -> "Kiskotyö"
+        TyomaaTyyppi.MUU -> "Muu"
+        TyomaaTyyppi.KADUNRAKENNUS -> "Kadunrakennus"
+        TyomaaTyyppi.KADUN_KUNNOSSAPITO -> "Kadun kunnossapito"
+        TyomaaTyyppi.KIINTEISTOLIITTYMA -> "Kiinteistöliittymä"
+        TyomaaTyyppi.SULKU_TAI_KAIVO -> "Sulku tai kaivo"
+        TyomaaTyyppi.UUDISRAKENNUS -> "Uudisrakentaminen"
+        TyomaaTyyppi.SANEERAUS -> "Saneeraus"
+        TyomaaTyyppi.AKILLINEN_VIKAKORJAUS -> "Äkillinen vikakorjaus"
+        TyomaaTyyppi.VIHERTYO -> "Vihertyö"
+        TyomaaTyyppi.RUNKOLINJA -> "Runkolinja"
+        TyomaaTyyppi.NOSTOTYO -> "Nostotyö"
+        TyomaaTyyppi.MUUTTO -> "Muutto"
+        TyomaaTyyppi.PYSAKKITYO -> "Pysäkkityö"
+        TyomaaTyyppi.KIINTEISTOREMONTTI -> "Kiinteistöremontti"
+        TyomaaTyyppi.ULKOMAINOS -> "Ulkomainos"
+        TyomaaTyyppi.KUVAUKSET -> "Kuvaukset"
+        TyomaaTyyppi.LUMENPUDOTUS -> "Lumenpudotus"
+        TyomaaTyyppi.YLEISOTILAISUUS -> "Yleisötilaisuus"
+        TyomaaTyyppi.VAIHTOLAVA -> "Vaihtolava"
+    }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusFactory.kt
@@ -53,10 +53,7 @@ class HakemusFactory(
 
     fun builder(applicationType: ApplicationType) =
         builder(
-            USERNAME,
-            hankeFactory.builder(USERNAME).withHankealue().saveEntity(),
-            applicationType
-        )
+            USERNAME, hankeFactory.builder(USERNAME).withHankealue().saveEntity(), applicationType)
 
     private fun builder(
         userId: String,
@@ -160,7 +157,7 @@ class HakemusFactory(
         fun createKaivuilmoitusData(
             pendingOnClient: Boolean = false,
             name: String = ApplicationFactory.DEFAULT_APPLICATION_NAME,
-            workDescription: String = "Work description.",
+            workDescription: String = ApplicationFactory.DEFAULT_WORK_DESCRIPTION,
             constructionWork: Boolean = false,
             maintenanceWork: Boolean = false,
             emergencyWork: Boolean = false,

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceTest.kt
@@ -148,10 +148,7 @@ class HakemusServiceTest {
             val applicationCapturingSlot = slot<AlluCableReportApplicationData>()
             justRun {
                 disclosureLogService.saveDisclosureLogsForAllu(
-                    3,
-                    capture(applicationCapturingSlot),
-                    Status.SUCCESS
-                )
+                    3, capture(applicationCapturingSlot), Status.SUCCESS)
             }
 
             hakemusService.sendHakemus(3, USERNAME)
@@ -230,8 +227,8 @@ class HakemusServiceTest {
                 hakemusRepository.findOneById(3)
                 geometriatDao.isInsideHankeAlueet(1, any())
                 geometriatDao.calculateCombinedArea(any())
-                geometriatDao.calculateArea(any())
                 attachmentService.getMetadataList(applicationEntity.id)
+                geometriatDao.calculateArea(any())
                 alluClient.create(any())
                 disclosureLogService.saveDisclosureLogsForAllu(3, any(), Status.SUCCESS)
                 alluClient.addAttachment(alluId, any())
@@ -257,15 +254,11 @@ class HakemusServiceTest {
                 hakemusRepository.findOneById(3)
                 geometriatDao.isInsideHankeAlueet(1, any())
                 geometriatDao.calculateCombinedArea(any())
-                geometriatDao.calculateArea(any())
                 attachmentService.getMetadataList(applicationEntity.id)
+                geometriatDao.calculateArea(any())
                 alluClient.create(any())
                 disclosureLogService.saveDisclosureLogsForAllu(
-                    3,
-                    any(),
-                    Status.FAILED,
-                    ALLU_APPLICATION_ERROR_MSG
-                )
+                    3, any(), Status.FAILED, ALLU_APPLICATION_ERROR_MSG)
             }
         }
 
@@ -285,8 +278,8 @@ class HakemusServiceTest {
                 hakemusRepository.findOneById(3)
                 geometriatDao.isInsideHankeAlueet(any(), any())
                 geometriatDao.calculateCombinedArea(any())
-                geometriatDao.calculateArea(any())
                 attachmentService.getMetadataList(applicationEntity.id)
+                geometriatDao.calculateArea(any())
                 alluClient.create(any())
             }
             verify { disclosureLogService wasNot called }
@@ -301,8 +294,7 @@ class HakemusServiceTest {
             val applicationEntity = applicationEntity()
             applicationEntity.hakemusEntityData =
                 (applicationEntity.hakemusEntityData as JohtoselvityshakemusEntityData).copy(
-                    rockExcavation = rockExcavation
-                )
+                    rockExcavation = rockExcavation)
             every { hakemusRepository.findOneById(3) } returns applicationEntity
             every { hakemusRepository.save(any()) } answers { firstArg() }
             every { geometriatDao.isInsideHankeAlueet(1, any()) } returns true
@@ -326,8 +318,8 @@ class HakemusServiceTest {
                 hakemusRepository.findOneById(3)
                 geometriatDao.isInsideHankeAlueet(1, any())
                 geometriatDao.calculateCombinedArea(any())
-                geometriatDao.calculateArea(any())
                 attachmentService.getMetadataList(applicationEntity.id)
+                geometriatDao.calculateArea(any())
                 alluClient.create(any())
                 disclosureLogService.saveDisclosureLogsForAllu(3, any(), Status.SUCCESS)
                 alluClient.addAttachment(alluId, any())
@@ -371,8 +363,7 @@ class HakemusServiceTest {
                 .all {
                     hasClass(InvalidHakemusDataException::class)
                     hasMessage(
-                        "Application contains invalid data. Errors at paths: applicationData.customerWithContacts.nimi"
-                    )
+                        "Application contains invalid data. Errors at paths: applicationData.customerWithContacts.nimi")
                 }
 
             verifySequence {
@@ -396,8 +387,7 @@ class HakemusServiceTest {
                     hasClass(InvalidHakemusDataException::class)
                     hasMessage(
                         "Application contains invalid data. Errors at paths: " +
-                            "applicationData.contractorWithContacts.yhteyshenkilot[0].etunimi"
-                    )
+                            "applicationData.contractorWithContacts.yhteyshenkilot[0].etunimi")
                 }
 
             verifySequence {
@@ -411,12 +401,9 @@ class HakemusServiceTest {
             val applicationEntity = applicationEntity()
             applicationEntity.yhteystiedot[ApplicationContactType.RAKENNUTTAJA] =
                 HakemusyhteystietoFactory.createEntity(
-                        application = applicationEntity,
-                        sahkoposti = "  "
-                    )
+                        application = applicationEntity, sahkoposti = "  ")
                     .withYhteyshenkilo(
-                        permission = PermissionFactory.createEntity(userId = USERNAME)
-                    )
+                        permission = PermissionFactory.createEntity(userId = USERNAME))
             every { hakemusRepository.findOneById(3) } returns applicationEntity
             every { geometriatDao.isInsideHankeAlueet(1, any()) } returns true
 
@@ -425,8 +412,7 @@ class HakemusServiceTest {
                     hasClass(InvalidHakemusDataException::class)
                     hasMessage(
                         "Application contains invalid data. Errors at paths: " +
-                            "applicationData.propertyDeveloperWithContacts.sahkoposti"
-                    )
+                            "applicationData.propertyDeveloperWithContacts.sahkoposti")
                 }
 
             verifySequence {
@@ -440,12 +426,9 @@ class HakemusServiceTest {
             val applicationEntity = applicationEntity()
             applicationEntity.yhteystiedot[ApplicationContactType.ASIANHOITAJA] =
                 HakemusyhteystietoFactory.createEntity(
-                        application = applicationEntity,
-                        puhelinnumero = "  "
-                    )
+                        application = applicationEntity, puhelinnumero = "  ")
                     .withYhteyshenkilo(
-                        permission = PermissionFactory.createEntity(userId = USERNAME)
-                    )
+                        permission = PermissionFactory.createEntity(userId = USERNAME))
             every { hakemusRepository.findOneById(3) } returns applicationEntity
             every { geometriatDao.isInsideHankeAlueet(1, any()) } returns true
 
@@ -454,8 +437,7 @@ class HakemusServiceTest {
                     hasClass(InvalidHakemusDataException::class)
                     hasMessage(
                         "Application contains invalid data. Errors at paths: " +
-                            "applicationData.representativeWithContacts.puhelinnumero"
-                    )
+                            "applicationData.representativeWithContacts.puhelinnumero")
                 }
 
             verifySequence {
@@ -475,13 +457,11 @@ class HakemusServiceTest {
             applicationEntity.yhteystiedot[ApplicationContactType.HAKIJA] =
                 HakemusyhteystietoFactory.createEntity(application = applicationEntity)
                     .withYhteyshenkilo(
-                        permission = PermissionFactory.createEntity(userId = USERNAME)
-                    )
+                        permission = PermissionFactory.createEntity(userId = USERNAME))
             applicationEntity.yhteystiedot[ApplicationContactType.TYON_SUORITTAJA] =
                 HakemusyhteystietoFactory.createEntity(application = applicationEntity)
                     .withYhteyshenkilo(
-                        permission = PermissionFactory.createEntity(userId = USERNAME)
-                    )
+                        permission = PermissionFactory.createEntity(userId = USERNAME))
             return applicationEntity
         }
     }
@@ -501,10 +481,7 @@ class HakemusServiceTest {
             every { hakemusRepository.getOneByAlluid(42) } returns applicationEntityWithCustomer()
             justRun {
                 emailSenderService.sendJohtoselvitysCompleteEmail(
-                    receiver,
-                    applicationId,
-                    identifier
-                )
+                    receiver, applicationId, identifier)
             }
             every { hakemusRepository.save(any()) } answers { firstArg() }
             every { alluStatusRepository.getReferenceById(1) } returns AlluStatus(1, updateTime)
@@ -515,10 +492,7 @@ class HakemusServiceTest {
             verifySequence {
                 hakemusRepository.getOneByAlluid(42)
                 emailSenderService.sendJohtoselvitysCompleteEmail(
-                    receiver,
-                    applicationId,
-                    identifier
-                )
+                    receiver, applicationId, identifier)
                 hakemusRepository.save(any())
                 alluStatusRepository.getReferenceById(1)
                 alluStatusRepository.save(any())
@@ -537,9 +511,7 @@ class HakemusServiceTest {
                         alluid,
                         ApplicationHistoryFactory.createEvent(
                             applicationIdentifier = identifier,
-                            newStatus = ApplicationStatus.HANDLING
-                        )
-                    ),
+                            newStatus = ApplicationStatus.HANDLING)),
                 )
 
             hakemusService.handleHakemusUpdates(histories, updateTime)
@@ -618,8 +590,7 @@ class HakemusServiceTest {
             entity.yhteystiedot[ApplicationContactType.HAKIJA] =
                 HakemusyhteystietoFactory.createEntity(application = entity, sahkoposti = receiver)
                     .withYhteyshenkilo(
-                        permission = PermissionFactory.createEntity(userId = USERNAME)
-                    )
+                        permission = PermissionFactory.createEntity(userId = USERNAME))
             return entity
         }
 
@@ -630,8 +601,7 @@ class HakemusServiceTest {
                     ApplicationHistoryFactory.createEvent(
                         applicationIdentifier = identifier,
                         newStatus = status,
-                    )
-                ),
+                    )),
             )
     }
 

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/pdf/JohtoselvityshakemusPdfEncoderTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/pdf/JohtoselvityshakemusPdfEncoderTest.kt
@@ -151,13 +151,13 @@ class JohtoselvityshakemusPdfEncoderTest {
             assertThat(getPdfAsText(pdfData)).all {
                 contains("18.11.2022")
                 contains("28.11.2022")
-                contains("614.0 m²")
+                contains("614,00 m²")
                 contains("Ensimmäinen työalue")
-                contains("185.0 m²")
+                contains("185,00 m²")
                 contains("Toinen alue")
-                contains("231.0 m²")
+                contains("231,00 m²")
                 contains("Työalue 3")
-                contains("198.0 m²")
+                contains("198,00 m²")
             }
         }
 

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/pdf/KaivuilmoitusPdfEncoderTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/pdf/KaivuilmoitusPdfEncoderTest.kt
@@ -1,132 +1,136 @@
 package fi.hel.haitaton.hanke.pdf
 
+import assertk.Assert
 import assertk.all
 import assertk.assertThat
 import assertk.assertions.contains
+import assertk.assertions.containsMatch
 import assertk.assertions.doesNotContain
 import com.lowagie.text.pdf.PdfReader
 import com.lowagie.text.pdf.parser.PdfTextExtractor
+import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType
+import fi.hel.haitaton.hanke.domain.TyomaaTyyppi
 import fi.hel.haitaton.hanke.factory.ApplicationAttachmentFactory
 import fi.hel.haitaton.hanke.factory.ApplicationFactory
+import fi.hel.haitaton.hanke.factory.GeometriaFactory
 import fi.hel.haitaton.hanke.factory.HakemusFactory
-import fi.hel.haitaton.hanke.factory.HakemusyhteyshenkiloFactory
 import fi.hel.haitaton.hanke.factory.HakemusyhteystietoFactory
 import fi.hel.haitaton.hanke.factory.HakemusyhteystietoFactory.withYhteyshenkilo
-import fi.hel.haitaton.hanke.hakemus.JohtoselvitysHakemusalue
+import fi.hel.haitaton.hanke.hakemus.KaivuilmoitusAlue
+import fi.hel.haitaton.hanke.hakemus.Tyoalue
+import fi.hel.haitaton.hanke.tormaystarkastelu.AutoliikenteenKaistavaikutustenPituus
+import fi.hel.haitaton.hanke.tormaystarkastelu.Meluhaitta
+import fi.hel.haitaton.hanke.tormaystarkastelu.Polyhaitta
+import fi.hel.haitaton.hanke.tormaystarkastelu.Tarinahaitta
+import fi.hel.haitaton.hanke.tormaystarkastelu.VaikutusAutoliikenteenKaistamaariin
 import java.time.ZonedDateTime
-import org.geojson.Polygon
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
-class JohtoselvityshakemusPdfEncoderTest {
+class KaivuilmoitusPdfEncoderTest {
 
     @Nested
     inner class CreatePdf {
         @Test
         fun `created PDF contains title and section headers`() {
-            val hakemusData = HakemusFactory.createJohtoselvityshakemusData()
+            val hakemusData = HakemusFactory.createKaivuilmoitusData()
 
-            val pdfData =
-                JohtoselvityshakemusPdfEncoder.createPdf(hakemusData, 1f, listOf(), listOf())
+            val pdfData = KaivuilmoitusPdfEncoder.createPdf(hakemusData, 1f, listOf(), listOf())
 
             assertThat(getPdfAsText(pdfData))
                 .contains(
-                    "Johtoselvityshakemus", "Perustiedot", "Alueet", "Yhteystiedot", "Liitteet")
+                    "Kaivuilmoitus",
+                    "Perustiedot",
+                    "Alueet",
+                    "Yhteystiedot",
+                    "Liitteet ja lisätiedot")
         }
 
         @Test
         fun `created PDF contains headers for basic information`() {
-            val hakemusData = HakemusFactory.createJohtoselvityshakemusData()
+            val hakemusData = HakemusFactory.createKaivuilmoitusData(cableReportDone = false)
 
-            val pdfData =
-                JohtoselvityshakemusPdfEncoder.createPdf(hakemusData, 614f, listOf(), listOf())
+            val pdfData = KaivuilmoitusPdfEncoder.createPdf(hakemusData, 1f, listOf(), listOf())
 
             assertThat(getPdfAsText(pdfData)).all {
                 contains("Työn nimi")
-                contains("Osoitetiedot")
-                contains("Työssä on kyse")
                 contains("Työn kuvaus")
-                contains("Omat tiedot")
+                contains("Työssä on kyse")
+                hasPhrase("Tehtyjen johtoselvitysten tunnukset")
+                contains("Uusi johtoselvitys")
+                contains("Sijoitussopimustunnukset")
+                contains("Työhön vaadittavat pätevyydet")
+                contains("Tilaaja")
             }
         }
 
         @Test
         fun `created PDF contains basic information`() {
             val applicationData =
-                HakemusFactory.createJohtoselvityshakemusData(
-                    postalAddress = ApplicationFactory.createPostalAddress(),
-                    customerWithContacts = HakemusyhteystietoFactory.create().withYhteyshenkilo(),
+                HakemusFactory.createKaivuilmoitusData(
                     constructionWork = true,
                     maintenanceWork = true,
                     emergencyWork = true,
-                    propertyConnectivity = true,
+                    cableReports = listOf("JS2400001", "JS2400002"),
+                    cableReportDone = false,
+                    rockExcavation = false,
+                    placementContracts = listOf("Sopimus1", "Sopimus2"),
+                    requiredCompetence = true,
+                    contractorWithContacts = HakemusyhteystietoFactory.create().withYhteyshenkilo(
+                        etunimi = "Tapio",
+                        sukunimi = "Tilaaja",
+                        sahkoposti = "tapio@tilaaja.test",
+                        puhelin = "09876543",
+                        tilaaja = true,)
                 )
 
-            val pdfData =
-                JohtoselvityshakemusPdfEncoder.createPdf(applicationData, 1f, listOf(), listOf())
+            val pdfData = KaivuilmoitusPdfEncoder.createPdf(applicationData, 1f, listOf(), listOf())
 
             val pdfText = getPdfAsText(pdfData)
             assertThat(pdfText).all {
                 contains(ApplicationFactory.DEFAULT_APPLICATION_NAME)
-                contains("Katu 1")
-                contains("00100")
-                contains("Helsinki")
+                contains(ApplicationFactory.DEFAULT_WORK_DESCRIPTION)
                 contains("Uuden rakenteen tai johdon rakentamisesta")
                 contains("Olemassaolevan rakenteen kunnossapitotyöstä")
-                // This is too long to fit on one line in the PDF. It's not found as a continuous
-                // String. Check for each word instead.
-                contains(
-                    "Kaivutyö",
-                    "on",
-                    "aloitettu",
-                    "ennen",
-                    "johtoselvityksen",
-                    "tilaamista",
-                    "merkittävien",
-                    "vahinkojen",
-                    "välttämiseksi",
-                )
-                contains("Kiinteistöliittymien rakentamisesta")
-                contains(ApplicationFactory.DEFAULT_WORK_DESCRIPTION)
-                contains(
-                    "${HakemusyhteyshenkiloFactory.DEFAULT_ETUNIMI} ${HakemusyhteyshenkiloFactory.DEFAULT_SUKUNIMI}")
-                contains(HakemusyhteyshenkiloFactory.DEFAULT_SAHKOPOSTI)
-                contains(HakemusyhteyshenkiloFactory.DEFAULT_PUHELIN)
+                hasPhrase(
+                    "Kaivutyö on aloitettu ennen kaivuilmoituksen tekemistä " +
+                        "merkittävien vahinkojen välttämiseksi")
+                contains("JS2400001, JS2400002")
+                hasPhrase("Louhitaanko työn yhteydessä, esimerkiksi maaperää? Ei")
+                contains("Sopimus1, Sopimus2")
+                contains("Kyllä")
+                hasPhrase("Tapio Tilaaja tapio@tilaaja.test 09876543")
             }
         }
 
         @Test
         fun `created PDF doesn't have this work involves fields if none are selected`() {
             val hakemusData =
-                HakemusFactory.createJohtoselvityshakemusData(
+                HakemusFactory.createKaivuilmoitusData(
                     constructionWork = false,
                     maintenanceWork = false,
                     emergencyWork = false,
-                    propertyConnectivity = false,
                 )
 
-            val pdfData =
-                JohtoselvityshakemusPdfEncoder.createPdf(hakemusData, 1f, listOf(), listOf())
+            val pdfData = KaivuilmoitusPdfEncoder.createPdf(hakemusData, 1f, listOf(), listOf())
 
             assertThat(getPdfAsText(pdfData)).all {
                 doesNotContain("Uuden rakenteen tai johdon rakentamisesta")
                 doesNotContain("Olemassaolevan rakenteen kunnossapitotyöstä")
                 doesNotContain("välttämiseksi")
-                doesNotContain("Kiinteistöliittymien rakentamisesta")
             }
         }
 
         @Test
         fun `created PDF contains headers for area information`() {
-            val hakemusData = HakemusFactory.createJohtoselvityshakemusData()
+            val hakemusData = HakemusFactory.createKaivuilmoitusData()
 
-            val pdfData =
-                JohtoselvityshakemusPdfEncoder.createPdf(hakemusData, 614f, listOf(), listOf())
+            val pdfData = KaivuilmoitusPdfEncoder.createPdf(hakemusData, 614f, listOf(), listOf())
 
             assertThat(getPdfAsText(pdfData)).all {
+                contains("Alueiden kokonaispinta-ala")
                 contains("Työn arvioitu alkupäivä")
                 contains("Työn arvioitu loppupäivä")
-                contains("Alueiden kokonaispinta-ala")
                 contains("Alueet")
             }
         }
@@ -134,37 +138,58 @@ class JohtoselvityshakemusPdfEncoderTest {
         @Test
         fun `created PDF contains area information`() {
             val hakemusData =
-                HakemusFactory.createJohtoselvityshakemusData(
+                HakemusFactory.createKaivuilmoitusData(
                     startTime = ZonedDateTime.parse("2022-11-17T22:00:00.000Z"),
                     endTime = ZonedDateTime.parse("2022-11-28T21:59:59.999Z"),
-                    areas =
-                        listOf(
-                            JohtoselvitysHakemusalue("Ensimmäinen työalue", Polygon()),
-                            JohtoselvitysHakemusalue("Toinen alue", Polygon()),
-                            JohtoselvitysHakemusalue("", Polygon()),
-                        ))
+                    areas = listOf())
+            val area =
+                EnrichedKaivuilmoitusalue(
+                    223.41411f,
+                    "Ensimmäinen hankealue",
+                    KaivuilmoitusAlue(
+                        name = "Hakemusalue",
+                        hankealueId = 11,
+                        tyoalueet =
+                            listOf(
+                                Tyoalue(GeometriaFactory.secondPolygon(), 147.5799, null),
+                                Tyoalue(GeometriaFactory.secondPolygon(), 75.83421, null),
+                            ),
+                        katuosoite = "Hakemusalueen osoite",
+                        tyonTarkoitukset = setOf(TyomaaTyyppi.VESI, TyomaaTyyppi.KAASUJOHTO),
+                        meluhaitta = Meluhaitta.TOISTUVA_MELUHAITTA,
+                        polyhaitta = Polyhaitta.SATUNNAINEN_POLYHAITTA,
+                        tarinahaitta = Tarinahaitta.JATKUVA_TARINAHAITTA,
+                        kaistahaitta = VaikutusAutoliikenteenKaistamaariin.EI_VAIKUTA,
+                        kaistahaittojenPituus =
+                            AutoliikenteenKaistavaikutustenPituus.EI_VAIKUTA_KAISTAJARJESTELYIHIN,
+                        lisatiedot = "Lisätiedot hakemusalueesta.",
+                    ))
 
             val pdfData =
-                JohtoselvityshakemusPdfEncoder.createPdf(
-                    hakemusData, 614f, listOf(185f, 231f, 198f), listOf())
+                KaivuilmoitusPdfEncoder.createPdf(hakemusData, 614f, listOf(), listOf(area))
 
             assertThat(getPdfAsText(pdfData)).all {
+                contains("614,00 m²")
                 contains("18.11.2022")
                 contains("28.11.2022")
-                contains("614.0 m²")
-                contains("Ensimmäinen työalue")
-                contains("185.0 m²")
-                contains("Toinen alue")
-                contains("231.0 m²")
-                contains("Työalue 3")
-                contains("198.0 m²")
+                contains("Työalueet (Ensimmäinen hankealue)")
+                contains("Työalue 1: (147,58 m²)")
+                contains("Työalue 2: (75,83 m²)")
+                contains("Pinta-ala: 223,41 m²")
+                contains("Katuosoite: Hakemusalueen osoite")
+                contains("Työn tarkoitus: Vesi, Kaasujohto")
+                contains("Meluhaitta: Toistuva meluhaitta")
+                contains("Pölyhaitta: Satunnainen pölyhaitta")
+                contains("Tärinähaitta: Jatkuva tärinähaitta")
+                contains("Kaistahaittojen pituus: Ei vaikuta")
+                contains("Lisätietoja alueesta: Lisätiedot hakemusalueesta.")
             }
         }
 
         @Test
         fun `contains headers for contact information`() {
             val hakemusData =
-                HakemusFactory.createJohtoselvityshakemusData(
+                HakemusFactory.createKaivuilmoitusData(
                     customerWithContacts = HakemusyhteystietoFactory.create().withYhteyshenkilo(),
                     contractorWithContacts = HakemusyhteystietoFactory.create().withYhteyshenkilo(),
                     representativeWithContacts =
@@ -172,14 +197,13 @@ class JohtoselvityshakemusPdfEncoderTest {
                     propertyDeveloperWithContacts =
                         HakemusyhteystietoFactory.create().withYhteyshenkilo())
 
-            val pdfData =
-                JohtoselvityshakemusPdfEncoder.createPdf(hakemusData, 1f, listOf(), listOf())
+            val pdfData = KaivuilmoitusPdfEncoder.createPdf(hakemusData, 1f, listOf(), listOf())
 
             assertThat(getPdfAsText(pdfData)).all {
-                contains("Työstä vastaavat")
-                contains("Työn suorittajat")
-                contains("Rakennuttajat")
-                contains("Asianhoitajat")
+                contains("Työstä vastaava")
+                contains("Työn suorittaja")
+                contains("Rakennuttaja")
+                contains("Asianhoitaja")
                 contains("Yhteyshenkilöt")
             }
         }
@@ -187,21 +211,20 @@ class JohtoselvityshakemusPdfEncoderTest {
         @Test
         fun `doesn't contain headers for missing optional contacts`() {
             val hakemusData =
-                HakemusFactory.createJohtoselvityshakemusData(
+                HakemusFactory.createKaivuilmoitusData(
                     customerWithContacts = HakemusyhteystietoFactory.create().withYhteyshenkilo(),
                     contractorWithContacts = HakemusyhteystietoFactory.create().withYhteyshenkilo(),
                     representativeWithContacts = null,
                     propertyDeveloperWithContacts = null,
                 )
 
-            val pdfData =
-                JohtoselvityshakemusPdfEncoder.createPdf(hakemusData, 614f, listOf(), listOf())
+            val pdfData = KaivuilmoitusPdfEncoder.createPdf(hakemusData, 614f, listOf(), listOf())
 
             assertThat(getPdfAsText(pdfData)).all {
-                contains("Työstä vastaavat")
-                contains("Työn suorittajat")
-                doesNotContain("Rakennuttajat")
-                doesNotContain("Asianhoitajat")
+                contains("Työstä vastaava")
+                contains("Työn suorittaja")
+                doesNotContain("Rakennuttaja")
+                doesNotContain("Asianhoitaja")
             }
         }
 
@@ -260,15 +283,14 @@ class JohtoselvityshakemusPdfEncoderTest {
                         puhelin = "0502222222")
 
             val hakemusData =
-                HakemusFactory.createJohtoselvityshakemusData(
+                HakemusFactory.createKaivuilmoitusData(
                     customerWithContacts = hakija,
                     contractorWithContacts = tyonSuorittaja,
                     representativeWithContacts = asianhoitaja,
                     propertyDeveloperWithContacts = rakennuttaja,
                 )
 
-            val pdfData =
-                JohtoselvityshakemusPdfEncoder.createPdf(hakemusData, 614f, listOf(), listOf())
+            val pdfData = KaivuilmoitusPdfEncoder.createPdf(hakemusData, 614f, listOf(), listOf())
 
             assertThat(getPdfAsText(pdfData)).all {
                 contains("Company Ltd")
@@ -305,24 +327,32 @@ class JohtoselvityshakemusPdfEncoderTest {
         @Test
         fun `created PDF contains attachment information`() {
             val hakemusData =
-                HakemusFactory.createJohtoselvityshakemusData(
+                HakemusFactory.createKaivuilmoitusData(
                     startTime = ZonedDateTime.parse("2022-11-17T22:00:00.000Z"),
                     endTime = ZonedDateTime.parse("2022-11-28T21:59:59.999Z"),
-                    areas = listOf())
+                )
             val attachments =
                 listOf(
                     ApplicationAttachmentFactory.create(fileName = "first.pdf"),
                     ApplicationAttachmentFactory.create(fileName = "second.png"),
                     ApplicationAttachmentFactory.create(fileName = "third.gt"),
+                    ApplicationAttachmentFactory.create(
+                        fileName = "valtakirja.pdf",
+                        attachmentType = ApplicationAttachmentType.VALTAKIRJA),
+                    ApplicationAttachmentFactory.create(
+                        fileName = "liikenne.pdf",
+                        attachmentType = ApplicationAttachmentType.LIIKENNEJARJESTELY),
                 )
 
             val pdfData =
-                JohtoselvityshakemusPdfEncoder.createPdf(hakemusData, 614f, listOf(), attachments)
+                KaivuilmoitusPdfEncoder.createPdf(hakemusData, 614f, attachments, listOf())
 
             assertThat(getPdfAsText(pdfData)).all {
                 contains("first.pdf")
                 contains("second.png")
                 contains("third.gt")
+                contains("valtakirja.pdf")
+                contains("liikenne.pdf")
             }
         }
     }
@@ -333,4 +363,10 @@ class JohtoselvityshakemusPdfEncoderTest {
         val textExtractor = PdfTextExtractor(reader)
         return (1..pages).joinToString("\n") { textExtractor.getTextFromPage(it) }
     }
+
+    private fun phraseAsRegexWithEscapes(phrase: String): Regex =
+        phrase.splitToSequence(' ').map { "\\Q$it\\E" }.joinToString("\\s+").toRegex()
+
+    private fun Assert<String>.hasPhrase(phrase: String) =
+        containsMatch(phraseAsRegexWithEscapes(phrase))
 }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/pdf/KaivuilmoitusPdfEncoderTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/pdf/KaivuilmoitusPdfEncoderTest.kt
@@ -76,13 +76,15 @@ class KaivuilmoitusPdfEncoderTest {
                     rockExcavation = false,
                     placementContracts = listOf("Sopimus1", "Sopimus2"),
                     requiredCompetence = true,
-                    contractorWithContacts = HakemusyhteystietoFactory.create().withYhteyshenkilo(
-                        etunimi = "Tapio",
-                        sukunimi = "Tilaaja",
-                        sahkoposti = "tapio@tilaaja.test",
-                        puhelin = "09876543",
-                        tilaaja = true,)
-                )
+                    contractorWithContacts =
+                        HakemusyhteystietoFactory.create()
+                            .withYhteyshenkilo(
+                                etunimi = "Tapio",
+                                sukunimi = "Tilaaja",
+                                sahkoposti = "tapio@tilaaja.test",
+                                puhelin = "09876543",
+                                tilaaja = true,
+                            ))
 
             val pdfData = KaivuilmoitusPdfEncoder.createPdf(applicationData, 1f, listOf(), listOf())
 


### PR DESCRIPTION
# Description

When sending a kaivuilmoitus to Allu, create a PDF with the form content
and upload it to Allu. This way the Allu handlers can see the
information as it was entered into Haitaton before it was converted to
Allu data format.

Change the johtoselvityshakemus PDF to use Finnish formatting for decimal numbers while implementing that for kaivuilmoitus.

Refactor `Document.section` in `PdfHelpers` to take a receiver function as a parameter. This makes using it easier because the caller can call `row()` directly in the function body.

Also, upgrade ktfmt to latest version. This adds some formatting changes to
edited files, especially with trailing parentheses.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1549

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
Send a kaivuilmoitus to Allu. The form data can be found from Allu UI under attachments.

For quickly testing just the PDF generation:
- Uncomment the `@EventListener` in `HakemusService`.
- Change the hakemus ID and hanketunnus to a kaivuilmoitus in your DB.
- Start the application with `HAITATON_GDPR_DISABLED=true ./gradlew bootRun`.
- The application will exit after creating the PDF. The PDF will be saved in `services/hanke-service/haitaton-form-data.pdf`.
- While doing this, you can keep the docker-compose service running to edit the hakemus from the UI easily. Or edit it directly from the DB.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 