### PR TITLE
HAI-2398 Create and send johtoselvityshakemus when kaivuilmoitus is sent

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceITest.kt
@@ -1809,7 +1809,7 @@ class HakemusServiceITest(
             val founder = hankeKayttajaFactory.getFounderFromHakemus(hakemus.id)
             val expectedJohtoselvityshakemusDataAfterSend =
                 (applicationEntity.hakemusEntityData as KaivuilmoitusEntityData)
-                    .toJohtoselvityshakemusEntityData()
+                    .createAccompanyingJohtoselvityshakemusData()
                     .toHakemusData(hakemusData.yhteystiedotMap())
                     .setOrdererForContractor(founder.id)
             val expectedKaivuilmoitusDataAfterSend =

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceITest.kt
@@ -1818,14 +1818,14 @@ class HakemusServiceITest(
                 expectedJohtoselvityshakemusDataAfterSend.toAlluCableReportData(hakemus.hankeTunnus)
             val expectedExcavationAnnouncementAlluRequest =
                 expectedKaivuilmoitusDataAfterSend.toAlluExcavationNotificationData(
-                    hakemus.hankeTunnus
-                )
+                    hakemus.hankeTunnus)
             val cableReportAlluId = alluId
             val excavationAnnouncenemtAlluId = alluId + 1
             every { alluClient.create(expectedCableReportAlluRequest) } returns cableReportAlluId
             every { alluClient.create(expectedExcavationAnnouncementAlluRequest) } returns
                 excavationAnnouncenemtAlluId
             justRun { alluClient.addAttachment(cableReportAlluId, any()) }
+            justRun { alluClient.addAttachment(excavationAnnouncenemtAlluId, any()) }
             justRun { alluClient.addAttachments(cableReportAlluId, any(), any()) }
             justRun { alluClient.addAttachments(excavationAnnouncenemtAlluId, any(), any()) }
             every { alluClient.getApplicationInformation(cableReportAlluId) } returns
@@ -1833,8 +1833,7 @@ class HakemusServiceITest(
             every { alluClient.getApplicationInformation(excavationAnnouncenemtAlluId) } returns
                 AlluFactory.createAlluApplicationResponse(
                     excavationAnnouncenemtAlluId,
-                    applicationId = DEFAULT_EXCAVATION_ANNOUNCEMENT_IDENTIFIER
-                )
+                    applicationId = DEFAULT_EXCAVATION_ANNOUNCEMENT_IDENTIFIER)
 
             val response = hakemusService.sendHakemus(hakemus.id, USERNAME)
 
@@ -1865,6 +1864,7 @@ class HakemusServiceITest(
                 alluClient.getApplicationInformation(cableReportAlluId)
                 // then the excavation announcement is sent
                 alluClient.create(expectedExcavationAnnouncementAlluRequest)
+                alluClient.addAttachment(excavationAnnouncenemtAlluId, any())
                 alluClient.addAttachments(excavationAnnouncenemtAlluId, any(), any())
                 alluClient.getApplicationInformation(excavationAnnouncenemtAlluId)
             }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentService.kt
@@ -102,8 +102,7 @@ class ApplicationAttachmentService(
                     content.size.toLong(),
                     blobPath,
                     attachmentType,
-                    hakemus.id
-                )
+                    hakemus.id)
             } catch (e: Exception) {
                 logger.error(e) {
                     "Attachment metadata save failed, deleting attachment content $blobPath"

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusDataMapper.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusDataMapper.kt
@@ -58,7 +58,7 @@ object HakemusDataMapper {
         hankeTunnus: String
     ): AlluExcavationNotificationData =
         AlluExcavationNotificationData(
-            postalAddress = areas.toPostalAddress()?.toAlluData(),
+            postalAddress = areas.combinedAddress()?.toAlluData(),
             name = name,
             customerWithContacts =
                 customerWithContacts?.toAlluCustomer()

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusDataMapper.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusDataMapper.kt
@@ -57,14 +57,9 @@ object HakemusDataMapper {
 
     fun KaivuilmoitusData.toAlluExcavationNotificationData(
         hankeTunnus: String
-    ): AlluExcavationNotificationData {
-        val addresses =
-            areas?.map { it.katuosoite }?.toSet()?.joinToString(", ")
-                ?: throw throw AlluDataException(path("areas"), EMPTY_OR_NULL)
-
-        return AlluExcavationNotificationData(
-            postalAddress =
-                PostalAddress(streetAddress = StreetAddress(addresses), postalCode = "", city = ""),
+    ): AlluExcavationNotificationData =
+        AlluExcavationNotificationData(
+            postalAddress = areas.toPostalAddress()?.toAlluData(),
             name = name,
             customerWithContacts =
                 customerWithContacts?.toAlluCustomer()
@@ -92,7 +87,6 @@ object HakemusDataMapper {
             placementContracts = placementContracts?.toList(),
             cableReports = cableReports?.toList()
         )
-    }
 
     /** If areas are missing, throw an exception. */
     internal fun HakemusData.getGeometries(): GeometryCollection =

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusDataMapper.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusDataMapper.kt
@@ -51,8 +51,7 @@ object HakemusDataMapper {
             constructionWork = constructionWork,
             maintenanceWork = maintenanceWork,
             emergencyWork = emergencyWork,
-            propertyConnectivity = propertyConnectivity
-        )
+            propertyConnectivity = propertyConnectivity)
     }
 
     fun KaivuilmoitusData.toAlluExcavationNotificationData(
@@ -85,8 +84,7 @@ object HakemusDataMapper {
             propertyConnectivity = null,
             workPurpose = workDescription,
             placementContracts = placementContracts?.toList(),
-            cableReports = cableReports?.toList()
-        )
+            cableReports = cableReports?.toList())
 
     /** If areas are missing, throw an exception. */
     internal fun HakemusData.getGeometries(): GeometryCollection =
@@ -130,8 +128,7 @@ object HakemusDataMapper {
                 invoicingOperator = null,
                 sapCustomerNumber = null,
             ),
-            yhteyshenkilot.map { it.toAlluContact() }
-        )
+            yhteyshenkilot.map { it.toAlluContact() })
 
     fun Hakemusyhteyshenkilo.toAlluContact() =
         Contact("$etunimi $sukunimi".trim(), sahkoposti, puhelin, tilaaja)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusEntityData.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusEntityData.kt
@@ -131,7 +131,7 @@ data class KaivuilmoitusEntityData(
             applicationType = ApplicationType.CABLE_REPORT,
             pendingOnClient = pendingOnClient,
             name = name,
-            postalAddress = areas.toPostalAddress(),
+            postalAddress = areas.combinedAddress(),
             constructionWork = constructionWork,
             maintenanceWork = maintenanceWork,
             propertyConnectivity = false,

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusEntityData.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusEntityData.kt
@@ -20,8 +20,7 @@ enum class ApplicationContactType {
     use = JsonTypeInfo.Id.NAME,
     include = JsonTypeInfo.As.EXISTING_PROPERTY,
     property = "applicationType",
-    visible = true
-)
+    visible = true)
 @JsonSubTypes(
     JsonSubTypes.Type(value = JohtoselvityshakemusEntityData::class, name = "CABLE_REPORT"),
     JsonSubTypes.Type(value = KaivuilmoitusEntityData::class, name = "EXCAVATION_NOTIFICATION"),
@@ -158,8 +157,7 @@ fun InvoicingCustomer?.toLaskutusyhteystieto(customerReference: String?): Laskut
             it.postalAddress?.postalCode,
             it.postalAddress?.city,
             it.email,
-            it.phone
-        )
+            it.phone)
     }
 
 class AlluDataException(path: String, error: AlluDataError) :

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusEntityData.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusEntityData.kt
@@ -126,7 +126,7 @@ data class KaivuilmoitusEntityData(
             additionalInfo = additionalInfo,
         )
 
-    fun toJohtoselvityshakemusEntityData(): JohtoselvityshakemusEntityData =
+    fun createAccompanyingJohtoselvityshakemusData(): JohtoselvityshakemusEntityData =
         JohtoselvityshakemusEntityData(
             applicationType = ApplicationType.CABLE_REPORT,
             pendingOnClient = pendingOnClient,
@@ -140,7 +140,7 @@ data class KaivuilmoitusEntityData(
             workDescription = workDescription,
             startTime = startTime,
             endTime = endTime,
-            areas = areas?.flatMap { it.toJohtoselvitysHakemusalues() },
+            areas = areas?.flatMap { it.geometries() }?.map { JohtoselvitysHakemusalue("", it) },
         )
 }
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusEntityData.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusEntityData.kt
@@ -126,6 +126,23 @@ data class KaivuilmoitusEntityData(
             invoicingCustomer = invoicingCustomer.toLaskutusyhteystieto(customerReference),
             additionalInfo = additionalInfo,
         )
+
+    fun toJohtoselvityshakemusEntityData(): JohtoselvityshakemusEntityData =
+        JohtoselvityshakemusEntityData(
+            applicationType = ApplicationType.CABLE_REPORT,
+            pendingOnClient = pendingOnClient,
+            name = name,
+            postalAddress = areas.toPostalAddress(),
+            constructionWork = constructionWork,
+            maintenanceWork = maintenanceWork,
+            propertyConnectivity = false,
+            emergencyWork = emergencyWork,
+            rockExcavation = rockExcavation,
+            workDescription = workDescription,
+            startTime = startTime,
+            endTime = endTime,
+            areas = areas?.flatMap { it.toJohtoselvitysHakemusalues() },
+        )
 }
 
 fun InvoicingCustomer?.toLaskutusyhteystieto(customerReference: String?): Laskutusyhteystieto? =

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
@@ -215,9 +215,7 @@ class HakemusService(
                 hakemusEntityData.copy(
                     cableReports =
                         hakemusEntityData.cableReports?.plus(
-                            sentJohtoselvityshakemus.applicationIdentifier!!
-                        )
-                )
+                            sentJohtoselvityshakemus.applicationIdentifier!!))
         }
 
         logger.info("Sending hakemus id=$id")
@@ -268,8 +266,7 @@ class HakemusService(
         val savedJohtoselvityshakemus = hakemusRepository.save(johtoselvityshakemus)
         copyOtherAttachments(hakemus, savedJohtoselvityshakemus)
         logger.info(
-            "Created a new johtoselvityshakemus (${savedJohtoselvityshakemus.id}) for a kaivuilmoitus (${hakemus.id})"
-        )
+            "Created a new johtoselvityshakemus (${savedJohtoselvityshakemus.id}) for a kaivuilmoitus (${hakemus.id})")
         return savedJohtoselvityshakemus
     }
 
@@ -292,8 +289,7 @@ class HakemusService(
                     content.bytes,
                     metadata.fileName,
                     MediaType.parseMediaType(metadata.contentType),
-                    ApplicationAttachmentType.MUU
-                )
+                    ApplicationAttachmentType.MUU)
             }
     }
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
@@ -249,7 +249,8 @@ class HakemusService(
             return null
         }
         logger.info("Creating a new johtoselvityshakemus for a kaivuilmoitus. id=${hakemus.id}")
-        val johtoselvityshakemusData = hakemusEntityData.toJohtoselvityshakemusEntityData()
+        val johtoselvityshakemusData =
+            hakemusEntityData.createAccompanyingJohtoselvityshakemusData()
         val johtoselvityshakemus =
             hakemus
                 .copy(

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
@@ -16,6 +16,7 @@ import fi.hel.haitaton.hanke.allu.ApplicationStatusEvent
 import fi.hel.haitaton.hanke.allu.Attachment
 import fi.hel.haitaton.hanke.allu.AttachmentMetadata
 import fi.hel.haitaton.hanke.attachment.application.ApplicationAttachmentService
+import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType
 import fi.hel.haitaton.hanke.email.ApplicationNotificationData
 import fi.hel.haitaton.hanke.email.EmailSenderService
 import fi.hel.haitaton.hanke.geometria.GeometriatDao
@@ -182,6 +183,8 @@ class HakemusService(
     fun sendHakemus(id: Long, currentUserId: String): Hakemus {
         val hakemus = getEntityById(id)
 
+        HakemusDataValidator.ensureValidForSend(hakemus.toHakemus().applicationData)
+
         setOrdererOnSend(hakemus, currentUserId)
 
         val hanke = hakemus.hanke
@@ -200,6 +203,23 @@ class HakemusService(
         // The application should no longer be a draft
         hakemus.hakemusEntityData = hakemus.hakemusEntityData.copy(pendingOnClient = false)
 
+        // For excavation announcements, a cable report can be applied for at the same time.
+        // If so, it should be sent before the excavation announcement.
+        val newJohtoselvityshakemus = newJohtoselvitysAppliedFor(hakemus)
+        if (newJohtoselvityshakemus != null) {
+            val sentJohtoselvityshakemus = sendHakemus(newJohtoselvityshakemus.id, currentUserId)
+            // add the application identifier of the cable report to the list of cable reports in
+            // the excavation announcement
+            val hakemusEntityData = hakemus.hakemusEntityData as KaivuilmoitusEntityData
+            hakemus.hakemusEntityData =
+                hakemusEntityData.copy(
+                    cableReports =
+                        hakemusEntityData.cableReports?.plus(
+                            sentJohtoselvityshakemus.applicationIdentifier!!
+                        )
+                )
+        }
+
         logger.info("Sending hakemus id=$id")
         hakemus.alluid = createApplicationInAllu(hakemus.toHakemus())
 
@@ -212,6 +232,69 @@ class HakemusService(
         logger.info("Sent hakemus. ${hakemus.logString()}, alluStatus = ${hakemus.alluStatus}")
         // Save only if sendApplicationToAllu didn't throw an exception
         return hakemusRepository.save(hakemus).toHakemus()
+    }
+
+    /**
+     * Create a new cable report application for an excavation announcement that has a cable report
+     * applied for.
+     *
+     * @return the new cable report application entity or null if no new application was applied for
+     */
+    private fun newJohtoselvitysAppliedFor(hakemus: HakemusEntity): HakemusEntity? {
+        val hakemusEntityData = hakemus.hakemusEntityData
+        val appliedFor =
+            when (hakemusEntityData) {
+                is KaivuilmoitusEntityData -> !hakemusEntityData.cableReportDone
+                else -> return null
+            }
+        if (!appliedFor) {
+            return null
+        }
+        logger.info("Creating a new johtoselvityshakemus for a kaivuilmoitus. id=${hakemus.id}")
+        val johtoselvityshakemusData = hakemusEntityData.toJohtoselvityshakemusEntityData()
+        val johtoselvityshakemus =
+            hakemus
+                .copy(
+                    id = 0,
+                    applicationType = ApplicationType.CABLE_REPORT,
+                    hakemusEntityData = johtoselvityshakemusData,
+                )
+                .apply {
+                    yhteystiedot =
+                        hakemus.yhteystiedot
+                            .mapValues { it.value.copyToHakemus(this) }
+                            .toMutableMap()
+                }
+        val savedJohtoselvityshakemus = hakemusRepository.save(johtoselvityshakemus)
+        copyOtherAttachments(hakemus, savedJohtoselvityshakemus)
+        logger.info(
+            "Created a new johtoselvityshakemus (${savedJohtoselvityshakemus.id}) for a kaivuilmoitus (${hakemus.id})"
+        )
+        return savedJohtoselvityshakemus
+    }
+
+    /**
+     * Copy other attachments from excavation announcement to cable report application. This is used
+     * when a cable report is applied for at the same time as an excavation announcement is sent.
+     */
+    private fun copyOtherAttachments(
+        kaivuilmoitus: HakemusEntity,
+        johtoselvityshakemus: HakemusEntity
+    ) {
+        val johtoselvityshakemusMetadata = johtoselvityshakemus.toMetadata()
+        attachmentService
+            .getMetadataList(kaivuilmoitus.id)
+            .filter { it.attachmentType == ApplicationAttachmentType.MUU }
+            .forEach { metadata ->
+                val content = attachmentService.getContent(metadata.id)
+                attachmentService.saveAttachment(
+                    johtoselvityshakemusMetadata,
+                    content.bytes,
+                    metadata.fileName,
+                    MediaType.parseMediaType(metadata.contentType),
+                    ApplicationAttachmentType.MUU
+                )
+            }
     }
 
     /**
@@ -456,7 +539,6 @@ class HakemusService(
 
     /** Creates new application in Allu. All attachments are sent after creation. */
     private fun createApplicationInAllu(hakemus: Hakemus): Int {
-        HakemusDataValidator.ensureValidForSend(hakemus.applicationData)
         val alluId =
             createApplicationToAllu(hakemus.id, hakemus.hankeTunnus, hakemus.applicationData)
         try {

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusUpdateRequest.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusUpdateRequest.kt
@@ -13,12 +13,10 @@ import java.util.UUID
     use = JsonTypeInfo.Id.NAME,
     include = JsonTypeInfo.As.EXISTING_PROPERTY,
     property = "applicationType",
-    visible = true
-)
+    visible = true)
 @JsonSubTypes(
     JsonSubTypes.Type(value = JohtoselvityshakemusUpdateRequest::class, name = "CABLE_REPORT"),
-    JsonSubTypes.Type(value = KaivuilmoitusUpdateRequest::class, name = "EXCAVATION_NOTIFICATION")
-)
+    JsonSubTypes.Type(value = KaivuilmoitusUpdateRequest::class, name = "EXCAVATION_NOTIFICATION"))
 @JsonInclude(JsonInclude.Include.NON_NULL)
 sealed interface HakemusUpdateRequest {
     val applicationType: ApplicationType
@@ -103,17 +101,13 @@ data class JohtoselvityshakemusUpdateRequest(
             endTime != applicationData.endTime ||
             areas != applicationData.areas ||
             customerWithContacts.hasChanges(
-                hakemusEntity.yhteystiedot[ApplicationContactType.HAKIJA]
-            ) ||
+                hakemusEntity.yhteystiedot[ApplicationContactType.HAKIJA]) ||
             contractorWithContacts.hasChanges(
-                hakemusEntity.yhteystiedot[ApplicationContactType.TYON_SUORITTAJA]
-            ) ||
+                hakemusEntity.yhteystiedot[ApplicationContactType.TYON_SUORITTAJA]) ||
             propertyDeveloperWithContacts.hasChanges(
-                hakemusEntity.yhteystiedot[ApplicationContactType.RAKENNUTTAJA]
-            ) ||
+                hakemusEntity.yhteystiedot[ApplicationContactType.RAKENNUTTAJA]) ||
             representativeWithContacts.hasChanges(
-                hakemusEntity.yhteystiedot[ApplicationContactType.ASIANHOITAJA]
-            )
+                hakemusEntity.yhteystiedot[ApplicationContactType.ASIANHOITAJA])
     }
 
     override fun toEntityData(baseData: HakemusEntityData) =
@@ -209,21 +203,15 @@ data class KaivuilmoitusUpdateRequest(
             endTime != applicationData.endTime ||
             areas != applicationData.areas ||
             customerWithContacts.hasChanges(
-                hakemusEntity.yhteystiedot[ApplicationContactType.HAKIJA]
-            ) ||
+                hakemusEntity.yhteystiedot[ApplicationContactType.HAKIJA]) ||
             contractorWithContacts.hasChanges(
-                hakemusEntity.yhteystiedot[ApplicationContactType.TYON_SUORITTAJA]
-            ) ||
+                hakemusEntity.yhteystiedot[ApplicationContactType.TYON_SUORITTAJA]) ||
             propertyDeveloperWithContacts.hasChanges(
-                hakemusEntity.yhteystiedot[ApplicationContactType.RAKENNUTTAJA]
-            ) ||
+                hakemusEntity.yhteystiedot[ApplicationContactType.RAKENNUTTAJA]) ||
             representativeWithContacts.hasChanges(
-                hakemusEntity.yhteystiedot[ApplicationContactType.ASIANHOITAJA]
-            ) ||
+                hakemusEntity.yhteystiedot[ApplicationContactType.ASIANHOITAJA]) ||
             invoicingCustomer.hasChanges(
-                applicationData.invoicingCustomer,
-                applicationData.customerReference
-            ) ||
+                applicationData.invoicingCustomer, applicationData.customerReference) ||
             additionalInfo != applicationData.additionalInfo
     }
 
@@ -374,7 +362,7 @@ fun InvoicingCustomerRequest?.toCustomer(): InvoicingCustomer? =
         InvoicingCustomer(
             type = it.type,
             name = it.name ?: "",
-            postalAddress = it.postalAddress?.toPostalAddress(),
+            postalAddress = it.postalAddress?.combinedAddress(),
             email = it.email,
             phone = it.phone,
             registryKey = it.registryKey,
@@ -383,7 +371,7 @@ fun InvoicingCustomerRequest?.toCustomer(): InvoicingCustomer? =
         )
     }
 
-fun InvoicingPostalAddressRequest?.toPostalAddress(): PostalAddress? =
+fun InvoicingPostalAddressRequest?.combinedAddress(): PostalAddress? =
     this?.let {
         PostalAddress(
             streetAddress = StreetAddress(it.streetAddress?.streetName),

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/Hakemusalue.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/Hakemusalue.kt
@@ -34,9 +34,6 @@ data class KaivuilmoitusAlue(
     val lisatiedot: String?,
 ) : Hakemusalue {
     override fun geometries(): List<Polygon> = tyoalueet.map { it.geometry }
-
-    fun toJohtoselvitysHakemusalues(): List<JohtoselvitysHakemusalue> =
-        tyoalueet.map { JohtoselvitysHakemusalue("", it.geometry) }
 }
 
 data class Tyoalue(

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/Hakemusalue.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/Hakemusalue.kt
@@ -42,7 +42,7 @@ data class Tyoalue(
     val tormaystarkasteluTulos: TormaystarkasteluTulos?,
 )
 
-fun List<KaivuilmoitusAlue>?.toPostalAddress(): PostalAddress? =
+fun List<KaivuilmoitusAlue>?.combinedAddress(): PostalAddress? =
     this?.map { it.katuosoite }
         ?.toSet()
         ?.joinToString(", ")

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/Hakemusalue.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/Hakemusalue.kt
@@ -34,6 +34,9 @@ data class KaivuilmoitusAlue(
     val lisatiedot: String?,
 ) : Hakemusalue {
     override fun geometries(): List<Polygon> = tyoalueet.map { it.geometry }
+
+    fun toJohtoselvitysHakemusalues(): List<JohtoselvitysHakemusalue> =
+        tyoalueet.map { JohtoselvitysHakemusalue("", it.geometry) }
 }
 
 data class Tyoalue(
@@ -41,3 +44,10 @@ data class Tyoalue(
     val area: Double,
     val tormaystarkasteluTulos: TormaystarkasteluTulos?,
 )
+
+fun List<KaivuilmoitusAlue>?.toPostalAddress(): PostalAddress? =
+    this?.map { it.katuosoite }
+        ?.toSet()
+        ?.joinToString(", ")
+        ?.let { StreetAddress(it) }
+        ?.let { PostalAddress(it, "", "") }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusyhteystietoEntity.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusyhteystietoEntity.kt
@@ -62,6 +62,18 @@ class HakemusyhteystietoEntity(
                     )
                 }
         )
+
+    fun copyToHakemus(hakemus: HakemusEntity) =
+        HakemusyhteystietoEntity(
+            tyyppi = tyyppi,
+            rooli = rooli,
+            nimi = nimi,
+            sahkoposti = sahkoposti,
+            puhelinnumero = puhelinnumero,
+            ytunnus = ytunnus,
+            application = hakemus,
+            yhteyshenkilot = yhteyshenkilot.map { it.copyToYhteystieto(this) }.toMutableList()
+        )
 }
 
 @Entity
@@ -75,7 +87,14 @@ class HakemusyhteyshenkiloEntity(
     @JoinColumn(name = "hankekayttaja_id")
     var hankekayttaja: HankekayttajaEntity,
     var tilaaja: Boolean
-)
+) {
+    fun copyToYhteystieto(yhteystieto: HakemusyhteystietoEntity) =
+        HakemusyhteyshenkiloEntity(
+            hakemusyhteystieto = yhteystieto,
+            hankekayttaja = hankekayttaja,
+            tilaaja = tilaaja
+        )
+}
 
 interface HakemusyhteystietoRepository : JpaRepository<HakemusyhteystietoEntity, UUID>
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusyhteystietoEntity.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusyhteystietoEntity.kt
@@ -34,8 +34,7 @@ class HakemusyhteystietoEntity(
         fetch = FetchType.LAZY,
         mappedBy = "hakemusyhteystieto",
         cascade = [CascadeType.ALL],
-        orphanRemoval = true
-    )
+        orphanRemoval = true)
     @BatchSize(size = 100)
     val yhteyshenkilot: MutableList<HakemusyhteyshenkiloEntity> = mutableListOf(),
 ) {
@@ -60,8 +59,7 @@ class HakemusyhteystietoEntity(
                         puhelin = yhteyshenkilo.hankekayttaja.puhelin,
                         tilaaja = yhteyshenkilo.tilaaja,
                     )
-                }
-        )
+                })
 
     fun copyToHakemus(hakemus: HakemusEntity) =
         HakemusyhteystietoEntity(
@@ -72,8 +70,7 @@ class HakemusyhteystietoEntity(
             puhelinnumero = puhelinnumero,
             ytunnus = ytunnus,
             application = hakemus,
-            yhteyshenkilot = yhteyshenkilot.map { it.copyToYhteystieto(this) }.toMutableList()
-        )
+            yhteyshenkilot = yhteyshenkilot.map { it.copyToYhteystieto(this) }.toMutableList())
 }
 
 @Entity
@@ -90,10 +87,7 @@ class HakemusyhteyshenkiloEntity(
 ) {
     fun copyToYhteystieto(yhteystieto: HakemusyhteystietoEntity) =
         HakemusyhteyshenkiloEntity(
-            hakemusyhteystieto = yhteystieto,
-            hankekayttaja = hankekayttaja,
-            tilaaja = tilaaja
-        )
+            hakemusyhteystieto = yhteystieto, hankekayttaja = hankekayttaja, tilaaja = tilaaja)
 }
 
 interface HakemusyhteystietoRepository : JpaRepository<HakemusyhteystietoEntity, UUID>

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusyhteystietoEntity.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusyhteystietoEntity.kt
@@ -61,16 +61,19 @@ class HakemusyhteystietoEntity(
                     )
                 })
 
-    fun copyToHakemus(hakemus: HakemusEntity) =
+    fun copyWithHakemus(hakemus: HakemusEntity) =
         HakemusyhteystietoEntity(
-            tyyppi = tyyppi,
-            rooli = rooli,
-            nimi = nimi,
-            sahkoposti = sahkoposti,
-            puhelinnumero = puhelinnumero,
-            ytunnus = ytunnus,
-            application = hakemus,
-            yhteyshenkilot = yhteyshenkilot.map { it.copyToYhteystieto(this) }.toMutableList())
+                tyyppi = tyyppi,
+                rooli = rooli,
+                nimi = nimi,
+                sahkoposti = sahkoposti,
+                puhelinnumero = puhelinnumero,
+                ytunnus = ytunnus,
+                application = hakemus)
+            .also { newEntity ->
+                newEntity.yhteyshenkilot.addAll(
+                    yhteyshenkilot.map { it.copyWithYhteystieto(newEntity) })
+            }
 }
 
 @Entity
@@ -85,7 +88,7 @@ class HakemusyhteyshenkiloEntity(
     var hankekayttaja: HankekayttajaEntity,
     var tilaaja: Boolean
 ) {
-    fun copyToYhteystieto(yhteystieto: HakemusyhteystietoEntity) =
+    fun copyWithYhteystieto(yhteystieto: HakemusyhteystietoEntity) =
         HakemusyhteyshenkiloEntity(
             hakemusyhteystieto = yhteystieto, hankekayttaja = hankekayttaja, tilaaja = tilaaja)
 }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/AlluFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/AlluFactory.kt
@@ -32,8 +32,7 @@ object AlluFactory {
             kindsWithSpecifiers = mapOf(),
             terms = null,
             customerReference = null,
-            surveyRequired = false
-        )
+            surveyRequired = false)
 
     fun createAttachmentMetadata(
         id: Int? = null,
@@ -77,20 +76,17 @@ object AlluFactory {
             registryKey = "101010-FAKE",
             ovt = null,
             invoicingOperator = null,
-            sapCustomerNumber = null
-        )
+            sapCustomerNumber = null)
     val hannu =
         Contact(
             name = "Hannu Haitaton",
             email = "hannu@haitaton.fi",
             phone = "042-555-5216",
-            orderer = true
-        )
+            orderer = true)
     val kerttu =
         Contact(
             name = "Kerttu Haitaton",
             email = "kerttu@haitaton.fi",
             phone = "042-555-2182",
-            orderer = false
-        )
+            orderer = false)
 }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/AlluFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/AlluFactory.kt
@@ -17,13 +17,14 @@ object AlluFactory {
         id: Int = 42,
         status: ApplicationStatus = ApplicationStatus.PENDING,
         name: String = ApplicationFactory.DEFAULT_APPLICATION_NAME,
+        applicationId: String = ApplicationFactory.DEFAULT_CABLE_REPORT_APPLICATION_IDENTIFIER,
         startTime: ZonedDateTime = DateFactory.getStartDatetime(),
         endTime: ZonedDateTime = DateFactory.getEndDatetime(),
     ) =
         AlluApplicationResponse(
             id = id,
             name = name,
-            applicationId = ApplicationFactory.DEFAULT_APPLICATION_IDENTIFIER,
+            applicationId = applicationId,
             status = status,
             startTime = startTime,
             endTime = endTime,

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/ApplicationFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/ApplicationFactory.kt
@@ -120,11 +120,7 @@ class ApplicationFactory(
             area: Double = 100.0,
             tormaystarkasteluTulos: TormaystarkasteluTulos =
                 TormaystarkasteluTulos(
-                    TORMAYSTARKASTELU_DEFAULT_AUTOLIIKENNELUOKITTELU,
-                    3.0f,
-                    5.0f,
-                    5.0f
-                ),
+                    TORMAYSTARKASTELU_DEFAULT_AUTOLIIKENNELUOKITTELU, 3.0f, 5.0f, 5.0f),
         ) = Tyoalue(geometry, area, tormaystarkasteluTulos)
 
         fun createBlankApplicationData(applicationType: ApplicationType): HakemusEntityData =
@@ -164,8 +160,7 @@ class ApplicationFactory(
                 pendingOnClient = false,
                 workDescription = "",
                 rockExcavation = false,
-                postalAddress = PostalAddress(StreetAddress(""), "", "")
-            )
+                postalAddress = PostalAddress(StreetAddress(""), "", ""))
 
         fun createExcavationNotificationData(
             pendingOnClient: Boolean = false,
@@ -212,8 +207,7 @@ class ApplicationFactory(
                 areas = null,
                 startTime = null,
                 endTime = null,
-                additionalInfo = null
-            )
+                additionalInfo = null)
 
         fun createApplicationEntity(
             id: Long = 3,

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/ApplicationFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/ApplicationFactory.kt
@@ -37,7 +37,8 @@ class ApplicationFactory(
     companion object {
         const val DEFAULT_APPLICATION_ID: Long = 1
         const val DEFAULT_APPLICATION_NAME: String = "Hakemuksen oletusnimi"
-        const val DEFAULT_APPLICATION_IDENTIFIER: String = "JS230014"
+        const val DEFAULT_CABLE_REPORT_APPLICATION_IDENTIFIER: String = "JS2300014"
+        const val DEFAULT_EXCAVATION_ANNOUNCEMENT_IDENTIFIER: String = "KP2300015"
         const val DEFAULT_WORK_DESCRIPTION: String = "Työn kuvaus."
         const val TEPPO = "Teppo"
         const val TESTIHENKILO = "Testihenkilö"

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/ApplicationFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/ApplicationFactory.kt
@@ -38,7 +38,7 @@ class ApplicationFactory(
         const val DEFAULT_APPLICATION_ID: Long = 1
         const val DEFAULT_APPLICATION_NAME: String = "Hakemuksen oletusnimi"
         const val DEFAULT_CABLE_REPORT_APPLICATION_IDENTIFIER: String = "JS2300014"
-        const val DEFAULT_EXCAVATION_ANNOUNCEMENT_IDENTIFIER: String = "KP2300015"
+        const val DEFAULT_EXCAVATION_NOTIFICATION_IDENTIFIER: String = "KP2300015"
         const val DEFAULT_WORK_DESCRIPTION: String = "Työn kuvaus."
         const val TEPPO = "Teppo"
         const val TESTIHENKILO = "Testihenkilö"

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusBuilder.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusBuilder.kt
@@ -129,6 +129,18 @@ data class HakemusBuilder(
             { copy(endTime = time) },
         )
 
+    fun withoutCableReports() =
+        updateApplicationData(
+            { throw InvalidParameterException("Not available for cable reports.") },
+            { copy(cableReportDone = false, cableReports = null) },
+        )
+
+    fun withCableReports(cableReports: List<String>) =
+        updateApplicationData(
+            { throw InvalidParameterException("Not available for cable reports.") },
+            { copy(cableReportDone = true, cableReports = cableReports) },
+        )
+
     fun withRockExcavation(rockExcavation: Boolean?) =
         updateApplicationData(
             { copy(rockExcavation = rockExcavation) },
@@ -192,7 +204,9 @@ data class HakemusBuilder(
                     .withStartTime()
                     .withEndTime()
                     .withArea(hankealue?.id)
-                    .withRockExcavation(false)
+                    .withCableReports(
+                        listOf(ApplicationFactory.DEFAULT_CABLE_REPORT_APPLICATION_IDENTIFIER)
+                    )
                     .withWorkInvolves()
                     .withRequiredCompetence()
                     .hakija()

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusBuilder.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusBuilder.kt
@@ -111,9 +111,7 @@ data class HakemusBuilder(
                 copy(
                     areas =
                         (areas ?: listOf()).plus(
-                            createExcavationNotificationArea(hankealueId = hankealueId ?: 0)
-                        )
-                )
+                            createExcavationNotificationArea(hankealueId = hankealueId ?: 0)))
             },
         )
 
@@ -205,8 +203,7 @@ data class HakemusBuilder(
                     .withEndTime()
                     .withArea(hankealue?.id)
                     .withCableReports(
-                        listOf(ApplicationFactory.DEFAULT_CABLE_REPORT_APPLICATION_IDENTIFIER)
-                    )
+                        listOf(ApplicationFactory.DEFAULT_CABLE_REPORT_APPLICATION_IDENTIFIER))
                     .withWorkInvolves()
                     .withRequiredCompetence()
                     .hakija()
@@ -376,8 +373,5 @@ data class HakemusBuilder(
         tilaaja: Boolean = false
     ) =
         HakemusyhteyshenkiloEntity(
-            hankekayttaja = kayttaja,
-            hakemusyhteystieto = yhteystietoEntity,
-            tilaaja = tilaaja
-        )
+            hankekayttaja = kayttaja, hakemusyhteystieto = yhteystietoEntity, tilaaja = tilaaja)
 }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceTest.kt
@@ -338,7 +338,6 @@ class HakemusServiceTest {
             val applicationEntity = applicationEntity()
             applicationEntity.hakemusEntityData = hakemusEntityData
             every { hakemusRepository.findOneById(3) } returns applicationEntity
-            every { geometriatDao.isInsideHankeAlueet(1, any()) } returns true
 
             assertFailure { hakemusService.sendHakemus(3, USERNAME) }
                 .all {
@@ -346,10 +345,7 @@ class HakemusServiceTest {
                     hasMessage("Application contains invalid data. Errors at paths: $path")
                 }
 
-            verifySequence {
-                hakemusRepository.findOneById(3)
-                geometriatDao.isInsideHankeAlueet(1, any())
-            }
+            verifySequence { hakemusRepository.findOneById(3) }
         }
 
         @Test
@@ -357,7 +353,6 @@ class HakemusServiceTest {
             val applicationEntity = applicationEntity()
             applicationEntity.yhteystiedot[ApplicationContactType.HAKIJA]!!.nimi = ""
             every { hakemusRepository.findOneById(3) } returns applicationEntity
-            every { geometriatDao.isInsideHankeAlueet(1, any()) } returns true
 
             assertFailure { hakemusService.sendHakemus(3, USERNAME) }
                 .all {
@@ -366,10 +361,7 @@ class HakemusServiceTest {
                         "Application contains invalid data. Errors at paths: applicationData.customerWithContacts.nimi")
                 }
 
-            verifySequence {
-                hakemusRepository.findOneById(3)
-                geometriatDao.isInsideHankeAlueet(1, any())
-            }
+            verifySequence { hakemusRepository.findOneById(3) }
         }
 
         @Test
@@ -380,7 +372,6 @@ class HakemusServiceTest {
             hankekayttaja.etunimi = ""
             hankekayttaja.sukunimi = ""
             every { hakemusRepository.findOneById(3) } returns applicationEntity
-            every { geometriatDao.isInsideHankeAlueet(1, any()) } returns true
 
             assertFailure { hakemusService.sendHakemus(3, USERNAME) }
                 .all {
@@ -390,10 +381,7 @@ class HakemusServiceTest {
                             "applicationData.contractorWithContacts.yhteyshenkilot[0].etunimi")
                 }
 
-            verifySequence {
-                hakemusRepository.findOneById(3)
-                geometriatDao.isInsideHankeAlueet(1, any())
-            }
+            verifySequence { hakemusRepository.findOneById(3) }
         }
 
         @Test
@@ -405,7 +393,6 @@ class HakemusServiceTest {
                     .withYhteyshenkilo(
                         permission = PermissionFactory.createEntity(userId = USERNAME))
             every { hakemusRepository.findOneById(3) } returns applicationEntity
-            every { geometriatDao.isInsideHankeAlueet(1, any()) } returns true
 
             assertFailure { hakemusService.sendHakemus(3, USERNAME) }
                 .all {
@@ -415,10 +402,7 @@ class HakemusServiceTest {
                             "applicationData.propertyDeveloperWithContacts.sahkoposti")
                 }
 
-            verifySequence {
-                hakemusRepository.findOneById(3)
-                geometriatDao.isInsideHankeAlueet(1, any())
-            }
+            verifySequence { hakemusRepository.findOneById(3) }
         }
 
         @Test
@@ -430,7 +414,6 @@ class HakemusServiceTest {
                     .withYhteyshenkilo(
                         permission = PermissionFactory.createEntity(userId = USERNAME))
             every { hakemusRepository.findOneById(3) } returns applicationEntity
-            every { geometriatDao.isInsideHankeAlueet(1, any()) } returns true
 
             assertFailure { hakemusService.sendHakemus(3, USERNAME) }
                 .all {
@@ -440,10 +423,7 @@ class HakemusServiceTest {
                             "applicationData.representativeWithContacts.puhelinnumero")
                 }
 
-            verifySequence {
-                hakemusRepository.findOneById(3)
-                geometriatDao.isInsideHankeAlueet(1, any())
-            }
+            verifySequence { hakemusRepository.findOneById(3) }
         }
 
         private fun applicationEntity(): HakemusEntity {


### PR DESCRIPTION
# Description

If the user chooses to create a new johtoselvityshakemus in kaivuilmoitus, it is created and sent to Allu before kaivuilmoitus is sent.
Changes include:
* Application data is validated at the beginning of the send process - before it was done later in the process
* In data-mapping there is no need to throw an exception if there is no address (there is no areas with address) because the address is not mandatory in Allu and the existence of areas is validated when they are mapped
* It is possible to create a johtoselvityshakemus from kaivuilmoitus with `KaivuilmoitusEntityData.toJohtoselvityshakemusEntityData()`
* There is a "shortcut" for saving attachments without running all the validations on it. This is more suitable for this use case when an existing attachment is copied from one application to another.
* `ApplicationFactory.DEFAULT_APPLICATION_IDENTIFIER` is renamed as `DEFAULT_CABLE_REPORT_APPLICATION_IDENTIFIER` (also fixed its format to be valid) and added `DEFAULT_EXCAVATION_ANNOUNCEMENT_IDENTIFIER` alongside it

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2398

## Type of change

- [ ] Bug fix 
- [x] New feature 
- [ ] Other

# Instructions for testing
* Use the latest dev version of UI
* Create a new kaivuilmoitus, fill it and choose to create a new johtoselvitys on the first page of the form. Add some other ("Muut liitteet") attachment. NOTICE: the validation of "Laskutustiedot" is not yet fully working for private persons so please choose a company with a valid y-tunnus and valid ovt.
* Send the application
* In Haitaton:
    * kaivuilmoitus should have status "Odottaa käsittelyä" and it should have the new johtoselvityshakemus included in its list of "Tehtyjen johtoselvitysten tunnukset".
    * a new johtoselvityshakemus is created for the same hanke. It should have the same data (basic information, areas, contacts, the other attachments) as the kaivuilmoitus. It should also have status "Odottaa käsittelyä".
* In Allu:
    * there should be both applications with the proper data and attachments

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 

# Other relevant info
Please describe here if there is e.g. some requirements for this change or
 other info that the tester/user needs to know.