### PR TITLE
HAI-2568 API for serving banner texts

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/IntegrationTestConfiguration.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/IntegrationTestConfiguration.kt
@@ -5,6 +5,7 @@ import fi.hel.haitaton.hanke.attachment.application.ApplicationAttachmentService
 import fi.hel.haitaton.hanke.attachment.hanke.HankeAttachmentAuthorizer
 import fi.hel.haitaton.hanke.attachment.hanke.HankeAttachmentMetadataService
 import fi.hel.haitaton.hanke.attachment.hanke.HankeAttachmentService
+import fi.hel.haitaton.hanke.banners.BannerService
 import fi.hel.haitaton.hanke.configuration.FeatureFlags
 import fi.hel.haitaton.hanke.configuration.FeatureService
 import fi.hel.haitaton.hanke.gdpr.GdprProperties
@@ -44,23 +45,19 @@ import org.springframework.security.web.SecurityFilterChain
 @EnableMethodSecurity(prePostEnabled = true)
 class IntegrationTestConfiguration {
 
-    @Bean fun jdbcOperations(): JdbcOperations = mockk()
+    @Bean fun applicationAttachmentMetadataService(): ApplicationAttachmentMetadataService = mockk()
 
-    @Bean fun hankeRepository(): HankeRepository = mockk()
+    @Bean fun applicationAttachmentService(): ApplicationAttachmentService = mockk()
 
     @Bean fun auditLogRepository(): AuditLogRepository = mockk()
 
-    @Bean fun hanketunnusService(): HanketunnusService = mockk()
+    @Bean fun bannerService(): BannerService = mockk()
 
-    @Bean fun hankeService(): HankeService = mockk()
+    @Bean fun disclosureLogService(): DisclosureLogService = mockk(relaxUnitFun = true)
 
-    @Bean fun hakemusService(): HakemusService = mockk()
+    @Bean fun featureService(featureFlags: FeatureFlags) = FeatureService(featureFlags)
 
     @Bean fun gdprService(): GdprService = mockk(relaxUnitFun = true)
-
-    @Bean fun testDataService(): TestDataService = mockk(relaxUnitFun = true)
-
-    @Bean fun permissionService(): PermissionService = mockk()
 
     @Bean fun geometriatDao(jdbcOperations: JdbcOperations): GeometriatDao = mockk()
 
@@ -68,36 +65,42 @@ class IntegrationTestConfiguration {
     fun geometriatService(service: HankeService, geometriatDao: GeometriatDao): GeometriatService =
         mockk()
 
+    @Bean fun hakemusAuthorizer(): HakemusAuthorizer = mockk(relaxUnitFun = true)
+
+    @Bean fun hakemusService(): HakemusService = mockk()
+
+    @Bean fun hankeAttachmentAuthorizer(): HankeAttachmentAuthorizer = mockk(relaxUnitFun = true)
+
+    @Bean fun hankeAttachmentMetadataService(): HankeAttachmentMetadataService = mockk()
+
+    @Bean fun hankeAttachmentService(): HankeAttachmentService = mockk()
+
+    @Bean fun hankeAuthorizer(): HankeAuthorizer = mockk(relaxUnitFun = true)
+
+    @Bean fun hankeKayttajaAuthorizer(): HankeKayttajaAuthorizer = mockk(relaxUnitFun = true)
+
+    @Bean fun hankekayttajaDeleteService(): HankekayttajaDeleteService = mockk()
+
+    @Bean fun hankeKayttajaService(): HankeKayttajaService = mockk()
+
+    @Bean fun hankeRepository(): HankeRepository = mockk()
+
+    @Bean fun hankeService(): HankeService = mockk()
+
+    @Bean fun hanketunnusService(): HanketunnusService = mockk()
+
+    @Bean fun jdbcOperations(): JdbcOperations = mockk()
+
+    @Bean fun permissionService(): PermissionService = mockk()
+
+    @Bean fun profiiliClient(): ProfiiliClient = mockk()
+
+    @Bean fun testDataService(): TestDataService = mockk(relaxUnitFun = true)
+
     @Bean
     fun tormaysService(jdbcOperations: JdbcOperations): TormaystarkasteluTormaysService = mockk()
 
     @Bean fun tormaystarkasteluLaskentaService(): TormaystarkasteluLaskentaService = mockk()
-
-    @Bean fun disclosureLogService(): DisclosureLogService = mockk(relaxUnitFun = true)
-
-    @Bean fun hankeAttachmentService(): HankeAttachmentService = mockk()
-
-    @Bean fun hankeAttachmentMetadataService(): HankeAttachmentMetadataService = mockk()
-
-    @Bean fun applicationAttachmentMetadataService(): ApplicationAttachmentMetadataService = mockk()
-
-    @Bean fun applicationAttachmentService(): ApplicationAttachmentService = mockk()
-
-    @Bean fun hankeKayttajaService(): HankeKayttajaService = mockk()
-
-    @Bean fun hankekayttajaDeleteService(): HankekayttajaDeleteService = mockk()
-
-    @Bean fun hankeKayttajaAuthorizer(): HankeKayttajaAuthorizer = mockk(relaxUnitFun = true)
-
-    @Bean fun hankeAuthorizer(): HankeAuthorizer = mockk(relaxUnitFun = true)
-
-    @Bean fun hakemusAuthorizer(): HakemusAuthorizer = mockk(relaxUnitFun = true)
-
-    @Bean fun hankeAttachmentAuthorizer(): HankeAttachmentAuthorizer = mockk(relaxUnitFun = true)
-
-    @Bean fun featureService(featureFlags: FeatureFlags) = FeatureService(featureFlags)
-
-    @Bean fun profiiliClient(): ProfiiliClient = mockk()
 
     @EventListener
     fun onApplicationEvent(event: ContextRefreshedEvent) {

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/banners/BannerControllerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/banners/BannerControllerITest.kt
@@ -1,0 +1,72 @@
+package fi.hel.haitaton.hanke.banners
+
+import fi.hel.haitaton.hanke.ControllerTest
+import fi.hel.haitaton.hanke.IntegrationTestConfiguration
+import io.mockk.checkUnnecessaryStub
+import io.mockk.clearAllMocks
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.verifySequence
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.context.annotation.Import
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+@WebMvcTest(controllers = [BannerController::class])
+@Import(IntegrationTestConfiguration::class)
+@ActiveProfiles("test")
+class BannerControllerITest(@Autowired override val mockMvc: MockMvc) : ControllerTest {
+
+    @Autowired private lateinit var bannerService: BannerService
+
+    @BeforeEach
+    fun clearMocks() {
+        clearAllMocks()
+    }
+
+    @AfterEach
+    fun checkMocks() {
+        checkUnnecessaryStub()
+        confirmVerified(bannerService)
+    }
+
+    @Nested
+    inner class ListBanners {
+        private val url = "/banners"
+
+        @Test
+        fun `returns banners for an anonymous user`() {
+            every { bannerService.listBanners() } returns
+                BannerFactory.createResponseMap(BannerType.INFO)
+
+            get(url)
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.INFO.label.fi").value("Finnish INFO label"))
+                .andExpect(jsonPath("$.INFO.label.sv").value("Swedish INFO label"))
+                .andExpect(jsonPath("$.INFO.label.en").value("English INFO label"))
+                .andExpect(jsonPath("$.INFO.text.fi").value("Finnish INFO body"))
+                .andExpect(jsonPath("$.INFO.text.sv").value("Swedish INFO body"))
+                .andExpect(jsonPath("$.INFO.text.en").value("English INFO body"))
+
+            verifySequence { bannerService.listBanners() }
+        }
+
+        @Test
+        fun `returns empty object when there are no banners`() {
+            every { bannerService.listBanners() } returns mapOf()
+
+            get(url).andExpect(status().isOk).andExpect(content().string("{}"))
+
+            verifySequence { bannerService.listBanners() }
+        }
+    }
+}

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/banners/BannerFactory.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/banners/BannerFactory.kt
@@ -1,0 +1,25 @@
+package fi.hel.haitaton.hanke.banners
+
+object BannerFactory {
+    fun createEntity(type: BannerType): BannerEntity =
+        BannerEntity(
+            type,
+            "Finnish $type body",
+            "Swedish $type body",
+            "English $type body",
+            "Finnish $type label",
+            "Swedish $type label",
+            "English $type label",
+        )
+
+    fun createResponseMap(vararg types: BannerType): BannersResponse =
+        types.associateWith { createResponse(it) }
+
+    fun createResponse(type: BannerType): BannerResponse {
+        val entity = createEntity(type)
+        return BannerResponse(
+            label = LocalizedText(entity.labelFi, entity.labelSv, entity.labelEn),
+            text = LocalizedText(entity.textFi, entity.textSv, entity.textEn),
+        )
+    }
+}

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/banners/BannerServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/banners/BannerServiceITest.kt
@@ -1,0 +1,65 @@
+package fi.hel.haitaton.hanke.banners
+
+import assertk.all
+import assertk.assertThat
+import assertk.assertions.containsOnly
+import assertk.assertions.isEmpty
+import assertk.assertions.isEqualTo
+import assertk.assertions.key
+import assertk.assertions.prop
+import fi.hel.haitaton.hanke.IntegrationTest
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+
+class BannerServiceITest(
+    @Autowired private val bannerService: BannerService,
+    @Autowired private val bannerRepository: BannerRepository,
+) : IntegrationTest() {
+
+    @Nested
+    inner class ListBanners {
+        @Test
+        fun `returns empty map when there are no banners`() {
+            val result = bannerService.listBanners()
+
+            assertThat(result).isEmpty()
+        }
+
+        @Test
+        fun `returns banners when there are some`() {
+            bannerRepository.saveAll(
+                listOf(
+                    BannerFactory.createEntity(BannerType.INFO),
+                    BannerFactory.createEntity(BannerType.WARNING),
+                    BannerFactory.createEntity(BannerType.ERROR),
+                ))
+
+            val result = bannerService.listBanners()
+
+            assertThat(result)
+                .transform { it.keys }
+                .containsOnly(BannerType.INFO, BannerType.WARNING, BannerType.ERROR)
+        }
+
+        @Test
+        fun `returns the correct texts`() {
+            bannerRepository.save(BannerFactory.createEntity(BannerType.WARNING))
+
+            val result = bannerService.listBanners()
+
+            assertThat(result).key(BannerType.WARNING).all {
+                prop(BannerResponse::label).all {
+                    prop(LocalizedText::fi).isEqualTo("Finnish WARNING label")
+                    prop(LocalizedText::sv).isEqualTo("Swedish WARNING label")
+                    prop(LocalizedText::en).isEqualTo("English WARNING label")
+                }
+                prop(BannerResponse::text).all {
+                    prop(LocalizedText::fi).isEqualTo("Finnish WARNING body")
+                    prop(LocalizedText::sv).isEqualTo("Swedish WARNING body")
+                    prop(LocalizedText::en).isEqualTo("English WARNING body")
+                }
+            }
+        }
+    }
+}

--- a/services/hanke-service/src/integrationTest/resources/clear-db.sql
+++ b/services/hanke-service/src/integrationTest/resources/clear-db.sql
@@ -7,16 +7,17 @@ TRUNCATE TABLE
     hakemusyhteystieto,
     hanke,
     hanke_attachment,
-    hankekayttaja,
     hankealue,
     hankegeometria,
+    hankekayttaja,
     hanketyomaatyyppi,
     hankeyhteyshenkilo,
     hankeyhteystieto,
+    hankkeen_haittojenhallintasuunnitelma,
     int_lock,
     kayttajakutsu,
     paatos,
     permissions,
     tormaystarkastelutulos,
-    hankkeen_haittojenhallintasuunnitelma;
+    ui_notification_banner;
 UPDATE allu_status SET history_last_updated = '2017-01-01T00:00:00Z';

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/banners/BannerController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/banners/BannerController.kt
@@ -1,0 +1,24 @@
+package fi.hel.haitaton.hanke.banners
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/banners")
+class BannerController(private val bannerService: BannerService) {
+    @GetMapping
+    @Operation(
+        summary = "Get current notification banners",
+        description = "Get a list of banners the UI should display to the users.",
+    )
+    @ApiResponses(
+        value =
+            [
+                ApiResponse(description = "Success", responseCode = "200"),
+                ApiResponse(description = "Internal server error", responseCode = "500")])
+    fun listBanners(): BannersResponse = bannerService.listBanners()
+}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/banners/BannerEntity.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/banners/BannerEntity.kt
@@ -1,0 +1,20 @@
+package fi.hel.haitaton.hanke.banners
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "ui_notification_banner")
+class BannerEntity(
+    @Enumerated(EnumType.STRING) @Id val id: BannerType,
+    @Column(name = "text_fi") val textFi: String,
+    @Column(name = "text_sv") val textSv: String,
+    @Column(name = "text_en") val textEn: String,
+    @Column(name = "label_fi") val labelFi: String,
+    @Column(name = "label_sv") val labelSv: String,
+    @Column(name = "label_en") val labelEn: String,
+)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/banners/BannerRepository.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/banners/BannerRepository.kt
@@ -1,0 +1,6 @@
+package fi.hel.haitaton.hanke.banners
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository interface BannerRepository : JpaRepository<BannerEntity, BannerType> {}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/banners/BannerService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/banners/BannerService.kt
@@ -1,0 +1,18 @@
+package fi.hel.haitaton.hanke.banners
+
+import org.springframework.stereotype.Service
+
+@Service
+class BannerService(private val bannerRepository: BannerRepository) {
+
+    fun listBanners(): BannersResponse =
+        bannerRepository
+            .findAll()
+            .associateBy { it.id }
+            .mapValues { (_, v) ->
+                BannerResponse(
+                    label = LocalizedText(v.labelFi, v.labelSv, v.labelEn),
+                    text = LocalizedText(v.textFi, v.textSv, v.textEn),
+                )
+            }
+}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/banners/BannerType.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/banners/BannerType.kt
@@ -1,0 +1,7 @@
+package fi.hel.haitaton.hanke.banners
+
+enum class BannerType {
+    INFO,
+    WARNING,
+    ERROR,
+}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/banners/BannersResponse.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/banners/BannersResponse.kt
@@ -1,0 +1,14 @@
+package fi.hel.haitaton.hanke.banners
+
+typealias BannersResponse = Map<BannerType, BannerResponse>
+
+data class BannerResponse(
+    val label: LocalizedText,
+    val text: LocalizedText,
+)
+
+data class LocalizedText(
+    val fi: String,
+    val sv: String,
+    val en: String,
+)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/security/AccessRules.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/security/AccessRules.kt
@@ -21,6 +21,7 @@ object AccessRules {
                         "/actuator/health/liveness",
                         "/actuator/health/readiness",
                         "/status",
+                        "/banners",
                         "/public-hankkeet",
                         "/swagger-ui.html",
                         "/swagger-ui/**",

--- a/services/hanke-service/src/main/resources/db/changelog/changesets/080-create-ui-banners-table.sql
+++ b/services/hanke-service/src/main/resources/db/changelog/changesets/080-create-ui-banners-table.sql
@@ -1,0 +1,37 @@
+--liquibase formatted sql
+--changeset Topias Heinonen:080-create-ui-banners-table
+--comment: Add an index to paatos, to make finding decisions by application identifier efficient.
+
+CREATE TABLE ui_notification_banner_types
+(
+    id varchar(255) PRIMARY KEY NOT NULL
+);
+
+INSERT INTO ui_notification_banner_types
+VALUES ('INFO'),
+       ('WARNING'),
+       ('ERROR');
+
+CREATE TABLE ui_notification_banner
+(
+    id       varchar(255) PRIMARY KEY NOT NULL, -- INFO, WARNING or ERROR
+    text_fi  TEXT                     NOT NULL CHECK (text_fi <> ''),
+    text_sv  TEXT                     NOT NULL CHECK (text_sv <> ''),
+    text_en  TEXT                     NOT NULL CHECK (text_en <> ''),
+    label_fi TEXT                     NOT NULL CHECK (label_fi <> ''),
+    label_sv TEXT                     NOT NULL CHECK (label_sv <> ''),
+    label_en TEXT                     NOT NULL CHECK (label_en <> ''),
+    FOREIGN KEY (id) references ui_notification_banner_types (id)
+);
+
+COMMENT ON TABLE ui_notification_banner_types IS 'Enum types for different kinds of notifications.';
+COMMENT ON COLUMN ui_notification_banner_types.id is 'An allowed type for notifications.';
+
+COMMENT ON TABLE ui_notification_banner IS 'Notifications that will be displayed in the UI. Uses more checking than most tables, because the values are meant to be edited directly to the DB for now.';
+COMMENT ON COLUMN ui_notification_banner.id IS 'The type of notification this is. Only one notification per type is allowed.';
+COMMENT ON COLUMN ui_notification_banner.text_fi IS 'Finnish text body';
+COMMENT ON COLUMN ui_notification_banner.text_sv IS 'Swedish text body';
+COMMENT ON COLUMN ui_notification_banner.text_en IS 'English text body';
+COMMENT ON COLUMN ui_notification_banner.label_fi IS 'Finnish label text';
+COMMENT ON COLUMN ui_notification_banner.label_sv IS 'Swedish label text';
+COMMENT ON COLUMN ui_notification_banner.label_en IS 'English label text';

--- a/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -187,3 +187,5 @@ databaseChangeLog:
       file: db/changelog/changesets/078-create-paatos-table.sql
   - include:
       file: db/changelog/changesets/079-add-hakemustunnus-index-to-paatos.sql
+  - include:
+      file: db/changelog/changesets/080-create-ui-banners-table.sql


### PR DESCRIPTION
# Description

Add an API for serving notification banners for the UI. The UI will
fetch and display the banners. At this time, the banners need to be
manually added to the DB.

Also alphabetically sort the integration test configuration and clear-db
script.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2568

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
- Follow the maintenance guide instructions for adding and removing banners.
- Use Swagger UI to see how it affects the API: http://localhost:3001/api/swagger-ui/index.html#/banner-controller/listBanners

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [X] I have made necessary changes to the documentation, link to confluence
 or other location: https://helsinkisolutionoffice.atlassian.net/wiki/spaces/HAI/pages/8297807895/Yll+pito-ohje+maintenance+guide (Under expandable "Uudet ohjeet") 