### PR TITLE
HAI-2620 Add decisions to application response

### DIFF
--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusController.kt
@@ -50,7 +50,9 @@ class HakemusController(
     @GetMapping("/hakemukset/{id}")
     @Operation(
         summary = "Get one application",
-        description = "Returns one application if it exists and the user can access it."
+        description =
+            "Returns one application if it exists and the user can access it. " +
+                "Returns any decisions for the application as well.",
     )
     @ApiResponses(
         value =
@@ -59,37 +61,35 @@ class HakemusController(
                 ApiResponse(
                     description = "An application was not found with the given id",
                     responseCode = "404",
-                    content = [Content(schema = Schema(implementation = HankeError::class))]
+                    content = [Content(schema = Schema(implementation = HankeError::class))],
                 ),
-            ]
-    )
+            ])
     @PreAuthorize("@hakemusAuthorizer.authorizeHakemusId(#id, 'VIEW')")
-    fun getById(@PathVariable(name = "id") id: Long): HakemusResponse {
+    fun getById(@PathVariable(name = "id") id: Long): HakemusWithPaatoksetResponse {
         logger.info { "Finding application $id" }
-        val response = hakemusService.hakemusResponse(id)
-        disclosureLogService.saveDisclosureLogsForHakemusResponse(response, currentUserId())
+        val response = hakemusService.getWithPaatokset(id).toResponse()
+        disclosureLogService.saveDisclosureLogsForHakemusResponse(response.hakemus, currentUserId())
         return response
     }
 
     @GetMapping("/hankkeet/{hankeTunnus}/hakemukset")
     @Operation(
         summary = "Get hanke applications",
-        description = "Returns list of applications belonging to the given hanke."
+        description = "Returns list of applications belonging to the given hanke.",
     )
     @ApiResponses(
         value =
             [
                 ApiResponse(
                     description = "Applications of the requested hanke",
-                    responseCode = "200"
+                    responseCode = "200",
                 ),
                 ApiResponse(
                     description = "Hanke was not found with the given id",
                     responseCode = "404",
-                    content = [Content(schema = Schema(implementation = HankeError::class))]
+                    content = [Content(schema = Schema(implementation = HankeError::class))],
                 ),
-            ]
-    )
+            ])
     @PreAuthorize("@hakemusAuthorizer.authorizeHankeTunnus(#hankeTunnus, 'VIEW')")
     fun getHankkeenHakemukset(@PathVariable hankeTunnus: String): HankkeenHakemuksetResponse {
         logger.info { "Finding applications for hanke $hankeTunnus" }
@@ -103,7 +103,7 @@ class HakemusController(
         summary = "Create a new application",
         description =
             "Returns the created application. The new application is created as a draft, " +
-                "i.e. with true in pendingOnClient. The draft is not sent to Allu."
+                "i.e. with true in pendingOnClient. The draft is not sent to Allu.",
     )
     @ApiResponses(
         value =
@@ -112,10 +112,9 @@ class HakemusController(
                 ApiResponse(
                     description = "The request body was invalid",
                     responseCode = "400",
-                    content = [Content(schema = Schema(implementation = HankeError::class))]
+                    content = [Content(schema = Schema(implementation = HankeError::class))],
                 ),
-            ]
-    )
+            ])
     @PreAuthorize("@hakemusAuthorizer.authorizeCreate(#createHakemusRequest)")
     fun create(
         @ValidCreateHakemusRequest @RequestBody createHakemusRequest: CreateHakemusRequest
@@ -131,7 +130,7 @@ class HakemusController(
             "Generates new hanke from a cable report application and saves an application to it.",
         description =
             "Returns the created application. The new application is created as a draft, " +
-                "i.e. with true in pendingOnClient. The draft is not sent to Allu. "
+                "i.e. with true in pendingOnClient. The draft is not sent to Allu. ",
     )
     @ApiResponses(
         value =
@@ -140,10 +139,9 @@ class HakemusController(
                 ApiResponse(
                     description = "The request body was invalid",
                     responseCode = "400",
-                    content = [Content(schema = Schema(implementation = HankeError::class))]
+                    content = [Content(schema = Schema(implementation = HankeError::class))],
                 ),
-            ]
-    )
+            ])
     fun createWithGeneratedHanke(
         @ValidCreateHankeRequest @RequestBody request: CreateHankeRequest,
         @Parameter(hidden = true) @CurrentSecurityContext securityContext: SecurityContext,
@@ -165,7 +163,7 @@ class HakemusController(
                If the application hasn't changed since the last update, nothing more is done.
                The pendingOnClient value can't be changed with this endpoint.
                Use [POST /hakemukset/{id}/laheta](#/application-controller/sendHakemus) for that.
-            """
+            """,
     )
     @ApiResponses(
         value =
@@ -184,30 +182,28 @@ class HakemusController(
                                         ExampleObject(
                                             name = "Validation error",
                                             summary = "Validation error example",
-                                            value = "{hankeError: 'HAI2008', errorPaths: ['name']}"
+                                            value = "{hankeError: 'HAI2008', errorPaths: ['name']}",
                                         ),
                                         ExampleObject(
                                             name = "Incompatible request",
                                             summary = "Incompatible request example",
-                                            value = "{hankeError: 'HAI2002'}"
+                                            value = "{hankeError: 'HAI2002'}",
                                         ),
-                                    ]
-                            )
-                        ]
+                                    ],
+                            )],
                 ),
                 ApiResponse(
                     description = "An application was not found with the given id",
                     responseCode = "404",
-                    content = [Content(schema = Schema(implementation = HankeError::class))]
+                    content = [Content(schema = Schema(implementation = HankeError::class))],
                 ),
                 ApiResponse(
                     description =
                         "The application can't be updated because it has been sent to Allu",
                     responseCode = "409",
-                    content = [Content(schema = Schema(implementation = HankeError::class))]
+                    content = [Content(schema = Schema(implementation = HankeError::class))],
                 ),
-            ]
-    )
+            ])
     @PreAuthorize("@hakemusAuthorizer.authorizeHakemusId(#id, 'EDIT_APPLICATIONS')")
     fun update(
         @PathVariable(name = "id") id: Long,
@@ -227,8 +223,7 @@ class HakemusController(
                If the application hasn't been sent to Allu, delete it directly.
                If the application is pending in Allu, cancel it in Allu before deleting it locally.
                If the application has proceeded beyond pending in Allu, refuse to delete it.
-            """
-    )
+            """)
     @ApiResponses(
         value =
             [
@@ -236,16 +231,13 @@ class HakemusController(
                 ApiResponse(
                     description = "An application was not found with the given id",
                     responseCode = "404",
-                    content = [Content(schema = Schema(implementation = HankeError::class))]
-                ),
+                    content = [Content(schema = Schema(implementation = HankeError::class))]),
                 ApiResponse(
                     description =
                         "The application is already processing in Allu and can't be deleted",
                     responseCode = "409",
-                    content = [Content(schema = Schema(implementation = HankeError::class))]
-                ),
-            ]
-    )
+                    content = [Content(schema = Schema(implementation = HankeError::class))]),
+            ])
     @PreAuthorize("@hakemusAuthorizer.authorizeHakemusId(#id, 'EDIT_APPLICATIONS')")
     fun delete(@PathVariable(name = "id") id: Long): HakemusDeletionResultDto {
         val userId = currentUserId()
@@ -263,8 +255,7 @@ class HakemusController(
                - A clerk at Allu can start processing the application after this call.
                - The application cannot be edited after it has been sent.
                - The caller needs to be a contact on the application for at least one customer. 
-            """
-    )
+            """)
     @ApiResponses(
         value =
             [
@@ -272,20 +263,16 @@ class HakemusController(
                 ApiResponse(
                     description = "Application contains invalid data",
                     responseCode = "400",
-                    content = [Content(schema = Schema(implementation = HankeErrorDetail::class))]
-                ),
+                    content = [Content(schema = Schema(implementation = HankeErrorDetail::class))]),
                 ApiResponse(
                     description = "An application was not found with the given id",
                     responseCode = "404",
-                    content = [Content(schema = Schema(implementation = HankeError::class))]
-                ),
+                    content = [Content(schema = Schema(implementation = HankeError::class))]),
                 ApiResponse(
                     description = "The application has been sent already",
                     responseCode = "409",
-                    content = [Content(schema = Schema(implementation = HankeError::class))]
-                ),
-            ]
-    )
+                    content = [Content(schema = Schema(implementation = HankeError::class))]),
+            ])
     @PreAuthorize("@hakemusAuthorizer.authorizeHakemusId(#id, 'EDIT_APPLICATIONS')")
     fun sendHakemus(@PathVariable(name = "id") id: Long): HakemusResponse =
         hakemusService.sendHakemus(id, currentUserId()).toResponse()
@@ -293,7 +280,7 @@ class HakemusController(
     @GetMapping("/hakemukset/{id}/paatos")
     @Operation(
         summary = "Download a decision",
-        description = "Downloads a decision for this application from Allu."
+        description = "Downloads a decision for this application from Allu.",
     )
     @ApiResponses(
         value =
@@ -301,16 +288,15 @@ class HakemusController(
                 ApiResponse(
                     description = "The decision PDF",
                     responseCode = "200",
-                    content = [Content(mediaType = MediaType.APPLICATION_PDF_VALUE)]
+                    content = [Content(mediaType = MediaType.APPLICATION_PDF_VALUE)],
                 ),
                 ApiResponse(
                     description =
                         "An application was not found with the given id or the application didn't have a decision",
                     responseCode = "404",
-                    content = [Content(schema = Schema(implementation = HankeError::class))]
+                    content = [Content(schema = Schema(implementation = HankeError::class))],
                 ),
-            ]
-    )
+            ])
     @PreAuthorize("@hakemusAuthorizer.authorizeHakemusId(#id, 'VIEW')")
     fun downloadDecision(@PathVariable(name = "id") id: Long): ResponseEntity<ByteArray> {
         val userId = currentUserId()

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
@@ -69,6 +69,13 @@ class HakemusService(
     fun getById(applicationId: Long): Hakemus = getEntityById(applicationId).toHakemus()
 
     @Transactional(readOnly = true)
+    fun getWithPaatokset(applicationId: Long): HakemusWithPaatokset {
+        val hakemus = getById(applicationId)
+        val paatokset = paatosService.findByHakemusId(applicationId)
+        return HakemusWithPaatokset(hakemus, paatokset)
+    }
+
+    @Transactional(readOnly = true)
     fun hakemusResponse(applicationId: Long): HakemusResponse = getById(applicationId).toResponse()
 
     @Transactional(readOnly = true)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusWithPaatokset.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusWithPaatokset.kt
@@ -1,0 +1,18 @@
+package fi.hel.haitaton.hanke.hakemus
+
+import com.fasterxml.jackson.annotation.JsonUnwrapped
+import fi.hel.haitaton.hanke.paatos.Paatos
+import fi.hel.haitaton.hanke.paatos.PaatosResponse
+
+data class HakemusWithPaatokset(val hakemus: Hakemus, val paatokset: List<Paatos>) {
+    fun toResponse(): HakemusWithPaatoksetResponse =
+        HakemusWithPaatoksetResponse(
+            hakemus.toResponse(),
+            paatokset.map { it.toResponse() }.groupBy { it.hakemustunnus },
+        )
+}
+
+data class HakemusWithPaatoksetResponse(
+    @JsonUnwrapped val hakemus: HakemusResponse,
+    val paatokset: Map<String, List<PaatosResponse>>,
+)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/paatos/PaatosResponse.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/paatos/PaatosResponse.kt
@@ -3,7 +3,7 @@ package fi.hel.haitaton.hanke.paatos
 import java.time.LocalDate
 import java.util.UUID
 
-data class Paatos(
+data class PaatosResponse(
     val id: UUID,
     val hakemusId: Long,
     val hakemustunnus: String,
@@ -12,10 +12,5 @@ data class Paatos(
     val nimi: String,
     val alkupaiva: LocalDate,
     val loppupaiva: LocalDate,
-    val blobLocation: String,
     val size: Int,
-) {
-    fun toResponse(): PaatosResponse =
-        PaatosResponse(
-            id, hakemusId, hakemustunnus, tyyppi, tila, nimi, alkupaiva, loppupaiva, size)
-}
+)

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusFactory.kt
@@ -12,6 +12,7 @@ import fi.hel.haitaton.hanke.hakemus.HakemusEntity
 import fi.hel.haitaton.hanke.hakemus.HakemusEntityData
 import fi.hel.haitaton.hanke.hakemus.HakemusRepository
 import fi.hel.haitaton.hanke.hakemus.HakemusService
+import fi.hel.haitaton.hanke.hakemus.HakemusWithPaatokset
 import fi.hel.haitaton.hanke.hakemus.HakemusyhteyshenkiloRepository
 import fi.hel.haitaton.hanke.hakemus.Hakemusyhteystieto
 import fi.hel.haitaton.hanke.hakemus.HakemusyhteystietoRepository
@@ -21,6 +22,7 @@ import fi.hel.haitaton.hanke.hakemus.KaivuilmoitusAlue
 import fi.hel.haitaton.hanke.hakemus.KaivuilmoitusData
 import fi.hel.haitaton.hanke.hakemus.Laskutusyhteystieto
 import fi.hel.haitaton.hanke.hakemus.PostalAddress
+import fi.hel.haitaton.hanke.paatos.Paatos
 import fi.hel.haitaton.hanke.permissions.HankeKayttajaService
 import fi.hel.haitaton.hanke.test.USERNAME
 import java.time.ZonedDateTime
@@ -219,6 +221,31 @@ class HakemusFactory(
                 applicationType = applicationType,
                 hakemusEntityData = hakemusEntityData,
                 hanke = hanke,
+            )
+
+        fun createWithPaatokset(
+            id: Long = 1,
+            alluid: Int? = null,
+            alluStatus: ApplicationStatus? = null,
+            applicationIdentifier: String? = null,
+            applicationType: ApplicationType = ApplicationType.CABLE_REPORT,
+            applicationData: HakemusData = createHakemusData(applicationType),
+            hankeTunnus: String = "HAI-1234",
+            hankeId: Int = 1,
+            paatokset: List<Paatos>,
+        ) =
+            HakemusWithPaatokset(
+                create(
+                    id,
+                    alluid,
+                    alluStatus,
+                    applicationIdentifier,
+                    applicationType,
+                    applicationData,
+                    hankeTunnus,
+                    hankeId,
+                ),
+                paatokset,
             )
     }
 }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/PaatosFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/PaatosFactory.kt
@@ -24,10 +24,30 @@ class PaatosFactory(private val paatosRepository: PaatosRepository) {
         hakemustunnus: String = hakemus.applicationIdentifier!!,
         tyyppi: PaatosTyyppi = PaatosTyyppi.PAATOS,
         tila: PaatosTila = PaatosTila.NYKYINEN,
-    ): PaatosEntity = paatosRepository.save(createForHakemus(hakemus, hakemustunnus, tyyppi, tila))
+    ): PaatosEntity =
+        paatosRepository.save(createEntityForHakemus(hakemus, hakemustunnus, tyyppi, tila))
 
     companion object {
         fun createForHakemus(
+            hakemus: Hakemus,
+            hakemustunnus: String = hakemus.applicationIdentifier!!,
+            tyyppi: PaatosTyyppi = PaatosTyyppi.PAATOS,
+            tila: PaatosTila = PaatosTila.NYKYINEN,
+        ) =
+            Paatos(
+                id = UUID.randomUUID(),
+                hakemusId = hakemus.id,
+                hakemustunnus = hakemustunnus,
+                tyyppi = tyyppi,
+                tila = tila,
+                nimi = hakemus.applicationData.name,
+                alkupaiva = hakemus.applicationData.startTime?.toLocalDate()!!,
+                loppupaiva = hakemus.applicationData.endTime?.toLocalDate()!!,
+                blobLocation = "${hakemus.id}/${UUID.randomUUID()}",
+                size = 53,
+            )
+
+        fun createEntityForHakemus(
             hakemus: Hakemus,
             hakemustunnus: String = hakemus.applicationIdentifier!!,
             tyyppi: PaatosTyyppi = PaatosTyyppi.PAATOS,


### PR DESCRIPTION
# Description

Add any decisions the application might have to the response when requesting a single decision. The decisions are returned under `paatokset`. Otherwise, the response remains the same.


### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2620

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
1. Find an application that has decisions in DB.
2. Use Swagger UI to call the API: http://localhost:3001/api/swagger-ui/index.html#/hakemus-controller/getById

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [X] I have made necessary changes to the documentation, link to confluence
 or other location: API docs