### PR TITLE
HAI-2556 Add API for reporting operational condition

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/allu/AlluClientITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/allu/AlluClientITests.kt
@@ -1,6 +1,7 @@
 package fi.hel.haitaton.hanke.allu
 
 import assertk.Assert
+import assertk.all
 import assertk.assertFailure
 import assertk.assertThat
 import assertk.assertions.containsExactly
@@ -11,6 +12,7 @@ import assertk.assertions.isGreaterThan
 import assertk.assertions.isNull
 import assertk.assertions.isTrue
 import assertk.assertions.isZero
+import assertk.assertions.messageContains
 import assertk.assertions.prop
 import com.auth0.jwt.JWT
 import com.auth0.jwt.algorithms.Algorithm
@@ -22,6 +24,7 @@ import fi.hel.haitaton.hanke.factory.ApplicationHistoryFactory
 import fi.hel.haitaton.hanke.hakemus.HakemusDecisionNotFoundException
 import fi.hel.haitaton.hanke.toJsonString
 import java.time.Instant
+import java.time.LocalDate
 import java.time.ZonedDateTime
 import okhttp3.MultipartReader
 import okhttp3.mockwebserver.MockResponse
@@ -217,8 +220,7 @@ class AlluClientITests {
                     .setResponseCode(400)
                     .setHeader(CONTENT_TYPE, APPLICATION_JSON_VALUE)
                     .setBody(
-                        """[{"errorMessage":"Cable report should have one orderer contact","additionalInfo":"customerWithContacts"}]"""
-                    )
+                        """[{"errorMessage":"Cable report should have one orderer contact","additionalInfo":"customerWithContacts"}]""")
             mockWebServer.enqueue(applicationIdResponse)
 
             assertThrows<WebClientResponseException.BadRequest> {
@@ -233,6 +235,38 @@ class AlluClientITests {
     }
 
     @Nested
+    inner class OperationalCondition {
+        private val applicationId = 241
+        private val date = LocalDate.of(2024, 8, 12)
+
+        @Test
+        fun `calls Allu with the correct path and time`() {
+            mockWebServer.enqueue(MockResponse().setResponseCode(200))
+
+            service.operationalCondition(applicationId, date)
+
+            val createRequest = mockWebServer.takeRequest()
+            assertThat(createRequest.method).isEqualTo("PUT")
+            assertThat(createRequest.path)
+                .isEqualTo("/v2/excavationannouncements/$applicationId/operationalcondition")
+            assertThat(createRequest.body.readUtf8()).isEqualTo("\"2024-08-12T00:00:00Z\"")
+        }
+
+        @Test
+        fun `throws an exception if there's a problem with the call`() {
+            mockWebServer.enqueue(MockResponse().setResponseCode(409))
+
+            val failure = assertFailure { service.operationalCondition(applicationId, date) }
+
+            failure.all {
+                hasClass(WebClientResponseException.Conflict::class)
+                messageContains("/v2/excavationannouncements/$applicationId/operationalcondition")
+                messageContains("409 Conflict from PUT")
+            }
+        }
+    }
+
+    @Nested
     inner class GetDecisionPdf {
         @Test
         fun `returns PDF file as bytes`() {
@@ -240,8 +274,7 @@ class AlluClientITests {
                 MockResponse()
                     .setResponseCode(200)
                     .setHeader(CONTENT_TYPE, APPLICATION_PDF_VALUE)
-                    .setBody(pdfContent())
-            )
+                    .setBody(pdfContent()))
 
             val response = service.getDecisionPdf(12)
 
@@ -260,8 +293,7 @@ class AlluClientITests {
                 MockResponse()
                     .setResponseCode(200)
                     .setHeader(CONTENT_TYPE, APPLICATION_PDF_VALUE)
-                    .setBody(content)
-            )
+                    .setBody(content))
 
             val response = service.getDecisionPdf(12)
 
@@ -274,8 +306,7 @@ class AlluClientITests {
                 MockResponse()
                     .setResponseCode(404)
                     .setHeader(CONTENT_TYPE, APPLICATION_JSON_VALUE)
-                    .setBody("Not found")
-            )
+                    .setBody("Not found"))
 
             val exception =
                 assertThrows<HakemusDecisionNotFoundException> { service.getDecisionPdf(12) }
@@ -289,8 +320,7 @@ class AlluClientITests {
                 MockResponse()
                     .setResponseCode(500)
                     .setHeader(CONTENT_TYPE, APPLICATION_JSON_VALUE)
-                    .setBody("Other error")
-            )
+                    .setBody("Other error"))
 
             assertThrows<WebClientResponseException> { service.getDecisionPdf(12) }
         }
@@ -301,8 +331,7 @@ class AlluClientITests {
                 MockResponse()
                     .setResponseCode(200)
                     .setHeader(CONTENT_TYPE, IMAGE_PNG)
-                    .setBody(pdfContent())
-            )
+                    .setBody(pdfContent()))
 
             assertThrows<AlluApiException> { service.getDecisionPdf(12) }
         }
@@ -313,8 +342,7 @@ class AlluClientITests {
                 MockResponse()
                     .setResponseCode(200)
                     .setHeader(CONTENT_TYPE, APPLICATION_PDF)
-                    .setBody("")
-            )
+                    .setBody(""))
 
             assertThrows<AlluApiException> { service.getDecisionPdf(12) }
         }
@@ -328,8 +356,7 @@ class AlluClientITests {
                 MockResponse()
                     .setResponseCode(200)
                     .setHeader(CONTENT_TYPE, APPLICATION_PDF_VALUE)
-                    .setBody(pdfContent())
-            )
+                    .setBody(pdfContent()))
 
             val response = service.getOperationalConditionPdf(12)
 
@@ -349,8 +376,7 @@ class AlluClientITests {
                 MockResponse()
                     .setResponseCode(200)
                     .setHeader(CONTENT_TYPE, APPLICATION_PDF_VALUE)
-                    .setBody(content)
-            )
+                    .setBody(content))
 
             val response = service.getOperationalConditionPdf(12)
 
@@ -363,8 +389,7 @@ class AlluClientITests {
                 MockResponse()
                     .setResponseCode(404)
                     .setHeader(CONTENT_TYPE, APPLICATION_JSON_VALUE)
-                    .setBody("Not found")
-            )
+                    .setBody("Not found"))
 
             val exception =
                 assertThrows<HakemusDecisionNotFoundException> {
@@ -380,8 +405,7 @@ class AlluClientITests {
                 MockResponse()
                     .setResponseCode(500)
                     .setHeader(CONTENT_TYPE, APPLICATION_JSON_VALUE)
-                    .setBody("Other error")
-            )
+                    .setBody("Other error"))
 
             assertThrows<WebClientResponseException> { service.getOperationalConditionPdf(12) }
         }
@@ -392,8 +416,7 @@ class AlluClientITests {
                 MockResponse()
                     .setResponseCode(200)
                     .setHeader(CONTENT_TYPE, IMAGE_PNG)
-                    .setBody(pdfContent())
-            )
+                    .setBody(pdfContent()))
 
             assertThrows<AlluApiException> { service.getOperationalConditionPdf(12) }
         }
@@ -404,8 +427,7 @@ class AlluClientITests {
                 MockResponse()
                     .setResponseCode(200)
                     .setHeader(CONTENT_TYPE, APPLICATION_PDF)
-                    .setBody("")
-            )
+                    .setBody(""))
 
             assertThrows<AlluApiException> { service.getOperationalConditionPdf(12) }
         }
@@ -420,8 +442,7 @@ class AlluClientITests {
                 MockResponse()
                     .setResponseCode(200)
                     .setHeader(CONTENT_TYPE, APPLICATION_PDF_VALUE)
-                    .setBody(pdfContent())
-            )
+                    .setBody(pdfContent()))
 
             val response = service.getWorkFinishedPdf(12)
 
@@ -441,8 +462,7 @@ class AlluClientITests {
                 MockResponse()
                     .setResponseCode(200)
                     .setHeader(CONTENT_TYPE, APPLICATION_PDF_VALUE)
-                    .setBody(content)
-            )
+                    .setBody(content))
 
             val response = service.getOperationalConditionPdf(12)
 
@@ -455,8 +475,7 @@ class AlluClientITests {
                 MockResponse()
                     .setResponseCode(404)
                     .setHeader(CONTENT_TYPE, APPLICATION_JSON_VALUE)
-                    .setBody("Not found")
-            )
+                    .setBody("Not found"))
 
             val exception =
                 assertThrows<HakemusDecisionNotFoundException> { service.getWorkFinishedPdf(12) }
@@ -470,8 +489,7 @@ class AlluClientITests {
                 MockResponse()
                     .setResponseCode(500)
                     .setHeader(CONTENT_TYPE, APPLICATION_JSON_VALUE)
-                    .setBody("Other error")
-            )
+                    .setBody("Other error"))
 
             assertThrows<WebClientResponseException> { service.getWorkFinishedPdf(12) }
         }
@@ -482,8 +500,7 @@ class AlluClientITests {
                 MockResponse()
                     .setResponseCode(200)
                     .setHeader(CONTENT_TYPE, IMAGE_PNG)
-                    .setBody(pdfContent())
-            )
+                    .setBody(pdfContent()))
 
             assertThrows<AlluApiException> { service.getWorkFinishedPdf(12) }
         }
@@ -494,8 +511,7 @@ class AlluClientITests {
                 MockResponse()
                     .setResponseCode(200)
                     .setHeader(CONTENT_TYPE, APPLICATION_PDF)
-                    .setBody("")
-            )
+                    .setBody(""))
 
             assertThrows<AlluApiException> { service.getWorkFinishedPdf(12) }
         }
@@ -512,8 +528,7 @@ class AlluClientITests {
                 MockResponse()
                     .setResponseCode(200)
                     .setHeader(CONTENT_TYPE, APPLICATION_JSON_VALUE)
-                    .setBody(histories.toJsonString())
-            )
+                    .setBody(histories.toJsonString()))
 
             val response = service.getApplicationStatusHistories(alluids, eventsAfter)
 
@@ -532,8 +547,7 @@ class AlluClientITests {
                 MockResponse()
                     .setResponseCode(200)
                     .setHeader(CONTENT_TYPE, APPLICATION_JSON_VALUE)
-                    .setBody("[]")
-            )
+                    .setBody("[]"))
 
             val response = service.getApplicationStatusHistories(alluids, eventsAfter)
 
@@ -548,8 +562,7 @@ class AlluClientITests {
                 MockResponse()
                     .setResponseCode(404)
                     .setHeader(CONTENT_TYPE, APPLICATION_JSON_VALUE)
-                    .setBody("Error message")
-            )
+                    .setBody("Error message"))
 
             assertFailure { service.getApplicationStatusHistories(alluids, eventsAfter) }
                 .hasClass(WebClientResponseException.NotFound::class)
@@ -643,14 +656,10 @@ class AlluClientITests {
     private fun getTestApplication(): AlluCableReportApplicationData {
         val customerWContacts =
             CustomerWithContacts(
-                customer = AlluFactory.customer,
-                contacts = listOf(AlluFactory.hannu)
-            )
+                customer = AlluFactory.customer, contacts = listOf(AlluFactory.hannu))
         val contractorWContacts =
             CustomerWithContacts(
-                customer = AlluFactory.customer,
-                contacts = listOf(AlluFactory.kerttu)
-            )
+                customer = AlluFactory.customer, contacts = listOf(AlluFactory.kerttu))
 
         val geometry = GeometryCollection()
         geometry.add(
@@ -658,9 +667,8 @@ class AlluClientITests {
                 LngLatAlt(25495815.0, 6673160.0),
                 LngLatAlt(25495855.0, 6673160.0),
                 LngLatAlt(25495855.0, 6673190.0),
-                LngLatAlt(25495815.0, 6673160.0)
-            )
-        )
+                LngLatAlt(25495815.0, 6673160.0),
+            ))
         geometry.crs = Crs()
         geometry.crs.properties["name"] = "EPSG:3879"
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeError.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeError.kt
@@ -43,6 +43,9 @@ enum class HankeError(val errorMessage: String) {
     HAI2010("Application contains invalid customer"),
     HAI2011("Application contains invalid contact"),
     HAI2012("User is not a contact on the application, operation forbidden"),
+    HAI2013("Application has not been sent to Allu yet, operation prohibited."),
+    HAI2014("Date reported is before work was started or in the future."),
+    HAI2015("Operation not allowed in this application status."),
     HAI3001("Attachment upload failed"),
     HAI3002("Loading attachment failed"),
     HAI3003("Attachment limit reached"),
@@ -84,8 +87,7 @@ class HankeArgumentException(message: String) : RuntimeException(message)
 
 class HankeYhteystietoNotFoundException(val hanke: HankeIdentifier, ytId: Int) :
     RuntimeException(
-        "HankeYhteystieto not found for Hanke, yhteystieto: $ytId, ${hanke.logString()}"
-    )
+        "HankeYhteystieto not found for Hanke, yhteystieto: $ytId, ${hanke.logString()}")
 
 class HankeAlluConflictException(message: String) : RuntimeException(message)
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/DateReportRequest.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/DateReportRequest.kt
@@ -1,0 +1,5 @@
+package fi.hel.haitaton.hanke.hakemus
+
+import java.time.LocalDate
+
+data class DateReportRequest(val date: LocalDate)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
@@ -32,6 +32,7 @@ import fi.hel.haitaton.hanke.pdf.KaivuilmoitusPdfEncoder
 import fi.hel.haitaton.hanke.permissions.CurrentUserWithoutKayttajaException
 import fi.hel.haitaton.hanke.permissions.HankeKayttajaService
 import fi.hel.haitaton.hanke.toJsonString
+import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.OffsetDateTime
 import java.util.UUID
@@ -343,6 +344,48 @@ class HakemusService(
         }
 
         return HakemusDeletionResultDto(hankeDeleted = false)
+    }
+
+    @Transactional
+    fun operationalCondition(hakemusId: Long, date: LocalDate) {
+        val hakemus = getById(hakemusId)
+        val alluid = hakemus.alluid ?: throw HakemusNotYetInAlluException(hakemus)
+
+        val hakemusData =
+            when (hakemus.applicationData) {
+                is JohtoselvityshakemusData ->
+                    throw WrongHakemusTypeException(
+                        hakemus,
+                        hakemus.applicationType,
+                        listOf(ApplicationType.EXCAVATION_NOTIFICATION))
+                is KaivuilmoitusData -> hakemus.applicationData
+            }
+
+        if (hakemusData.startTime == null || date.isBefore(hakemusData.startTime.toLocalDate())) {
+            throw OperationalConditionDateException(
+                "Date is before the hakemus start date: ${hakemusData.startTime}", date, hakemus)
+        }
+        if (date.isAfter(LocalDate.now())) {
+            throw OperationalConditionDateException("Date is in the future.", date, hakemus)
+        }
+
+        val allowedStatuses =
+            listOf(
+                ApplicationStatus.PENDING,
+                ApplicationStatus.HANDLING,
+                ApplicationStatus.INFORMATION_RECEIVED,
+                ApplicationStatus.RETURNED_TO_PREPARATION,
+                ApplicationStatus.DECISIONMAKING,
+                ApplicationStatus.DECISION,
+            )
+        if (hakemus.alluStatus !in allowedStatuses) {
+            throw HakemusInWrongStatusException(hakemus, hakemus.alluStatus, allowedStatuses)
+        }
+
+        logger.info {
+            "Reporting operational condition for hakemus with the date $date. ${hakemus.logString()}"
+        }
+        alluClient.operationalCondition(alluid, date)
     }
 
     @Transactional(readOnly = true)
@@ -1050,3 +1093,32 @@ class HakemusGeometryException(message: String) : RuntimeException(message)
 class HakemusGeometryNotInsideHankeException(message: String) : RuntimeException(message)
 
 class HakemusDecisionNotFoundException(message: String) : RuntimeException(message)
+
+class HakemusNotYetInAlluException(hakemus: HakemusIdentifier) :
+    RuntimeException("Hakemus is not yet in Allu. ${hakemus.logString()}")
+
+class WrongHakemusTypeException(
+    hakemus: HakemusIdentifier,
+    type: ApplicationType,
+    allowed: List<ApplicationType>
+) :
+    RuntimeException(
+        "Wrong application type for this action. type=$type, " +
+            "allowed types=${allowed.joinToString(", ")}, ${hakemus.logString()}")
+
+class HakemusInWrongStatusException(
+    hakemus: HakemusIdentifier,
+    status: ApplicationStatus?,
+    allowed: List<ApplicationStatus>
+) :
+    RuntimeException(
+        "Hakemus is in the wrong status for this operation. status=$status, " +
+            "allowed statuses=${allowed.joinToString(", ")}, ${hakemus.logString()}, ")
+
+class OperationalConditionDateException(
+    error: String,
+    date: LocalDate,
+    hakemus: HakemusIdentifier,
+) :
+    RuntimeException(
+        "Invalid date in operational condition report. $error date=$date, ${hakemus.logString()}")


### PR DESCRIPTION
# Description

Check for 3 things:
1. The application is an excavation notification.
2. The reported date is between the start of the application work time and today.
3. The application is in a status where reporting operational condition is allowed.

If everything is OK, send the date to Allu.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2556

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
Use [Swagger-UI](http://localhost:3001/api/swagger-ui/index.html#/hakemus-controller/operationalCondition) to report a operational condition.

When successful, it should create a supervision task in Allu (Toiminnallisen kunnon valvonta under Valvonta). The operational condition date should also be on the basic info tab under Asiakkaan ilmoittama voimassaolo -> Talvityön toiminn. kunto.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [X] I have made necessary changes to the documentation, link to confluence
 or other location: API docs