### PR TITLE
HAI-2398 Add audit logging to accompanying johtoselvityshakemus

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
@@ -73,6 +73,8 @@ import fi.hel.haitaton.hanke.test.Asserts.isRecentUTC
 import fi.hel.haitaton.hanke.test.Asserts.isRecentZDT
 import fi.hel.haitaton.hanke.test.AuditLogEntryEntityAsserts.hasId
 import fi.hel.haitaton.hanke.test.AuditLogEntryEntityAsserts.hasMockedIp
+import fi.hel.haitaton.hanke.test.AuditLogEntryEntityAsserts.hasNoObjectAfter
+import fi.hel.haitaton.hanke.test.AuditLogEntryEntityAsserts.hasNoObjectBefore
 import fi.hel.haitaton.hanke.test.AuditLogEntryEntityAsserts.hasUserActor
 import fi.hel.haitaton.hanke.test.AuditLogEntryEntityAsserts.isSuccess
 import fi.hel.haitaton.hanke.test.AuditLogEntryEntityAsserts.withTarget
@@ -340,7 +342,7 @@ class HankeServiceITests(
                 withTarget {
                     hasId(hanke.id)
                     prop(AuditLogTarget::type).isEqualTo(ObjectType.HANKE)
-                    prop(AuditLogTarget::objectBefore).isNull()
+                    hasNoObjectBefore()
                     prop(AuditLogTarget::objectAfter).given {
                         val expectedObject = expectedNewHankeLogObject(hanke)
                         JSONAssert.assertEquals(expectedObject, it, JSONCompareMode.STRICT_ORDER)
@@ -409,7 +411,7 @@ class HankeServiceITests(
             hasUserActor(USERNAME)
             withTarget {
                 prop(AuditLogTarget::type).isEqualTo(ObjectType.YHTEYSTIETO)
-                prop(AuditLogTarget::objectBefore).isNull()
+                hasNoObjectBefore()
                 prop(AuditLogTarget::objectAfter).isNotNull().contains(NAME_1)
             }
         }
@@ -417,7 +419,7 @@ class HankeServiceITests(
             hasUserActor(USERNAME)
             withTarget {
                 prop(AuditLogTarget::type).isEqualTo(ObjectType.YHTEYSTIETO)
-                prop(AuditLogTarget::objectBefore).isNull()
+                hasNoObjectBefore()
                 prop(AuditLogTarget::objectAfter).isNotNull().contains(NAME_2)
             }
         }
@@ -473,7 +475,7 @@ class HankeServiceITests(
                 hasId(yhteystietoId2)
                 prop(AuditLogTarget::type).isEqualTo(ObjectType.YHTEYSTIETO)
                 prop(AuditLogTarget::objectBefore).isNotNull().contains(NAME_SOMETHING)
-                prop(AuditLogTarget::objectAfter).isNull()
+                hasNoObjectAfter()
             }
         }
     }
@@ -703,8 +705,7 @@ class HankeServiceITests(
                 hankeFactory
                     .builder(USERNAME)
                     .withHankealue(
-                        haittojenhallintasuunnitelma = createHaittojenhallintasuunnitelma()
-                    )
+                        haittojenhallintasuunnitelma = createHaittojenhallintasuunnitelma())
                     .save()
             auditLogRepository.deleteAll()
             assertEquals(0, auditLogRepository.count())
@@ -739,7 +740,7 @@ class HankeServiceITests(
             JSONAssert.assertEquals(
                 expectedObject,
                 event.target.objectBefore,
-                JSONCompareMode.NON_EXTENSIBLE
+                JSONCompareMode.NON_EXTENSIBLE,
             )
         }
 
@@ -774,28 +775,28 @@ class HankeServiceITests(
             JSONAssert.assertEquals(
                 expectedYhteystietoDeleteLogObject(omistajaId, 1),
                 omistajaEvent.target.objectBefore,
-                JSONCompareMode.NON_EXTENSIBLE
+                JSONCompareMode.NON_EXTENSIBLE,
             )
             val rakennuttajaId = hanke.rakennuttajat[0].id!!
             val rakennuttajaEvent = deleteLogs.findByTargetId(rakennuttajaId).message.auditEvent
             JSONAssert.assertEquals(
                 expectedYhteystietoDeleteLogObject(rakennuttajaId, 2),
                 rakennuttajaEvent.target.objectBefore,
-                JSONCompareMode.NON_EXTENSIBLE
+                JSONCompareMode.NON_EXTENSIBLE,
             )
             val toteuttajaId = hanke.toteuttajat[0].id!!
             val toteuttajaEvent = deleteLogs.findByTargetId(toteuttajaId).message.auditEvent
             JSONAssert.assertEquals(
                 expectedYhteystietoDeleteLogObject(toteuttajaId, 3),
                 toteuttajaEvent.target.objectBefore,
-                JSONCompareMode.NON_EXTENSIBLE
+                JSONCompareMode.NON_EXTENSIBLE,
             )
             val muuId = hanke.muut[0].id!!
             val muuEvent = deleteLogs.findByTargetId(muuId).message.auditEvent
             JSONAssert.assertEquals(
                 expectedYhteystietoDeleteLogObject(muuId, 4),
                 muuEvent.target.objectBefore,
-                JSONCompareMode.NON_EXTENSIBLE
+                JSONCompareMode.NON_EXTENSIBLE,
             )
         }
 
@@ -908,8 +909,7 @@ class HankeServiceITests(
         val templateData =
             mapOf("hankeId" to hanke.id.toString(), "hankeTunnus" to hanke.hankeTunnus)
         return Template.parse(
-                "/fi/hel/haitaton/hanke/logging/expectedNewHanke.json.mustache".getResourceAsText()
-            )
+                "/fi/hel/haitaton/hanke/logging/expectedNewHanke.json.mustache".getResourceAsText())
             .processToString(templateData)
     }
 
@@ -977,8 +977,7 @@ object ExpectedHankeLogObject {
     private val expectedHankeWithPolygon =
         Template.parse(
             "/fi/hel/haitaton/hanke/logging/expectedHankeWithPolygon.json.mustache"
-                .getResourceAsText()
-        )
+                .getResourceAsText())
 
     fun expectedHankeLogObject(
         hanke: Hanke,

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankekayttajaDeleteServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankekayttajaDeleteServiceITest.kt
@@ -43,6 +43,7 @@ import fi.hel.haitaton.hanke.logging.ObjectType
 import fi.hel.haitaton.hanke.logging.Operation
 import fi.hel.haitaton.hanke.permissions.HankekayttajaDeleteService.DeleteInfo
 import fi.hel.haitaton.hanke.test.AuditLogEntryEntityAsserts.hasId
+import fi.hel.haitaton.hanke.test.AuditLogEntryEntityAsserts.hasNoObjectAfter
 import fi.hel.haitaton.hanke.test.AuditLogEntryEntityAsserts.hasObjectBefore
 import fi.hel.haitaton.hanke.test.AuditLogEntryEntityAsserts.hasUserActor
 import fi.hel.haitaton.hanke.test.AuditLogEntryEntityAsserts.isSuccess
@@ -264,9 +265,7 @@ class HankekayttajaDeleteServiceITest(
             val hanke = hankeFactory.builder().save()
             val founder = hankeKayttajaService.getKayttajaByUserId(hanke.id, USERNAME)!!
             hankeKayttajaFactory.saveUnidentifiedUser(
-                hanke.id,
-                kayttooikeustaso = Kayttooikeustaso.KAIKKI_OIKEUDET
-            )
+                hanke.id, kayttooikeustaso = Kayttooikeustaso.KAIKKI_OIKEUDET)
 
             val failure = assertFailure { deleteService.delete(founder.id, USERNAME) }
 
@@ -430,7 +429,7 @@ class HankekayttajaDeleteServiceITest(
             hankeKayttajaFactory.saveIdentifiedUser(
                 hanke.id,
                 sahkoposti = "Something else",
-                kayttooikeustaso = Kayttooikeustaso.KAIKKI_OIKEUDET
+                kayttooikeustaso = Kayttooikeustaso.KAIKKI_OIKEUDET,
             )
             val kayttaja = hankeKayttajaService.getKayttaja(founder.id)
             auditLogRepository.deleteAll()
@@ -444,7 +443,7 @@ class HankekayttajaDeleteServiceITest(
                     prop(AuditLogTarget::type).isEqualTo(ObjectType.HANKE_KAYTTAJA)
                     hasId(founder.id)
                     hasObjectBefore(kayttaja)
-                    prop(AuditLogTarget::objectAfter).isNull()
+                    hasNoObjectAfter()
                 }
             }
         }
@@ -456,7 +455,7 @@ class HankekayttajaDeleteServiceITest(
             hankeKayttajaFactory.saveIdentifiedUser(
                 hanke.id,
                 sahkoposti = "Something else",
-                kayttooikeustaso = Kayttooikeustaso.KAIKKI_OIKEUDET
+                kayttooikeustaso = Kayttooikeustaso.KAIKKI_OIKEUDET,
             )
             val permission = permissionRepository.findOneByHankeIdAndUserId(hanke.id, USERNAME)!!
             auditLogRepository.deleteAll()
@@ -470,7 +469,7 @@ class HankekayttajaDeleteServiceITest(
                     prop(AuditLogTarget::type).isEqualTo(ObjectType.PERMISSION)
                     hasId(permission.id)
                     hasObjectBefore(permission.toDomain())
-                    prop(AuditLogTarget::objectAfter).isNull()
+                    hasNoObjectAfter()
                 }
             }
         }

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/PermissionServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/PermissionServiceITest.kt
@@ -22,6 +22,7 @@ import fi.hel.haitaton.hanke.logging.ObjectType
 import fi.hel.haitaton.hanke.logging.Operation
 import fi.hel.haitaton.hanke.test.AuditLogEntryEntityAsserts.auditEvent
 import fi.hel.haitaton.hanke.test.AuditLogEntryEntityAsserts.hasId
+import fi.hel.haitaton.hanke.test.AuditLogEntryEntityAsserts.hasNoObjectBefore
 import fi.hel.haitaton.hanke.test.AuditLogEntryEntityAsserts.hasObjectAfter
 import fi.hel.haitaton.hanke.test.AuditLogEntryEntityAsserts.hasObjectBefore
 import fi.hel.haitaton.hanke.test.AuditLogEntryEntityAsserts.hasUserActor
@@ -190,7 +191,7 @@ class PermissionServiceITest : IntegrationTest() {
                 withTarget {
                     prop(AuditLogTarget::type).isEqualTo(ObjectType.PERMISSION)
                     hasId(permission.id)
-                    prop(AuditLogTarget::objectBefore).isNull()
+                    hasNoObjectBefore()
                     hasObjectAfter(expectedObject)
                 }
                 prop(AuditLogEvent::operation).isEqualTo(Operation.CREATE)
@@ -248,8 +249,7 @@ class PermissionServiceITest : IntegrationTest() {
                     hasId(permission.id)
                     hasObjectBefore(expectedObject)
                     hasObjectAfter(
-                        expectedObject.copy(kayttooikeustaso = Kayttooikeustaso.HAKEMUSASIOINTI)
-                    )
+                        expectedObject.copy(kayttooikeustaso = Kayttooikeustaso.HAKEMUSASIOINTI))
                 }
                 hasUserActor(USERNAME)
             }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
@@ -284,7 +284,7 @@ class HakemusService(
         copyOtherAttachments(hakemus, savedJohtoselvityshakemus)
         logger.info(
             "Created a new johtoselvityshakemus (${savedJohtoselvityshakemus.logString()}) for a kaivuilmoitus. ${hakemus.logString()}")
-        hakemusLoggingService.logCreate(johtoselvityshakemus.toHakemus(), currentUserId)
+        hakemusLoggingService.logCreate(savedJohtoselvityshakemus.toHakemus(), currentUserId)
         return savedJohtoselvityshakemus
     }
 

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/test/AuditLogEntryEntityAsserts.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/test/AuditLogEntryEntityAsserts.kt
@@ -53,6 +53,8 @@ object AuditLogEntryEntityAsserts {
     fun Assert<AuditLogEvent>.withTarget(body: Assert<AuditLogTarget>.() -> Unit) =
         prop(AuditLogEvent::target).all(body)
 
+    fun Assert<AuditLogTarget>.hasNoObjectBefore() = prop(AuditLogTarget::objectBefore).isNull()
+
     inline fun <reified T> Assert<AuditLogTarget>.hasObjectBefore(before: T) =
         hasObjectBefore<T> { isEqualTo(before) }
 
@@ -74,6 +76,8 @@ object AuditLogEntryEntityAsserts {
             .isNotNull()
             .transform { it.parseJson<T>() }
             .all { body(this) }
+
+    fun Assert<AuditLogTarget>.hasNoObjectAfter() = prop(AuditLogTarget::objectAfter).isNull()
 
     fun Assert<AuditLogTarget>.hasId(id: Any) =
         prop(AuditLogTarget::id).isNotNull().isEqualTo(id.toString())


### PR DESCRIPTION
# Description

When an accompanying johtoselvityshakemus is created, write the creation to the audit logs.

Create a new entity for the johtoselvityshakemus instead of copying one from the excavation notification. Set the founder to the current user instead of the excavation notification founder.

Also, introduce convenience methods for asserting that the object before or after is null. Adopt their use wherever it was done manually.

## Type of change

- [X] Bug fix 
- [ ] New feature 
- [ ] Other

# Instructions for testing
- Send an accompanying johtoselvityshakemus.
- Check the audit_logs database table for the CREATE entry.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 