### PR TITLE
HAI-1504 Add an API for downloading kaivuilmoitus decisions

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/IntegrationTestConfiguration.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/IntegrationTestConfiguration.kt
@@ -16,6 +16,8 @@ import fi.hel.haitaton.hanke.hakemus.HakemusAuthorizer
 import fi.hel.haitaton.hanke.hakemus.HakemusService
 import fi.hel.haitaton.hanke.logging.AuditLogRepository
 import fi.hel.haitaton.hanke.logging.DisclosureLogService
+import fi.hel.haitaton.hanke.paatos.PaatosAuthorizer
+import fi.hel.haitaton.hanke.paatos.PaatosService
 import fi.hel.haitaton.hanke.permissions.HankeKayttajaAuthorizer
 import fi.hel.haitaton.hanke.permissions.HankeKayttajaService
 import fi.hel.haitaton.hanke.permissions.HankekayttajaDeleteService
@@ -90,6 +92,10 @@ class IntegrationTestConfiguration {
     @Bean fun hanketunnusService(): HanketunnusService = mockk()
 
     @Bean fun jdbcOperations(): JdbcOperations = mockk()
+
+    @Bean fun paatosAuthorizer(): PaatosAuthorizer = mockk()
+
+    @Bean fun paatosService(): PaatosService = mockk()
 
     @Bean fun permissionService(): PermissionService = mockk()
 

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusControllerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusControllerITest.kt
@@ -1094,15 +1094,5 @@ class HakemusControllerITest(@Autowired override val mockMvc: MockMvc) : Control
                 )
             }
         }
-
-        @Test
-        fun `when no hanke permission should return 404`() {
-            every { authorizer.authorizeHakemusId(id, PermissionCode.VIEW.name) } throws
-                HakemusNotFoundException(id)
-
-            get(url).andExpect(status().isNotFound)
-
-            verify { authorizer.authorizeHakemusId(id, PermissionCode.VIEW.name) }
-        }
     }
 }

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceITest.kt
@@ -672,16 +672,14 @@ class HakemusServiceITest(
             fun `does not create a new audit log entry when the application has not changed`() {
                 val entity = hakemusFactory.builder().saveEntity()
                 val hakemus = hakemusService.hakemusResponse(entity.id)
-                val originalAuditLogSize =
-                    auditLogRepository.findByType(ObjectType.APPLICATION).size
+                val originalAuditLogSize = auditLogRepository.findByType(ObjectType.HAKEMUS).size
                 // The saved hakemus has null in areas, but the response replaces it with an empty
-                // list,
-                // so set the value back to null in the request.
+                // list, so set the value back to null in the request.
                 val request = hakemus.toUpdateRequest().withAreas(null)
 
                 hakemusService.updateHakemus(hakemus.id, request, USERNAME)
 
-                val applicationLogs = auditLogRepository.findByType(ObjectType.APPLICATION)
+                val applicationLogs = auditLogRepository.findByType(ObjectType.HAKEMUS)
                 assertThat(applicationLogs).hasSize(originalAuditLogSize)
             }
 
@@ -1041,8 +1039,7 @@ class HakemusServiceITest(
                             applicationType = ApplicationType.EXCAVATION_NOTIFICATION)
                         .saveEntity()
                 val hakemus = hakemusService.hakemusResponse(entity.id)
-                val originalAuditLogSize =
-                    auditLogRepository.findByType(ObjectType.APPLICATION).size
+                val originalAuditLogSize = auditLogRepository.findByType(ObjectType.HAKEMUS).size
                 // The saved hakemus has null in areas, but the response replaces it with an empty
                 // list,
                 // so set the value back to null in the request.
@@ -1050,7 +1047,7 @@ class HakemusServiceITest(
 
                 hakemusService.updateHakemus(hakemus.id, request, USERNAME)
 
-                val applicationLogs = auditLogRepository.findByType(ObjectType.APPLICATION)
+                val applicationLogs = auditLogRepository.findByType(ObjectType.HAKEMUS)
                 assertThat(applicationLogs).hasSize(originalAuditLogSize)
             }
 

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/paatos/PaatosAuthorizerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/paatos/PaatosAuthorizerITest.kt
@@ -1,0 +1,78 @@
+package fi.hel.haitaton.hanke.paatos
+
+import assertk.all
+import assertk.assertFailure
+import assertk.assertThat
+import assertk.assertions.hasClass
+import assertk.assertions.isTrue
+import assertk.assertions.messageContains
+import fi.hel.haitaton.hanke.IntegrationTest
+import fi.hel.haitaton.hanke.factory.HakemusFactory
+import fi.hel.haitaton.hanke.factory.HankeKayttajaFactory
+import fi.hel.haitaton.hanke.factory.PaatosFactory
+import fi.hel.haitaton.hanke.permissions.Kayttooikeustaso.KATSELUOIKEUS
+import fi.hel.haitaton.hanke.permissions.PermissionCode.EDIT_APPLICATIONS
+import fi.hel.haitaton.hanke.permissions.PermissionCode.VIEW
+import fi.hel.haitaton.hanke.test.USERNAME
+import java.util.UUID
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+
+class PaatosAuthorizerITest(
+    @Autowired private val authorizer: PaatosAuthorizer,
+    @Autowired private val hankeKayttajaFactory: HankeKayttajaFactory,
+    @Autowired private val hakemusFactory: HakemusFactory,
+    @Autowired private val paatosFactory: PaatosFactory,
+) : IntegrationTest() {
+
+    val paatosId = UUID.fromString("871565c5-cdbb-4d29-9d63-68467f5bf9d6")
+
+    @Nested
+    inner class AuthorizePaatosId {
+        @Test
+        fun `throws exception if paatos doesn't exist`() {
+            assertFailure { authorizer.authorizePaatosId(paatosId, VIEW.name) }
+                .all {
+                    hasClass(PaatosNotFoundException::class)
+                    messageContains(paatosId.toString())
+                }
+        }
+
+        @Test
+        fun `throws exception if user doesn't have a permission for the hanke`() {
+            val hakemus = hakemusFactory.builder(userId = "Other user").asSent().save()
+            val paatos = paatosFactory.save(hakemus)
+
+            assertFailure { authorizer.authorizePaatosId(paatos.id, VIEW.name) }
+                .all {
+                    hasClass(PaatosNotFoundException::class)
+                    messageContains(paatos.id.toString())
+                }
+        }
+
+        @Test
+        fun `throws exception if user doesn't have the required permission`() {
+            val hakemus = hakemusFactory.builder(userId = "Other user").asSent().save()
+            val paatos = paatosFactory.save(hakemus)
+            hankeKayttajaFactory.saveIdentifiedUser(
+                hakemus.hankeId, userId = USERNAME, kayttooikeustaso = KATSELUOIKEUS)
+
+            assertFailure { authorizer.authorizePaatosId(paatos.id, EDIT_APPLICATIONS.name) }
+                .all {
+                    hasClass(PaatosNotFoundException::class)
+                    messageContains(paatos.id.toString())
+                }
+        }
+
+        @Test
+        fun `returns true if user has the required permission`() {
+            val hakemus = hakemusFactory.builder(userId = "Other user").asSent().save()
+            val paatos = paatosFactory.save(hakemus)
+            hankeKayttajaFactory.saveIdentifiedUser(
+                hakemus.hankeId, userId = USERNAME, kayttooikeustaso = KATSELUOIKEUS)
+
+            assertThat(authorizer.authorizePaatosId(paatos.id, VIEW.name)).isTrue()
+        }
+    }
+}

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/paatos/PaatosControllerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/paatos/PaatosControllerITest.kt
@@ -1,0 +1,157 @@
+package fi.hel.haitaton.hanke.paatos
+
+import fi.hel.haitaton.hanke.ControllerTest
+import fi.hel.haitaton.hanke.HankeError
+import fi.hel.haitaton.hanke.IntegrationTestConfiguration
+import fi.hel.haitaton.hanke.allu.ApplicationStatus
+import fi.hel.haitaton.hanke.attachment.PDF_BYTES
+import fi.hel.haitaton.hanke.attachment.azure.Container
+import fi.hel.haitaton.hanke.attachment.common.DownloadNotFoundException
+import fi.hel.haitaton.hanke.factory.HakemusFactory
+import fi.hel.haitaton.hanke.factory.PaatosFactory
+import fi.hel.haitaton.hanke.hakemus.ApplicationType
+import fi.hel.haitaton.hanke.hankeError
+import fi.hel.haitaton.hanke.logging.DisclosureLogService
+import fi.hel.haitaton.hanke.permissions.PermissionCode
+import fi.hel.haitaton.hanke.test.USERNAME
+import io.mockk.Called
+import io.mockk.checkUnnecessaryStub
+import io.mockk.clearAllMocks
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.verify
+import io.mockk.verifySequence
+import java.util.UUID
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.context.annotation.Import
+import org.springframework.http.MediaType
+import org.springframework.security.test.context.support.WithAnonymousUser
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+@WebMvcTest(controllers = [PaatosController::class])
+@Import(IntegrationTestConfiguration::class)
+@ActiveProfiles("test")
+@WithMockUser(USERNAME)
+class PaatosControllerITest(
+    @Autowired override val mockMvc: MockMvc,
+    @Autowired private val paatosService: PaatosService,
+    @Autowired private val authorizer: PaatosAuthorizer,
+    @Autowired private val disclosureLogService: DisclosureLogService,
+) : ControllerTest {
+    private val id = UUID.fromString("34efbc8c-caae-4254-8170-98b009c5a866")
+
+    @BeforeEach
+    fun clearMocks() {
+        clearAllMocks()
+    }
+
+    @AfterEach
+    fun checkMocks() {
+        checkUnnecessaryStub()
+        confirmVerified(paatosService, authorizer)
+    }
+
+    @Nested
+    inner class Download {
+        private val url = "/paatokset/$id"
+
+        private val hakemusId = 673L
+        private val alluId = 51
+        private val hakemustunnus = "KP2425421-2"
+        val hakemus =
+            HakemusFactory.create(
+                id = hakemusId,
+                alluid = alluId,
+                alluStatus = ApplicationStatus.DECISION,
+                applicationIdentifier = hakemustunnus,
+                applicationType = ApplicationType.EXCAVATION_NOTIFICATION,
+            )
+        private val paatos = PaatosFactory.createForHakemus(hakemus)
+
+        @Test
+        @WithAnonymousUser
+        fun `returns 401 when user is not authenticated`() {
+            get(url).andExpect(status().isUnauthorized)
+
+            verify { paatosService wasNot Called }
+        }
+
+        @Test
+        fun `returns 404 when paatos doesn't exist`() {
+            every { authorizer.authorizePaatosId(id, PermissionCode.VIEW.name) } throws
+                PaatosNotFoundException(id)
+
+            get(url).andExpect(status().isNotFound).andExpect(hankeError(HankeError.HAI5001))
+
+            verifySequence { authorizer.authorizePaatosId(id, PermissionCode.VIEW.name) }
+        }
+
+        @Test
+        fun `returns 500 when paatos download fails`() {
+            every { authorizer.authorizePaatosId(id, PermissionCode.VIEW.name) } returns true
+            every { paatosService.findById(id) } returns paatos
+            every { paatosService.downloadDecision(paatos) } throws
+                DownloadNotFoundException(paatos.blobLocation, Container.PAATOKSET)
+
+            get(url)
+                .andExpect(status().isInternalServerError)
+                .andExpect(hankeError(HankeError.HAI0002))
+
+            verifySequence {
+                authorizer.authorizePaatosId(id, PermissionCode.VIEW.name)
+                paatosService.findById(id)
+                paatosService.downloadDecision(paatos)
+            }
+        }
+
+        @Test
+        fun `returns bytes and correct headers`() {
+            every { authorizer.authorizePaatosId(id, PermissionCode.VIEW.name) } returns true
+            every { paatosService.findById(id) } returns paatos
+            every { paatosService.downloadDecision(paatos) } returns
+                Pair("$hakemustunnus-paatos.pdf", PDF_BYTES)
+
+            get(url, MediaType.APPLICATION_PDF)
+                .andExpect(status().isOk)
+                .andExpect(
+                    MockMvcResultMatchers.header()
+                        .string("Content-Disposition", "inline; filename=KP2425421-2-paatos.pdf"))
+                .andExpect(MockMvcResultMatchers.content().bytes(PDF_BYTES))
+
+            verifySequence {
+                authorizer.authorizePaatosId(id, PermissionCode.VIEW.name)
+                paatosService.findById(id)
+                paatosService.downloadDecision(paatos)
+            }
+        }
+
+        @Test
+        fun `writes access to audit logs`() {
+            every { authorizer.authorizePaatosId(id, PermissionCode.VIEW.name) } returns true
+            every { paatosService.findById(id) } returns paatos
+            every { paatosService.downloadDecision(paatos) } returns
+                Pair("$hakemustunnus-paatos.pdf", PDF_BYTES)
+
+            get(url, MediaType.APPLICATION_PDF).andExpect(status().isOk)
+
+            verifySequence {
+                authorizer.authorizePaatosId(id, PermissionCode.VIEW.name)
+                paatosService.findById(id)
+                paatosService.downloadDecision(paatos)
+                disclosureLogService.saveDisclosureLogsForPaatos(
+                    paatos.toMetadata(),
+                    USERNAME,
+                )
+            }
+        }
+    }
+}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeError.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeError.kt
@@ -57,6 +57,7 @@ enum class HankeError(val errorMessage: String) {
     HAI4005("Could not verify user identity"),
     HAI4006("Duplicate hankekayttaja"),
     HAI4007("Verified name not found in Profiili"),
+    HAI5001("Decision not found"),
     ;
 
     val errorCode: String

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/AuditLogEntry.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/AuditLogEntry.kt
@@ -45,7 +45,6 @@ enum class Status {
 enum class ObjectType {
     ALLU_CONTACT,
     ALLU_CUSTOMER,
-    APPLICATION,
     APPLICATION_CONTACT,
     APPLICATION_CUSTOMER,
     CABLE_REPORT,
@@ -54,6 +53,7 @@ enum class ObjectType {
     HANKE,
     HANKE_KAYTTAJA,
     KAYTTAJA_TUNNISTE,
+    PAATOS,
     PERMISSION,
     PROFIILI_NIMI,
     YHTEYSTIETO,
@@ -87,7 +87,5 @@ data class AuditLogEntry(
                         failureDescription = failureDescription,
                         actor = AuditLogActor(userId, userRole, ipAddress),
                         target = AuditLogTarget(objectId, objectType, objectBefore, objectAfter),
-                    )
-                )
-        )
+                    )))
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/paatos/Paatos.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/paatos/Paatos.kt
@@ -18,4 +18,6 @@ data class Paatos(
     fun toResponse(): PaatosResponse =
         PaatosResponse(
             id, hakemusId, hakemustunnus, tyyppi, tila, nimi, alkupaiva, loppupaiva, size)
+
+    fun toMetadata(): PaatosMetadata = PaatosMetadata(id, hakemusId, hakemustunnus, tyyppi, tila)
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/paatos/PaatosAuthorizer.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/paatos/PaatosAuthorizer.kt
@@ -1,0 +1,32 @@
+package fi.hel.haitaton.hanke.paatos
+
+import fi.hel.haitaton.hanke.HankeRepository
+import fi.hel.haitaton.hanke.hakemus.HakemusRepository
+import fi.hel.haitaton.hanke.permissions.Authorizer
+import fi.hel.haitaton.hanke.permissions.PermissionCode
+import fi.hel.haitaton.hanke.permissions.PermissionService
+import java.util.UUID
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+class PaatosAuthorizer(
+    permissionService: PermissionService,
+    hankeRepository: HankeRepository,
+    private val paatosRepository: PaatosRepository,
+    private val hakemusRepository: HakemusRepository,
+) : Authorizer(permissionService, hankeRepository) {
+
+    @Transactional(readOnly = true)
+    fun authorizePaatosId(paatosId: UUID, permissionCode: String): Boolean {
+        val hankeId =
+            paatosRepository.findByIdOrNull(paatosId)?.let {
+                hakemusRepository.findByIdOrNull(it.hakemusId)?.hanke?.id
+            }
+        authorize(hankeId, PermissionCode.valueOf(permissionCode)) {
+            PaatosNotFoundException(paatosId)
+        }
+        return true
+    }
+}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/paatos/PaatosController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/paatos/PaatosController.kt
@@ -1,0 +1,79 @@
+package fi.hel.haitaton.hanke.paatos
+
+import fi.hel.haitaton.hanke.HankeError
+import fi.hel.haitaton.hanke.currentUserId
+import fi.hel.haitaton.hanke.logging.DisclosureLogService
+import io.swagger.v3.oas.annotations.Hidden
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
+import java.util.UUID
+import mu.KotlinLogging
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+
+private val logger = KotlinLogging.logger {}
+
+@RestController
+@RequestMapping("/paatokset")
+@SecurityRequirement(name = "bearerAuth")
+class PaatosController(
+    private val paatosService: PaatosService,
+    private val disclosureLogService: DisclosureLogService,
+) {
+    @GetMapping("/{id}")
+    @Operation(
+        summary = "Download decision with the given ID.",
+        description =
+            """
+                Downloads the decision PDF for this decision. Decision can also be an approval
+                document for an operational condition or a work finished.
+            """)
+    @ApiResponses(
+        value =
+            [
+                ApiResponse(
+                    description = "The decision PDF",
+                    responseCode = "200",
+                    content = [Content(mediaType = MediaType.APPLICATION_PDF_VALUE)],
+                ),
+                ApiResponse(
+                    description = "A decision was not found with the given id",
+                    responseCode = "404",
+                    content = [Content(schema = Schema(implementation = HankeError::class))],
+                ),
+            ])
+    @PreAuthorize("@paatosAuthorizer.authorizePaatosId(#id, 'VIEW')")
+    fun download(@PathVariable("id") id: UUID): ResponseEntity<ByteArray> {
+        val paatos: Paatos = paatosService.findById(id)
+        val (filename, pdfBytes) = paatosService.downloadDecision(paatos)
+        disclosureLogService.saveDisclosureLogsForPaatos(paatos.toMetadata(), currentUserId())
+
+        val headers = HttpHeaders()
+        headers.add("Content-Disposition", "inline; filename=$filename")
+        return ResponseEntity.ok()
+            .headers(headers)
+            .contentType(MediaType.APPLICATION_PDF)
+            .body(pdfBytes)
+    }
+
+    @ExceptionHandler(PaatosNotFoundException::class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    @Hidden
+    fun paatosNotFoundException(ex: PaatosNotFoundException): HankeError {
+        logger.warn(ex) { ex.message }
+        return HankeError.HAI5001
+    }
+}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/paatos/PaatosMetadata.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/paatos/PaatosMetadata.kt
@@ -1,0 +1,11 @@
+package fi.hel.haitaton.hanke.paatos
+
+import java.util.UUID
+
+data class PaatosMetadata(
+    val id: UUID,
+    val hakemusId: Long,
+    val hakemustunnus: String,
+    val tyyppi: PaatosTyyppi,
+    val tila: PaatosTila,
+)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/paatos/PaatosNotFoundException.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/paatos/PaatosNotFoundException.kt
@@ -1,0 +1,6 @@
+package fi.hel.haitaton.hanke.paatos
+
+import java.util.UUID
+
+class PaatosNotFoundException(paatosId: UUID) :
+    RuntimeException("Paatos not found with id $paatosId")

--- a/services/hanke-service/src/main/resources/application.yml
+++ b/services/hanke-service/src/main/resources/application.yml
@@ -143,3 +143,4 @@ springdoc:
   swagger-ui:
     config-url: ${HAITATON_SWAGGER_PATH_PREFIX:/api/v3}/api-docs/swagger-config
     url: ${HAITATON_SWAGGER_PATH_PREFIX:/api/v3}/api-docs
+  trim-kotlin-indent: true

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusBuilder.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusBuilder.kt
@@ -210,6 +210,17 @@ data class HakemusBuilder(
                     .tyonSuorittaja(founder())
         }
 
+    /**
+     * Make the hakemus appear like it has been just sent. I.e. it has mandatory fields and allu
+     * status fields filled.
+     */
+    fun asSent(
+        status: ApplicationStatus? = ApplicationStatus.PENDING,
+        alluId: Int? = 1,
+        identifier: String? = "JS000$alluId",
+        hankealue: SavedHankealue? = null
+    ) = this.withMandatoryFields(hankealue).withStatus(status, alluId, identifier)
+
     private fun founder(): HankekayttajaEntity =
         hankeKayttajaService.getKayttajaByUserId(hankeId, userId)!!
 

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusBuilder.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusBuilder.kt
@@ -55,7 +55,7 @@ data class HakemusBuilder(
     fun withStatus(
         status: ApplicationStatus? = ApplicationStatus.PENDING,
         alluId: Int? = 1,
-        identifier: String? = "JS000$alluId",
+        identifier: String? = defaultIdentifier(alluId),
     ): HakemusBuilder {
         hakemusEntity.apply {
             alluid = alluId
@@ -217,7 +217,7 @@ data class HakemusBuilder(
     fun asSent(
         status: ApplicationStatus? = ApplicationStatus.PENDING,
         alluId: Int? = 1,
-        identifier: String? = "JS000$alluId",
+        identifier: String? = defaultIdentifier(alluId),
         hankealue: SavedHankealue? = null
     ) = this.withMandatoryFields(hankealue).withStatus(status, alluId, identifier)
 
@@ -385,4 +385,10 @@ data class HakemusBuilder(
     ) =
         HakemusyhteyshenkiloEntity(
             hankekayttaja = kayttaja, hakemusyhteystieto = yhteystietoEntity, tilaaja = tilaaja)
+
+    private fun defaultIdentifier(alluId: Int?) =
+        when (hakemusEntity.applicationType) {
+            ApplicationType.EXCAVATION_NOTIFICATION -> "KP23%05d".format(alluId)
+            ApplicationType.CABLE_REPORT -> "JS23%05d".format(alluId)
+        }
 }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/PaatosFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/PaatosFactory.kt
@@ -41,8 +41,8 @@ class PaatosFactory(private val paatosRepository: PaatosRepository) {
                 tyyppi = tyyppi,
                 tila = tila,
                 nimi = hakemus.applicationData.name,
-                alkupaiva = hakemus.applicationData.startTime?.toLocalDate()!!,
-                loppupaiva = hakemus.applicationData.endTime?.toLocalDate()!!,
+                alkupaiva = hakemus.applicationData.startTime!!.toLocalDate(),
+                loppupaiva = hakemus.applicationData.endTime!!.toLocalDate(),
                 blobLocation = "${hakemus.id}/${UUID.randomUUID()}",
                 size = 53,
             )
@@ -59,8 +59,8 @@ class PaatosFactory(private val paatosRepository: PaatosRepository) {
                 tyyppi = tyyppi,
                 tila = tila,
                 nimi = hakemus.applicationData.name,
-                alkupaiva = hakemus.applicationData.startTime?.toLocalDate()!!,
-                loppupaiva = hakemus.applicationData.endTime?.toLocalDate()!!,
+                alkupaiva = hakemus.applicationData.startTime!!.toLocalDate(),
+                loppupaiva = hakemus.applicationData.endTime!!.toLocalDate(),
                 blobLocation = "${hakemus.id}/${UUID.randomUUID()}",
                 size = 53,
             )

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/logging/DisclosureLogServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/logging/DisclosureLogServiceTest.kt
@@ -41,6 +41,9 @@ import fi.hel.haitaton.hanke.hakemus.HakemusDataMapper.toAlluCustomer
 import fi.hel.haitaton.hanke.hakemus.HakemusDataMapper.toAlluExcavationNotificationData
 import fi.hel.haitaton.hanke.hakemus.toLaskutusyhteystieto
 import fi.hel.haitaton.hanke.hasSameElementsAs
+import fi.hel.haitaton.hanke.paatos.PaatosMetadata
+import fi.hel.haitaton.hanke.paatos.PaatosTila
+import fi.hel.haitaton.hanke.paatos.PaatosTyyppi
 import fi.hel.haitaton.hanke.reformatJson
 import fi.hel.haitaton.hanke.test.AuditLogEntryAsserts.hasAlluActor
 import fi.hel.haitaton.hanke.test.AuditLogEntryAsserts.isSuccess
@@ -92,8 +95,7 @@ internal class DisclosureLogServiceTest {
                     StringNode("sukunimi", TESTIHENKILO),
                     StringNode("sahkoposti", TEPPO_EMAIL),
                     StringNode("puhelin", TEPPO_PHONE),
-                )
-            )
+                ))
 
         disclosureLogService.saveDisclosureLogsForProfiili(userId, info)
 
@@ -115,7 +117,7 @@ internal class DisclosureLogServiceTest {
                 userRole = UserRole.SERVICE,
                 objectType = ObjectType.GDPR_RESPONSE,
                 objectId = userId,
-                objectBefore = expectedObject
+                objectBefore = expectedObject,
             )
         verify { auditLogService.create(expectedEntry) }
     }
@@ -178,7 +180,7 @@ internal class DisclosureLogServiceTest {
         val hankkeet =
             listOf(
                 HankeFactory.create().withYhteystiedot(),
-                HankeFactory.create().withOmistaja(5).withRakennuttaja(6).withToteuttaja(7)
+                HankeFactory.create().withOmistaja(5).withRakennuttaja(6).withToteuttaja(7),
             )
         val expectedLogs = hankkeet.flatMap { AuditLogEntryFactory.createReadEntriesForHanke(it) }
 
@@ -192,7 +194,7 @@ internal class DisclosureLogServiceTest {
         val hankkeet =
             listOf(
                 HankeFactory.create().withYhteystiedot(),
-                HankeFactory.create().withYhteystiedot()
+                HankeFactory.create().withYhteystiedot(),
             )
         val expectedLogs = AuditLogEntryFactory.createReadEntriesForHanke(hankkeet[0])
 
@@ -234,7 +236,7 @@ internal class DisclosureLogServiceTest {
                     applicationData =
                         HakemusResponseFactory.createJohtoselvitysHakemusDataResponse(
                             customerWithContacts = customerWithoutContacts,
-                            contractorWithContacts = contractorWithoutContacts
+                            contractorWithContacts = contractorWithoutContacts,
                         ),
                     hankeTunnus = hankeTunnus,
                 )
@@ -256,7 +258,7 @@ internal class DisclosureLogServiceTest {
                     applicationData =
                         HakemusResponseFactory.createJohtoselvitysHakemusDataResponse(
                             customerWithContacts = customerWithoutContacts,
-                            contractorWithContacts = contractorWithoutContacts
+                            contractorWithContacts = contractorWithoutContacts,
                         ),
                     hankeTunnus = hankeTunnus,
                 )
@@ -277,7 +279,7 @@ internal class DisclosureLogServiceTest {
                     applicationData =
                         HakemusResponseFactory.createJohtoselvitysHakemusDataResponse(
                             customerWithContacts = customerWithoutContacts,
-                            contractorWithContacts = contractorWithoutContacts
+                            contractorWithContacts = contractorWithoutContacts,
                         ),
                     hankeTunnus = hankeTunnus,
                 )
@@ -310,7 +312,7 @@ internal class DisclosureLogServiceTest {
                     AuditLogEntryFactory.createReadEntryForCustomerResponse(
                         hakemusResponse.id,
                         customerWithoutContacts.customer,
-                        it
+                        it,
                     )
                 }
             assertThat(capturedLogs.captured).hasSameElementsAs(expectedLogs)
@@ -328,7 +330,7 @@ internal class DisclosureLogServiceTest {
                 HakemusResponseFactory.create(
                     applicationId = applicationId,
                     applicationData = hakemusDataResponse,
-                    hankeTunnus = hankeTunnus
+                    hankeTunnus = hankeTunnus,
                 )
             val capturedLogs = slot<Collection<AuditLogEntry>>()
             every { auditLogService.createAll(capture(capturedLogs)) } returns mutableListOf()
@@ -338,15 +340,9 @@ internal class DisclosureLogServiceTest {
             assertThat(capturedLogs.captured)
                 .containsAtLeast(
                     AuditLogEntryFactory.createReadEntryForContactResponse(
-                        applicationId,
-                        firstContact,
-                        HAKIJA
-                    ),
+                        applicationId, firstContact, HAKIJA),
                     AuditLogEntryFactory.createReadEntryForContactResponse(
-                        applicationId,
-                        secondContact,
-                        TYON_SUORITTAJA
-                    ),
+                        applicationId, secondContact, TYON_SUORITTAJA),
                 )
             verify(exactly = 1) { auditLogService.createAll(any()) }
         }
@@ -368,14 +364,10 @@ internal class DisclosureLogServiceTest {
             val expectedLogs =
                 listOf(
                         HAKIJA to hakija.yhteyshenkilot[0],
-                        TYON_SUORITTAJA to rakennuttaja.yhteyshenkilot[0]
-                    )
+                        TYON_SUORITTAJA to rakennuttaja.yhteyshenkilot[0])
                     .map { (role, contact) ->
                         AuditLogEntryFactory.createReadEntryForContact(
-                                applicationId,
-                                contact.toAlluContact(),
-                                role
-                            )
+                                applicationId, contact.toAlluContact(), role)
                             .copy(
                                 status = expectedStatus,
                                 userId = ALLU_AUDIT_LOG_USERID,
@@ -388,7 +380,7 @@ internal class DisclosureLogServiceTest {
             disclosureLogService.saveDisclosureLogsForAllu(
                 applicationId,
                 hakemusData.toAlluCableReportData(hankeTunnus),
-                expectedStatus
+                expectedStatus,
             )
 
             assertThat(capturedLogs.captured).hasSameElementsAs(expectedLogs)
@@ -403,7 +395,7 @@ internal class DisclosureLogServiceTest {
             val hakemusData =
                 HakemusFactory.createJohtoselvityshakemusData(
                     customerWithContacts = personCustomer,
-                    contractorWithContacts = companyCustomer
+                    contractorWithContacts = companyCustomer,
                 )
             val capturedLogs = slot<Collection<AuditLogEntry>>()
             every { auditLogService.createAll(capture(capturedLogs)) } returns mutableListOf()
@@ -411,7 +403,7 @@ internal class DisclosureLogServiceTest {
             disclosureLogService.saveDisclosureLogsForAllu(
                 applicationId,
                 hakemusData.toAlluCableReportData(hankeTunnus),
-                Status.SUCCESS
+                Status.SUCCESS,
             )
 
             assertThat(capturedLogs.captured).single().all {
@@ -421,8 +413,7 @@ internal class DisclosureLogServiceTest {
                 prop(AuditLogEntry::objectBefore)
                     .isEqualTo(
                         AlluCustomerWithRole(HAKIJA, personCustomer.toAlluCustomer().customer)
-                            .toJsonString()
-                    )
+                            .toJsonString())
             }
             verify(exactly = 1) { auditLogService.createAll(any()) }
         }
@@ -432,22 +423,18 @@ internal class DisclosureLogServiceTest {
             val applicationId = 41L
             val personCustomer =
                 HakemusyhteystietoFactory.createPerson(
-                    nimi = "",
-                    puhelinnumero = "",
-                    sahkoposti = "",
-                    ytunnus = ""
-                )
+                    nimi = "", puhelinnumero = "", sahkoposti = "", ytunnus = "")
             val companyCustomer = HakemusyhteystietoFactory.create()
             val hakemusData =
                 HakemusFactory.createJohtoselvityshakemusData(
                     customerWithContacts = personCustomer,
-                    contractorWithContacts = companyCustomer
+                    contractorWithContacts = companyCustomer,
                 )
 
             disclosureLogService.saveDisclosureLogsForAllu(
                 applicationId,
                 hakemusData.toAlluCableReportData(hankeTunnus),
-                Status.SUCCESS
+                Status.SUCCESS,
             )
 
             verify { auditLogService wasNot Called }
@@ -469,9 +456,7 @@ internal class DisclosureLogServiceTest {
                     objectType = ObjectType.ALLU_CUSTOMER,
                     objectBefore =
                         AlluMetaCustomerWithRole(
-                                MetaCustomerType.INVOICING,
-                                invoicingCustomer.toAlluData("")
-                            )
+                                MetaCustomerType.INVOICING, invoicingCustomer.toAlluData(""))
                             .toJsonString(),
                     userId = ALLU_AUDIT_LOG_USERID,
                     userRole = UserRole.SERVICE,
@@ -482,7 +467,7 @@ internal class DisclosureLogServiceTest {
             disclosureLogService.saveDisclosureLogsForAllu(
                 applicationId,
                 hakemusData.toAlluExcavationNotificationData(hankeTunnus),
-                Status.SUCCESS
+                Status.SUCCESS,
             )
 
             val customerLogs =
@@ -507,7 +492,7 @@ internal class DisclosureLogServiceTest {
             disclosureLogService.saveDisclosureLogsForAllu(
                 applicationId,
                 hakemusData.toAlluExcavationNotificationData(hankeTunnus),
-                Status.SUCCESS
+                Status.SUCCESS,
             )
 
             val customerLogs =
@@ -518,9 +503,9 @@ internal class DisclosureLogServiceTest {
     }
 
     @Nested
-    inner class SaveDisclosureLogsForDecision {
+    inner class SaveDisclosureLogsForCableReport {
         @Test
-        fun `saves log with application details but decision type`() {
+        fun `saves log with application details but cable report type`() {
             val applicationId = 42L
             val alluId = 2
             val alluStatus = ApplicationStatus.DECISION
@@ -531,7 +516,7 @@ internal class DisclosureLogServiceTest {
                     alluid = alluId,
                     alluStatus = alluStatus,
                     applicationIdentifier = applicationIdentifier,
-                    hankeTunnus = hankeTunnus
+                    hankeTunnus = hankeTunnus,
                 )
             val expectedObject =
                 """{
@@ -548,12 +533,44 @@ internal class DisclosureLogServiceTest {
                     userId,
                     objectType = ObjectType.CABLE_REPORT,
                     objectId = hakemus.id,
-                    objectBefore = expectedObject
+                    objectBefore = expectedObject,
                 )
 
             disclosureLogService.saveDisclosureLogsForCableReport(hakemus.toMetadata(), userId)
 
             verify { auditLogService.create(expectedLog) }
+        }
+    }
+
+    @Nested
+    inner class SaveDisclosureLogsForPaatos {
+        @Test
+        fun `saves log with paatos type`() {
+            val paatosId = UUID.fromString("fa0f538a-09ef-48bf-ba6a-681e0c979b14")
+            val hakemusId = 42L
+            val hakemustunnus = "JS2300050-2"
+            val tyyppi = PaatosTyyppi.TOIMINNALLINEN_KUNTO
+            val tila = PaatosTila.KORVATTU
+            val expectedObject =
+                """{
+                  "id": "$paatosId",
+                  "hakemusId": $hakemusId,
+                  "hakemustunnus": "$hakemustunnus",
+                  "tyyppi": "$tyyppi",
+                  "tila": "$tila"
+                }"""
+                    .reformatJson()
+            val expectedLog =
+                AuditLogEntryFactory.createReadEntry(
+                    userId,
+                    objectType = ObjectType.PAATOS,
+                    objectId = paatosId,
+                    objectBefore = expectedObject)
+            val metadata = PaatosMetadata(paatosId, hakemusId, hakemustunnus, tyyppi, tila)
+
+            disclosureLogService.saveDisclosureLogsForPaatos(metadata, userId)
+
+            verifySequence { auditLogService.create(expectedLog) }
         }
     }
 


### PR DESCRIPTION
# Description

Add an API for downloading decision and approval documents for operational conditions and work finished. Downloads are allowed to anyone with view access to the hanke.

Write the decision downloads to audit logs. The decisions contain personal information, so accessing them needs to be logged. Log paatos metadata, since we can't know what personal information is on the decisions.

Also, remove `APPLICATION` from audit log object types. It was only used in tests, and incorrectly in those. The tests were fixed as well.

Enable a recently added feature in Springdoc that trims indentation from Kotlin's multiline strings. Long descriptions and descriptions with markdown formatting can be written with natural indentations.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1504

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
- Find out the decisions for an application with decisions with get single hakemus endpoint: http://localhost:3001/api/swagger-ui/index.html#/hakemus-controller/getById or look in `paatos` table in DB.
- Call the download API. Swagger UI doesn't work correctly with files, so this can be done with cURL:
  - ```curl 'http://localhost:3001/api/paatokset/<id>' -H 'Authorization: Bearer <token>' -H 'Connection: keep-alive' -H 'accept: application/pdf' -OJ -w "Downloaded: %{filename_effective}" -v"```
  - `-OJ` makes cURL use the filename from the Content-Disposition header.
  - `-w` tells cURL to output the name of the downloaded file
  - `-v` makes cURL show headers
  - cURL will not overwrite files by default. To download the same file again, delete the file or add `--clobber` to make cURL overwrite the existing file.
- Check in DB that there's an entry in audit logs.
  - `select * from audit_logs where message->'audit_event'->'target'->>'type' = 'PAATOS';`

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 