### PR TITLE
HAI-2651 Configure Haitaton for Keycloak instead of tunnistamo

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,9 @@ Haitaton supports uploading of attachment files. Files are validated with ClamAV
 
 ## Authentication
 
-Authentication is done by calling Helsinki Profiili's userinfo-url with the Bearer-token.
+Authentication is handled by Spring Boot's default configuration. It defaults to the Authentication
+code with PKCE flow Profiili Keycloak uses as well. The access token's signature, issuer and
+audience are checked and the subject is read from the token.
 
 ## GDPR API
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -98,8 +98,6 @@ services:
       HAITATON_PORT: 5432
       HAITATON_USER: haitaton_user
       HAITATON_PASSWORD: haitaton
-      HAITATON_OAUTH2_CLIENT_ID: https://api.hel.fi/auth/haitatonapidev
-      HAITATON_OAUTH2_USER_INFO_URI: https://tunnistamo.test.hel.ninja/openid/userinfo
       HAITATON_BLOB_CONNECTION_STRING: BlobEndpoint=http://azurite:10000/devstoreaccount1;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;
       #      HAITATON_CORS_ALLOWED_ORIGINS: http://localhost:8000
       HAITATON_GDPR_DISABLED: ${HAITATON_GDPR_DISABLED:-true}
@@ -137,7 +135,7 @@ services:
       # - haitaton-ui-dev for Suomi.fi authentication
       # - haitaton-admin-ui-dev for Helsinki AD authentication
       REACT_APP_OIDC_CLIENT_ID: haitaton-ui-dev
-      LOGIN_SERVER: https://tunnistamo.test.hel.ninja
+      LOGIN_SERVER: https://tunnistus.test.hel.ninja
       REACT_APP_FEATURE_HANKE: 1
       REACT_APP_FEATURE_ACCESS_RIGHTS: 1
     ports:

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/profiili/ProfiiliProperties.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/profiili/ProfiiliProperties.kt
@@ -5,6 +5,5 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 @ConfigurationProperties(prefix = "haitaton.profiili-api")
 data class ProfiiliProperties(
     val graphQlUrl: String,
-    val apiTokensUrl: String,
     val audience: String,
 )

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/security/OAuth2ResourceServerSecurityConfiguration.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/security/OAuth2ResourceServerSecurityConfiguration.kt
@@ -1,19 +1,15 @@
 package fi.hel.haitaton.hanke.security
 
 import fi.hel.haitaton.hanke.gdpr.GdprProperties
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.core.ParameterizedTypeReference
 import org.springframework.core.annotation.Order
 import org.springframework.security.config.Customizer
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator
-import org.springframework.security.oauth2.core.OAuth2AuthenticatedPrincipal
 import org.springframework.security.oauth2.core.OAuth2TokenValidator
-import org.springframework.security.oauth2.core.user.DefaultOAuth2User
 import org.springframework.security.oauth2.jwt.Jwt
 import org.springframework.security.oauth2.jwt.JwtClaimNames
 import org.springframework.security.oauth2.jwt.JwtClaimValidator
@@ -21,27 +17,16 @@ import org.springframework.security.oauth2.jwt.JwtDecoder
 import org.springframework.security.oauth2.jwt.JwtDecoders
 import org.springframework.security.oauth2.jwt.JwtValidators
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder
-import org.springframework.security.oauth2.server.resource.introspection.OpaqueTokenIntrospector
 import org.springframework.security.web.SecurityFilterChain
-import org.springframework.web.reactive.function.client.WebClient
 
 @Configuration
 @EnableMethodSecurity(prePostEnabled = true)
-class OAuth2ResourceServerSecurityConfiguration(
-    @Value("\${security.oauth2.resource.user-info-uri}") private val userinfoUri: String,
-    private val gdprProperties: GdprProperties,
-) {
-    @Bean
-    fun introspector(): OpaqueTokenIntrospector {
-        return UserInfoOpaqueTokenIntrospector(userinfoUri)
-    }
+class OAuth2ResourceServerSecurityConfiguration(private val gdprProperties: GdprProperties) {
 
     @Bean
     fun filterChain(http: HttpSecurity): SecurityFilterChain {
         AccessRules.configureHttpAccessRules(http)
-        http.oauth2ResourceServer { resourceServer ->
-            resourceServer.opaqueToken { opaqueToken -> opaqueToken.introspector(introspector()) }
-        }
+        http.oauth2ResourceServer { it.jwt {} }
         return http.build()
     }
 
@@ -108,22 +93,5 @@ class OAuth2ResourceServerSecurityConfiguration(
         jwtDecoder.setJwtValidator(withAudience)
 
         return jwtDecoder
-    }
-}
-
-class UserInfoOpaqueTokenIntrospector(private val userinfoUri: String) : OpaqueTokenIntrospector {
-    private val rest: WebClient = WebClient.create()
-
-    override fun introspect(token: String): OAuth2AuthenticatedPrincipal {
-        val attributes =
-            rest
-                .get()
-                .uri(userinfoUri)
-                .headers { it.setBearerAuth(token) }
-                .retrieve()
-                .bodyToMono(object : ParameterizedTypeReference<Map<String, Any>>() {})
-                .block()
-
-        return DefaultOAuth2User(listOf(), attributes, "sub")
     }
 }

--- a/services/hanke-service/src/main/resources/application.yml
+++ b/services/hanke-service/src/main/resources/application.yml
@@ -45,9 +45,8 @@ haitaton:
     issuer: ${HAITATON_GDPR_ISSUER:http://gdpr-api-tester:8888/}
     query-scope: ${HAITATON_GDPR_QUERY_SCOPE:haitaton.gdprquery}
   profiili-api:
-    api-tokens-url: ${PROFIILI_API_TOKENS_URL:https://tunnistamo.test.hel.ninja/api-tokens/}
     graph-ql-url: ${PROFIILI_GRAPHQL_URL:https://profile-api.test.hel.ninja/graphql/}
-    audience: ${PROFIILI_AUDIENCE:https://api.hel.fi/auth/helsinkiprofile}
+    audience: ${PROFIILI_AUDIENCE:profile-api-test}
   testdata:
     enabled: ${HAITATON_TESTDATA_ENABLED:false}  # For dev and test environments, enable the testdata controller for resetting data
 
@@ -72,14 +71,6 @@ management:
       enabled: true
   server:
     port: 8081
-
-security:
-  oauth2:
-    client:
-      client-id: ${HAITATON_OAUTH2_CLIENT_ID:iTestMock}
-    resource:
-      prefer-token-info: false
-      user-info-uri: ${HAITATON_OAUTH2_USER_INFO_URI:iTestMock}
 
 sentry:
   # DSN is a public detail.
@@ -129,6 +120,11 @@ spring:
       # REST API request parameter parsing to work for date values
       date: yyyy-MM-dd
   security:
+    oauth2:
+      resourceserver:
+        jwt:
+          issuer-uri: ${HAITATON_OAUTH2_ISSUER:https://tunnistus.test.hel.ninja/auth/realms/helsinki-tunnistus}
+          audiences: ${HAITATON_OAUTH2_AUDIENCE:haitaton-api-dev}
     filter:
       order: -100
   servlet:


### PR DESCRIPTION
# Description

Use the default JWT flow in Spring Security, since the default is Authorization Code with PKCE, which is what's used for the new Keycloak authorization.

Update the authentication to the Profiili API. With keycloak, getting the API token needs a different kind of request than before.

The address for the API token request can be fetched from the OpenID configuration endpoint. Getting it from there means we have one less environment-specific thing to configure.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2651

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [X] Other

# Instructions for testing
- Start UI from the https://github.com/City-of-Helsinki/haitaton-ui/pull/828 branch.
- Login.
- See that you get the verified name on the header bar and the everything is working as it should.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 