### PR TITLE
HAI-2657 Send attachment type to Allu in description

### DIFF
--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/AlluClient.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/AlluClient.kt
@@ -442,16 +442,7 @@ data class LoginInfo(val username: String, val password: String)
 data class Attachment(
     val metadata: AttachmentMetadata,
     @Suppress("ArrayInDataClass") val file: ByteArray
-) {
-    constructor(
-        contentType: String,
-        fileName: String,
-        content: ByteArray
-    ) : this(
-        AttachmentMetadata(id = null, mimeType = contentType, name = fileName, description = null),
-        content,
-    )
-}
+)
 
 class AlluLoginException(cause: Throwable) : RuntimeException(cause)
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/common/AttachmentEntity.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/common/AttachmentEntity.kt
@@ -171,4 +171,12 @@ enum class ApplicationAttachmentType {
     MUU,
     LIIKENNEJARJESTELY,
     VALTAKIRJA,
+    ;
+
+    fun toFinnish(): String =
+        when (this) {
+            MUU -> "Muu liite"
+            LIIKENNEJARJESTELY -> "Liikennejärjestelysuunnitelma"
+            VALTAKIRJA -> "Valtakirja"
+        }
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/common/Domain.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/common/Domain.kt
@@ -57,9 +57,9 @@ data class ApplicationAttachmentMetadata(
                     id = null,
                     mimeType = contentType,
                     name = fileName,
-                    description = null,
+                    description = attachmentType.toFinnish(),
                 ),
-            file = content
+            file = content,
         )
     }
 }


### PR DESCRIPTION
# Description

There's no field in Allu that would say which kind of attachment we're sending there. For the handlers looking at the application, it's useful knowledge so they don't have to open each one to see which one it is. So we include the type in the description field of the attachment.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2657

## Type of change

- [x] Bug fix 
- [ ] New feature 
- [ ] Other

# Instructions for testing
1. Add attachments to an application
2. Send it to Allu
3. Look at the application in Allu and check that the attachments have descriptions with the attachment type
    - The generated form data PDF has a different description which doesn't include the type

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 