### PR TITLE
HAI-2655 GDPR-API changes for new Tunnistus

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,10 +244,11 @@ Set the API Tester configuration as follows (in profile-gdpr-api-tester/.env):
 
 ```
   ISSUER = http://gdpr-api-tester:8888/
-  GDPR_API_AUDIENCE = http://localhost:8080/haitaton
+  ISSUER_TYPE = keycloak
+  GDPR_API_AUDIENCE = haitaton-api-dev
   GDPR_API_AUTHORIZATION_FIELD = http://localhost:8080
-  GDPR_API_QUERY_SCOPE = haitaton.gdprquery
-  GDPR_API_DELETE_SCOPE = haitaton.gdprdelete
+  GDPR_API_QUERY_SCOPE = gdprquery
+  GDPR_API_DELETE_SCOPE = gdprdelete
   GDPR_API_URL = http://haitaton-hanke:8080/gdpr-api/$user_uuid
   PROFILE_ID = 65d4015d-1736-4848-9466-25d43a1fe8c7
   USER_UUID = <Your user id>
@@ -263,6 +264,11 @@ from hanke;
 -- Or
 select userid
 from applications;
+```
+
+Build the tester tool with:
+```shell
+docker build -t gdpr-api-tester .
 ```
 
 To make the API tester work with Haitaton running in Docker Compose, start it like this:

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/gdpr/GdprProperties.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/gdpr/GdprProperties.kt
@@ -7,7 +7,6 @@ data class GdprProperties(
     val disabled: Boolean,
     val issuer: String,
     val audience: String,
-    val authorizationField: String,
     val queryScope: String,
     val deleteScope: String,
 )

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/profiili/ProfiiliClient.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/profiili/ProfiiliClient.kt
@@ -79,6 +79,11 @@ class ProfiiliClient(
                     .with("permission", TOKEN_API_PERMISSION))
             .retrieve()
             .bodyToMono(JsonNode::class.java)
+            .doOnError(WebClientResponseException::class.java) { ex ->
+                logger.error {
+                    "Error from Profiili API call. Response status=${ex.statusCode}, body=${ex.responseBodyAsString}"
+                }
+            }
             .block()!!
     }
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/security/OAuth2ResourceServerSecurityConfiguration.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/security/OAuth2ResourceServerSecurityConfiguration.kt
@@ -5,7 +5,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.core.annotation.Order
-import org.springframework.security.config.Customizer
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator
@@ -48,7 +47,7 @@ class OAuth2ResourceServerSecurityConfiguration(private val gdprProperties: Gdpr
         http
             .securityMatcher("/gdpr-api/**")
             .authorizeHttpRequests { it.anyRequest().authenticated() }
-            .oauth2ResourceServer { it.jwt(Customizer.withDefaults()) }
+            .oauth2ResourceServer { it.jwt { jwt -> jwt.decoder(gdprJwtDecoder()) } }
         return http.build()
     }
 
@@ -74,13 +73,7 @@ class OAuth2ResourceServerSecurityConfiguration(private val gdprProperties: Gdpr
         }
 
     /** Custom decoder needed to check the audience. */
-    @Bean
-    @ConditionalOnProperty(
-        value = ["haitaton.gdpr.disabled"],
-        havingValue = "false",
-        matchIfMissing = true,
-    )
-    fun jwtDecoder(): JwtDecoder {
+    fun gdprJwtDecoder(): JwtDecoder {
         val jwtDecoder: NimbusJwtDecoder =
             JwtDecoders.fromIssuerLocation(gdprProperties.issuer) as NimbusJwtDecoder
 

--- a/services/hanke-service/src/main/resources/application.yml
+++ b/services/hanke-service/src/main/resources/application.yml
@@ -34,16 +34,17 @@ haitaton:
     # Disable endpoints that are e.g. in development and should not be in production.
   features:
     hanke-editing: ${HAITATON_FEATURE_HANKE_EDITING:false}
+  gdpr:
     # GDPR API is disabled by default for tests and local running.
     # Spring Security will otherwise try to call the issuer's openid-configuration URL,
     # which will fail, unless the developer has also started profile-gdpr-api-tester.
-  gdpr:
-    audience: ${HAITATON_GDPR_AUDIENCE:http://localhost:8080/haitaton}
-    authorization-field: ${HAITATON_GDPR_AUTHORIZATION_FIELD:http://localhost:8080}
-    delete-scope: ${HAITATON_GDPR_DELETE_SCOPE:haitaton.gdprdelete}
     disabled: ${HAITATON_GDPR_DISABLED:false}
-    issuer: ${HAITATON_GDPR_ISSUER:http://gdpr-api-tester:8888/}
-    query-scope: ${HAITATON_GDPR_QUERY_SCOPE:haitaton.gdprquery}
+    # Audience and issuer are the same for GDPR API and other APIs in cloud environments.
+    # They are only different in local development, where GDPR queries come from the tester.
+    audience: ${HAITATON_OAUTH2_AUDIENCE:haitaton-api-dev}
+    issuer: ${HAITATON_OAUTH2_ISSUER:http://gdpr-api-tester:8888/}
+    delete-scope: gdprdelete
+    query-scope: gdprquery
   profiili-api:
     graph-ql-url: ${PROFIILI_GRAPHQL_URL:https://profile-api.test.hel.ninja/graphql/}
     audience: ${PROFIILI_AUDIENCE:profile-api-test}


### PR DESCRIPTION
# Description

Fix authentication when GDPR API is enabled. Tunnistamo used a different authentication flow for regular API calls and GDPR API calls. Only the GDPR API used JWT, so we had a JWT decoder bean that handled that GDPR API authentication. After adopting the new Tunnistus (Keycloak) authentication, it would break when GDPR API was enabled since all incoming tokens would be decoded with the GDPR decoder. Fix this by making the GDPR flow call the proper function instead of relying on a special registered bean.

With Keycloak, the GDPR API authentication has a lot less environment-specific variables compared to Tunnistamo. The scope structure is always as same as the scopes themselves. The issuer and audience of the token are the same as the general purpose API, so the environment variables can be shared. If we didn't need gdpr-api-tester for testing the calls locally, we wouldn't need a separate authentication at all, just the subject and scope authorization in GdprController.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2655

## Type of change

- [X] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
Set `HAITATON_GDPR_DISABLED` to false in `.env` and then test using the profile-gdpr-api-tester as instructed in README. Also, check that Haitaton works in general.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 