### PR TITLE
HAI-2674 Send johtoselvitys complete emails after commit

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/email/EmailSenderServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/email/EmailSenderServiceITest.kt
@@ -44,10 +44,7 @@ class EmailSenderServiceITest : IntegrationTest() {
         @Test
         fun `sendJohtoselvitysCompleteEmail sends email with correct recipient`() {
             emailSenderService.sendJohtoselvitysCompleteEmail(
-                TEST_EMAIL,
-                13L,
-                APPLICATION_IDENTIFIER
-            )
+                JohtoselvitysCompleteEmail(TEST_EMAIL, 13L, APPLICATION_IDENTIFIER))
 
             val email = greenMail.firstReceivedMessage()
             assertThat(email.allRecipients).hasSize(1)
@@ -57,10 +54,7 @@ class EmailSenderServiceITest : IntegrationTest() {
         @Test
         fun `sendJohtoselvitysCompleteEmail sends email with sender from properties`() {
             emailSenderService.sendJohtoselvitysCompleteEmail(
-                TEST_EMAIL,
-                13L,
-                APPLICATION_IDENTIFIER
-            )
+                JohtoselvitysCompleteEmail(TEST_EMAIL, 13L, APPLICATION_IDENTIFIER))
 
             val email = greenMail.firstReceivedMessage()
             assertThat(email.from).hasSize(1)
@@ -70,25 +64,18 @@ class EmailSenderServiceITest : IntegrationTest() {
         @Test
         fun `sendJohtoselvitysCompleteEmail sends email with correct subject`() {
             emailSenderService.sendJohtoselvitysCompleteEmail(
-                TEST_EMAIL,
-                13L,
-                APPLICATION_IDENTIFIER
-            )
+                JohtoselvitysCompleteEmail(TEST_EMAIL, 13L, APPLICATION_IDENTIFIER))
 
             val email = greenMail.firstReceivedMessage()
             assertThat(email.subject)
                 .isEqualTo(
-                    "Haitaton: Johtoselvitys JS2300001 / Ledningsutredning JS2300001 / Cable report JS2300001"
-                )
+                    "Haitaton: Johtoselvitys JS2300001 / Ledningsutredning JS2300001 / Cable report JS2300001")
         }
 
         @Test
         fun `sendJohtoselvitysCompleteEmail sends email with parametrized hybrid body`() {
             emailSenderService.sendJohtoselvitysCompleteEmail(
-                TEST_EMAIL,
-                13L,
-                APPLICATION_IDENTIFIER
-            )
+                JohtoselvitysCompleteEmail(TEST_EMAIL, 13L, APPLICATION_IDENTIFIER))
 
             val email = greenMail.firstReceivedMessage()
             val (textBody, htmlBody) = email.bodies()
@@ -149,8 +136,7 @@ class EmailSenderServiceITest : IntegrationTest() {
                 .isEqualTo(
                     "Haitaton: Sinut on kutsuttu hankkeelle HAI24-1 " +
                         "/ Du har blivit inbjuden till projektet HAI24-1 " +
-                        "/ You have been invited to project HAI24-1"
-                )
+                        "/ You have been invited to project HAI24-1")
         }
 
         @Test
@@ -161,8 +147,7 @@ class EmailSenderServiceITest : IntegrationTest() {
             val (textBody, htmlBody) = email.bodies()
             assertThat(textBody).all {
                 contains(
-                    "${notification.inviterName} (${notification.inviterEmail}) on kutsunut sinut"
-                )
+                    "${notification.inviterName} (${notification.inviterEmail}) on kutsunut sinut")
                 contains("hankkeelle ${notification.hankeNimi} (${notification.hankeTunnus}).")
                 contains("http://localhost:3001/fi/kutsu?id=${notification.invitationToken}")
             }
@@ -170,11 +155,9 @@ class EmailSenderServiceITest : IntegrationTest() {
                 val htmlEscapedName = "Matti Meik&auml;l&auml;inen"
                 contains("$htmlEscapedName (${notification.inviterEmail})")
                 contains(
-                    "hankkeelle <b>${notification.hankeNimi} (${notification.hankeTunnus})</b>."
-                )
+                    "hankkeelle <b>${notification.hankeNimi} (${notification.hankeTunnus})</b>.")
                 contains(
-                    """<a href="http://localhost:3001/fi/kutsu?id=${notification.invitationToken}">"""
-                )
+                    """<a href="http://localhost:3001/fi/kutsu?id=${notification.invitationToken}">""")
             }
         }
     }
@@ -218,8 +201,7 @@ class EmailSenderServiceITest : IntegrationTest() {
                 .isEqualTo(
                     "Haitaton: Sinut on lisätty hakemukselle " +
                         "/ Du har lagts till i en ansökan " +
-                        "/ You have been added to an application"
-                )
+                        "/ You have been added to an application")
         }
 
         @Test
@@ -231,16 +213,14 @@ class EmailSenderServiceITest : IntegrationTest() {
             assertThat(textBody).all {
                 contains("${notification.senderName} (${notification.senderEmail}) on")
                 contains(
-                    "laatimassa johtoselvityshakemusta hankkeelle \"${notification.hankeNimi}\" (${notification.hankeTunnus})"
-                )
+                    "laatimassa johtoselvityshakemusta hankkeelle \"${notification.hankeNimi}\" (${notification.hankeTunnus})")
                 contains("Tarkastele hakemusta Haitattomassa: http://localhost:3001")
             }
             assertThat(htmlBody).all {
                 val htmlEscapedName = "Matti Meik&auml;l&auml;inen"
                 contains("$htmlEscapedName (${notification.senderEmail})")
                 contains(
-                    "laatimassa johtoselvityshakemusta hankkeelle <b>${notification.hankeNimi} (${notification.hankeTunnus})</b>"
-                )
+                    "laatimassa johtoselvityshakemusta hankkeelle <b>${notification.hankeNimi} (${notification.hankeTunnus})</b>")
                 contains("""<a href="http://localhost:3001">""")
             }
         }
@@ -283,8 +263,7 @@ class EmailSenderServiceITest : IntegrationTest() {
             val email = greenMail.firstReceivedMessage()
             assertThat(email.subject)
                 .isEqualTo(
-                    "Haitaton: Käyttöoikeustasoasi on muutettu (HAI24-1) / Dina användarrättigheter har förändrats (HAI24-1) / Your access right level has been changed (HAI24-1)"
-                )
+                    "Haitaton: Käyttöoikeustasoasi on muutettu (HAI24-1) / Dina användarrättigheter har förändrats (HAI24-1) / Your access right level has been changed (HAI24-1)")
         }
 
         @Test
@@ -296,28 +275,21 @@ class EmailSenderServiceITest : IntegrationTest() {
             assertThat(textBody).all {
                 contains("${notification.updatedByName} (${notification.updatedByEmail}) on")
                 contains(
-                    "muuttanut käyttöoikeustasoasi hankkeella \"${notification.hankeNimi}\" (${notification.hankeTunnus})"
-                )
+                    "muuttanut käyttöoikeustasoasi hankkeella \"${notification.hankeNimi}\" (${notification.hankeTunnus})")
                 contains(
-                    "Uusi käyttöoikeutesi on \"${notification.newAccessRights.translations().fi}\""
-                )
+                    "Uusi käyttöoikeutesi on \"${notification.newAccessRights.translations().fi}\"")
                 contains(
-                    "Tarkastele hanketta täällä: http://localhost:3001/fi/hankesalkku/${notification.hankeTunnus}"
-                )
+                    "Tarkastele hanketta täällä: http://localhost:3001/fi/hankesalkku/${notification.hankeTunnus}")
             }
             assertThat(htmlBody).all {
                 contains(
-                    "${StringEscapeUtils.escapeHtml4(notification.updatedByName)} (${notification.updatedByEmail}) on"
-                )
+                    "${StringEscapeUtils.escapeHtml4(notification.updatedByName)} (${notification.updatedByEmail}) on")
                 contains(
-                    "muuttanut käyttöoikeustasoasi hankkeella <b>${notification.hankeNimi} (${notification.hankeTunnus})</b>"
-                )
+                    "muuttanut käyttöoikeustasoasi hankkeella <b>${notification.hankeNimi} (${notification.hankeTunnus})</b>")
                 contains(
-                    "Uusi käyttöoikeutesi on <b>${notification.newAccessRights.translations().fi}</b>"
-                )
+                    "Uusi käyttöoikeutesi on <b>${notification.newAccessRights.translations().fi}</b>")
                 contains(
-                    "Tarkastele hanketta täällä: <a href=\"http://localhost:3001/fi/hankesalkku/${notification.hankeTunnus}\">http://localhost:3001/fi/hankesalkku/${notification.hankeTunnus}</a>"
-                )
+                    "Tarkastele hanketta täällä: <a href=\"http://localhost:3001/fi/hankesalkku/${notification.hankeTunnus}\">http://localhost:3001/fi/hankesalkku/${notification.hankeTunnus}</a>")
             }
         }
     }
@@ -358,8 +330,7 @@ class EmailSenderServiceITest : IntegrationTest() {
             val email = greenMail.firstReceivedMessage()
             assertThat(email.subject)
                 .isEqualTo(
-                    "Haitaton: Sinut on poistettu hankkeelta (HAI24-1) / Du har tagits bort från projektet (HAI24-1) / You have been removed from the project (HAI24-1)"
-                )
+                    "Haitaton: Sinut on poistettu hankkeelta (HAI24-1) / Du har tagits bort från projektet (HAI24-1) / You have been removed from the project (HAI24-1)")
         }
 
         @Test
@@ -371,16 +342,13 @@ class EmailSenderServiceITest : IntegrationTest() {
             assertThat(textBody).all {
                 contains("${notification.deletedByName} (${notification.deletedByEmail}) on")
                 contains(
-                    "poistanut sinut hankkeelta \"${notification.hankeNimi}\" (${notification.hankeTunnus})"
-                )
+                    "poistanut sinut hankkeelta \"${notification.hankeNimi}\" (${notification.hankeTunnus})")
             }
             assertThat(htmlBody).all {
                 contains(
-                    "${StringEscapeUtils.escapeHtml4(notification.deletedByName)} (${notification.deletedByEmail}) on"
-                )
+                    "${StringEscapeUtils.escapeHtml4(notification.deletedByName)} (${notification.deletedByEmail}) on")
                 contains(
-                    "poistanut sinut hankkeelta <b>${notification.hankeNimi} (${notification.hankeTunnus})</b>"
-                )
+                    "poistanut sinut hankkeelta <b>${notification.hankeNimi} (${notification.hankeTunnus})</b>")
             }
         }
     }

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/email/FilteredEmailSenderServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/email/FilteredEmailSenderServiceITest.kt
@@ -18,8 +18,7 @@ import org.springframework.boot.test.context.SpringBootTest
         [
             "haitaton.email.filter.use=true",
             "haitaton.email.filter.allow-list=test@test.test;something@mail.com;*@wildcard.com",
-        ]
-)
+        ])
 class FilteredEmailSenderServiceITest : IntegrationTest() {
 
     companion object {
@@ -34,7 +33,8 @@ class FilteredEmailSenderServiceITest : IntegrationTest() {
 
     @Test
     fun `sendJohtoselvitysCompleteEmail sends email with allowed recipient`() {
-        emailSenderService.sendJohtoselvitysCompleteEmail("test@test.test", 15L, "JS2300001")
+        emailSenderService.sendJohtoselvitysCompleteEmail(
+            JohtoselvitysCompleteEmail("test@test.test", 15L, "JS2300001"))
 
         val email = greenMail.firstReceivedMessage()
         assertThat(email.allRecipients).hasSize(1)
@@ -43,28 +43,32 @@ class FilteredEmailSenderServiceITest : IntegrationTest() {
 
     @Test
     fun `sendJohtoselvitysCompleteEmail blocks send when recipient is not in allow list`() {
-        emailSenderService.sendJohtoselvitysCompleteEmail("foo@bar.test", 13L, "JS2300001")
+        emailSenderService.sendJohtoselvitysCompleteEmail(
+            JohtoselvitysCompleteEmail("foo@bar.test", 13L, "JS2300001"))
 
         assertThat(greenMail.receivedMessages.size).isEqualTo(0)
     }
 
     @Test
     fun `sendJohtoselvitysCompleteEmail blocks send when recipient is close to an allowed email`() {
-        emailSenderService.sendJohtoselvitysCompleteEmail("atest@test.test", 13L, "JS2300001")
+        emailSenderService.sendJohtoselvitysCompleteEmail(
+            JohtoselvitysCompleteEmail("atest@test.test", 13L, "JS2300001"))
 
         assertThat(greenMail.receivedMessages.size).isEqualTo(0)
     }
 
     @Test
     fun `sendJohtoselvitysCompleteEmail blocks send when dot is replaced`() {
-        emailSenderService.sendJohtoselvitysCompleteEmail("test@test-test", 13L, "JS2300001")
+        emailSenderService.sendJohtoselvitysCompleteEmail(
+            JohtoselvitysCompleteEmail("test@test-test", 13L, "JS2300001"))
 
         assertThat(greenMail.receivedMessages.size).isEqualTo(0)
     }
 
     @Test
     fun `sendJohtoselvitysCompleteEmail sends email when email matches wildcard`() {
-        emailSenderService.sendJohtoselvitysCompleteEmail("test@wildcard.com", 15L, "JS2300001")
+        emailSenderService.sendJohtoselvitysCompleteEmail(
+            JohtoselvitysCompleteEmail("test@wildcard.com", 15L, "JS2300001"))
 
         val email = greenMail.firstReceivedMessage()
         assertThat(email.allRecipients).hasSize(1)
@@ -74,10 +78,7 @@ class FilteredEmailSenderServiceITest : IntegrationTest() {
     @Test
     fun `sendJohtoselvitysCompleteEmail sends email when email with suffix matches wildcard`() {
         emailSenderService.sendJohtoselvitysCompleteEmail(
-            "test+suffix@wildcard.com",
-            15L,
-            "JS2300001"
-        )
+            JohtoselvitysCompleteEmail("test+suffix@wildcard.com", 15L, "JS2300001"))
 
         val email = greenMail.firstReceivedMessage()
         assertThat(email.allRecipients).hasSize(1)

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceITest.kt
@@ -2612,6 +2612,7 @@ class HakemusServiceITest(
 
             hakemusService.handleHakemusUpdates(histories, updateTime)
 
+            assertThat(greenMail.waitForIncomingEmail(1000L, 1)).isTrue()
             val email = greenMail.firstReceivedMessage()
             assertThat(email.allRecipients).hasSize(1)
             assertThat(email.allRecipients[0].toString()).isEqualTo(hakija.sahkoposti)


### PR DESCRIPTION
# Description

A bug has occurred a couple of times in dev environment where Haitaton starts spamming emails to the contacts of a hanke. This has happened because the database changes have been rolled back because of a key conflict. The emails were sent during the transaction before we were sure they could be completed successfully.

Fix this by using `@TransactionalEvenListener`, which listens to events sent through `ApplicationEventPublisher`, but waits (by default) for the database transaction to commit successfully before handling the event. If the commit fails, the event is not handled. This ensures that the changes have been committed to the database before we send the email, so we don't send the same email several times.

It's not really possible to test the case where the database commit fails, except by waiting x number of seconds and see that no email was sent. I don't want to add unnecessary delays to tests, so we only check the positive case in integration tests. The unit tests test that the email is sent through the event publisher, so things should work as long as Spring handles it's job correctly.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2674

## Type of change

- [X] Bug fix 
- [ ] New feature 
- [ ] Other

# Instructions for testing
Check the ticket for reproduction instructions. Without this fix, there should be a steady stream of emails in smtp4dev (http://localhost:3003/). When restarting with this fix, the emails should stop.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 