### PR TITLE
HAI-2600 Use only table for street class calculation

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluTormaysServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluTormaysServiceITest.kt
@@ -22,26 +22,6 @@ internal class TormaystarkasteluTormaysServiceITest : IntegrationTest() {
 
     @Autowired private lateinit var tormaysService: TormaystarkasteluTormaysService
 
-    /**
-     * Test manually whether Hanke geometries are located on general street area ("yleinen katuosa",
-     * ylre_parts)
-     */
-    @ParameterizedTest
-    @CsvSource("Kaivokatu,true", "Mustikkamaa,false")
-    fun `general street area`(location: String, result: Boolean) {
-        val geometriaIds = createHankeGeometriat(location)
-        assertThat(tormaysService.anyIntersectsYleinenKatuosa(geometriaIds)).isEqualTo(result)
-    }
-
-    /** Test manually what general street classes (ylre_classes) Hanke geometries are located on */
-    @ParameterizedTest
-    @CsvSource("Kaivokatu,4", "Mustikkamaa,")
-    fun `general street classes`(location: String, result: Int?) {
-        val geometriaIds = createHankeGeometriat(location)
-        assertThat(tormaysService.maxIntersectingYleinenkatualueKatuluokka(geometriaIds))
-            .isEqualTo(result)
-    }
-
     /** Test manually what street classes (street_classes) Hanke geometries are located on */
     @ParameterizedTest
     @CsvSource("Kaivokatu,4", "Mustikkamaa,")
@@ -71,10 +51,7 @@ internal class TormaystarkasteluTormaysServiceITest : IntegrationTest() {
         val geometriaIds = createHankeGeometriat(location)
         assertThat(
                 tormaysService.maxLiikennemaara(
-                    geometriaIds,
-                    TormaystarkasteluLiikennemaaranEtaisyys.RADIUS_15
-                )
-            )
+                    geometriaIds, TormaystarkasteluLiikennemaaranEtaisyys.RADIUS_15))
             .isEqualTo(result)
     }
 
@@ -87,10 +64,7 @@ internal class TormaystarkasteluTormaysServiceITest : IntegrationTest() {
         val geometriaIds = createHankeGeometriat(location)
         assertThat(
                 tormaysService.maxLiikennemaara(
-                    geometriaIds,
-                    TormaystarkasteluLiikennemaaranEtaisyys.RADIUS_30
-                )
-            )
+                    geometriaIds, TormaystarkasteluLiikennemaaranEtaisyys.RADIUS_30))
             .isEqualTo(result)
     }
 
@@ -154,23 +128,6 @@ internal class TormaystarkasteluTormaysServiceITest : IntegrationTest() {
     inner class WithGeometry {
 
         @ParameterizedTest
-        @CsvSource("Kaivokatu,true", "Mustikkamaa,false")
-        fun `general street area`(location: String, result: Boolean) {
-            val geometry = createGeometryCollection(location)
-
-            assertThat(tormaysService.anyIntersectsYleinenKatuosa(geometry)).isEqualTo(result)
-        }
-
-        @ParameterizedTest
-        @CsvSource("Kaivokatu,4", "Mustikkamaa,")
-        fun `general street classes`(location: String, result: Int?) {
-            val geometry = createGeometryCollection(location)
-
-            assertThat(tormaysService.maxIntersectingYleinenkatualueKatuluokka(geometry))
-                .isEqualTo(result)
-        }
-
-        @ParameterizedTest
         @CsvSource("Kaivokatu,4", "Mustikkamaa,")
         fun `street classes`(location: String, result: Int?) {
             val geometry = createGeometryCollection(location)
@@ -186,10 +143,7 @@ internal class TormaystarkasteluTormaysServiceITest : IntegrationTest() {
 
             assertThat(
                     tormaysService.maxLiikennemaara(
-                        geometry,
-                        TormaystarkasteluLiikennemaaranEtaisyys.RADIUS_15
-                    )
-                )
+                        geometry, TormaystarkasteluLiikennemaaranEtaisyys.RADIUS_15))
                 .isEqualTo(result)
         }
 
@@ -200,10 +154,7 @@ internal class TormaystarkasteluTormaysServiceITest : IntegrationTest() {
 
             assertThat(
                     tormaysService.maxLiikennemaara(
-                        geometry,
-                        TormaystarkasteluLiikennemaaranEtaisyys.RADIUS_30
-                    )
-                )
+                        geometry, TormaystarkasteluLiikennemaaranEtaisyys.RADIUS_30))
                 .isEqualTo(result)
         }
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluLaskentaService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluLaskentaService.kt
@@ -82,7 +82,7 @@ class TormaystarkasteluLaskentaService(
             katuluokka,
             liikennemaara,
             kaistahaitta.value,
-            kaistapituushaitta.value
+            kaistapituushaitta.value,
         )
     }
 
@@ -100,44 +100,15 @@ class TormaystarkasteluLaskentaService(
             katuluokka,
             liikennemaara,
             kaistahaitta.value,
-            kaistapituushaitta.value
+            kaistapituushaitta.value,
         )
     }
 
     internal fun katuluokkaluokittelu(geometriaIds: Set<Int>): Int =
-        katuluokkaluokittelu(
-            { tormaysService.anyIntersectsYleinenKatuosa(geometriaIds) },
-            { tormaysService.maxIntersectingLiikenteellinenKatuluokka(geometriaIds) },
-            { tormaysService.maxIntersectingYleinenkatualueKatuluokka(geometriaIds) },
-        )
+        tormaysService.maxIntersectingLiikenteellinenKatuluokka(geometriaIds) ?: 0
 
     internal fun katuluokkaluokittelu(geometry: GeoJsonObject): Int =
-        katuluokkaluokittelu(
-            { tormaysService.anyIntersectsYleinenKatuosa(geometry) },
-            { tormaysService.maxIntersectingLiikenteellinenKatuluokka(geometry) },
-            { tormaysService.maxIntersectingYleinenkatualueKatuluokka(geometry) },
-        )
-
-    private fun katuluokkaluokittelu(
-        ylreParts: () -> Boolean,
-        streetClasses: () -> Int?,
-        ylreClasses: () -> Int?,
-    ): Int =
-        if (ylreParts()) {
-            // Use street classes if they are available.
-            // Otherwise, default to ylre classes.
-            streetClasses() ?: ylreClasses() ?: 0
-        } else {
-            val max = ylreClasses()
-            if (max == null) {
-                // If there are no ylre parts or classes, return 0
-                0
-            } else {
-                // Use street classes if they are available.
-                // Otherwise default to ylre classes.
-                streetClasses() ?: max
-            }
-        }
+        tormaysService.maxIntersectingLiikenteellinenKatuluokka(geometry) ?: 0
 
     internal fun liikennemaaraluokittelu(geometriaIds: Set<Int>, katuluokkaluokittelu: Int): Int =
         liikennemaaraluokittelu(katuluokkaluokittelu) { radius ->

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluTormaysService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluTormaysService.kt
@@ -10,29 +10,10 @@ import org.springframework.stereotype.Service
 @Service
 class TormaystarkasteluTormaysService(private val jdbcOperations: JdbcOperations) {
 
-    /** yleinen katuosa, ylre_parts */
-    fun anyIntersectsYleinenKatuosa(geometriaIds: Set<Int>): Boolean =
-        anyIntersectsWith(geometriaIds, "tormays_ylre_parts_polys")
-
-    fun anyIntersectsYleinenKatuosa(geometry: GeoJsonObject): Boolean =
-        anyIntersectsWith(geometry, "tormays_ylre_parts_polys")
-
-    /** yleinen katualue, ylre_classes */
-    fun maxIntersectingYleinenkatualueKatuluokka(geometriaIds: Set<Int>): Int? =
-        getDistinctValuesIntersectingRows(geometriaIds, "tormays_ylre_classes_polys", "ylre_class")
-            .maxOfOrNull { TormaystarkasteluKatuluokka.valueOfKatuluokka(it).value }
-
-    fun maxIntersectingYleinenkatualueKatuluokka(geometry: GeoJsonObject): Int? =
-        getDistinctValuesIntersectingRows(geometry, "tormays_ylre_classes_polys", "ylre_class")
-            .maxOfOrNull { TormaystarkasteluKatuluokka.valueOfKatuluokka(it).value }
-
     /** liikenteellinen katuluokka, street_classes */
     fun maxIntersectingLiikenteellinenKatuluokka(geometriaIds: Set<Int>): Int? =
         getDistinctValuesIntersectingRows(
-                geometriaIds,
-                "tormays_street_classes_polys",
-                "street_class"
-            )
+                geometriaIds, "tormays_street_classes_polys", "street_class")
             .maxOfOrNull { TormaystarkasteluKatuluokka.valueOfKatuluokka(it).value }
 
     fun maxIntersectingLiikenteellinenKatuluokka(geometry: GeoJsonObject): Int? =
@@ -209,7 +190,7 @@ class TormaystarkasteluTormaysService(private val jdbcOperations: JdbcOperations
                 rs.getString(1),
                 rs.getInt(2),
                 rs.getInt(3),
-                TormaystarkasteluBussiRunkolinja.valueOfRunkolinja(rs.getString(4))
+                TormaystarkasteluBussiRunkolinja.valueOfRunkolinja(rs.getString(4)),
             )
         }
     }
@@ -244,9 +225,7 @@ enum class TormaystarkasteluKatuluokka(val value: Int, val katuluokka: String) {
     OLD_TONTTIKATU_TAI_AJOYHTEYS(1, "Tonttikatu tai ajoyhteys"),
     TONTTIKATU_TAI_AJOYHTEYS(1, "Asuntokatu, huoltoväylä tai muu vähäliikenteinen katu"),
     KANTAKAUPUNGIN_ASUNTOKATU_HUOLTAVAYLA_TAI_VAHALIIKENTEINEN_KATU(
-        2,
-        "Kantakaupungin asuntokatu, huoltoväylä tai muu vähäliikenteinen katu"
-    ),
+        2, "Kantakaupungin asuntokatu, huoltoväylä tai muu vähäliikenteinen katu"),
     PAIKALLINEN_KOKOOJAKATU(3, "Paikallinen kokoojakatu"),
     ALUEELLINEN_KOKOOJAKATU(4, "Alueellinen kokoojakatu"),
     PAAKATU_TAI_MOOTTORIVAYLA(5, "Pääkatu tai moottoriväylä"),
@@ -267,8 +246,7 @@ enum class TormaystarkasteluBussiRunkolinja(val runkolinja: String) {
         fun valueOfRunkolinja(runkolinja: String): TormaystarkasteluBussiRunkolinja {
             return entries.find { it.runkolinja == runkolinja }
                 ?: throw IllegalArgumentException(
-                    "Unknown runkolinja value: $runkolinja. Only 'yes' and 'no' are allowed."
-                )
+                    "Unknown runkolinja value: $runkolinja. Only 'yes' and 'no' are allowed.")
         }
     }
 

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluLaskentaServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluLaskentaServiceTest.kt
@@ -48,141 +48,27 @@ internal class TormaystarkasteluLaskentaServiceTest {
         // The parameter is only used to call mocks
         val geometriat = setOf<Int>()
 
-        @Nested
-        inner class WithYlreParts {
-            @BeforeEach
-            fun mockYlreParts() {
-                every { tormaysService.anyIntersectsYleinenKatuosa(geometriat) } returns true
-            }
+        @Test
+        fun `returns 0 when there are no street classes`() {
+            every { tormaysService.maxIntersectingLiikenteellinenKatuluokka(geometriat) } returns
+                null
 
-            @AfterEach
-            fun verifyYlreParts() {
-                verify { tormaysService.anyIntersectsYleinenKatuosa(geometriat) }
-            }
+            val result = laskentaService.katuluokkaluokittelu(geometriat)
 
-            @Nested
-            inner class WithoutStreetClasses {
-                @BeforeEach
-                fun mockStreetClasses() {
-                    every {
-                        tormaysService.maxIntersectingLiikenteellinenKatuluokka(geometriat)
-                    } returns null
-                }
-
-                @AfterEach
-                fun verifyYlreParts() {
-                    verify { tormaysService.maxIntersectingLiikenteellinenKatuluokka(geometriat) }
-                }
-
-                @Test
-                fun `returns 0 when there are no ylre classes`() {
-                    every {
-                        tormaysService.maxIntersectingYleinenkatualueKatuluokka(geometriat)
-                    } returns null
-
-                    val result = laskentaService.katuluokkaluokittelu(geometriat)
-
-                    assertThat(result).isEqualTo(0)
-                    verify { tormaysService.maxIntersectingYleinenkatualueKatuluokka(geometriat) }
-                }
-
-                @ParameterizedTest
-                @EnumSource(TormaystarkasteluKatuluokka::class)
-                fun `returns ylre class value when it exists`(
-                    ylreClass: TormaystarkasteluKatuluokka
-                ) {
-                    every {
-                        tormaysService.maxIntersectingYleinenkatualueKatuluokka(geometriat)
-                    } returns ylreClass.value
-
-                    val result = laskentaService.katuluokkaluokittelu(geometriat)
-
-                    assertThat(result).isEqualTo(ylreClass.value)
-                    verify { tormaysService.maxIntersectingYleinenkatualueKatuluokka(geometriat) }
-                }
-            }
-
-            @ParameterizedTest
-            @EnumSource(TormaystarkasteluKatuluokka::class)
-            fun `returns street class value when it exists`(
-                streetClass: TormaystarkasteluKatuluokka
-            ) {
-                every {
-                    tormaysService.maxIntersectingLiikenteellinenKatuluokka(geometriat)
-                } returns streetClass.value
-
-                val result = laskentaService.katuluokkaluokittelu(geometriat)
-
-                assertThat(result).isEqualTo(streetClass.value)
-                verify { tormaysService.maxIntersectingLiikenteellinenKatuluokka(geometriat) }
-            }
+            assertThat(result).isEqualTo(0)
+            verifySequence { tormaysService.maxIntersectingLiikenteellinenKatuluokka(geometriat) }
         }
 
-        @Nested
-        inner class WithoutYlreParts {
-            @BeforeEach
-            fun mockYlreParts() {
-                every { tormaysService.anyIntersectsYleinenKatuosa(geometriat) } returns false
-            }
+        @ParameterizedTest
+        @EnumSource(TormaystarkasteluKatuluokka::class)
+        fun `returns street class value when it exists`(streetClass: TormaystarkasteluKatuluokka) {
+            every { tormaysService.maxIntersectingLiikenteellinenKatuluokka(geometriat) } returns
+                streetClass.value
 
-            @AfterEach
-            fun verifyYlreParts() {
-                verify { tormaysService.anyIntersectsYleinenKatuosa(geometriat) }
-            }
+            val result = laskentaService.katuluokkaluokittelu(geometriat)
 
-            @Test
-            fun `returns 0 without ylre classes`() {
-                every {
-                    tormaysService.maxIntersectingYleinenkatualueKatuluokka(geometriat)
-                } returns null
-
-                val result = laskentaService.katuluokkaluokittelu(geometriat)
-
-                assertThat(result).isEqualTo(0)
-                verify { tormaysService.maxIntersectingYleinenkatualueKatuluokka(geometriat) }
-            }
-
-            @ParameterizedTest
-            @EnumSource(TormaystarkasteluKatuluokka::class)
-            fun `returns ylre classes when it exists and street classes doesn't`(
-                ylreClass: TormaystarkasteluKatuluokka
-            ) {
-                every {
-                    tormaysService.maxIntersectingYleinenkatualueKatuluokka(geometriat)
-                } returns ylreClass.value
-                every {
-                    tormaysService.maxIntersectingLiikenteellinenKatuluokka(geometriat)
-                } returns null
-
-                val result = laskentaService.katuluokkaluokittelu(geometriat)
-
-                assertThat(result).isEqualTo(ylreClass.value)
-                verify {
-                    tormaysService.maxIntersectingYleinenkatualueKatuluokka(geometriat)
-                    tormaysService.maxIntersectingLiikenteellinenKatuluokka(geometriat)
-                }
-            }
-
-            @ParameterizedTest
-            @EnumSource(TormaystarkasteluKatuluokka::class)
-            fun `returns street classes when both it and ylre classes exist`(
-                streetClass: TormaystarkasteluKatuluokka
-            ) {
-                every {
-                    tormaysService.maxIntersectingYleinenkatualueKatuluokka(geometriat)
-                } returns 2
-                every {
-                    tormaysService.maxIntersectingLiikenteellinenKatuluokka(geometriat)
-                } returns streetClass.value
-
-                val result = laskentaService.katuluokkaluokittelu(geometriat)
-
-                assertThat(result).isEqualTo(streetClass.value)
-                verify {
-                    tormaysService.maxIntersectingYleinenkatualueKatuluokka(geometriat)
-                    tormaysService.maxIntersectingLiikenteellinenKatuluokka(geometriat)
-                }
-            }
+            assertThat(result).isEqualTo(streetClass.value)
+            verifySequence { tormaysService.maxIntersectingLiikenteellinenKatuluokka(geometriat) }
         }
     }
 
@@ -380,9 +266,8 @@ internal class TormaystarkasteluLaskentaServiceTest {
                         "",
                         0,
                         rushHourBuses,
-                        TormaystarkasteluBussiRunkolinja.EI
-                    )
-                )
+                        TormaystarkasteluBussiRunkolinja.EI,
+                    ))
             every { tormaysService.anyIntersectsCriticalBusRoutes(geometriat) } returns false
             every { tormaysService.getIntersectingBusRoutes(geometriat) } returns busLines
 
@@ -441,7 +326,6 @@ internal class TormaystarkasteluLaskentaServiceTest {
 
         val geometriaIds = setOf(alue.geometriat!!)
         verifySequence {
-            tormaysService.anyIntersectsYleinenKatuosa(geometriaIds)
             tormaysService.maxIntersectingLiikenteellinenKatuluokka(geometriaIds)
             tormaysService.maxLiikennemaara(geometriaIds, RADIUS_30)
             tormaysService.maxIntersectingPyoraliikenneHierarkia(geometriaIds)
@@ -456,7 +340,6 @@ internal class TormaystarkasteluLaskentaServiceTest {
         val alue = HankealueFactory.createHankeAlueEntity(hankeEntity = HankeFactory.createEntity())
         val geometriaIds = setOf(alue.geometriat!!)
 
-        every { tormaysService.anyIntersectsYleinenKatuosa(geometriaIds) } returns true
         every { tormaysService.maxIntersectingLiikenteellinenKatuluokka(geometriaIds) } returns
             TormaystarkasteluKatuluokka.ALUEELLINEN_KOKOOJAKATU.value
         every { tormaysService.maxLiikennemaara(geometriaIds, RADIUS_30) } returns 1000
@@ -479,7 +362,7 @@ internal class TormaystarkasteluLaskentaServiceTest {
             "1,2,2,2,2,1.9",
             "3,3,3,3,3,3.0",
             "3,4,4,4,4,3.9",
-            "5,5,5,5,5,5.0"
+            "5,5,5,5,5,5.0",
         )
         fun `calculate index`(
             haittaAjanKesto: Int,
@@ -496,8 +379,7 @@ internal class TormaystarkasteluLaskentaServiceTest {
                         liikennemaara,
                         kaistahaitta,
                         kaistapituushaitta,
-                    )
-                )
+                    ))
                 .isEqualTo(indeksi)
         }
 
@@ -510,8 +392,7 @@ internal class TormaystarkasteluLaskentaServiceTest {
                         0,
                         5,
                         5,
-                    )
-                )
+                    ))
                 .isEqualTo(0.0f)
         }
     }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluLaskentaServiceWithGeometryTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluLaskentaServiceWithGeometryTest.kt
@@ -52,135 +52,26 @@ internal class TormaystarkasteluLaskentaServiceWithGeometryTest {
 
     @Nested
     inner class Katuluokkaluokittelu {
-        @Nested
-        inner class WithYlreParts {
-            @BeforeEach
-            fun mockYlreParts() {
-                every { tormaysService.anyIntersectsYleinenKatuosa(geometry) } returns true
-            }
+        @Test
+        fun `returns 0 when there are no street classes`() {
+            every { tormaysService.maxIntersectingLiikenteellinenKatuluokka(geometry) } returns null
 
-            @AfterEach
-            fun verifyYlreParts() {
-                verify { tormaysService.anyIntersectsYleinenKatuosa(geometry) }
-            }
+            val result = laskentaService.katuluokkaluokittelu(geometry)
 
-            @Nested
-            inner class WithoutStreetClasses {
-                @BeforeEach
-                fun mockStreetClasses() {
-                    every {
-                        tormaysService.maxIntersectingLiikenteellinenKatuluokka(geometry)
-                    } returns null
-                }
-
-                @AfterEach
-                fun verifyYlreParts() {
-                    verify { tormaysService.maxIntersectingLiikenteellinenKatuluokka(geometry) }
-                }
-
-                @Test
-                fun `returns 0 when there are no ylre classes`() {
-                    every {
-                        tormaysService.maxIntersectingYleinenkatualueKatuluokka(geometry)
-                    } returns null
-
-                    val result = laskentaService.katuluokkaluokittelu(geometry)
-
-                    assertThat(result).isEqualTo(0)
-                    verify { tormaysService.maxIntersectingYleinenkatualueKatuluokka(geometry) }
-                }
-
-                @ParameterizedTest
-                @EnumSource(TormaystarkasteluKatuluokka::class)
-                fun `returns ylre class value when it exists`(
-                    ylreClass: TormaystarkasteluKatuluokka
-                ) {
-                    every {
-                        tormaysService.maxIntersectingYleinenkatualueKatuluokka(geometry)
-                    } returns ylreClass.value
-
-                    val result = laskentaService.katuluokkaluokittelu(geometry)
-
-                    assertThat(result).isEqualTo(ylreClass.value)
-                    verify { tormaysService.maxIntersectingYleinenkatualueKatuluokka(geometry) }
-                }
-            }
-
-            @ParameterizedTest
-            @EnumSource(TormaystarkasteluKatuluokka::class)
-            fun `returns street class value when it exists`(
-                streetClass: TormaystarkasteluKatuluokka
-            ) {
-                every { tormaysService.maxIntersectingLiikenteellinenKatuluokka(geometry) } returns
-                    streetClass.value
-
-                val result = laskentaService.katuluokkaluokittelu(geometry)
-
-                assertThat(result).isEqualTo(streetClass.value)
-                verify { tormaysService.maxIntersectingLiikenteellinenKatuluokka(geometry) }
-            }
+            assertThat(result).isEqualTo(0)
+            verify { tormaysService.maxIntersectingLiikenteellinenKatuluokka(geometry) }
         }
 
-        @Nested
-        inner class WithoutYlreParts {
-            @BeforeEach
-            fun mockYlreParts() {
-                every { tormaysService.anyIntersectsYleinenKatuosa(geometry) } returns false
-            }
+        @ParameterizedTest
+        @EnumSource(TormaystarkasteluKatuluokka::class)
+        fun `returns street class value when it exists`(streetClass: TormaystarkasteluKatuluokka) {
+            every { tormaysService.maxIntersectingLiikenteellinenKatuluokka(geometry) } returns
+                streetClass.value
 
-            @AfterEach
-            fun verifyYlreParts() {
-                verify { tormaysService.anyIntersectsYleinenKatuosa(geometry) }
-            }
+            val result = laskentaService.katuluokkaluokittelu(geometry)
 
-            @Test
-            fun `returns 0 without ylre classes`() {
-                every { tormaysService.maxIntersectingYleinenkatualueKatuluokka(geometry) } returns
-                    null
-
-                val result = laskentaService.katuluokkaluokittelu(geometry)
-
-                assertThat(result).isEqualTo(0)
-                verify { tormaysService.maxIntersectingYleinenkatualueKatuluokka(geometry) }
-            }
-
-            @ParameterizedTest
-            @EnumSource(TormaystarkasteluKatuluokka::class)
-            fun `returns ylre classes when it exists and street classes doesn't`(
-                ylreClass: TormaystarkasteluKatuluokka
-            ) {
-                every { tormaysService.maxIntersectingYleinenkatualueKatuluokka(geometry) } returns
-                    ylreClass.value
-                every { tormaysService.maxIntersectingLiikenteellinenKatuluokka(geometry) } returns
-                    null
-
-                val result = laskentaService.katuluokkaluokittelu(geometry)
-
-                assertThat(result).isEqualTo(ylreClass.value)
-                verify {
-                    tormaysService.maxIntersectingYleinenkatualueKatuluokka(geometry)
-                    tormaysService.maxIntersectingLiikenteellinenKatuluokka(geometry)
-                }
-            }
-
-            @ParameterizedTest
-            @EnumSource(TormaystarkasteluKatuluokka::class)
-            fun `returns street classes when both it and ylre classes exist`(
-                streetClass: TormaystarkasteluKatuluokka
-            ) {
-                every { tormaysService.maxIntersectingYleinenkatualueKatuluokka(geometry) } returns
-                    2
-                every { tormaysService.maxIntersectingLiikenteellinenKatuluokka(geometry) } returns
-                    streetClass.value
-
-                val result = laskentaService.katuluokkaluokittelu(geometry)
-
-                assertThat(result).isEqualTo(streetClass.value)
-                verify {
-                    tormaysService.maxIntersectingYleinenkatualueKatuluokka(geometry)
-                    tormaysService.maxIntersectingLiikenteellinenKatuluokka(geometry)
-                }
-            }
+            assertThat(result).isEqualTo(streetClass.value)
+            verify { tormaysService.maxIntersectingLiikenteellinenKatuluokka(geometry) }
         }
     }
 
@@ -366,9 +257,8 @@ internal class TormaystarkasteluLaskentaServiceWithGeometryTest {
                         "",
                         0,
                         rushHourBuses,
-                        TormaystarkasteluBussiRunkolinja.EI
-                    )
-                )
+                        TormaystarkasteluBussiRunkolinja.EI,
+                    ))
             every { tormaysService.anyIntersectsCriticalBusRoutes(geometry) } returns false
             every { tormaysService.getIntersectingBusRoutes(geometry) } returns busLines
 
@@ -414,7 +304,7 @@ internal class TormaystarkasteluLaskentaServiceWithGeometryTest {
                 featureCollection,
                 5,
                 VaikutusAutoliikenteenKaistamaariin.VAHENTAA_KAISTAN_YHDELLA_AJOSUUNNALLA,
-                AutoliikenteenKaistavaikutustenPituus.PITUUS_100_499_METRIA
+                AutoliikenteenKaistavaikutustenPituus.PITUUS_100_499_METRIA,
             )
 
         assertThat(tulos.liikennehaittaindeksi.indeksi).isEqualTo(5.0f)
@@ -431,7 +321,6 @@ internal class TormaystarkasteluLaskentaServiceWithGeometryTest {
         assertThat(tulos.pyoraliikenneindeksi).isEqualTo(3.0f)
 
         verifySequence {
-            tormaysService.anyIntersectsYleinenKatuosa(geometry)
             tormaysService.maxIntersectingLiikenteellinenKatuluokka(geometry)
             tormaysService.maxLiikennemaara(geometry, RADIUS_30)
             tormaysService.maxIntersectingPyoraliikenneHierarkia(geometry)
@@ -442,7 +331,6 @@ internal class TormaystarkasteluLaskentaServiceWithGeometryTest {
     }
 
     private fun setupHappyCase() {
-        every { tormaysService.anyIntersectsYleinenKatuosa(geometry) } returns true
         every { tormaysService.maxIntersectingLiikenteellinenKatuluokka(geometry) } returns
             TormaystarkasteluKatuluokka.ALUEELLINEN_KOKOOJAKATU.value
         every { tormaysService.maxLiikennemaara(geometry, RADIUS_30) } returns 1000


### PR DESCRIPTION
# Description

Only use the `tormays_street_classes_polys` for calculating the street class of an area. Ylre data will be merged into that table as needed.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2600

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [X] Other

# Instructions for testing
It's hard to find a place where this makes a difference. One such place is in Kalasatama / Suvilahti.

In dev, this shows green for a class 1 road because the planned Kaasutehtaankatu is in the YLRE material:
![image](https://github.com/user-attachments/assets/12abf46f-c8ff-45fb-8922-344ec7c152d8)

With this change, it's not recognized, because Liikenneväylät only have existing roads:
![image](https://github.com/user-attachments/assets/688e87ee-4186-4ee5-9272-d20bfcc416f1)

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 