### PR TITLE
HAI-2697 Send all emails after transactions

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/email/EmailSenderServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/email/EmailSenderServiceITest.kt
@@ -159,10 +159,10 @@ class EmailSenderServiceITest : IntegrationTest() {
     @Nested
     inner class HankeInvitation {
         private val notification =
-            HankeInvitationData(
+            HankeInvitationEmail(
                 inviterName = INVITER_NAME,
                 inviterEmail = INVITER_EMAIL,
-                recipientEmail = TEST_EMAIL,
+                to = TEST_EMAIL,
                 hankeTunnus = HANKE_TUNNUS,
                 hankeNimi = HANKE_NIMI,
                 invitationToken = "MgtzRbcPsvoKQamnaSxCnmW7",
@@ -224,10 +224,10 @@ class EmailSenderServiceITest : IntegrationTest() {
     @Nested
     inner class ApplicationNotification {
         private val notification =
-            ApplicationNotificationData(
+            ApplicationNotificationEmail(
                 senderName = INVITER_NAME,
                 senderEmail = INVITER_EMAIL,
-                recipientEmail = TEST_EMAIL,
+                to = TEST_EMAIL,
                 applicationType = ApplicationType.CABLE_REPORT,
                 hankeTunnus = HANKE_TUNNUS,
                 hankeNimi = HANKE_NIMI,
@@ -288,8 +288,8 @@ class EmailSenderServiceITest : IntegrationTest() {
     @Nested
     inner class AccessRightsUpdateNotification {
         private val notification =
-            AccessRightsUpdateNotificationData(
-                recipientEmail = TEST_EMAIL,
+            AccessRightsUpdateNotificationEmail(
+                to = TEST_EMAIL,
                 hankeTunnus = HANKE_TUNNUS,
                 hankeNimi = HANKE_NIMI,
                 updatedByName = INVITER_NAME,
@@ -356,8 +356,8 @@ class EmailSenderServiceITest : IntegrationTest() {
     @Nested
     inner class RemovalFromHankeNotification {
         private val notification =
-            RemovalFromHankeNotificationData(
-                recipientEmail = TEST_EMAIL,
+            RemovalFromHankeNotificationEmail(
+                to = TEST_EMAIL,
                 hankeTunnus = HANKE_TUNNUS,
                 hankeNimi = HANKE_NIMI,
                 deletedByName = INVITER_NAME,

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceITest.kt
@@ -919,7 +919,7 @@ class HakemusServiceITest(
             }
 
             @Test
-            fun `sends email for new contacts`() {
+            fun `sends email to new contacts`() {
                 val hanke = hankeFactory.builder(USERNAME).withHankealue().saveEntity()
                 val entity = hakemusFactory.builder(USERNAME, hanke).hakija().saveEntity()
                 val hakemus = hakemusService.hakemusResponse(entity.id)
@@ -2609,7 +2609,6 @@ class HakemusServiceITest(
 
             hakemusService.handleHakemusUpdates(histories, updateTime)
 
-            assertThat(greenMail.waitForIncomingEmail(1000L, 1)).isTrue()
             val email = greenMail.firstReceivedMessage()
             assertThat(email.allRecipients).hasSize(1)
             assertThat(email.allRecipients[0].toString()).isEqualTo(hakija.sahkoposti)
@@ -2642,7 +2641,6 @@ class HakemusServiceITest(
 
             hakemusService.handleHakemusUpdates(histories, updateTime)
 
-            assertThat(greenMail.waitForIncomingEmail(1000L, 1)).isTrue()
             val email = greenMail.firstReceivedMessage()
             assertThat(email.allRecipients).hasSize(1)
             assertThat(email.allRecipients[0].toString()).isEqualTo(hakija.sahkoposti)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/email/EmailEvent.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/email/EmailEvent.kt
@@ -1,0 +1,55 @@
+package fi.hel.haitaton.hanke.email
+
+import fi.hel.haitaton.hanke.hakemus.ApplicationType
+import fi.hel.haitaton.hanke.permissions.Kayttooikeustaso
+
+sealed interface EmailEvent {
+    val to: String
+}
+
+data class JohtoselvitysCompleteEmail(
+    override val to: String,
+    val applicationId: Long?,
+    val applicationIdentifier: String,
+) : EmailEvent
+
+data class KaivuilmoitusDecisionEmail(
+    override val to: String,
+    val applicationId: Long?,
+    val applicationIdentifier: String,
+) : EmailEvent
+
+data class ApplicationNotificationEmail(
+    val senderName: String,
+    val senderEmail: String,
+    override val to: String,
+    val applicationType: ApplicationType,
+    val hankeTunnus: String,
+    val hankeNimi: String,
+) : EmailEvent
+
+data class HankeInvitationEmail(
+    val inviterName: String,
+    val inviterEmail: String,
+    override val to: String,
+    val hankeTunnus: String,
+    val hankeNimi: String,
+    val invitationToken: String,
+) : EmailEvent
+
+data class AccessRightsUpdateNotificationEmail(
+    override val to: String,
+    val hankeTunnus: String,
+    val hankeNimi: String,
+    val updatedByName: String,
+    val updatedByEmail: String,
+    val newAccessRights: Kayttooikeustaso,
+) : EmailEvent
+
+data class RemovalFromHankeNotificationEmail(
+    override val to: String,
+    val hankeTunnus: String,
+    val hankeNimi: String,
+    val deletedByName: String,
+    val deletedByEmail: String,
+) : EmailEvent

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
@@ -17,8 +17,7 @@ import fi.hel.haitaton.hanke.allu.Attachment
 import fi.hel.haitaton.hanke.allu.AttachmentMetadata
 import fi.hel.haitaton.hanke.attachment.application.ApplicationAttachmentService
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType
-import fi.hel.haitaton.hanke.email.ApplicationNotificationData
-import fi.hel.haitaton.hanke.email.EmailSenderService
+import fi.hel.haitaton.hanke.email.ApplicationNotificationEmail
 import fi.hel.haitaton.hanke.email.JohtoselvitysCompleteEmail
 import fi.hel.haitaton.hanke.email.KaivuilmoitusDecisionEmail
 import fi.hel.haitaton.hanke.geometria.GeometriatDao
@@ -66,7 +65,6 @@ class HakemusService(
     private val attachmentService: ApplicationAttachmentService,
     private val alluClient: AlluClient,
     private val alluStatusRepository: AlluStatusRepository,
-    private val emailSenderService: EmailSenderService,
     private val paatosService: PaatosService,
     private val applicationEventPublisher: ApplicationEventPublisher,
 ) {
@@ -989,7 +987,7 @@ class HakemusService(
 
         for (newContact in newContacts.filter { it.sahkoposti != inviter.sahkoposti }) {
             val data =
-                ApplicationNotificationData(
+                ApplicationNotificationEmail(
                     inviter.fullName(),
                     inviter.sahkoposti,
                     newContact.sahkoposti,
@@ -997,7 +995,7 @@ class HakemusService(
                     hakemusEntity.hanke.hankeTunnus,
                     hakemusEntity.hanke.nimi,
                 )
-            emailSenderService.sendApplicationNotificationEmail(data)
+            applicationEventPublisher.publishEvent(data)
         }
     }
 

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/TestExtensions.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/TestExtensions.kt
@@ -1,7 +1,10 @@
 package fi.hel.haitaton.hanke
 
 import assertk.Assert
+import assertk.assertThat
 import assertk.assertions.containsExactlyInAnyOrder
+import assertk.assertions.isEqualTo
+import assertk.assertions.isTrue
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.icegreen.greenmail.junit5.GreenMailExtension
 import fi.hel.haitaton.hanke.logging.AuditLogRepository
@@ -11,7 +14,6 @@ import java.nio.charset.StandardCharsets
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
 import java.util.UUID
-import org.junit.jupiter.api.Assertions
 import org.springframework.test.web.servlet.ResultActions
 
 fun <T> String.asJsonResource(type: Class<T>): T =
@@ -50,7 +52,8 @@ fun AuditLogRepository.findByType(type: ObjectType) =
 fun OffsetDateTime.asUtc(): OffsetDateTime = this.withOffsetSameInstant(ZoneOffset.UTC)
 
 fun GreenMailExtension.firstReceivedMessage(): MimeMessage {
-    Assertions.assertEquals(1, receivedMessages.size)
+    assertThat(waitForIncomingEmail(1000L, 1)).isTrue()
+    assertThat(receivedMessages.size).isEqualTo(1)
     return receivedMessages[0]
 }
 

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/email/EmailSenderServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/email/EmailSenderServiceTest.kt
@@ -36,7 +36,7 @@ class EmailSenderServiceTest {
         EmailProperties(
             from = "haitaton@hel.fi",
             baseUrl = "https://haitaton.hel.fi",
-            filter = EmailFilterProperties(false, listOf())
+            filter = EmailFilterProperties(false, listOf()),
         )
     private val mailSender: JavaMailSender = spyk()
     private val emailSenderService = EmailSenderService(mailSender, emailConfig)
@@ -53,10 +53,10 @@ class EmailSenderServiceTest {
     inner class HankeInvitation {
         private val invitationToken = "MgtzRbcPsvoKQamnaSxCnmW7"
         private val hankeInvitation =
-            HankeInvitationData(
+            HankeInvitationEmail(
                 inviterName = INVITER_NAME,
                 inviterEmail = INVITER_EMAIL,
-                recipientEmail = TEST_EMAIL,
+                to = TEST_EMAIL,
                 hankeTunnus = HANKE_TUNNUS,
                 hankeNimi = HANKE_NIMI,
                 invitationToken = invitationToken,
@@ -79,8 +79,7 @@ class EmailSenderServiceTest {
                 .isEqualTo(
                     "Haitaton: Sinut on kutsuttu hankkeelle HAI24-1 " +
                         "/ Du har blivit inbjuden till projektet HAI24-1 " +
-                        "/ You have been invited to project HAI24-1"
-                )
+                        "/ You have been invited to project HAI24-1")
         }
 
         @Test
@@ -120,8 +119,7 @@ class EmailSenderServiceTest {
                 assertThat(textBody).contains(invitationUrl)
                 assertThat(htmlBody)
                     .containsMatch(
-                        """\Q<a href="$invitationUrl">\E\s*\Q$invitationUrl\E\s*</a>""".toRegex()
-                    )
+                        """\Q<a href="$invitationUrl">\E\s*\Q$invitationUrl\E\s*</a>""".toRegex())
             }
 
             @Test
@@ -192,10 +190,10 @@ class EmailSenderServiceTest {
     @Nested
     inner class ApplicationNotification {
         private val applicationNotification =
-            ApplicationNotificationData(
+            ApplicationNotificationEmail(
                 senderName = INVITER_NAME,
                 senderEmail = "matti.meikalainen@test.fi",
-                recipientEmail = TEST_EMAIL,
+                to = TEST_EMAIL,
                 applicationType = ApplicationType.CABLE_REPORT,
                 hankeTunnus = HANKE_TUNNUS,
                 hankeNimi = HANKE_NIMI,
@@ -218,8 +216,7 @@ class EmailSenderServiceTest {
                 .isEqualTo(
                     "Haitaton: Sinut on lisätty hakemukselle " +
                         "/ Du har lagts till i en ansökan " +
-                        "/ You have been added to an application"
-                )
+                        "/ You have been added to an application")
         }
 
         @Test
@@ -285,8 +282,7 @@ class EmailSenderServiceTest {
                 assertThat(textBody).contains("$linkPrefix https://haitaton.hel.fi")
                 assertThat(htmlBody)
                     .contains(
-                        """$linkPrefix <a href="https://haitaton.hel.fi">https://haitaton.hel.fi</a>"""
-                    )
+                        """$linkPrefix <a href="https://haitaton.hel.fi">https://haitaton.hel.fi</a>""")
             }
 
             @Test
@@ -344,8 +340,8 @@ class EmailSenderServiceTest {
     @Nested
     inner class AccessRightsUpdateNotification {
         private val notification =
-            AccessRightsUpdateNotificationData(
-                recipientEmail = TEST_EMAIL,
+            AccessRightsUpdateNotificationEmail(
+                to = TEST_EMAIL,
                 hankeTunnus = HANKE_TUNNUS,
                 hankeNimi = HANKE_NIMI,
                 updatedByName = INVITER_NAME,
@@ -368,8 +364,7 @@ class EmailSenderServiceTest {
 
             assertThat(email.subject)
                 .isEqualTo(
-                    "Haitaton: Käyttöoikeustasoasi on muutettu ($HANKE_TUNNUS) / Dina användarrättigheter har förändrats ($HANKE_TUNNUS) / Your access right level has been changed ($HANKE_TUNNUS)"
-                )
+                    "Haitaton: Käyttöoikeustasoasi on muutettu ($HANKE_TUNNUS) / Dina användarrättigheter har förändrats ($HANKE_TUNNUS) / Your access right level has been changed ($HANKE_TUNNUS)")
         }
 
         @Test
@@ -493,8 +488,8 @@ class EmailSenderServiceTest {
     @Nested
     inner class RemovalFromHanke {
         private val notification =
-            RemovalFromHankeNotificationData(
-                recipientEmail = TEST_EMAIL,
+            RemovalFromHankeNotificationEmail(
+                to = TEST_EMAIL,
                 hankeTunnus = HANKE_TUNNUS,
                 hankeNimi = HANKE_NIMI,
                 deletedByName = INVITER_NAME,
@@ -516,8 +511,7 @@ class EmailSenderServiceTest {
 
             assertThat(email.subject)
                 .isEqualTo(
-                    "Haitaton: Sinut on poistettu hankkeelta ($HANKE_TUNNUS) / Du har tagits bort från projektet ($HANKE_TUNNUS) / You have been removed from the project ($HANKE_TUNNUS)"
-                )
+                    "Haitaton: Sinut on poistettu hankkeelta ($HANKE_TUNNUS) / Du har tagits bort från projektet ($HANKE_TUNNUS) / You have been removed from the project ($HANKE_TUNNUS)")
         }
 
         @Test

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceTest.kt
@@ -25,7 +25,6 @@ import fi.hel.haitaton.hanke.allu.Contact
 import fi.hel.haitaton.hanke.allu.Customer
 import fi.hel.haitaton.hanke.allu.CustomerWithContacts
 import fi.hel.haitaton.hanke.attachment.application.ApplicationAttachmentService
-import fi.hel.haitaton.hanke.email.EmailSenderService
 import fi.hel.haitaton.hanke.email.JohtoselvitysCompleteEmail
 import fi.hel.haitaton.hanke.email.KaivuilmoitusDecisionEmail
 import fi.hel.haitaton.hanke.factory.AlluFactory
@@ -90,7 +89,6 @@ class HakemusServiceTest {
     private val attachmentService: ApplicationAttachmentService = mockk()
     private val alluClient: AlluClient = mockk()
     private val alluStatusRepository: AlluStatusRepository = mockk()
-    private val emailSenderService: EmailSenderService = mockk()
     private val paatosService: PaatosService = mockk()
     private val publisher: ApplicationEventPublisher = mockk()
 
@@ -107,7 +105,6 @@ class HakemusServiceTest {
             attachmentService,
             alluClient,
             alluStatusRepository,
-            emailSenderService,
             paatosService,
             publisher,
         )
@@ -132,7 +129,6 @@ class HakemusServiceTest {
             attachmentService,
             alluClient,
             alluStatusRepository,
-            emailSenderService,
             paatosService,
             publisher,
         )


### PR DESCRIPTION
# Description

Use `TransactionalEventListener` in all emails to send them after the database transaction has been closed. Sending the emails seems to be taking a while in production, so keeping the transaction active while the email is being sent can lead to problems.

There were cases in production where two application updates were sent back-to-back - probably because the user skipped the attachments page instinctively - which caused errors because the second update didn't see the database changes the first one had made, so it tried to create a second version of the same user.

This isn't a perfect solution for that problem, but keeping the transaction short should mitigate the problem.

One of the side effects of the problem was that the notification email for being added to an application was sent twice. This should be completely solved since the second update failed inside the transaction, so the email event will not be processed.

Also, add some extra logging to sending the emails, so we know how long it takes.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2697

## Type of change

- [X] Bug fix 
- [ ] New feature 
- [ ] Other

# Instructions for testing
The affected emails are:
- Hanke invitation
- Application notification
- Access update
- Removal from hanke

So to test all of them:
1. Create a new application (either a cable report or an excavation notification).
2. Fill it out while creating a new contact person and adding it to the application.
3. Save the application, don't send it.
4. Go to the project's User management and give the new user higher access rights.
5. Remove the user.

After these steps, 4 emails should have been sent to the new user, one for each on the previous list.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 