### PR TITLE
HAI-2661 Hanke into RAKENTAMINEN phase when new application is created

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
@@ -29,6 +29,7 @@ import fi.hel.haitaton.hanke.domain.CreateHankeRequest
 import fi.hel.haitaton.hanke.domain.Hanke
 import fi.hel.haitaton.hanke.domain.HankeStatus
 import fi.hel.haitaton.hanke.domain.HankeYhteystieto
+import fi.hel.haitaton.hanke.domain.Hankevaihe
 import fi.hel.haitaton.hanke.domain.SavedHankealue
 import fi.hel.haitaton.hanke.domain.Yhteyshenkilo
 import fi.hel.haitaton.hanke.domain.YhteystietoTyyppi
@@ -678,6 +679,17 @@ class HankeServiceITests(
 
             val hanke = hankeRepository.findByHankeTunnus(hakemus.hankeTunnus)!!
             assertThat(hanke.nimi).isEqualTo(expectedName)
+        }
+
+        @Test
+        fun `sets the hanke phase to RAKENTAMINEN`() {
+            val request = CreateHankeRequest(hakemusNimi, DEFAULT_HANKE_PERUSTAJA)
+
+            val hakemus =
+                hankeService.generateHankeWithJohtoselvityshakemus(request, setUpProfiiliMocks())
+
+            val hanke = hankeRepository.findByHankeTunnus(hakemus.hankeTunnus)!!
+            assertThat(hanke.vaihe).isEqualTo(Hankevaihe.RAKENTAMINEN)
         }
 
         @Test

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceITest.kt
@@ -491,7 +491,7 @@ class HakemusServiceITest(
             }
 
             @Test
-            fun `writes the updated hanke to the audit log`() {
+            fun `writes the updated hanke to the audit log if the phase has changed`() {
                 val hanke = hankeFactory.builder(USERNAME).withHankealue().save()
                 val request = request.withHanketunnus(hanke.hankeTunnus)
                 auditLogRepository.deleteAll()
@@ -512,6 +512,22 @@ class HakemusServiceITest(
                                 .contains("\"vaihe\":\"RAKENTAMINEN\"")
                         }
                     }
+            }
+
+            @Test
+            fun `does not write hanke to the audit log if the phase has not changed`() {
+                val hanke =
+                    hankeFactory
+                        .builder(USERNAME)
+                        .withHankealue()
+                        .withVaihe(Hankevaihe.RAKENTAMINEN)
+                        .save()
+                val request = request.withHanketunnus(hanke.hankeTunnus)
+                auditLogRepository.deleteAll()
+
+                hakemusService.create(request, USERNAME)
+
+                assertThat(auditLogRepository.findByType(ObjectType.HANKE)).isEmpty()
             }
         }
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
@@ -17,8 +17,8 @@ import fi.hel.haitaton.hanke.allu.Attachment
 import fi.hel.haitaton.hanke.allu.AttachmentMetadata
 import fi.hel.haitaton.hanke.attachment.application.ApplicationAttachmentService
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType
-import fi.hel.haitaton.hanke.email.ApplicationNotificationEmail
 import fi.hel.haitaton.hanke.domain.Hankevaihe
+import fi.hel.haitaton.hanke.email.ApplicationNotificationEmail
 import fi.hel.haitaton.hanke.email.JohtoselvitysCompleteEmail
 import fi.hel.haitaton.hanke.email.KaivuilmoitusDecisionEmail
 import fi.hel.haitaton.hanke.geometria.GeometriatDao

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
@@ -127,10 +127,9 @@ class HakemusService(
             hanke.version = hanke.version?.inc() ?: 1
             hanke.modifiedByUserId = userId
             hanke.modifiedAt = getCurrentTimeUTCAsLocalTime()
-            hanke.generated = false
 
-            hankeRepository.save(hanke)
-            val hankeAfterUpdate = HankeMapper.domainFrom(hanke, geometriatMap)
+            val savedHanke = hankeRepository.save(hanke)
+            val hankeAfterUpdate = HankeMapper.domainFrom(savedHanke, geometriatMap)
             hankeLoggingService.logUpdate(hankeBeforeUpdate, hankeAfterUpdate, userId)
         }
     }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
@@ -18,9 +18,11 @@ import fi.hel.haitaton.hanke.allu.AttachmentMetadata
 import fi.hel.haitaton.hanke.attachment.application.ApplicationAttachmentService
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType
 import fi.hel.haitaton.hanke.email.ApplicationNotificationEmail
+import fi.hel.haitaton.hanke.domain.Hankevaihe
 import fi.hel.haitaton.hanke.email.JohtoselvitysCompleteEmail
 import fi.hel.haitaton.hanke.email.KaivuilmoitusDecisionEmail
 import fi.hel.haitaton.hanke.geometria.GeometriatDao
+import fi.hel.haitaton.hanke.getCurrentTimeUTCAsLocalTime
 import fi.hel.haitaton.hanke.hakemus.HakemusDataMapper.toAlluData
 import fi.hel.haitaton.hanke.logging.DisclosureLogService
 import fi.hel.haitaton.hanke.logging.HakemusLoggingService
@@ -111,7 +113,26 @@ class HakemusService(
                     hanke = hanke))
         val hakemus = entity.toHakemus()
         hakemusLoggingService.logCreate(hakemus, userId)
+        // A hanke with a hakemus should be in RAKENTAMINEN phase
+        updateHankevaiheToRakentaminen(hanke, userId)
         return hakemus
+    }
+
+    /** Update the hankevaihe of a Hanke to RAKENTAMINEN if it's not already there. */
+    private fun updateHankevaiheToRakentaminen(hanke: HankeEntity, userId: String) {
+        if (hanke.vaihe != Hankevaihe.RAKENTAMINEN) {
+            val geometriatMap = hankealueService.geometryMapFrom(hanke.alueet)
+            val hankeBeforeUpdate = HankeMapper.domainFrom(hanke, geometriatMap)
+            hanke.vaihe = Hankevaihe.RAKENTAMINEN
+            hanke.version = hanke.version?.inc() ?: 1
+            hanke.modifiedByUserId = userId
+            hanke.modifiedAt = getCurrentTimeUTCAsLocalTime()
+            hanke.generated = false
+
+            hankeRepository.save(hanke)
+            val hankeAfterUpdate = HankeMapper.domainFrom(hanke, geometriatMap)
+            hankeLoggingService.logUpdate(hankeBeforeUpdate, hankeAfterUpdate, userId)
+        }
     }
 
     /** Create a johtoselvitys from a hanke that was just created. */

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeBuilder.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeBuilder.kt
@@ -135,7 +135,9 @@ data class HankeBuilder(
                 Names(
                     firstName = perustaja.etunimi,
                     lastName = perustaja.sukunimi,
-                    givenName = perustaja.etunimi))
+                    givenName = perustaja.etunimi,
+                ),
+        )
 
     fun withTyomaaKatuosoite(tyomaaKatuosoite: String?): HankeBuilder = applyToHanke {
         this.tyomaaKatuosoite = tyomaaKatuosoite
@@ -183,7 +185,8 @@ data class HankeBuilder(
                 rooli = rooli,
                 tyyppi = tyyppi,
                 ytunnus = ytunnus,
-                yhteyshenkilot = yhteyshenkilot.map { it.id })
+                yhteyshenkilot = yhteyshenkilot.map { it.id },
+            )
 
         fun SavedHankealue.toModifyRequest(id: Int? = this.id) =
             ModifyHankealueRequest(
@@ -198,7 +201,8 @@ data class HankeBuilder(
                 meluHaitta = meluHaitta,
                 polyHaitta = polyHaitta,
                 tarinaHaitta = tarinaHaitta,
-                haittojenhallintasuunnitelma = haittojenhallintasuunnitelma)
+                haittojenhallintasuunnitelma = haittojenhallintasuunnitelma,
+            )
     }
 }
 
@@ -297,7 +301,9 @@ data class HankeYhteystietoBuilder(
     ) {
         hankeYhteyshenkiloRepository.save(
             HankeYhteyshenkiloEntity(
-                hankeKayttaja = kayttaja, hankeYhteystieto = yhteystietoEntity))
+                hankeKayttaja = kayttaja,
+                hankeYhteystieto = yhteystietoEntity,
+            ))
     }
 
     private fun saveYhteystieto(

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeBuilder.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeBuilder.kt
@@ -13,6 +13,7 @@ import fi.hel.haitaton.hanke.domain.Haittojenhallintasuunnitelma
 import fi.hel.haitaton.hanke.domain.Hanke
 import fi.hel.haitaton.hanke.domain.HankePerustaja
 import fi.hel.haitaton.hanke.domain.HankeYhteystieto
+import fi.hel.haitaton.hanke.domain.Hankevaihe
 import fi.hel.haitaton.hanke.domain.ModifyGeometriaRequest
 import fi.hel.haitaton.hanke.domain.ModifyHankeRequest
 import fi.hel.haitaton.hanke.domain.ModifyHankeYhteystietoRequest
@@ -63,9 +64,7 @@ data class HankeBuilder(
     fun save(): Hanke {
         val createdHanke = create()
         return hankeService.updateHanke(
-            createdHanke.hankeTunnus,
-            hanke.toModifyRequest(idMapper = { null })
-        )
+            createdHanke.hankeTunnus, hanke.toModifyRequest(idMapper = { null }))
     }
 
     /** Save the entity with [save], and - for convenience - get the saved entity from DB. */
@@ -136,9 +135,7 @@ data class HankeBuilder(
                 Names(
                     firstName = perustaja.etunimi,
                     lastName = perustaja.sukunimi,
-                    givenName = perustaja.etunimi
-                )
-        )
+                    givenName = perustaja.etunimi))
 
     fun withTyomaaKatuosoite(tyomaaKatuosoite: String?): HankeBuilder = applyToHanke {
         this.tyomaaKatuosoite = tyomaaKatuosoite
@@ -147,6 +144,8 @@ data class HankeBuilder(
     fun withTyomaaTyypit(vararg tyypit: TyomaaTyyppi): HankeBuilder = applyToHanke {
         tyomaaTyyppi.addAll(tyypit)
     }
+
+    fun withVaihe(vaihe: Hankevaihe): HankeBuilder = applyToHanke { this.vaihe = vaihe }
 
     private fun applyToHanke(f: Hanke.() -> Unit) = apply { hanke.apply { f() } }
 
@@ -184,8 +183,7 @@ data class HankeBuilder(
                 rooli = rooli,
                 tyyppi = tyyppi,
                 ytunnus = ytunnus,
-                yhteyshenkilot = yhteyshenkilot.map { it.id }
-            )
+                yhteyshenkilot = yhteyshenkilot.map { it.id })
 
         fun SavedHankealue.toModifyRequest(id: Int? = this.id) =
             ModifyHankealueRequest(
@@ -200,8 +198,7 @@ data class HankeBuilder(
                 meluHaitta = meluHaitta,
                 polyHaitta = polyHaitta,
                 tarinaHaitta = tarinaHaitta,
-                haittojenhallintasuunnitelma = haittojenhallintasuunnitelma
-            )
+                haittojenhallintasuunnitelma = haittojenhallintasuunnitelma)
     }
 }
 
@@ -299,8 +296,8 @@ data class HankeYhteystietoBuilder(
         kayttaja: HankekayttajaEntity
     ) {
         hankeYhteyshenkiloRepository.save(
-            HankeYhteyshenkiloEntity(hankeKayttaja = kayttaja, hankeYhteystieto = yhteystietoEntity)
-        )
+            HankeYhteyshenkiloEntity(
+                hankeKayttaja = kayttaja, hankeYhteystieto = yhteystietoEntity))
     }
 
     private fun saveYhteystieto(


### PR DESCRIPTION
# Description

When creating a new johtoselvitys without existing hanke, the phase of generated hanke is set to RAKENTAMINEN. Also, when creating new johtoselvityshakemus or kaivuilmoitus for an existing hanke, the phase of the hanke is set to RAKENTAMINEN if not already set.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2661

## Type of change

- [ ] Bug fix 
- [x] New feature 
- [ ] Other

# Instructions for testing
For generated hanke:
* Create a new johtoselvityshakemus (without existing hanke)
* Fill enough data for johtoselvityshakemus in order to be able to save it
* Go to the hanke page of the generated hanke and see that its phase is Rakentaminen
* Check audit log rows that should be created for hanke updates

For other hanke:
* Create a new hanke and fill enough data for it in order it to public (ie. allow applications to be created for it) - also, SET THE PHASE TO SOMETHING ELSE THAN RAKENTAMINEN
* Create a new application for the hanke (johtoselvitys or kaivuilmoitus)
* Fill enough data for the application in order to be able to save it
* Go to the hanke page and see that its phase is Rakentaminen
* Check audit log rows that should be created for hanke updates

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 

# Other relevant info
Please describe here if there is e.g. some requirements for this change or
 other info that the tester/user needs to know.