### PR TITLE
HAI-2324 Send kaivuilmoitus operational condition approval email

### DIFF
--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
@@ -570,11 +570,13 @@ class HakemusService(
 
         if (receivers.isEmpty()) {
             logger.error {
-                "No receivers found for hakemus decision ready email, not sending any. ${application.logString()}"
+                "No receivers found for hakemus ${application.alluStatus} ready email, not sending any. ${application.logString()}"
             }
             return
         }
-        logger.info { "Sending hakemus decision ready emails to ${receivers.size} receivers" }
+        logger.info {
+            "Sending hakemus ${application.alluStatus} ready emails to ${receivers.size} receivers"
+        }
 
         receivers.forEach {
             val event =

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
@@ -536,8 +536,10 @@ class HakemusService(
                         logger.error {
                             "Got ${event.newStatus} update for a cable report. ${application.logString()}"
                         }
-                    ApplicationType.EXCAVATION_NOTIFICATION ->
+                    ApplicationType.EXCAVATION_NOTIFICATION -> {
+                        sendDecisionReadyEmails(application, event.applicationIdentifier)
                         paatosService.saveKaivuilmoituksenToiminnallinenKunto(application, event)
+                    }
                 }
             }
             ApplicationStatus.FINISHED -> {
@@ -568,11 +570,11 @@ class HakemusService(
 
         if (receivers.isEmpty()) {
             logger.error {
-                "No receivers found for decision ready email, not sending any. ${application.logString()}"
+                "No receivers found for hakemus decision ready email, not sending any. ${application.logString()}"
             }
             return
         }
-        logger.info { "Sending hakemus ready emails to ${receivers.size} receivers" }
+        logger.info { "Sending hakemus decision ready emails to ${receivers.size} receivers" }
 
         receivers.forEach {
             val event =

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceTest.kt
@@ -645,8 +645,11 @@ class HakemusServiceTest {
             }
         }
 
-        @Test
-        fun `sends email to the contacts when a kaivuilmoitus gets a decision`() {
+        @ParameterizedTest
+        @EnumSource(ApplicationStatus::class, names = ["DECISION", "OPERATIONAL_CONDITION"])
+        fun `sends email to the contacts when a kaivuilmoitus gets a decision`(
+            applicationStatus: ApplicationStatus
+        ) {
             every { hakemusRepository.getOneByAlluid(42) } returns
                 applicationEntityWithCustomer(type = ApplicationType.EXCAVATION_NOTIFICATION)
             justRun {
@@ -656,15 +659,33 @@ class HakemusServiceTest {
             every { hakemusRepository.save(any()) } answers { firstArg() }
             every { alluStatusRepository.getReferenceById(1) } returns AlluStatus(1, updateTime)
             every { alluStatusRepository.save(any()) } answers { firstArg() }
-            justRun { paatosService.saveKaivuilmoituksenPaatos(any(), any()) }
+            justRun {
+                when (applicationStatus) {
+                    ApplicationStatus.DECISION -> {
+                        paatosService.saveKaivuilmoituksenPaatos(any(), any())
+                    }
+                    ApplicationStatus.OPERATIONAL_CONDITION -> {
+                        paatosService.saveKaivuilmoituksenToiminnallinenKunto(any(), any())
+                    }
+                    else -> throw IllegalArgumentException("Invalid status")
+                }
+            }
 
-            hakemusService.handleHakemusUpdates(createHistories(), updateTime)
+            hakemusService.handleHakemusUpdates(createHistories(applicationStatus), updateTime)
 
             verifySequence {
                 hakemusRepository.getOneByAlluid(42)
                 publisher.publishEvent(
                     KaivuilmoitusDecisionEmail(receiver, applicationId, identifier))
-                paatosService.saveKaivuilmoituksenPaatos(any(), any())
+                when (applicationStatus) {
+                    ApplicationStatus.DECISION -> {
+                        paatosService.saveKaivuilmoituksenPaatos(any(), any())
+                    }
+                    ApplicationStatus.OPERATIONAL_CONDITION -> {
+                        paatosService.saveKaivuilmoituksenToiminnallinenKunto(any(), any())
+                    }
+                    else -> throw IllegalArgumentException("Invalid status")
+                }
                 hakemusRepository.save(any())
                 alluStatusRepository.getReferenceById(1)
                 alluStatusRepository.save(any())
@@ -707,7 +728,7 @@ class HakemusServiceTest {
             hakemusService.handleHakemusUpdates(createHistories(), updateTime)
 
             assertThat(output)
-                .contains("No receivers found for decision ready email, not sending any.")
+                .contains("No receivers found for hakemus decision ready email, not sending any.")
             verifySequence {
                 hakemusRepository.getOneByAlluid(42)
                 hakemusRepository.save(any())

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceTest.kt
@@ -659,17 +659,14 @@ class HakemusServiceTest {
             every { hakemusRepository.save(any()) } answers { firstArg() }
             every { alluStatusRepository.getReferenceById(1) } returns AlluStatus(1, updateTime)
             every { alluStatusRepository.save(any()) } answers { firstArg() }
-            justRun {
+            val saveMethod =
                 when (applicationStatus) {
                     ApplicationStatus.DECISION -> {
-                        paatosService.saveKaivuilmoituksenPaatos(any(), any())
+                        paatosService::saveKaivuilmoituksenPaatos
                     }
-                    ApplicationStatus.OPERATIONAL_CONDITION -> {
-                        paatosService.saveKaivuilmoituksenToiminnallinenKunto(any(), any())
-                    }
-                    else -> throw IllegalArgumentException("Invalid status")
+                    else -> paatosService::saveKaivuilmoituksenToiminnallinenKunto
                 }
-            }
+            justRun { saveMethod(any(), any()) }
 
             hakemusService.handleHakemusUpdates(createHistories(applicationStatus), updateTime)
 

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceTest.kt
@@ -728,7 +728,7 @@ class HakemusServiceTest {
             hakemusService.handleHakemusUpdates(createHistories(), updateTime)
 
             assertThat(output)
-                .contains("No receivers found for hakemus decision ready email, not sending any.")
+                .contains("No receivers found for hakemus DECISION ready email, not sending any.")
             verifySequence {
                 hakemusRepository.getOneByAlluid(42)
                 hakemusRepository.save(any())

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceTest.kt
@@ -674,15 +674,7 @@ class HakemusServiceTest {
                 hakemusRepository.getOneByAlluid(42)
                 publisher.publishEvent(
                     KaivuilmoitusDecisionEmail(receiver, applicationId, identifier))
-                when (applicationStatus) {
-                    ApplicationStatus.DECISION -> {
-                        paatosService.saveKaivuilmoituksenPaatos(any(), any())
-                    }
-                    ApplicationStatus.OPERATIONAL_CONDITION -> {
-                        paatosService.saveKaivuilmoituksenToiminnallinenKunto(any(), any())
-                    }
-                    else -> throw IllegalArgumentException("Invalid status")
-                }
+                saveMethod(any(), any())
                 hakemusRepository.save(any())
                 alluStatusRepository.getReferenceById(1)
                 alluStatusRepository.save(any())


### PR DESCRIPTION
# Description

When kaivuilmoitus is approved in operational condition an email is sent to all contact persons. The email is identical to the decision email.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2324

## Type of change

- [ ] Bug fix 
- [x] New feature 
- [ ] Other

# Instructions for testing
* Create a kaivuilmoitus, fill it and send it to Allu
* Create a decision for it in Allu
* Announce it in operational condition in Haitaton
* Create an operational condition decision in Allu
* An identical email should come for both the decision and the operational condition decision

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 

# Other relevant info
Please describe here if there is e.g. some requirements for this change or
 other info that the tester/user needs to know.