### PR TITLE
Hai 2325/email notification for kaivuilmoitus finished

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceITest.kt
@@ -2704,7 +2704,8 @@ class HakemusServiceITest(
         }
 
         @ParameterizedTest
-        @EnumSource(ApplicationStatus::class, names = ["DECISION", "OPERATIONAL_CONDITION"])
+        @EnumSource(
+            ApplicationStatus::class, names = ["DECISION", "OPERATIONAL_CONDITION", "FINISHED"])
         fun `sends email to the contacts when a kaivuilmoitus gets a decision`(
             applicationStatus: ApplicationStatus
         ) {

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
@@ -549,8 +549,10 @@ class HakemusService(
                         logger.error {
                             "Got ${event.newStatus} update for a cable report. ${application.logString()}"
                         }
-                    ApplicationType.EXCAVATION_NOTIFICATION ->
+                    ApplicationType.EXCAVATION_NOTIFICATION -> {
+                        sendDecisionReadyEmails(application, event.applicationIdentifier)
                         paatosService.saveKaivuilmoituksenTyoValmis(application, event)
+                    }
                 }
             }
             ApplicationStatus.REPLACED -> {

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceTest.kt
@@ -646,7 +646,8 @@ class HakemusServiceTest {
         }
 
         @ParameterizedTest
-        @EnumSource(ApplicationStatus::class, names = ["DECISION", "OPERATIONAL_CONDITION"])
+        @EnumSource(
+            ApplicationStatus::class, names = ["DECISION", "OPERATIONAL_CONDITION", "FINISHED"])
         fun `sends email to the contacts when a kaivuilmoitus gets a decision`(
             applicationStatus: ApplicationStatus
         ) {
@@ -664,7 +665,9 @@ class HakemusServiceTest {
                     ApplicationStatus.DECISION -> {
                         paatosService::saveKaivuilmoituksenPaatos
                     }
-                    else -> paatosService::saveKaivuilmoituksenToiminnallinenKunto
+                    ApplicationStatus.OPERATIONAL_CONDITION ->
+                        paatosService::saveKaivuilmoituksenToiminnallinenKunto
+                    else -> paatosService::saveKaivuilmoituksenTyoValmis
                 }
             justRun { saveMethod(any(), any()) }
 


### PR DESCRIPTION
# Description

When kaivuilmoitus work is finished an email is sent to all contact persons. The email is identical to the decision email.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2325

## Type of change

- [ ] Bug fix 
- [x] New feature 
- [ ] Other

# Instructions for testing
* Create a kaivuilmoitus, fill it and send it to Allu
* Create a decision for it in Allu
* Mark it as finished in Allu (Valvonta - Loppuvalvonta)
* An identical email should come for both the decision and "työ valmis" decision

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 

# Other relevant info
Please describe here if there is e.g. some requirements for this change or
 other info that the tester/user needs to know.