### PR TITLE
HAI-2625 Add registryKeyHidden to hakemus responses

### DIFF
--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusResponse.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusResponse.kt
@@ -157,6 +157,7 @@ data class CustomerResponse(
     val email: String,
     val phone: String,
     val registryKey: String?,
+    val registryKeyHidden: Boolean,
 ) {
     /** Check if this customer contains any actual personal information. */
     fun hasPersonalInformation() =

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusUpdateRequest.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusUpdateRequest.kt
@@ -256,6 +256,7 @@ data class CustomerWithContactsRequest(
  * For updating an existing [Hakemusyhteystieto] (with [yhteystietoId]) or creating a new one
  * (without [yhteystietoId]).
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 data class CustomerRequest(
     /** Hakemusyhteystieto id */
     val yhteystietoId: UUID? = null,

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/Hakemusyhteystieto.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/Hakemusyhteystieto.kt
@@ -22,10 +22,14 @@ data class Hakemusyhteystieto(
                     name = nimi,
                     email = sahkoposti,
                     phone = puhelinnumero,
-                    registryKey = registryKey,
+                    registryKey = if (hideRegistryKey()) null else registryKey,
+                    registryKeyHidden = hideRegistryKey(),
                 ),
             contacts = yhteyshenkilot.map { it.toResponse() },
         )
+
+    private fun hideRegistryKey(): Boolean =
+        registryKey != null && (tyyppi == CustomerType.PERSON || tyyppi == CustomerType.OTHER)
 }
 
 data class Hakemusyhteyshenkilo(

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusResponseFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusResponseFactory.kt
@@ -62,12 +62,12 @@ object HakemusResponseFactory {
             listOf(ApplicationFactory.createCableReportApplicationArea()),
         customerWithContacts: CustomerWithContactsResponse? =
             CustomerWithContactsResponse(
-                createCompanyCustomerResponse(),
+                companyCustomer(),
                 listOf(createContactResponse()),
             ),
         contractorWithContacts: CustomerWithContactsResponse? =
             CustomerWithContactsResponse(
-                createPersonCustomerResponse(),
+                personCustomer(),
                 listOf(createContactResponse()),
             ),
         representativeWithContacts: CustomerWithContactsResponse? = null,
@@ -107,12 +107,12 @@ object HakemusResponseFactory {
             listOf(ApplicationFactory.createExcavationNotificationArea()),
         customerWithContacts: CustomerWithContactsResponse? =
             CustomerWithContactsResponse(
-                createCompanyCustomerResponse(),
+                companyCustomer(),
                 listOf(createContactResponse()),
             ),
         contractorWithContacts: CustomerWithContactsResponse? =
             CustomerWithContactsResponse(
-                createPersonCustomerResponse(),
+                personCustomer(),
                 listOf(createContactResponse()),
             ),
         representativeWithContacts: CustomerWithContactsResponse? = null,
@@ -144,6 +144,7 @@ object HakemusResponseFactory {
         )
 
     fun companyCustomer(
+        yhteystietoId: UUID = UUID.randomUUID(),
         type: CustomerType = CustomerType.COMPANY,
         name: String = "DNA",
         email: String = "info@dna.test",
@@ -151,68 +152,35 @@ object HakemusResponseFactory {
         registryKey: String? = "3766028-0",
     ): CustomerResponse =
         CustomerResponse(
-            UUID.randomUUID(),
-            type,
-            name,
-            email,
-            phone,
-            registryKey,
+            yhteystietoId = yhteystietoId,
+            type = type,
+            name = name,
+            email = email,
+            phone = phone,
+            registryKey = registryKey,
+            registryKeyHidden = false,
         )
 
     fun personCustomer(
+        yhteystietoId: UUID = UUID.randomUUID(),
         type: CustomerType = CustomerType.PERSON,
         name: String = TEPPO_TESTI,
         email: String = ApplicationFactory.TEPPO_EMAIL,
         phone: String = ApplicationFactory.TEPPO_PHONE,
-        registryKey: String? = "281192-937W",
     ) =
         CustomerResponse(
-            UUID.randomUUID(),
-            type,
-            name,
-            email,
-            phone,
-            registryKey,
+            yhteystietoId = yhteystietoId,
+            type = type,
+            name = name,
+            email = email,
+            phone = phone,
+            registryKey = null,
+            registryKeyHidden = true,
         )
 
     fun CustomerResponse.withContacts(
         vararg contacts: ContactResponse
     ): CustomerWithContactsResponse = CustomerWithContactsResponse(this, contacts.asList())
-
-    private fun createPersonCustomerResponse(
-        yhteystietoId: UUID = UUID.randomUUID(),
-        type: CustomerType = CustomerType.PERSON,
-        name: String = TEPPO_TESTI,
-        email: String = ApplicationFactory.TEPPO_EMAIL,
-        phone: String = "04012345678",
-        registryKey: String? = "281192-937W",
-    ) =
-        CustomerResponse(
-            yhteystietoId,
-            type,
-            name,
-            email,
-            phone,
-            registryKey,
-        )
-
-    private fun createCompanyCustomerResponse(
-        yhteystietoId: UUID = UUID.randomUUID(),
-        type: CustomerType = CustomerType.COMPANY,
-        name: String = "DNA",
-        email: String = "info@dna.test",
-        phone: String = "+3581012345678",
-        registryKey: String? = "3766028-0",
-    ): CustomerResponse {
-        return CustomerResponse(
-            yhteystietoId,
-            type,
-            name,
-            email,
-            phone,
-            registryKey,
-        )
-    }
 
     private fun createContactResponse(
         hankekayttajaId: UUID = UUID.randomUUID(),

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusUpdateRequestFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusUpdateRequestFactory.kt
@@ -243,7 +243,8 @@ object HakemusUpdateRequestFactory {
                                 name = name,
                                 email = email,
                                 phone = phone,
-                                registryKey = registryKey),
+                                registryKey = registryKey,
+                            ),
                             hankekayttajaIds.map { ContactRequest(it) },
                         ))
         }
@@ -348,7 +349,8 @@ object HakemusUpdateRequestFactory {
                                 name = name,
                                 email = email,
                                 phone = phone,
-                                registryKey = registryKey),
+                                registryKey = registryKey,
+                            ),
                             hankekayttajaIds.map { ContactRequest(it) },
                         ))
             is KaivuilmoitusUpdateRequest ->
@@ -361,7 +363,8 @@ object HakemusUpdateRequestFactory {
                                 name = name,
                                 email = email,
                                 phone = phone,
-                                registryKey = registryKey),
+                                registryKey = registryKey,
+                            ),
                             hankekayttajaIds.map { ContactRequest(it) },
                         ))
         }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/logging/DisclosureLogServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/logging/DisclosureLogServiceTest.kt
@@ -271,7 +271,7 @@ internal class DisclosureLogServiceTest {
         @Test
         fun `doesn't save entries for blank customers`() {
             val blankCustomer =
-                CustomerResponse(UUID.randomUUID(), CustomerType.PERSON, "", "", "", "")
+                CustomerResponse(UUID.randomUUID(), CustomerType.PERSON, "", "", "", null, true)
             val customerWithoutContacts = CustomerWithContactsResponse(blankCustomer, listOf())
             val contractorWithoutContacts = CustomerWithContactsResponse(blankCustomer, listOf())
             val hakemusResponse =


### PR DESCRIPTION
# Description

Add the `registryKeyHidden` field to all hakemus responses where customer information is available. The value is true when the customer is of type person or other and has a non-null `registryKey`. When registryKeyHidden is true, overwrite the registry key with a null value.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2625

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 