### PR TITLE
HAI-2315 Calculate kaivuilmoitus traffic nuisance indexes when the application is updated

### DIFF
--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankealueEntity.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankealueEntity.kt
@@ -26,7 +26,6 @@ import jakarta.persistence.MapKeyEnumerated
 import jakarta.persistence.OneToOne
 import jakarta.persistence.Table
 import java.time.LocalDate
-import java.time.temporal.ChronoUnit
 
 @Entity
 @Table(name = "hankealue")
@@ -53,25 +52,20 @@ class HankealueEntity(
         fetch = FetchType.LAZY,
         mappedBy = "hankealue",
         cascade = [CascadeType.ALL],
-        orphanRemoval = true
+        orphanRemoval = true,
     )
     var tormaystarkasteluTulos: TormaystarkasteluTulosEntity?,
     @ElementCollection(fetch = FetchType.LAZY)
     @CollectionTable(
         name = "hankkeen_haittojenhallintasuunnitelma",
-        joinColumns = [JoinColumn(name = "hankealue_id", referencedColumnName = "id")]
+        joinColumns = [JoinColumn(name = "hankealue_id", referencedColumnName = "id")],
     )
     @MapKeyColumn(name = "tyyppi")
     @Column(name = "sisalto")
     @MapKeyEnumerated(EnumType.STRING)
     var haittojenhallintasuunnitelma: MutableMap<Haittojenhallintatyyppi, String> = mutableMapOf(),
 ) : HasId<Int> {
-    fun haittaAjanKestoDays(): Int? =
-        if (haittaAlkuPvm != null && haittaLoppuPvm != null) {
-            ChronoUnit.DAYS.between(haittaAlkuPvm, haittaLoppuPvm).toInt() + 1
-        } else {
-            null
-        }
+    fun haittaAjanKestoDays(): Int? = daysBetween(haittaAlkuPvm, haittaLoppuPvm)
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Utils.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Utils.kt
@@ -4,6 +4,7 @@ import fi.hel.haitaton.hanke.domain.HasId
 import java.time.LocalDateTime
 import java.time.ZonedDateTime
 import java.time.temporal.ChronoUnit
+import java.time.temporal.Temporal
 import mu.KotlinLogging
 import org.springframework.security.core.context.SecurityContext
 import org.springframework.security.core.context.SecurityContextHolder
@@ -135,3 +136,11 @@ fun String?.isValidOVT(): Boolean {
 
     return this.length >= 12
 }
+
+/** Helper function to calculate the duration between two dates, inclusive. */
+fun daysBetween(haittaAlkuPvm: Temporal?, haittaLoppuPvm: Temporal?): Int? =
+    if (haittaAlkuPvm != null && haittaLoppuPvm != null) {
+        ChronoUnit.DAYS.between(haittaAlkuPvm, haittaLoppuPvm).toInt() + 1
+    } else {
+        null
+    }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/Hakemusalue.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/Hakemusalue.kt
@@ -39,7 +39,7 @@ data class KaivuilmoitusAlue(
 data class Tyoalue(
     val geometry: Polygon,
     val area: Double,
-    val tormaystarkasteluTulos: TormaystarkasteluTulos?,
+    var tormaystarkasteluTulos: TormaystarkasteluTulos?,
 )
 
 fun List<KaivuilmoitusAlue>?.combinedAddress(): PostalAddress? =

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluController.kt
@@ -1,6 +1,7 @@
 package fi.hel.haitaton.hanke.tormaystarkastelu
 
 import fi.hel.haitaton.hanke.HankeError
+import fi.hel.haitaton.hanke.daysBetween
 import fi.hel.haitaton.hanke.geometria.GeometriatValidator
 import io.sentry.Sentry
 import io.swagger.v3.oas.annotations.Hidden
@@ -11,7 +12,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import java.time.ZonedDateTime
-import java.time.temporal.ChronoUnit
 import mu.KotlinLogging
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.ExceptionHandler
@@ -34,7 +34,7 @@ class TormaystarkasteluController(
     @Operation(
         summary = "Calculate nuisance indices",
         description =
-            "Calculate nuisance indices with the given geometry and other information. The calculated indices will not be saved anywhere."
+            "Calculate nuisance indices with the given geometry and other information. The calculated indices will not be saved anywhere.",
     )
     @ApiResponses(
         value =
@@ -42,14 +42,14 @@ class TormaystarkasteluController(
                 ApiResponse(
                     description =
                         "The calculated nuisance indices for the given geometry and other information.",
-                    responseCode = "200"
+                    responseCode = "200",
                 ),
                 ApiResponse(
                     description = "The given information was not valid.",
                     responseCode = "400",
-                    content = [Content(schema = Schema(implementation = HankeError::class))]
+                    content = [Content(schema = Schema(implementation = HankeError::class))],
                 ),
-            ]
+            ],
     )
     fun calculate(@RequestBody request: TormaystarkasteluRequest): TormaystarkasteluTulos {
         GeometriatValidator.expectValid(request.geometriat.featureCollection)
@@ -58,14 +58,13 @@ class TormaystarkasteluController(
             throw EndBeforeStartException(request.haittaAlkuPvm, request.haittaLoppuPvm)
         }
 
-        val haittaajanKestoDays =
-            ChronoUnit.DAYS.between(request.haittaAlkuPvm, request.haittaLoppuPvm).toInt() + 1
+        val haittaajanKestoDays = daysBetween(request.haittaAlkuPvm, request.haittaLoppuPvm)!!
 
         return tormaystarkasteluLaskentaService.calculateTormaystarkastelu(
             request.geometriat.featureCollection,
             haittaajanKestoDays,
             request.kaistaHaitta,
-            request.kaistaPituusHaitta
+            request.kaistaPituusHaitta,
         )
     }
 

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/ApplicationFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/ApplicationFactory.kt
@@ -118,7 +118,7 @@ class ApplicationFactory(
         fun createTyoalue(
             geometry: Polygon = GeometriaFactory.secondPolygon(),
             area: Double = 100.0,
-            tormaystarkasteluTulos: TormaystarkasteluTulos =
+            tormaystarkasteluTulos: TormaystarkasteluTulos? =
                 TormaystarkasteluTulos(
                     TORMAYSTARKASTELU_DEFAULT_AUTOLIIKENNELUOKITTELU, 3.0f, 5.0f, 5.0f),
         ) = Tyoalue(geometry, area, tormaystarkasteluTulos)

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusUpdateRequestFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusUpdateRequestFactory.kt
@@ -267,6 +267,13 @@ object HakemusUpdateRequestFactory {
             is KaivuilmoitusUpdateRequest -> this.copy(requiredCompetence = requiredCompetence)
         }
 
+    fun HakemusUpdateRequest.withDates(startTime: ZonedDateTime?, endTime: ZonedDateTime?) =
+        when (this) {
+            is JohtoselvityshakemusUpdateRequest ->
+                this.copy(startTime = startTime, endTime = endTime)
+            is KaivuilmoitusUpdateRequest -> this.copy(startTime = startTime, endTime = endTime)
+        }
+
     fun HakemusUpdateRequest.withArea(area: Hakemusalue?) = withAreas(area?.let { listOf(it) })
 
     fun HakemusUpdateRequest.withAreas(areas: List<Hakemusalue>?) =

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceTest.kt
@@ -45,6 +45,7 @@ import fi.hel.haitaton.hanke.paatos.PaatosService
 import fi.hel.haitaton.hanke.permissions.HankeKayttajaService
 import fi.hel.haitaton.hanke.test.AlluException
 import fi.hel.haitaton.hanke.test.USERNAME
+import fi.hel.haitaton.hanke.tormaystarkastelu.TormaystarkasteluLaskentaService
 import io.mockk.called
 import io.mockk.checkUnnecessaryStub
 import io.mockk.clearAllMocks
@@ -91,6 +92,7 @@ class HakemusServiceTest {
     private val alluStatusRepository: AlluStatusRepository = mockk()
     private val paatosService: PaatosService = mockk()
     private val publisher: ApplicationEventPublisher = mockk()
+    private val tormaystarkasteluLaskentaService: TormaystarkasteluLaskentaService = mockk()
 
     private val hakemusService =
         HakemusService(
@@ -107,6 +109,7 @@ class HakemusServiceTest {
             alluStatusRepository,
             paatosService,
             publisher,
+            tormaystarkasteluLaskentaService,
         )
 
     @BeforeEach


### PR DESCRIPTION
# Description

When kaivuilmoitus is updated, new traffic nuisance indexes are calculated for its work areas. Calculated results are stored in database and returned for API endpoint caller.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2315

## Type of change

- [ ] Bug fix 
- [x] New feature 
- [ ] Other

# Instructions for testing
* With Swagger UI call the update endpoint: http://localhost:3001/api/swagger-ui/index.html#/hakemus-controller/update
* You can use e.g. the same geometry which is used in the integration test:  https://github.com/City-of-Helsinki/haitaton-backend/blob/main/services/hanke-service/src/test/resources/fi/hel/haitaton/hanke/geometria/toinen_polygoni.json
* API call should return filled `tormaystarkasteluTulos` for each work areas 

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 

# Other relevant info
Please describe here if there is e.g. some requirements for this change or
 other info that the tester/user needs to know.