### PR TITLE
HAI-2625 Add registry key hidden to customer request

### DIFF
--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusUpdateRequest.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusUpdateRequest.kt
@@ -265,6 +265,8 @@ data class CustomerRequest(
     val email: String,
     val phone: String,
     val registryKey: String? = null,
+    /** Value is false when read from JSON with null or empty value. */
+    val registryKeyHidden: Boolean = false,
 ) {
     /**
      * Returns true if this customer has changes compared to the given [hakemusyhteystietoEntity].
@@ -274,7 +276,7 @@ data class CustomerRequest(
             name != hakemusyhteystietoEntity.nimi ||
             email != hakemusyhteystietoEntity.sahkoposti ||
             phone != hakemusyhteystietoEntity.puhelinnumero ||
-            registryKey != hakemusyhteystietoEntity.registryKey
+            (!registryKeyHidden && registryKey != hakemusyhteystietoEntity.registryKey)
 }
 
 /** For referencing [fi.hel.haitaton.hanke.permissions.HankeKayttaja] by its id. */

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusUpdateRequestValidator.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusUpdateRequestValidator.kt
@@ -3,13 +3,17 @@ package fi.hel.haitaton.hanke.hakemus
 import fi.hel.haitaton.hanke.allu.CustomerType
 import fi.hel.haitaton.hanke.isValidBusinessId
 import fi.hel.haitaton.hanke.isValidOVT
+import fi.hel.haitaton.hanke.validation.HenkilotunnusValidator.isValidHenkilotunnus
 import fi.hel.haitaton.hanke.validation.ValidationResult
 import fi.hel.haitaton.hanke.validation.ValidationResult.Companion.whenNotNull
 import fi.hel.haitaton.hanke.validation.Validators.given
 import fi.hel.haitaton.hanke.validation.Validators.isBeforeOrEqual
+import fi.hel.haitaton.hanke.validation.Validators.notBlank
 import fi.hel.haitaton.hanke.validation.Validators.notJustWhitespace
 import fi.hel.haitaton.hanke.validation.Validators.notNull
 import fi.hel.haitaton.hanke.validation.Validators.validate
+import fi.hel.haitaton.hanke.validation.Validators.validateFalse
+import fi.hel.haitaton.hanke.validation.Validators.validateNull
 import fi.hel.haitaton.hanke.validation.Validators.validateTrue
 import jakarta.validation.ConstraintValidator
 import jakarta.validation.ConstraintValidatorContext
@@ -48,10 +52,6 @@ fun HakemusUpdateRequest.validateCommonFieldsForErrors(): ValidationResult =
         .andWhen(startTime != null && endTime != null) {
             isBeforeOrEqual(startTime!!, endTime!!, "endTime")
         }
-        .whenNotNull(customerWithContacts) { it.validateForErrors("customerWithContacts") }
-        .whenNotNull(representativeWithContacts) {
-            it.validateForErrors("representativeWithContacts")
-        }
 
 fun CustomerWithContactsRequest.validateForErrors(path: String): ValidationResult =
     customer.validateForErrors("$path.customer")
@@ -60,18 +60,72 @@ fun CustomerRequest.validateForErrors(path: String): ValidationResult =
     validate { notJustWhitespace(name, "$path.name") }
         .and { notJustWhitespace(email, "$path.email") }
         .and { notJustWhitespace(phone, "$path.phone") }
-        .andWhen(
-            registryKey != null &&
-                (type == CustomerType.COMPANY || type == CustomerType.ASSOCIATION)
-        ) {
+        .and { validateRegistryKey(path) }
+
+fun CustomerRequest.validateRegistryKey(path: String): ValidationResult =
+    when (type) {
+        CustomerType.COMPANY ->
+            validateRegistryKeyForCompanies(this.registryKey, this.registryKeyHidden, path)
+        CustomerType.ASSOCIATION ->
+            validateRegistryKeyForCompanies(this.registryKey, this.registryKeyHidden, path)
+        CustomerType.PERSON ->
+            validateRegistryKeyForPerson(this.registryKey, this.registryKeyHidden, path)
+        CustomerType.OTHER ->
+            validateRegistryKeyForOther(this.registryKey, this.registryKeyHidden, path)
+    }
+
+private fun validateRegistryKeyForCompanies(
+    registryKey: String?,
+    registryKeyHidden: Boolean,
+    path: String,
+) =
+    validateFalse(registryKeyHidden, "$path.registryKeyHidden").and {
+        whenNotNull(registryKey) {
             validateTrue(registryKey.isValidBusinessId(), "$path.registryKey")
         }
+    }
+
+private fun validateRegistryKeyForOther(
+    registryKey: String?,
+    registryKeyHidden: Boolean,
+    path: String,
+) =
+    validate()
+        .andWhen(registryKeyHidden) { validateNull(registryKey, "$path.registryKey") }
+        .andWhen(!registryKeyHidden) {
+            whenNotNull(registryKey) { notBlank(it, "$path.registryKey") }
+        }
+
+private fun validateRegistryKeyForPerson(
+    registryKey: String?,
+    registryKeyHidden: Boolean,
+    path: String,
+) =
+    validateRegistryKeyForOther(registryKey, registryKeyHidden, path).whenNotNull(registryKey) {
+        validateTrue(it.isValidHenkilotunnus(), "$path.registryKey")
+    }
 
 private fun JohtoselvityshakemusUpdateRequest.validateForErrors(): ValidationResult =
     whenNotNull(postalAddress) { it.validateForErrors("postalAddress") }
-        .whenNotNull(contractorWithContacts) { it.validateForErrors("contractorWithContacts") }
+        .whenNotNull(customerWithContacts) {
+            it.validateForErrors("customerWithContacts").and {
+                it.validateNoHenkilotunnus("customerWithContacts")
+            }
+        }
+        .whenNotNull(representativeWithContacts) {
+            it.validateForErrors("representativeWithContacts").and {
+                it.validateNoHenkilotunnus("representativeWithContacts")
+            }
+        }
+        .whenNotNull(contractorWithContacts) {
+            it.validateForErrors("contractorWithContacts").and {
+                it.validateNoHenkilotunnus("contractorWithContacts")
+            }
+        }
         .whenNotNull(propertyDeveloperWithContacts) {
-            it.validateForErrors("propertyDeveloperWithContacts")
+            it.validateForErrors("propertyDeveloperWithContacts").and {
+                it.validateNoHenkilotunnus("propertyDeveloperWithContacts")
+            }
         }
 
 fun PostalAddressRequest.validateForErrors(path: String) = validate {
@@ -80,21 +134,40 @@ fun PostalAddressRequest.validateForErrors(path: String) = validate {
 
 private fun KaivuilmoitusUpdateRequest.validateForErrors(): ValidationResult =
     given(!cableReportDone) { notNull(rockExcavation, "rockExcavation") }
-        .whenNotNull(contractorWithContacts) { it.validateForErrors("contractorWithContacts") }
+        .whenNotNull(customerWithContacts) { it.validateForErrors("customerWithContacts") }
+        .whenNotNull(representativeWithContacts) {
+            it.validateForErrors("representativeWithContacts").and {
+                it.validateNoHenkilotunnus("representativeWithContacts")
+            }
+        }
+        .whenNotNull(contractorWithContacts) {
+            it.validateForErrors("contractorWithContacts").and {
+                it.validateNoHenkilotunnus("contractorWithContacts")
+            }
+        }
         .whenNotNull(propertyDeveloperWithContacts) {
-            it.validateForErrors("propertyDeveloperWithContacts")
+            it.validateForErrors("propertyDeveloperWithContacts").and {
+                it.validateNoHenkilotunnus("propertyDeveloperWithContacts")
+            }
         }
         .whenNotNull(invoicingCustomer) { it.validateForErrors("invoicingCustomer") }
         .and { notJustWhitespace(additionalInfo, "additionalInfo") }
+
+private fun CustomerWithContactsRequest.validateNoHenkilotunnus(path: String) =
+    customer.validateNoHenkilotunnus("$path.customer")
+
+private fun CustomerRequest.validateNoHenkilotunnus(path: String) =
+    validate().andWhen(type in listOf(CustomerType.PERSON, CustomerType.OTHER)) {
+        validateNull(registryKey, "$path.registryKey")
+    }
 
 fun InvoicingCustomerRequest.validateForErrors(path: String): ValidationResult =
     validate { notJustWhitespace(name, "$path.name") }
         .andWhen(
             registryKey != null &&
-                (type == CustomerType.COMPANY || type == CustomerType.ASSOCIATION)
-        ) {
-            validateTrue(registryKey.isValidBusinessId(), "$path.registryKey")
-        }
+                (type == CustomerType.COMPANY || type == CustomerType.ASSOCIATION)) {
+                validateTrue(registryKey.isValidBusinessId(), "$path.registryKey")
+            }
         .andWhen(!ovt.isNullOrBlank()) { validateTrue(ovt.isValidOVT(), "$path.ovt") }
         .and { notJustWhitespace(ovt, "$path.ovt") }
         .and { notJustWhitespace(invoicingOperator, "$path.invoicingOperator") }
@@ -110,5 +183,4 @@ fun InvoicingPostalAddressRequest.validateForErrors(path: String): ValidationRes
 
 class InvalidHakemusDataException(val errorPaths: List<String>) :
     RuntimeException(
-        "Application contains invalid data. Errors at paths: ${errorPaths.joinToString { "applicationData.$it" }}"
-    )
+        "Application contains invalid data. Errors at paths: ${errorPaths.joinToString { "applicationData.$it" }}")

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/validation/HankePublicValidator.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/validation/HankePublicValidator.kt
@@ -18,6 +18,7 @@ import fi.hel.haitaton.hanke.validation.Validators.notNull
 import fi.hel.haitaton.hanke.validation.Validators.notNullOrBlank
 import fi.hel.haitaton.hanke.validation.Validators.notNullOrEmpty
 import fi.hel.haitaton.hanke.validation.Validators.validate
+import fi.hel.haitaton.hanke.validation.Validators.validateNull
 import fi.hel.haitaton.hanke.validation.Validators.validateTrue
 
 /**
@@ -52,13 +53,10 @@ object HankePublicValidator {
                 firstOf(
                     notNull(alue.geometriat, "$path.geometriat"),
                     notNull(
-                        alue.geometriat?.featureCollection,
-                        "$path.geometriat.featureCollection"
-                    ),
+                        alue.geometriat?.featureCollection, "$path.geometriat.featureCollection"),
                     notNullOrEmpty(
                         alue.geometriat?.featureCollection?.features,
-                        "$path.geometriat.featureCollection.features"
-                    ),
+                        "$path.geometriat.featureCollection.features"),
                 )
             }
             .and { notNullOrBlank(alue.nimi, "$path.nimi") }
@@ -78,7 +76,7 @@ object HankePublicValidator {
                 validateTrue(yhteystieto.ytunnus.isValidBusinessId(), "$path.ytunnus")
             }
             .andWhen(yhteystieto.tyyppi == YKSITYISHENKILO) {
-                validateTrue(yhteystieto.ytunnus == null, "$path.ytunnus")
+                validateNull(yhteystieto.ytunnus, "$path.ytunnus")
             }
 
     internal fun validateHaittojenhallintasuunnitelmaCommonFields(
@@ -102,9 +100,7 @@ object HankePublicValidator {
             }
             .andWhen(tt.linjaautoliikenneindeksi > 0) {
                 notNullOrBlank(
-                    hhs[Haittojenhallintatyyppi.LINJAAUTOLIIKENNE],
-                    "$path.LINJAAUTOLIIKENNE"
-                )
+                    hhs[Haittojenhallintatyyppi.LINJAAUTOLIIKENNE], "$path.LINJAAUTOLIIKENNE")
             }
             .andWhen(tt.raitioliikenneindeksi > 0f) {
                 notNullOrBlank(hhs[Haittojenhallintatyyppi.RAITIOLIIKENNE], "$path.RAITIOLIIKENNE")

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/validation/HankeValidator.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/validation/HankeValidator.kt
@@ -16,6 +16,7 @@ import fi.hel.haitaton.hanke.validation.Validators.isBeforeOrEqual
 import fi.hel.haitaton.hanke.validation.Validators.notBlank
 import fi.hel.haitaton.hanke.validation.Validators.notLongerThan
 import fi.hel.haitaton.hanke.validation.Validators.validate
+import fi.hel.haitaton.hanke.validation.Validators.validateNull
 import fi.hel.haitaton.hanke.validation.Validators.validateTrue
 import jakarta.validation.ConstraintValidator
 import jakarta.validation.ConstraintValidatorContext
@@ -75,4 +76,4 @@ private fun validateYhteystieto(yhteystieto: Yhteystieto, path: String): Validat
 
 private fun Yhteystieto.validate(path: String): ValidationResult =
     whenNotNull(ytunnus) { validateTrue(it.isValidBusinessId(), "$path.ytunnus") }
-        .andWhen(tyyppi == YKSITYISHENKILO) { validateTrue(ytunnus == null, "$path.ytunnus") }
+        .andWhen(tyyppi == YKSITYISHENKILO) { validateNull(ytunnus, "$path.ytunnus") }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/validation/HenkilotunnusValidator.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/validation/HenkilotunnusValidator.kt
@@ -1,0 +1,66 @@
+package fi.hel.haitaton.hanke.validation
+
+import java.time.LocalDate
+import java.time.format.DateTimeParseException
+import mu.KotlinLogging
+
+private val logger = KotlinLogging.logger {}
+
+object HenkilotunnusValidator {
+
+    private val hetuRegex =
+        "^(\\d{2})(\\d{2})(\\d{2})([-+U-YA-F])(\\d{3})([\\dA-FHJ-NPR-Y])\$".toRegex()
+
+    private val eighteens = listOf("+")
+    private val nineteens = listOf("-", "U", "V", "W", "X", "Y")
+    private val twenties = listOf("A", "B", "C", "D", "E", "F")
+
+    private val checkDigits = "0123456789ABCDEFHJKLMNPRSTUVWXY".toCharArray()
+
+    fun String.isValidHenkilotunnus(): Boolean {
+        try {
+            val matchResult = hetuRegex.find(this.uppercase())
+            if (matchResult == null) {
+                logger.warn { "Invalid format in henkilotunnus." }
+                return false
+            }
+
+            val (day, month, year, separator, index, checkDigit) = matchResult.destructured
+
+            return isValidDate(day, month, year, separator.toCentury()) &&
+                isValidCheckDigit("$day$month$year$index", checkDigit.first())
+        } catch (e: DateTimeParseException) {
+            logger.warn(e) { "Invalid date in henkilotunnus." }
+            return false
+        } catch (e: Exception) {
+            logger.error(e) { "Error while validating henkilotunnus." }
+            return false
+        }
+    }
+
+    private fun isValidDate(day: String, month: String, year: String, century: Int): Boolean {
+        val date = LocalDate.parse("$century$year-$month-$day")
+        val result = date.isAfter(LocalDate.parse("1850-01-01")) && date.isBefore(LocalDate.now())
+        if (!result) {
+            logger.warn { "Henkilotunnus date was ancient or in the future: $date" }
+        }
+        return result
+    }
+
+    private fun isValidCheckDigit(parts: String, checkDigit: Char): Boolean {
+        val index = parts.toInt() % 31
+        val result = checkDigits[index] == checkDigit
+        if (!result) {
+            logger.warn { "Henkilotunnus check digit was not valid." }
+        }
+        return result
+    }
+
+    private fun String.toCentury(): Int =
+        when (this) {
+            in eighteens -> 18
+            in nineteens -> 19
+            in twenties -> 20
+            else -> throw IllegalArgumentException("Invalid separator in henkilotunnus.")
+        }
+}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/validation/Validators.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/validation/Validators.kt
@@ -34,6 +34,9 @@ object Validators {
     fun validateFalse(condition: Boolean?, path: String): ValidationResult =
         if (condition == false) ValidationResult.success() else ValidationResult.failure(path)
 
+    fun validateNull(value: Any?, path: String): ValidationResult =
+        validateTrue(value == null, path)
+
     fun notNull(value: Any?, path: String): ValidationResult = validateFalse(value == null, path)
 
     fun notBlank(value: String, path: String): ValidationResult =
@@ -145,8 +148,9 @@ sealed class ValidationResult {
         f: (T, String) -> ValidationResult,
     ): ValidationResult {
         return this.addAll(
-            values.flatMapIndexed { index: Int, value: T -> f(value, "$path[$index]").errorPaths() }
-        )
+            values.flatMapIndexed { index: Int, value: T ->
+                f(value, "$path[$index]").errorPaths()
+            })
     }
 
     companion object {

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/HenkilotunnusValidatorValidatorTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/HenkilotunnusValidatorValidatorTest.kt
@@ -1,0 +1,63 @@
+package fi.hel.haitaton.hanke
+
+import assertk.assertThat
+import assertk.assertions.isFalse
+import assertk.assertions.isTrue
+import fi.hel.haitaton.hanke.validation.HenkilotunnusValidator.isValidHenkilotunnus
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+
+class HenkilotunnusValidatorValidatorTest {
+
+    @ParameterizedTest
+    @ValueSource(
+        strings =
+            [
+                "190950+016X", // First valid year of 1800s
+                "200299+703R", // Last year of 1800s
+                "180800V5272", // First year of 1900s
+                "090626-885W", // Classic separator of 1900s
+                "230577U869S", // The different separators of 1900s
+                "260570V398P",
+                "080720W894T",
+                "140288X700X",
+                "240411Y748N",
+                "110699W216E", // The last year of 1900s
+                "230500D7546", // First year of 2000s
+                "120621A3731", // Classic separator of 2000s
+                "120413B621B", // The different separators of 2000s
+                "130723C4416",
+                "241003D605U",
+                "100703E622X",
+                "060623F6387",
+                "180524E0426", // As of writing, the last valid year of 2000s
+                "290204A000B", // Leap day on a leap year
+                "110166-8080", // Zero as check digit
+            ])
+    fun `accepts valid henkilotunnus`(hetu: String) {
+        assertThat(hetu.isValidHenkilotunnus()).isTrue()
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+        strings =
+            [
+                "260570V398", // Missing check digit
+                "080720W84T", // Missing one index digit
+                "140288700X", // Missing separator
+                "24041Y748N", // Missing one date digit
+                "080720W8942T", // Extra digit
+                "190949+016N", // Before 1850
+                "120333B054D", // In the future
+                "120621K3731", // Invalid separator
+                "260570V398I", // Invalid check digits
+                "080720W8944",
+                "241003D605D",
+                "100703E6220",
+                "290204A000K",
+                "290203A0003", // Leap day in a non-leap year
+            ])
+    fun `rejects invalid henkilotunnus`(hetu: String) {
+        assertThat(hetu.isValidHenkilotunnus()).isFalse()
+    }
+}

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusUpdateRequestFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusUpdateRequestFactory.kt
@@ -153,21 +153,50 @@ object HakemusUpdateRequestFactory {
             additionalInfo = "Lisätiedot",
         )
 
-    private fun createCustomerWithContactsRequest(
+    fun createCustomerWithContactsRequest(
+        customerType: CustomerType = CustomerType.COMPANY,
+        yhteystietoId: UUID? = UUID.randomUUID(),
+        registryKey: String?,
+        vararg hankekayttajaIds: UUID
+    ) =
+        CustomerWithContactsRequest(
+            createCustomer(
+                yhteystietoId = yhteystietoId,
+                type = customerType,
+                registryKey = registryKey,
+            ),
+            hankekayttajaIds.map { ContactRequest(it) },
+        )
+
+    fun createCustomerWithContactsRequest(
         customerType: CustomerType = CustomerType.COMPANY,
         yhteystietoId: UUID? = UUID.randomUUID(),
         vararg hankekayttajaIds: UUID
     ) =
-        CustomerWithContactsRequest(
-            CustomerRequest(
-                yhteystietoId = yhteystietoId,
-                type = customerType,
-                name = DEFAULT_CUSTOMER_NAME,
-                email = DEFAULT_CUSTOMER_EMAIL,
-                phone = DEFAULT_CUSTOMER_PHONE,
-                registryKey = DEFAULT_CUSTOMER_REGISTRY_KEY,
-            ),
-            hankekayttajaIds.map { ContactRequest(it) },
+        createCustomerWithContactsRequest(
+            customerType = customerType,
+            yhteystietoId = yhteystietoId,
+            registryKey = DEFAULT_CUSTOMER_REGISTRY_KEY,
+            hankekayttajaIds = hankekayttajaIds,
+        )
+
+    fun createCustomer(
+        yhteystietoId: UUID? = UUID.randomUUID(),
+        type: CustomerType = CustomerType.COMPANY,
+        name: String = DEFAULT_CUSTOMER_NAME,
+        email: String = DEFAULT_CUSTOMER_EMAIL,
+        phone: String = DEFAULT_CUSTOMER_PHONE,
+        registryKey: String? = DEFAULT_CUSTOMER_REGISTRY_KEY,
+        registryKeyHidden: Boolean = false,
+    ) =
+        CustomerRequest(
+            yhteystietoId = yhteystietoId,
+            type = type,
+            name = name,
+            email = email,
+            phone = phone,
+            registryKey = registryKey,
+            registryKeyHidden = registryKeyHidden,
         )
 
     private fun createInvoicingCustomerRequest(

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/CustomerRequestDeserializeTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/CustomerRequestDeserializeTest.kt
@@ -1,0 +1,74 @@
+package fi.hel.haitaton.hanke.hakemus
+
+import assertk.assertFailure
+import assertk.assertThat
+import assertk.assertions.contains
+import assertk.assertions.doesNotContain
+import assertk.assertions.hasClass
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException
+import com.fasterxml.jackson.databind.node.ObjectNode
+import fi.hel.haitaton.hanke.OBJECT_MAPPER
+import fi.hel.haitaton.hanke.factory.HakemusUpdateRequestFactory
+import fi.hel.haitaton.hanke.parseJson
+import fi.hel.haitaton.hanke.toJsonString
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+
+class CustomerRequestDeserializeTest {
+
+    @Nested
+    inner class RegistryKeyHidden {
+        @Test
+        fun `is false when null in JSON`() {
+            val customer = HakemusUpdateRequestFactory.createCustomer()
+            val json: ObjectNode = OBJECT_MAPPER.valueToTree(customer)
+            json.putNull("registryKeyHidden")
+            val jsonString = json.toString()
+            assertThat(jsonString).contains("\"registryKeyHidden\":null")
+
+            val result: CustomerRequest = jsonString.parseJson()
+
+            assertThat(result.registryKeyHidden).isFalse()
+        }
+
+        @Test
+        fun `is false when missing from JSON`() {
+            val customer = HakemusUpdateRequestFactory.createCustomer()
+            val json: ObjectNode = OBJECT_MAPPER.valueToTree(customer)
+            json.remove("registryKeyHidden")
+            val jsonString = json.toString()
+            assertThat(jsonString).doesNotContain("registryKeyHidden")
+
+            val result: CustomerRequest = jsonString.parseJson()
+
+            assertThat(result.registryKeyHidden).isFalse()
+        }
+
+        @ParameterizedTest
+        @ValueSource(booleans = [true, false])
+        fun `uses value when value is proper boolean in JSON`(value: Boolean) {
+            val customer = HakemusUpdateRequestFactory.createCustomer(registryKeyHidden = value)
+            val jsonString = customer.toJsonString()
+            assertThat(jsonString).contains("\"registryKeyHidden\":$value")
+
+            val result: CustomerRequest = jsonString.parseJson()
+
+            assertThat(result.registryKeyHidden).isEqualTo(value)
+        }
+
+        @Test
+        fun `throws exception when value is nonsense in JSON`() {
+            val customer = HakemusUpdateRequestFactory.createCustomer()
+            val json: ObjectNode = OBJECT_MAPPER.valueToTree(customer)
+            json.put("registryKeyHidden", "nonsense")
+            val jsonString = json.toString()
+            assertThat(jsonString).contains("\"registryKeyHidden\":\"nonsense\"")
+
+            assertFailure { jsonString.parseJson() }.hasClass(UnrecognizedPropertyException::class)
+        }
+    }
+}

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/validation/HakemusUpdateRequestValidatorTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/validation/HakemusUpdateRequestValidatorTest.kt
@@ -6,24 +6,40 @@ import assertk.assertFailure
 import assertk.assertThat
 import assertk.assertions.containsExactlyInAnyOrder
 import assertk.assertions.hasClass
+import assertk.assertions.isFalse
 import assertk.assertions.isTrue
+import assertk.assertions.prop
+import fi.hel.haitaton.hanke.allu.CustomerType
 import fi.hel.haitaton.hanke.factory.HakemusUpdateRequestFactory
 import fi.hel.haitaton.hanke.factory.HakemusUpdateRequestFactory.withCustomer
 import fi.hel.haitaton.hanke.factory.HakemusUpdateRequestFactory.withInvoicingCustomer
+import fi.hel.haitaton.hanke.hakemus.CustomerWithContactsRequest
 import fi.hel.haitaton.hanke.hakemus.HakemusUpdateRequestValidator
 import fi.hel.haitaton.hanke.hakemus.InvalidHakemusDataException
 import fi.hel.haitaton.hanke.hakemus.InvoicingPostalAddressRequest
+import fi.hel.haitaton.hanke.hakemus.JohtoselvityshakemusUpdateRequest
+import fi.hel.haitaton.hanke.hakemus.KaivuilmoitusUpdateRequest
 import fi.hel.haitaton.hanke.hakemus.PostalAddressRequest
 import fi.hel.haitaton.hanke.hakemus.StreetAddress
+import fi.hel.haitaton.hanke.hakemus.validateRegistryKey
+import fi.hel.haitaton.hanke.test.Asserts.succeeds
 import java.time.ZonedDateTime
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.EnumSource
+import org.junit.jupiter.params.provider.MethodSource
 
 class HakemusUpdateRequestValidatorTest {
     private val validator = HakemusUpdateRequestValidator()
 
+    private val validHetu = "110296-926B"
+    private val validYtunnus = "7356217-8"
+
     @Nested
-    inner class JohtoselvityshakemusUpdateRequest {
+    inner class WithJohtoselvityshakemusUpdateRequest {
         @Test
         fun `valid request has no errors`() {
             val request =
@@ -68,7 +84,7 @@ class HakemusUpdateRequestValidatorTest {
                 HakemusUpdateRequestFactory.createFilledJohtoselvityshakemusUpdateRequest()
                     .copy(
                         startTime = ZonedDateTime.now(),
-                        endTime = ZonedDateTime.now().minusDays(1)
+                        endTime = ZonedDateTime.now().minusDays(1),
                     )
 
             val exception = assertFailure { validator.isValid(request, null) }
@@ -84,8 +100,7 @@ class HakemusUpdateRequestValidatorTest {
             val request =
                 HakemusUpdateRequestFactory.createFilledJohtoselvityshakemusUpdateRequest()
                     .copy(
-                        postalAddress = PostalAddressRequest(streetAddress = StreetAddress("   "))
-                    )
+                        postalAddress = PostalAddressRequest(streetAddress = StreetAddress("   ")))
 
             val exception = assertFailure { validator.isValid(request, null) }
 
@@ -112,13 +127,13 @@ class HakemusUpdateRequestValidatorTest {
                 hasErrorPaths(
                     "customerWithContacts.customer.name",
                     "customerWithContacts.customer.email",
-                    "customerWithContacts.customer.phone"
+                    "customerWithContacts.customer.phone",
                 )
             }
         }
 
         @Test
-        fun `customer registry key must be valid`() {
+        fun `customer registry key must be valid when customer is a company`() {
             val request =
                 HakemusUpdateRequestFactory.createFilledJohtoselvityshakemusUpdateRequest()
                     .withCustomer(registryKey = "1234567-8")
@@ -130,10 +145,74 @@ class HakemusUpdateRequestValidatorTest {
                 hasErrorPaths("customerWithContacts.customer.registryKey")
             }
         }
+
+        @ParameterizedTest
+        @EnumSource(CustomerType::class, names = ["PERSON", "OTHER"])
+        fun `customer registry key must be null when the customer is a person or an other`(
+            type: CustomerType
+        ) {
+            testRegistryKey(type, "customerWithContacts") { request, customer ->
+                request.copy(customerWithContacts = customer)
+            }
+        }
+
+        @ParameterizedTest
+        @EnumSource(CustomerType::class, names = ["PERSON", "OTHER"])
+        fun `contractor registry key must be null when the contractor is a person or an other`(
+            type: CustomerType
+        ) {
+            testRegistryKey(type, "contractorWithContacts") { request, customer ->
+                request.copy(contractorWithContacts = customer)
+            }
+        }
+
+        @ParameterizedTest
+        @EnumSource(CustomerType::class, names = ["PERSON", "OTHER"])
+        fun `representative registry key must be null when the representative is a person or an other`(
+            type: CustomerType
+        ) {
+            testRegistryKey(type, "representativeWithContacts") { request, customer ->
+                request.copy(representativeWithContacts = customer)
+            }
+        }
+
+        @ParameterizedTest
+        @EnumSource(CustomerType::class, names = ["PERSON", "OTHER"])
+        fun `developer registry key must be null when the developer is a person or an other`(
+            type: CustomerType
+        ) {
+            testRegistryKey(type, "propertyDeveloperWithContacts") { request, customer ->
+                request.copy(propertyDeveloperWithContacts = customer)
+            }
+        }
+
+        private fun testRegistryKey(
+            type: CustomerType,
+            pathPrefix: String,
+            addCustomer:
+                (
+                    JohtoselvityshakemusUpdateRequest,
+                    CustomerWithContactsRequest) -> JohtoselvityshakemusUpdateRequest
+        ) {
+            val customer =
+                HakemusUpdateRequestFactory.createCustomerWithContactsRequest(
+                    customerType = type, registryKey = validHetu)
+            val request =
+                addCustomer(
+                    HakemusUpdateRequestFactory.createFilledJohtoselvityshakemusUpdateRequest(),
+                    customer)
+
+            val exception = assertFailure { validator.isValid(request, null) }
+
+            exception.all {
+                hasClass(InvalidHakemusDataException::class)
+                hasErrorPaths("$pathPrefix.customer.registryKey")
+            }
+        }
     }
 
     @Nested
-    inner class KaivuilmoitusUpdateRequest {
+    inner class WithKaivuilmoitusUpdateRequest {
         @Test
         fun `valid request has no errors`() {
             val request = HakemusUpdateRequestFactory.createFilledKaivuilmoitusUpdateRequest()
@@ -177,7 +256,7 @@ class HakemusUpdateRequestValidatorTest {
                 HakemusUpdateRequestFactory.createFilledKaivuilmoitusUpdateRequest()
                     .copy(
                         startTime = ZonedDateTime.now(),
-                        endTime = ZonedDateTime.now().minusDays(1)
+                        endTime = ZonedDateTime.now().minusDays(1),
                     )
 
             val exception = assertFailure { validator.isValid(request, null) }
@@ -205,7 +284,7 @@ class HakemusUpdateRequestValidatorTest {
                 hasErrorPaths(
                     "customerWithContacts.customer.name",
                     "customerWithContacts.customer.email",
-                    "customerWithContacts.customer.phone"
+                    "customerWithContacts.customer.phone",
                 )
             }
         }
@@ -234,7 +313,7 @@ class HakemusUpdateRequestValidatorTest {
                             InvoicingPostalAddressRequest(
                                 streetAddress = StreetAddress("   "),
                                 postalCode = "   ",
-                                city = "   "
+                                city = "   ",
                             ),
                         email = "   ",
                         phone = "   ",
@@ -320,6 +399,204 @@ class HakemusUpdateRequestValidatorTest {
                 hasClass(InvalidHakemusDataException::class)
                 hasErrorPaths("additionalInfo")
             }
+        }
+
+        @Test
+        fun `customer registry key must be valid henkilotunnus when the customer is a person`() {
+            val request =
+                HakemusUpdateRequestFactory.createFilledKaivuilmoitusUpdateRequest()
+                    .withCustomer(CustomerType.PERSON, registryKey = "false")
+
+            val exception = assertFailure { validator.isValid(request, null) }
+
+            exception.all {
+                hasClass(InvalidHakemusDataException::class)
+                hasErrorPaths("customerWithContacts.customer.registryKey")
+            }
+        }
+
+        @Test
+        fun `customer registry key can be anything when the customer is an other`() {
+            val request =
+                HakemusUpdateRequestFactory.createFilledKaivuilmoitusUpdateRequest()
+                    .withCustomer(CustomerType.OTHER, registryKey = "false")
+
+            val result = validator.isValid(request, null)
+
+            assertThat(result).isTrue()
+        }
+
+        @ParameterizedTest
+        @EnumSource(CustomerType::class, names = ["PERSON", "OTHER"])
+        fun `is valid when customer registry key is a valid henkilotunnus and customer is a person or an other`(
+            type: CustomerType
+        ) {
+            val request =
+                HakemusUpdateRequestFactory.createFilledKaivuilmoitusUpdateRequest()
+                    .withCustomer(type, registryKey = validHetu)
+
+            val result = validator.isValid(request, null)
+
+            assertThat(result).isTrue()
+        }
+
+        @ParameterizedTest
+        @EnumSource(CustomerType::class, names = ["PERSON", "OTHER"])
+        fun `contractor registry key must be null when the contractor is a person or an other`(
+            type: CustomerType
+        ) {
+            testRegistryKey(type, "contractorWithContacts") { request, customer ->
+                request.copy(contractorWithContacts = customer)
+            }
+        }
+
+        @ParameterizedTest
+        @EnumSource(CustomerType::class, names = ["PERSON", "OTHER"])
+        fun `representative registry key must be null when the representative is a person or an other`(
+            type: CustomerType
+        ) {
+            testRegistryKey(type, "representativeWithContacts") { request, customer ->
+                request.copy(representativeWithContacts = customer)
+            }
+        }
+
+        @ParameterizedTest
+        @EnumSource(CustomerType::class, names = ["PERSON", "OTHER"])
+        fun `developer registry key must be null when the developer is a person or an other`(
+            type: CustomerType
+        ) {
+            testRegistryKey(type, "propertyDeveloperWithContacts") { request, customer ->
+                request.copy(propertyDeveloperWithContacts = customer)
+            }
+        }
+
+        private fun testRegistryKey(
+            type: CustomerType,
+            pathPrefix: String,
+            addCustomer:
+                (
+                    KaivuilmoitusUpdateRequest,
+                    CustomerWithContactsRequest) -> KaivuilmoitusUpdateRequest
+        ) {
+            val customer =
+                HakemusUpdateRequestFactory.createCustomerWithContactsRequest(
+                    customerType = type, registryKey = validHetu)
+            val request =
+                addCustomer(
+                    HakemusUpdateRequestFactory.createFilledKaivuilmoitusUpdateRequest(), customer)
+
+            val exception = assertFailure { validator.isValid(request, null) }
+
+            exception.all {
+                hasClass(InvalidHakemusDataException::class)
+                hasErrorPaths("$pathPrefix.customer.registryKey")
+            }
+        }
+    }
+
+    @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    inner class ValidateRegistryKey {
+
+        private fun otherSuccessParams() =
+            listOf(
+                Arguments.of(CustomerType.OTHER, true, null),
+                Arguments.of(CustomerType.OTHER, false, null),
+                Arguments.of(CustomerType.OTHER, false, validHetu),
+                Arguments.of(CustomerType.OTHER, false, "invalid"),
+            )
+
+        private fun otherFailureParams() =
+            listOf(
+                Arguments.of(CustomerType.OTHER, true, ""),
+                Arguments.of(CustomerType.OTHER, true, validHetu),
+                Arguments.of(CustomerType.OTHER, false, ""),
+            )
+
+        private fun personSuccessParams() =
+            listOf(
+                Arguments.of(CustomerType.PERSON, true, null),
+                Arguments.of(CustomerType.PERSON, false, null),
+                Arguments.of(CustomerType.PERSON, false, validHetu),
+            )
+
+        private fun personFailureParams() =
+            listOf(
+                Arguments.of(CustomerType.PERSON, true, ""),
+                Arguments.of(CustomerType.PERSON, true, validHetu),
+                Arguments.of(CustomerType.PERSON, false, ""),
+                Arguments.of(CustomerType.PERSON, false, "invalid"),
+            )
+
+        private fun companySuccessParams() =
+            listOf(
+                Arguments.of(CustomerType.COMPANY, false, null),
+                Arguments.of(CustomerType.COMPANY, false, validYtunnus),
+            )
+
+        private fun companyFailureParams() =
+            listOf(
+                Arguments.of(CustomerType.COMPANY, true, null),
+                Arguments.of(CustomerType.COMPANY, true, ""),
+                Arguments.of(CustomerType.COMPANY, true, validYtunnus),
+                Arguments.of(CustomerType.COMPANY, false, ""),
+                Arguments.of(CustomerType.COMPANY, false, "invalid"),
+            )
+
+        private fun associationSuccessParams() =
+            companySuccessParams().map {
+                it.get().let { args -> Arguments.of(CustomerType.ASSOCIATION, args[1], args[2]) }
+            }
+
+        private fun associationFailureParams() =
+            companyFailureParams().map {
+                it.get().let { args -> Arguments.of(CustomerType.ASSOCIATION, args[1], args[2]) }
+            }
+
+        @ParameterizedTest
+        @MethodSource(
+            value =
+                [
+                    "personSuccessParams",
+                    "otherSuccessParams",
+                    "companySuccessParams",
+                    "associationSuccessParams",
+                ])
+        fun `succeeds when parameters are correct`(
+            type: CustomerType,
+            registryKeyHidden: Boolean,
+            registryKey: String?,
+        ) {
+            val request =
+                HakemusUpdateRequestFactory.createCustomer(
+                    type = type, registryKey = registryKey, registryKeyHidden = registryKeyHidden)
+
+            val result = request.validateRegistryKey("path")
+
+            assertThat(result).succeeds()
+        }
+
+        @ParameterizedTest
+        @MethodSource(
+            value =
+                [
+                    "personFailureParams",
+                    "otherFailureParams",
+                    "companyFailureParams",
+                    "associationFailureParams",
+                ])
+        fun `fails when parameters are incorrect`(
+            type: CustomerType,
+            registryKeyHidden: Boolean,
+            registryKey: String?,
+        ) {
+            val request =
+                HakemusUpdateRequestFactory.createCustomer(
+                    type = type, registryKey = registryKey, registryKeyHidden = registryKeyHidden)
+
+            val result = request.validateRegistryKey("path")
+
+            assertThat(result).prop(ValidationResult::isOk).isFalse()
         }
     }
 


### PR DESCRIPTION
# Description

Add the `registryKeyHidden` field to `CustomerRequest`. The value is read as false if it's null or missing from the request JSON. The value and the registry key are validated to be acceptable.

The logic for updating the registry key or keeping the old value will be added later in a separate PR. Anything related to invoicing customers will be added later as well.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2625

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
Nothing should be very different yet.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 