### PR TITLE
HAI-2625 Don't update registry key when it's hidden

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusControllerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusControllerITest.kt
@@ -756,6 +756,25 @@ class HakemusControllerITest(@Autowired override val mockMvc: MockMvc) : Control
         }
 
         @Test
+        fun `returns 400 when request contain invalid use of hidden registry key`() {
+            val request = HakemusUpdateRequestFactory.createFilledKaivuilmoitusUpdateRequest()
+            every {
+                authorizer.authorizeHakemusId(id, PermissionCode.EDIT_APPLICATIONS.name)
+            } returns true
+            every { hakemusService.updateHakemus(id, request, USERNAME) } throws
+                InvalidHiddenRegistryKey(HakemusFactory.create(id = id), "Reason for error")
+
+            put(url, request)
+                .andExpect(status().isBadRequest)
+                .andExpect(hankeError(HankeError.HAI2010))
+
+            verifySequence {
+                authorizer.authorizeHakemusId(id, PermissionCode.EDIT_APPLICATIONS.name)
+                hakemusService.updateHakemus(id, request, USERNAME)
+            }
+        }
+
+        @Test
         fun `returns 400 when request contain invalid contact`() {
             val request =
                 HakemusUpdateRequestFactory.createFilledJohtoselvityshakemusUpdateRequest()

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusController.kt
@@ -418,6 +418,14 @@ The id needs to reference an excavation notification.
         return HankeError.HAI2010
     }
 
+    @ExceptionHandler(InvalidHiddenRegistryKey::class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @Hidden
+    fun invalidHiddenRegistryKey(ex: InvalidHiddenRegistryKey): HankeError {
+        logger.warn(ex) { ex.message }
+        return HankeError.HAI2010
+    }
+
     @ExceptionHandler(InvalidHakemusyhteyshenkiloException::class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     @Hidden

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusUpdateRequestFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusUpdateRequestFactory.kt
@@ -246,7 +246,8 @@ object HakemusUpdateRequestFactory {
         name: String = DEFAULT_CUSTOMER_NAME,
         email: String = DEFAULT_CUSTOMER_EMAIL,
         phone: String = DEFAULT_CUSTOMER_PHONE,
-        registryKey: String = DEFAULT_CUSTOMER_REGISTRY_KEY,
+        registryKey: String? = DEFAULT_CUSTOMER_REGISTRY_KEY,
+        registryKeyHidden: Boolean = false,
         vararg hankekayttajaIds: UUID
     ) =
         when (this) {
@@ -275,6 +276,7 @@ object HakemusUpdateRequestFactory {
                                 email = email,
                                 phone = phone,
                                 registryKey = registryKey,
+                                registryKeyHidden = registryKeyHidden,
                             ),
                             hankekayttajaIds.map { ContactRequest(it) },
                         ))


### PR DESCRIPTION
# Description

Don't update registry key when it's hidden.

Also, refactor hakemus tests to use `HakemusBuilder.save()` instead of `.saveEntity()` and a separate load.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2625

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
1. Create and modify a kaivuilmoitus so there's a person as the customer (hakija). The customer needs to be created with Swagger UI, since the frontend doesn't allow person customers to have registry IDs.
2. Make an update with Swagger UI. Set `registryKeyHidden` to true and `registryKey` to null for the customer.
3. Check that the registry key didn't change.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 