### PR TITLE
HAI-2684 Clear inviter when removing a user for a GDPR request

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/gdpr/GdprServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/gdpr/GdprServiceITest.kt
@@ -335,7 +335,7 @@ class GdprServiceITest(
         }
 
         @Test
-        fun `deletes hanke with applications when there only unidentified users`() {
+        fun `deletes hanke with applications when there are only unidentified users`() {
             val hanke = hankeFactory.builder(USERNAME).withHankealue().saveEntity()
             val founder = hankeKayttajaService.getKayttajaByUserId(hanke.id, USERNAME)!!
             hankeFactory.addYhteystiedotTo(hanke) { omistaja(founder) }
@@ -557,7 +557,7 @@ class GdprServiceITest(
         }
 
         @Test
-        fun `deletes the user sets the inviter to null when the user is an inviter for other users`() {
+        fun `deletes the user and sets the inviter to null when the user is an inviter for other users`() {
             val invitedUserId = "InvitedUser"
             val hanke = hankeFactory.builder(OTHER_USER_ID).withHankealue().saveEntity()
             val kayttaja =

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/gdpr/GdprServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/gdpr/GdprServiceITest.kt
@@ -335,6 +335,26 @@ class GdprServiceITest(
         }
 
         @Test
+        fun `deletes hanke with applications when there only unidentified users`() {
+            val hanke = hankeFactory.builder(USERNAME).withHankealue().saveEntity()
+            val founder = hankeKayttajaService.getKayttajaByUserId(hanke.id, USERNAME)!!
+            hankeFactory.addYhteystiedotTo(hanke) { omistaja(founder) }
+            hakemusFactory.builder(hanke).hakija(founder).save()
+            hankekayttajaFactory.saveUnidentifiedUser(
+                hankeId = hanke.id,
+                sahkoposti = "invited@user",
+                kayttooikeustaso = Kayttooikeustaso.HAKEMUSASIOINTI,
+                kutsujaId = founder.id,
+            )
+
+            gdprService.deleteInfo(USERNAME)
+
+            assertThat(hankeRepository.findAll()).isEmpty()
+            assertThat(hakemusRepository.findAll()).isEmpty()
+            assertThat(hankekayttajaRepository.findAll()).isEmpty()
+        }
+
+        @Test
         fun `deletes hankekayttaja when there are other non-admin users`() {
             val hanke =
                 hankeFactory.builder(USERNAME).withHankealue().saveWithYhteystiedot {
@@ -534,6 +554,54 @@ class GdprServiceITest(
             assertThat(hankekayttajaRepository.findByHankeId(oneAdminHanke.id))
                 .extracting { it.permission!!.userId }
                 .containsExactly(HankeKayttajaFactory.FAKE_USERID)
+        }
+
+        @Test
+        fun `deletes the user sets the inviter to null when the user is an inviter for other users`() {
+            val invitedUserId = "InvitedUser"
+            val hanke = hankeFactory.builder(OTHER_USER_ID).withHankealue().saveEntity()
+            val kayttaja =
+                hankekayttajaFactory.saveIdentifiedUser(
+                    kayttooikeustaso = Kayttooikeustaso.HAKEMUSASIOINTI,
+                    userId = USERNAME,
+                    hankeId = hanke.id,
+                )
+            hankeFactory.addYhteystiedotTo(hanke) { omistaja(kayttaja) }
+            val invitedKayttaja =
+                hankekayttajaFactory.saveIdentifiedUser(
+                    hankeId = hanke.id,
+                    sahkoposti = "invited@user",
+                    kayttooikeustaso = Kayttooikeustaso.HAKEMUSASIOINTI,
+                    kutsujaId = kayttaja.id,
+                    userId = invitedUserId,
+                )
+            val unidentifiedKayttaja =
+                hankekayttajaFactory.saveUnidentifiedUser(
+                    hankeId = hanke.id,
+                    sahkoposti = "notaccepted@user",
+                    kayttooikeustaso = Kayttooikeustaso.HAKEMUSASIOINTI,
+                    kutsujaId = kayttaja.id,
+                )
+            val hakemus = hakemusFactory.builder(hanke).hakija(kayttaja).save()
+            val founder: HankekayttajaEntity =
+                hankeKayttajaService.getKayttajaByUserId(hanke.id, OTHER_USER_ID)!!
+
+            gdprService.deleteInfo(USERNAME)
+
+            assertThat(hankeRepository.findAll()).single().prop(HankeEntity::id).isEqualTo(hanke.id)
+            assertThat(hakemusRepository.findAll())
+                .single()
+                .prop(HakemusEntity::id)
+                .isEqualTo(hakemus.id)
+            assertThat(hankeKayttajaService.getKayttajatByHankeId(hanke.id))
+                .extracting { it.id }
+                .containsExactlyInAnyOrder(founder.id, invitedKayttaja.id, unidentifiedKayttaja.id)
+            assertThat(hankeKayttajaService.getKayttajaForHanke(invitedKayttaja.id, hanke.id))
+                .prop(HankekayttajaEntity::kutsujaId)
+                .isNull()
+            assertThat(hankeKayttajaService.getKayttajaForHanke(unidentifiedKayttaja.id, hanke.id))
+                .prop(HankekayttajaEntity::kutsujaId)
+                .isNull()
         }
     }
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/gdpr/GdprService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/gdpr/GdprService.kt
@@ -189,11 +189,10 @@ class GdprService(
             "There are no other users for this hanke, so removing the hanke in response to the GDPR request. ${hanke.logString()}"
         }
 
+        deleteKayttaja(kayttaja)
         // Not really sure why the user delete needs to be flushed before deleting the hanke, but
         // not doing so causes a constraint violation from hakemusyhteystieto to
         // hakemusyhteyshenkilo.
-        hankekayttajaRepository.findByKutsujaId(kayttaja.id).forEach { it.kutsujaId = null }
-        hankekayttajaRepository.delete(kayttaja)
         hankekayttajaRepository.flush()
 
         hankeService.deleteHanke(hanke.hankeTunnus, kayttaja.permission!!.userId)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/gdpr/GdprService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/gdpr/GdprService.kt
@@ -192,6 +192,7 @@ class GdprService(
         // Not really sure why the user delete needs to be flushed before deleting the hanke, but
         // not doing so causes a constraint violation from hakemusyhteystieto to
         // hakemusyhteyshenkilo.
+        hankekayttajaRepository.findByKutsujaId(kayttaja.id).forEach { it.kutsujaId = null }
         hankekayttajaRepository.delete(kayttaja)
         hankekayttajaRepository.flush()
 
@@ -199,6 +200,7 @@ class GdprService(
     }
 
     private fun deleteKayttaja(kayttaja: HankekayttajaEntity) {
+        hankekayttajaRepository.findByKutsujaId(kayttaja.id).forEach { it.kutsujaId = null }
         hankekayttajaRepository.delete(kayttaja)
     }
 }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeKayttajaFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeKayttajaFactory.kt
@@ -39,6 +39,7 @@ class HankeKayttajaFactory(
         kayttooikeustaso: Kayttooikeustaso = KATSELUOIKEUS,
         tunniste: String = "existing",
         kutsuttu: OffsetDateTime = INVITATION_DATE,
+        kutsujaId: UUID? = null,
     ): HankekayttajaEntity =
         addToken(
             hankeKayttaja =
@@ -49,6 +50,7 @@ class HankeKayttajaFactory(
                     sahkoposti = sahkoposti,
                     puhelin = puhelin,
                     permissionEntity = null,
+                    kutsujaId = kutsujaId,
                 ),
             tunniste = tunniste,
             kayttooikeustaso = kayttooikeustaso,
@@ -89,7 +91,7 @@ class HankeKayttajaFactory(
                 sukunimi = input.sukunimi,
                 sahkoposti = input.email,
                 puhelin = input.puhelin,
-                kayttooikeustaso = kayttooikeustaso
+                kayttooikeustaso = kayttooikeustaso,
             )
 
     fun saveUser(
@@ -112,8 +114,7 @@ class HankeKayttajaFactory(
                 permission = permissionEntity,
                 kayttajakutsu = kayttajakutsuEntity,
                 kutsujaId = kutsujaId,
-            )
-        )
+            ))
 
     fun addToken(
         hankeKayttaja: HankekayttajaEntity,
@@ -136,8 +137,7 @@ class HankeKayttajaFactory(
                 createdAt = createdAt,
                 kayttooikeustaso = kayttooikeustaso,
                 hankekayttaja = this,
-            )
-        )
+            ))
 
     @Transactional
     fun getFounderFromHakemus(applicationId: Long): HankekayttajaEntity {
@@ -265,7 +265,7 @@ class HankeKayttajaFactory(
                 sahkoposti = sahkoposti,
                 puhelin = puhelin,
                 permission = permission,
-                kayttajakutsu = kutsu
+                kayttajakutsu = kutsu,
             )
 
         fun createDto(


### PR DESCRIPTION
# Description

When receiving a valid GDPR request to delete a user, clear the `kutsujaId` column of any users the deleted user so the foreign key reference doesn't stop the deletion.

Do this separately for the two cases:
- There are only unidentified users in a hanke besides the deleted user, so the whole hanke is deleted.
- There are identified and/or unidentified users in the hanke, so only the requested user is removed.

When a user requests their information should be deleted from Haitaton, being an inviter to another user is not a valid reason to stop the information from getting deleted.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2684

## Type of change

- [X] Bug fix 
- [ ] New feature 
- [ ] Other

# Instructions for testing
From the bug report:
1. Uudella käyttäjällä luo hanke
2. Kutsu sinne muita käyttäjiä, älä käy hyväksymässä kutsuja
3. Pyydä Profiilin UI:sta (tai paikallisesti profiile-gdpr-api-testerillä) käyttäjän tietojen poistoa

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 