### PR TITLE
HAI-2558 Add API for reporting work finished

### DIFF
--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/AlluClient.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/AlluClient.kt
@@ -5,6 +5,7 @@ import fi.hel.haitaton.hanke.TZ_UTC
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentMetadata
 import fi.hel.haitaton.hanke.hakemus.HakemusDecisionNotFoundException
 import fi.hel.haitaton.hanke.toJsonString
+import fi.hel.haitaton.hanke.valmistumisilmoitus.ValmistumisilmoitusType
 import java.time.Duration.ofSeconds
 import java.time.Instant
 import java.time.LocalDate
@@ -209,15 +210,19 @@ class AlluClient(
         }
     }
 
-    fun reportOperationalCondition(alluApplicationId: Int, operationalConditionDate: LocalDate) {
-        logger.info { "Reporting operational condition for application $alluApplicationId." }
+    fun reportCompletionDate(
+        type: ValmistumisilmoitusType,
+        alluApplicationId: Int,
+        reportDate: LocalDate,
+    ) {
+        logger.info { "Reporting ${type.logName} for application $alluApplicationId." }
         put(
-                "excavationannouncements/$alluApplicationId/operationalcondition",
-                operationalConditionDate.atStartOfDay(TZ_UTC).toJsonString())
+                "excavationannouncements/$alluApplicationId/${type.urlSuffix}",
+                reportDate.atStartOfDay(TZ_UTC).toJsonString())
             .bodyToMono(Void::class.java)
             .timeout(defaultTimeout)
             .doOnError(WebClientResponseException::class.java) {
-                logError("Error reporting operation condition to Allu", it)
+                logError("Error reporting ${type.logName} to Allu", it)
             }
             .block()
     }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusController.kt
@@ -529,7 +529,7 @@ The id needs to reference an excavation notification.
     @ExceptionHandler(CompletionDateException::class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     @Hidden
-    fun operationalConditionDateException(ex: CompletionDateException): HankeError {
+    fun conditionDateException(ex: CompletionDateException): HankeError {
         logger.warn(ex) { ex.message }
         return HankeError.HAI2014
     }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusController.kt
@@ -8,6 +8,7 @@ import fi.hel.haitaton.hanke.domain.CreateHankeRequest
 import fi.hel.haitaton.hanke.logging.DisclosureLogService
 import fi.hel.haitaton.hanke.toHankeError
 import fi.hel.haitaton.hanke.validation.ValidCreateHankeRequest
+import fi.hel.haitaton.hanke.valmistumisilmoitus.ValmistumisilmoitusType
 import io.swagger.v3.oas.annotations.Hidden
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
@@ -261,7 +262,7 @@ The valid states are:
   - HANDLING,
   - INFORMATION_RECEIVED,
   - RETURNED_TO_PREPARATION,
-  - DECISIONMAKING
+  - DECISIONMAKING,
   - DECISION.
 
 The date cannot be before the application was started and not in the future.
@@ -297,7 +298,58 @@ The id needs to reference an excavation notification.
         logger.info {
             "Received request to report application to operational condition id=$id, date=$date"
         }
-        hakemusService.reportOperationalCondition(id, date)
+        hakemusService.reportCompletionDate(ValmistumisilmoitusType.TOIMINNALLINEN_KUNTO, id, date)
+    }
+
+    @PostMapping("/hakemukset/{id}/tyo-valmis")
+    @Operation(
+        summary = "Report the work finished date for an excavation notification",
+        description =
+            """
+                Report the date the work finished on the excavation.
+                The reported date will be sent to Allu as the work finished date.
+
+                The excavation notification needs to be in a valid state to accept the report.
+                The valid states are:
+                  - PENDING,
+                  - HANDLING,
+                  - INFORMATION_RECEIVED,
+                  - RETURNED_TO_PREPARATION,
+                  - DECISIONMAKING,
+                  - DECISION,
+                  - OPERATIONAL_CONDITION.
+
+                The date cannot be before the application was started and not in the future.
+                The id needs to reference an excavation notification.
+            """,
+    )
+    @ApiResponses(
+        value =
+            [
+                ApiResponse(description = "Work finished reported, no body", responseCode = "200"),
+                ApiResponse(
+                    description =
+                        "The date is malformed, the date isn't in the allowed bounds " +
+                            "or the application not an excavation notification",
+                    responseCode = "400",
+                    content = [Content(schema = Schema(implementation = HankeError::class))]),
+                ApiResponse(
+                    description = "An application was not found with the given id",
+                    responseCode = "404",
+                    content = [Content(schema = Schema(implementation = HankeError::class))]),
+                ApiResponse(
+                    description = "The application is not in one of the allowed states",
+                    responseCode = "409",
+                    content = [Content(schema = Schema(implementation = HankeError::class))]),
+            ])
+    @PreAuthorize("@hakemusAuthorizer.authorizeHakemusId(#id, 'EDIT_APPLICATIONS')")
+    fun reportWorkFinished(
+        @PathVariable(name = "id") id: Long,
+        @RequestBody request: DateReportRequest,
+    ) {
+        val date = request.date
+        logger.info { "Received request to report application to work finished id=$id, date=$date" }
+        hakemusService.reportCompletionDate(ValmistumisilmoitusType.TYO_VALMIS, id, date)
     }
 
     @PostMapping("/hakemukset/{id}/laheta")
@@ -474,10 +526,10 @@ The id needs to reference an excavation notification.
         return HankeError.HAI2002
     }
 
-    @ExceptionHandler(OperationalConditionDateException::class)
+    @ExceptionHandler(CompletionDateException::class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     @Hidden
-    fun operationalConditionDateException(ex: OperationalConditionDateException): HankeError {
+    fun operationalConditionDateException(ex: CompletionDateException): HankeError {
         logger.warn(ex) { ex.message }
         return HankeError.HAI2014
     }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/valmistumisilmoitus/ValmistumisilmoitusType.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/valmistumisilmoitus/ValmistumisilmoitusType.kt
@@ -1,6 +1,6 @@
 package fi.hel.haitaton.hanke.valmistumisilmoitus
 
-enum class ValmistumisilmoitusType {
-    TOIMINNALLINEN_KUNTO,
-    TYO_VALMIS,
+enum class ValmistumisilmoitusType(val urlSuffix: String, val logName: String) {
+    TOIMINNALLINEN_KUNTO("operationalcondition", "operational condition"),
+    TYO_VALMIS("workfinished", "work finished"),
 }


### PR DESCRIPTION
# Description

Add an API for reporting the date the work on an excavation is finished. The date is passed on to Allu. The report event is also stored in the local database.

Since the functionalities of reporting the work being in operational condition and reporting work finished are so similar, the new API uses a lot of the same implementation, refactored to take the type of completion (operational condition or work finished) as a parameter.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2558

## Type of change

- [ ] Bug fix 
- [x] New feature 
- [ ] Other

# Instructions for testing

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 