### PR TITLE
HAI-2676 Send email about information requests

### DIFF
--- a/email/taydennyspyynto.mjml
+++ b/email/taydennyspyynto.mjml
@@ -1,0 +1,42 @@
+<mjml>
+    <mj-head>
+        <mj-include path="common/attributes.partial"/>
+    </mj-head>
+    <mj-body>
+        <mj-include path="common/header-content.partial"/>
+        <mj-section>
+            <mj-column>
+                <mj-text mj-class="header-txt">
+                    Hakemuksellesi on tullut täydennyspyyntö / Hakemuksellesi on tullut täydennyspyyntö / Hakemuksellesi
+                    on tullut täydennyspyyntö
+                </mj-text>
+                <mj-text mj-class="basic-txt">
+                    Hakemuksellesi {{hakemusNimi}} ({{hakemusTunnus}}) on tullut täydennyspyyntö. Käy vastaamassa siihen
+                    Haitattomassa:
+                    <a href="{{baseUrl}}/fi/hakemus/{{hakemusId}}">{{baseUrl}}/fi/hakemus/{{hakemusId}}</a>.
+                </mj-text>
+                <mj-include path="common/signature-fi.partial"/>
+
+                <mj-divider mj-class="language-separator"/>
+
+                <mj-text mj-class="basic-txt">
+                    Hakemuksellesi {{hakemusNimi}} ({{hakemusTunnus}}) on tullut täydennyspyyntö. Käy vastaamassa siihen
+                    Haitattomassa:
+                    <a href="{{baseUrl}}/sv/ansokan/{{hakemusTunnus}}">{{baseUrl}}/sv/ansokan/{{hakemusTunnus}}</a>.
+                </mj-text>
+                <mj-include path="common/signature-sv.partial"/>
+
+                <mj-divider mj-class="language-separator"/>
+
+                <mj-text mj-class="basic-txt">
+                    Hakemuksellesi {{hakemusNimi}} ({{hakemusTunnus}}) on tullut täydennyspyyntö. Käy vastaamassa siihen
+                    Haitattomassa:
+                    <a href="{{baseUrl}}/en/application/{{hakemusTunnus}}">
+                        {{baseUrl}}/en/application/{{hakemusTunnus}}</a>.
+                </mj-text>
+                <mj-include path="common/signature-en.partial"/>
+            </mj-column>
+        </mj-section>
+        <mj-include path="common/footer-content.partial"/>
+    </mj-body>
+</mjml>

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/email/EmailSenderServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/email/EmailSenderServiceITest.kt
@@ -411,4 +411,63 @@ class EmailSenderServiceITest : IntegrationTest() {
             }
         }
     }
+
+    @Nested
+    inner class InformationRequest {
+        private val notification =
+            InformationRequestEmail(
+                to = TEST_EMAIL,
+                hakemusNimi = HANKE_NIMI,
+                hakemusTunnus = APPLICATION_IDENTIFIER,
+                hakemusId = 13L,
+            )
+
+        @Test
+        fun `Send email with correct recipient`() {
+            emailSenderService.sendInformationRequestEmail(notification)
+
+            val email = greenMail.firstReceivedMessage()
+            assertThat(email.allRecipients).hasSize(1)
+            assertThat(email.allRecipients[0].toString()).isEqualTo(TEST_EMAIL)
+        }
+
+        @Test
+        fun `Send email with sender from properties`() {
+            emailSenderService.sendInformationRequestEmail(notification)
+
+            val email = greenMail.firstReceivedMessage()
+            assertThat(email.from).hasSize(1)
+            assertThat(email.from[0].toString()).isEqualTo(HAITATON_NO_REPLY)
+        }
+
+        @Test
+        fun `Send email with correct subject`() {
+            emailSenderService.sendInformationRequestEmail(notification)
+
+            val email = greenMail.firstReceivedMessage()
+            assertThat(email.subject)
+                .isEqualTo(
+                    "Haitaton: Hakemuksellesi on tullut täydennyspyyntö / Hakemuksellesi on tullut täydennyspyyntö / Hakemuksellesi on tullut täydennyspyyntö")
+        }
+
+        @Test
+        fun `Send email with parametrized hybrid body`() {
+            emailSenderService.sendInformationRequestEmail(notification)
+
+            val email = greenMail.firstReceivedMessage()
+            val (textBody, htmlBody) = email.bodies()
+            assertThat(textBody).all {
+                contains(
+                    "Hakemuksellesi $HANKE_NIMI ($APPLICATION_IDENTIFIER) on tullut täydennyspyyntö")
+                contains(
+                    "Käy vastaamassa siihen Haitattomassa: http://localhost:3001/fi/hakemus/13")
+            }
+            assertThat(htmlBody).all {
+                contains(
+                    "Hakemuksellesi $HANKE_NIMI ($APPLICATION_IDENTIFIER) on tullut täydennyspyyntö")
+                contains(
+                    """Käy vastaamassa siihen Haitattomassa: <a href="http://localhost:3001/fi/hakemus/13">http://localhost:3001/fi/hakemus/13</a>""")
+            }
+        }
+    }
 }

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/PermissionServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/PermissionServiceITest.kt
@@ -6,8 +6,10 @@ import assertk.assertions.containsExactly
 import assertk.assertions.hasSize
 import assertk.assertions.isEmpty
 import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
 import assertk.assertions.isNotNull
 import assertk.assertions.isNull
+import assertk.assertions.isTrue
 import assertk.assertions.prop
 import assertk.assertions.single
 import fi.hel.haitaton.hanke.HankeEntity
@@ -134,12 +136,12 @@ class PermissionServiceITest : IntegrationTest() {
     @Nested
     inner class HasPermission {
         @Test
-        fun `hasPermission returns false without permissions`() {
+        fun `returns false without permissions`() {
             assertFalse(permissionService.hasPermission(2, username, PermissionCode.EDIT))
         }
 
         @Test
-        fun `hasPermission with correct permission`() {
+        fun `returns true with correct permission`() {
             val hankeId = hankeFactory.saveMinimal().id
             permissionService.create(hankeId, username, Kayttooikeustaso.KAIKKI_OIKEUDET)
 
@@ -147,11 +149,31 @@ class PermissionServiceITest : IntegrationTest() {
         }
 
         @Test
-        fun `hasPermission with insufficient permissions`() {
+        fun `returns false with insufficient permissions`() {
             val hankeId = hankeFactory.saveMinimal().id
             permissionService.create(hankeId, username, Kayttooikeustaso.HAKEMUSASIOINTI)
 
             assertFalse(permissionService.hasPermission(hankeId, username, PermissionCode.EDIT))
+        }
+    }
+
+    @Nested
+    inner class HasPermissionWithKayttooikeustaso {
+        @Test
+        fun `returns true when kayttooikeustaso contains the permission`() {
+            val result =
+                permissionService.hasPermission(Kayttooikeustaso.HANKEMUOKKAUS, PermissionCode.EDIT)
+
+            assertThat(result).isTrue()
+        }
+
+        @Test
+        fun `returns false when kayttooikeustaso doesn't contain the permission`() {
+            val result =
+                permissionService.hasPermission(
+                    Kayttooikeustaso.HANKEMUOKKAUS, PermissionCode.EDIT_APPLICATIONS)
+
+            assertThat(result).isFalse()
         }
     }
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/email/EmailEvent.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/email/EmailEvent.kt
@@ -53,3 +53,10 @@ data class RemovalFromHankeNotificationEmail(
     val deletedByName: String,
     val deletedByEmail: String,
 ) : EmailEvent
+
+data class InformationRequestEmail(
+    override val to: String,
+    val hakemusNimi: String,
+    val hakemusTunnus: String,
+    val hakemusId: Long,
+) : EmailEvent

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/email/EmailSenderService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/email/EmailSenderService.kt
@@ -41,6 +41,7 @@ enum class EmailTemplate(val value: String) {
     EXCAVATION_NOTIFICATION_DECISION("kaivuilmoitus-paatos"),
     INVITATION_HANKE("kayttaja-lisatty-hanke"),
     REMOVAL_FROM_HANKE_NOTIFICATION("kayttaja-poistettu-hanke"),
+    INFORMATION_REQUEST("taydennyspyynto"),
 }
 
 @Service
@@ -155,6 +156,27 @@ class EmailSenderService(
         sendHybridEmail(
             data.to,
             EmailTemplate.REMOVAL_FROM_HANKE_NOTIFICATION,
+            templateData,
+        )
+    }
+
+    @TransactionalEventListener
+    fun sendInformationRequestEmail(data: InformationRequestEmail) {
+        logger.info { "Sending notification email for information request" }
+
+        val templateData =
+            mapOf(
+                "baseUrl" to emailConfig.baseUrl,
+                "recipientEmail" to data.to,
+                "hakemusNimi" to data.hakemusNimi,
+                "hakemusTunnus" to data.hakemusTunnus,
+                "hakemusId" to data.hakemusId,
+                "signatures" to signatures(),
+            )
+
+        sendHybridEmail(
+            data.to,
+            EmailTemplate.INFORMATION_REQUEST,
             templateData,
         )
     }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaService.kt
@@ -36,6 +36,12 @@ class HankeKayttajaService(
             ?: throw HankeKayttajaNotFoundException(kayttajaId)
 
     @Transactional(readOnly = true)
+    fun hasPermission(hankeKayttaja: HankekayttajaEntity, permission: PermissionCode): Boolean =
+        hankeKayttaja.deriveKayttooikeustaso()?.let {
+            permissionService.hasPermission(it, permission)
+        } ?: false
+
+    @Transactional(readOnly = true)
     fun getKayttajatByHankeId(hankeId: Int): List<HankeKayttajaDto> =
         hankekayttajaRepository.findByHankeId(hankeId).map { it.toDto() }
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/PermissionService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/PermissionService.kt
@@ -2,6 +2,8 @@ package fi.hel.haitaton.hanke.permissions
 
 import fi.hel.haitaton.hanke.currentUserId
 import fi.hel.haitaton.hanke.logging.PermissionLoggingService
+import java.util.EnumMap
+import java.util.EnumSet
 import mu.KotlinLogging
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -14,6 +16,9 @@ class PermissionService(
     private val kayttooikeustasoRepository: KayttooikeustasoRepository,
     private val logService: PermissionLoggingService,
 ) {
+    private val permissionCache: EnumMap<Kayttooikeustaso, EnumSet<PermissionCode>> =
+        EnumMap(Kayttooikeustaso::class.java)
+
     fun findByHankeId(hankeId: Int) = permissionRepository.findAllByHankeId(hankeId)
 
     fun getAllowedHankeIds(userId: String, permission: PermissionCode): List<Int> =
@@ -29,6 +34,17 @@ class PermissionService(
         permissionRepository.findOneByHankeIdAndUserId(hankeId, userId)?.hasPermission(permission)
             ?: false
 
+    fun hasPermission(kayttooikeustaso: Kayttooikeustaso, permission: PermissionCode): Boolean =
+        permissionCache
+            .getOrPut(kayttooikeustaso) {
+                val codes =
+                    kayttooikeustasoRepository
+                        .findOneByKayttooikeustaso(kayttooikeustaso)
+                        .permissionCodes
+                EnumSet.noneOf(PermissionCode::class.java).apply { addAll(codes) }
+            }
+            .contains(permission)
+
     fun findPermission(hankeId: Int, userId: String): PermissionEntity? =
         permissionRepository.findOneByHankeIdAndUserId(hankeId, userId)
 
@@ -41,14 +57,10 @@ class PermissionService(
                     userId = userId,
                     hankeId = hankeId,
                     kayttooikeustasoEntity = kayttooikeustasoEntity,
-                )
-            )
+                ))
         logService.logCreate(permission.toDomain(), currentUserId())
         return permission
     }
-
-    fun findKayttooikeustaso(kayttooikeustaso: Kayttooikeustaso): KayttooikeustasoEntity =
-        kayttooikeustasoRepository.findOneByKayttooikeustaso(kayttooikeustaso)
 
     @Transactional
     fun updateKayttooikeustaso(
@@ -65,4 +77,7 @@ class PermissionService(
         }
         logService.logUpdate(kayttooikeustasoBefore, permission.toDomain(), currentUser)
     }
+
+    private fun findKayttooikeustaso(kayttooikeustaso: Kayttooikeustaso): KayttooikeustasoEntity =
+        kayttooikeustasoRepository.findOneByKayttooikeustaso(kayttooikeustaso)
 }

--- a/services/hanke-service/src/main/resources/email/template/taydennyspyynto.html.mustache
+++ b/services/hanke-service/src/main/resources/email/template/taydennyspyynto.html.mustache
@@ -1,0 +1,216 @@
+<!doctype html>
+<html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
+
+<head>
+  <title></title>
+  <!--[if !mso]><!-->
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <!--<![endif]-->
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <style type="text/css">#outlook a{padding:0}body{margin:0;padding:0;-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%}table,td{border-collapse:collapse;mso-table-lspace:0;mso-table-rspace:0}img{border:0;height:auto;line-height:100%;outline:0;text-decoration:none;-ms-interpolation-mode:bicubic}p{display:block;margin:13px 0}</style>
+  <!--[if mso]>
+    <noscript>
+    <xml>
+    <o:OfficeDocumentSettings>
+      <o:AllowPNG/>
+      <o:PixelsPerInch>96</o:PixelsPerInch>
+    </o:OfficeDocumentSettings>
+    </xml>
+    </noscript>
+    <![endif]-->
+  <!--[if lte mso 11]>
+    <style type="text/css">
+      .mj-outlook-group-fix { width:100% !important; }
+    </style>
+    <![endif]-->
+  <style type="text/css">@media only screen and (min-width:480px){.mj-column-per-100{width:100%!important;max-width:100%}}</style>
+  <style media="screen and (min-width:480px)">.moz-text-html .mj-column-per-100{width:100%!important;max-width:100%}</style>
+</head>
+
+<body style="word-spacing:normal">
+  <div lang="und" dir="auto">
+    <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    <div style="margin:0 auto;max-width:600px">
+      <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%">
+        <tbody>
+          <tr>
+            <td style="direction:ltr;font-size:0;padding:20px 0;text-align:center">
+              <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
+              <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%">
+                <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top" width="100%">
+                  <tbody>
+                    <div style="display:flex;align-items:center">
+                      <div style="padding-left:24px;padding-top:16px">
+                        <img src="{{baseUrl}}/helsinki.png" alt="Helsingin logo" width="131" height="65">
+                      </div>
+                      <div style="padding-left:16px;padding-top:12px;font-family:Arial;font-size:24px"> Haitaton </div>
+                    </div>
+                  </tbody>
+                </table>
+              </div>
+              <!--[if mso | IE]></td></tr></table><![endif]-->
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    <div style="margin:0 auto;max-width:600px">
+      <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%">
+        <tbody>
+          <tr>
+            <td style="direction:ltr;font-size:0;padding:20px 0;text-align:center">
+              <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
+              <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%">
+                <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top" width="100%">
+                  <tbody>
+                    <tr>
+                      <td align="left" style="font-size:0;padding:16px 24px 16px 24px;word-break:break-word">
+                        <div style="font-family:Arial;font-size:36px;line-height:43px;text-align:left;color:#000">Hakemuksellesi on tullut täydennyspyyntö / Hakemuksellesi on tullut täydennyspyyntö / Hakemuksellesi on tullut täydennyspyyntö</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="left" style="font-size:0;padding:16px 24px 0 24px;word-break:break-word">
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">Hakemuksellesi {{hakemusNimi}} ({{hakemusTunnus}}) on tullut täydennyspyyntö. Käy vastaamassa siihen Haitattomassa: <a href="{{baseUrl}}/fi/hakemus/{{hakemusId}}">{{baseUrl}}/fi/hakemus/{{hakemusId}}</a>.</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="left" style="font-size:0;padding:16px 24px 0 24px;word-break:break-word">
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">Haitaton on Helsingin kaupungin asiointijärjestelmä yleisille alueille sijoittuvien hankkeiden edistämiseen ja haittojen hallintaan.</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="left" style="font-size:0;padding:16px 24px 0 24px;word-break:break-word">
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">Tämä on automaattinen sähköposti – älä vastaa tähän viestiin.</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="left" style="font-size:0;padding:16px 24px 0 24px;word-break:break-word">
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">Ystävällisin terveisin,</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="left" style="font-size:0;padding:16px 24px 16px 24px;word-break:break-word">
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">Helsingin kaupungin kaupunkiympäristön toimiala <br> Haitaton-asiointi <br> haitaton@hel.fi</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="center" style="font-size:0;padding:10px 25px;word-break:break-word">
+                        <p style="border-top:solid 1px #999898;font-size:1px;margin:0 auto;width:100%">
+                        </p>
+                        <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" style="border-top:solid 1px #999898;font-size:1px;margin:0px auto;width:550px;" role="presentation" width="550px" ><tr><td style="height:0;line-height:0;"> &nbsp;
+</td></tr></table><![endif]-->
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="left" style="font-size:0;padding:16px 24px 0 24px;word-break:break-word">
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">Hakemuksellesi {{hakemusNimi}} ({{hakemusTunnus}}) on tullut täydennyspyyntö. Käy vastaamassa siihen Haitattomassa: <a href="{{baseUrl}}/sv/ansokan/{{hakemusTunnus}}">{{baseUrl}}/sv/ansokan/{{hakemusTunnus}}</a>.</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="left" style="font-size:0;padding:16px 24px 0 24px;word-break:break-word">
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">Haitaton är Helsingfors stads hanteringssystem för att främja projekt i allmänna områden och att hantera olägenheter</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="left" style="font-size:0;padding:16px 24px 0 24px;word-break:break-word">
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">Det här är ett automatiskt e-postmeddelande – svara inte på det.</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="left" style="font-size:0;padding:16px 24px 0 24px;word-break:break-word">
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">Med vänlig hälsning,</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="left" style="font-size:0;padding:16px 24px 16px 24px;word-break:break-word">
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">Helsingfors stads stadsmiljösektor <br> Haitaton-ärenden <br> haitaton@hel.fi</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="center" style="font-size:0;padding:10px 25px;word-break:break-word">
+                        <p style="border-top:solid 1px #999898;font-size:1px;margin:0 auto;width:100%">
+                        </p>
+                        <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" style="border-top:solid 1px #999898;font-size:1px;margin:0px auto;width:550px;" role="presentation" width="550px" ><tr><td style="height:0;line-height:0;"> &nbsp;
+</td></tr></table><![endif]-->
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="left" style="font-size:0;padding:16px 24px 0 24px;word-break:break-word">
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">Hakemuksellesi {{hakemusNimi}} ({{hakemusTunnus}}) on tullut täydennyspyyntö. Käy vastaamassa siihen Haitattomassa: <a href="{{baseUrl}}/en/application/{{hakemusTunnus}}">
+                            {{baseUrl}}/en/application/{{hakemusTunnus}}</a>.</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="left" style="font-size:0;padding:16px 24px 0 24px;word-break:break-word">
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">Haitaton is the City of Helsinki’s service system intended for advancing projects taking place in public areas and managing the disturbances caused by them.</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="left" style="font-size:0;padding:16px 24px 0 24px;word-break:break-word">
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">This email was generated automatically – please do not reply to this message.</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="left" style="font-size:0;padding:16px 24px 0 24px;word-break:break-word">
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">Kind regards,</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="left" style="font-size:0;padding:16px 24px 16px 24px;word-break:break-word">
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">City of Helsinki Urban Environment Division <br> Haitaton services <br> haitaton@hel.fi</div>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+              <!--[if mso | IE]></td></tr></table><![endif]-->
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#FFC61E" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    <div style="background:#ffc61e;background-color:#ffc61e;margin:0 auto;max-width:600px">
+      <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#ffc61e;background-color:#ffc61e;width:100%">
+        <tbody>
+          <tr>
+            <td style="direction:ltr;font-size:0;padding:20px 0;text-align:center">
+              <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
+              <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%">
+                <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top" width="100%">
+                  <tbody>
+                    <div style="display:flex;align-items:center">
+                      <div style="padding-left:24px;padding-top:5px;padding-bottom:16px">
+                        <img src="{{baseUrl}}/helsinki.png" alt="Helsingin logo" width="87" height="43">
+                      </div>
+                      <div style="padding-left:16px;padding-top:12px;padding-bottom:26px;font-family:Arial;font-size:16px"> Haitaton </div>
+                    </div>
+                    <tr>
+                      <td align="center" style="font-size:0;padding:0 24px 16px 24px;word-break:break-word">
+                        <p style="border-top:solid 1px #999898;font-size:1px;margin:0 auto;width:100%">
+                        </p>
+                        <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" style="border-top:solid 1px #999898;font-size:1px;margin:0px auto;width:552px;" role="presentation" width="552px" ><tr><td style="height:0;line-height:0;"> &nbsp;
+</td></tr></table><![endif]-->
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="left" style="font-size:0;padding:0 24px 0 24px;word-break:break-word">
+                        <div style="font-family:Arial;font-size:16px;line-height:1;text-align:left;color:#000">© Helsingin kaupunki 2023</div>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+              <!--[if mso | IE]></td></tr></table><![endif]-->
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <!--[if mso | IE]></td></tr></table><![endif]-->
+  </div>
+</body>
+
+</html>

--- a/services/hanke-service/src/main/resources/email/template/taydennyspyynto.subject.mustache
+++ b/services/hanke-service/src/main/resources/email/template/taydennyspyynto.subject.mustache
@@ -1,0 +1,1 @@
+Haitaton: Hakemuksellesi on tullut täydennyspyyntö / Hakemuksellesi on tullut täydennyspyyntö / Hakemuksellesi on tullut täydennyspyyntö

--- a/services/hanke-service/src/main/resources/email/template/taydennyspyynto.text.mustache
+++ b/services/hanke-service/src/main/resources/email/template/taydennyspyynto.text.mustache
@@ -1,0 +1,15 @@
+Hakemuksellesi on tullut täydennyspyyntö / Hakemuksellesi on tullut täydennyspyyntö / Hakemuksellesi on tullut täydennyspyyntö
+
+Hakemuksellesi {{hakemusNimi}} ({{hakemusTunnus}}) on tullut täydennyspyyntö. Käy vastaamassa siihen Haitattomassa: {{baseUrl}}/fi/hakemus/{{hakemusId}}.
+
+{{{signatures.fi}}}
+
+
+Hakemuksellesi {{hakemusNimi}} ({{hakemusTunnus}}) on tullut täydennyspyyntö. Käy vastaamassa siihen Haitattomassa: {{baseUrl}}/fi/hakemus/{{hakemusId}}.
+
+{{{signatures.sv}}}
+
+
+Hakemuksellesi {{hakemusNimi}} ({{hakemusTunnus}}) on tullut täydennyspyyntö. Käy vastaamassa siihen Haitattomassa: {{baseUrl}}/fi/hakemus/{{hakemusId}}.
+
+{{{signatures.en}}}

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceTest.kt
@@ -43,6 +43,7 @@ import fi.hel.haitaton.hanke.logging.HankeLoggingService
 import fi.hel.haitaton.hanke.logging.Status
 import fi.hel.haitaton.hanke.paatos.PaatosService
 import fi.hel.haitaton.hanke.permissions.HankeKayttajaService
+import fi.hel.haitaton.hanke.permissions.PermissionService
 import fi.hel.haitaton.hanke.test.AlluException
 import fi.hel.haitaton.hanke.test.USERNAME
 import fi.hel.haitaton.hanke.tormaystarkastelu.TormaystarkasteluLaskentaService
@@ -93,6 +94,7 @@ class HakemusServiceTest {
     private val paatosService: PaatosService = mockk()
     private val publisher: ApplicationEventPublisher = mockk()
     private val tormaystarkasteluLaskentaService: TormaystarkasteluLaskentaService = mockk()
+    private val permissionService: PermissionService = mockk()
 
     private val hakemusService =
         HakemusService(

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/permissions/PermissionServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/permissions/PermissionServiceTest.kt
@@ -1,0 +1,56 @@
+package fi.hel.haitaton.hanke.permissions
+
+import fi.hel.haitaton.hanke.logging.PermissionLoggingService
+import io.mockk.checkUnnecessaryStub
+import io.mockk.clearAllMocks
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verifySequence
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class PermissionServiceTest {
+
+    private val permissionRepository: PermissionRepository = mockk()
+    private val kayttooikeustasoRepository: KayttooikeustasoRepository = mockk()
+    private val logService: PermissionLoggingService = mockk()
+
+    private val permissionService =
+        PermissionService(permissionRepository, kayttooikeustasoRepository, logService)
+
+    @BeforeEach
+    fun cleanup() {
+        clearAllMocks()
+    }
+
+    @AfterEach
+    fun checkMocks() {
+        checkUnnecessaryStub()
+        confirmVerified(permissionRepository, kayttooikeustasoRepository, logService)
+    }
+
+    @Nested
+    inner class HasPermissionWithKayttooikeustaso {
+        @Test
+        fun `calls repository only once for one kayttooikeustaso`() {
+            every {
+                kayttooikeustasoRepository.findOneByKayttooikeustaso(Kayttooikeustaso.HANKEMUOKKAUS)
+            } returns
+                KayttooikeustasoEntity(
+                    kayttooikeustaso = Kayttooikeustaso.HANKEMUOKKAUS,
+                    permissionCode = PermissionCode.EDIT.code,
+                )
+
+            permissionService.hasPermission(Kayttooikeustaso.HANKEMUOKKAUS, PermissionCode.EDIT)
+            permissionService.hasPermission(Kayttooikeustaso.HANKEMUOKKAUS, PermissionCode.VIEW)
+            permissionService.hasPermission(Kayttooikeustaso.HANKEMUOKKAUS, PermissionCode.DELETE)
+
+            verifySequence {
+                kayttooikeustasoRepository.findOneByKayttooikeustaso(Kayttooikeustaso.HANKEMUOKKAUS)
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Description

Send an email whenever the status of an application goes to WAITING_INFORMATION, meaning that a new information request (täydennyspyyntö) has been made in Allu. The email is sent to the contacts on the application that have permission to edit the application, i.e. respond to the request.

### Jira Issue:  https://helsinkisolutionoffice.atlassian.net/browse/HAI-2676

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
1. Send an application to Allu
2. In Allu, start handling the application and create a täydennyspyyntö for the application
3. After a minute, check smtp4dev (http://localhost:3003/) for the email

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 