### PR TITLE
HAI-2792 Send paper decision receiver to Allu

### DIFF
--- a/services/hanke-service/Dockerfile-local
+++ b/services/hanke-service/Dockerfile-local
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/docker/library/eclipse-temurin:17 as build
+FROM public.ecr.aws/docker/library/eclipse-temurin:17 AS build
 WORKDIR /workspace/app
 
 COPY gradlew settings.gradle.kts ./

--- a/services/hanke-service/Dockerfile-platta
+++ b/services/hanke-service/Dockerfile-platta
@@ -1,7 +1,7 @@
 # Uses different base images for build and run. RedHat Ubi stronger security policies prevent gradle builds.
 
 # Stage 1: Build application
-FROM public.ecr.aws/docker/library/eclipse-temurin:17 as build
+FROM public.ecr.aws/docker/library/eclipse-temurin:17 AS build
 
 # Set the working directory, copy gradle and source code
 WORKDIR /app

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusControllerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusControllerITest.kt
@@ -1167,8 +1167,8 @@ class HakemusControllerITest(@Autowired override val mockMvc: MockMvc) : Control
             every { hakemusService.sendHakemus(id, paperDecisionReceiver, USERNAME) } returns
                 HakemusFactory.create(
                     applicationData =
-                        HakemusFactory.createJohtoselvityshakemusData()
-                            .copy(paperDecisionReceiver = paperDecisionReceiver))
+                        HakemusFactory.createJohtoselvityshakemusData(
+                            paperDecisionReceiver = paperDecisionReceiver))
 
             post(url, request)
                 .andExpect(status().isOk)

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceITest.kt
@@ -1957,6 +1957,7 @@ class HakemusServiceITest(
             val paperDecisionReceiver = PaperDecisionReceiverFactory.default
             every { alluClient.create(any()) } returns alluId
             justRun { alluClient.addAttachment(alluId, any()) }
+            every { alluClient.sendSystemComment(alluId, any()) } returns 4
             every { alluClient.getApplicationInformation(any()) } returns
                 AlluFactory.createAlluApplicationResponse(alluId)
             auditLogRepository.deleteAll()
@@ -1977,6 +1978,7 @@ class HakemusServiceITest(
             verifySequence {
                 alluClient.create(any())
                 alluClient.addAttachment(alluId, any())
+                alluClient.sendSystemComment(alluId, any())
                 alluClient.getApplicationInformation(alluId)
             }
         }
@@ -1987,6 +1989,7 @@ class HakemusServiceITest(
             val paperDecisionReceiver = PaperDecisionReceiverFactory.default
             every { alluClient.create(any()) } returns alluId
             justRun { alluClient.addAttachment(alluId, any()) }
+            every { alluClient.sendSystemComment(alluId, any()) } returns 4
             every { alluClient.getApplicationInformation(any()) } returns
                 AlluFactory.createAlluApplicationResponse(alluId)
 
@@ -2003,6 +2006,30 @@ class HakemusServiceITest(
             verifySequence {
                 alluClient.create(any())
                 alluClient.addAttachment(alluId, any())
+                alluClient.sendSystemComment(alluId, any())
+                alluClient.getApplicationInformation(alluId)
+            }
+        }
+
+        @Test
+        fun `sends a system comment to Allu when there is a paper decision receiver`() {
+            val hakemus = hakemusFactory.builder().withMandatoryFields().save()
+            val paperDecisionReceiver = PaperDecisionReceiverFactory.default
+            every { alluClient.create(any()) } returns alluId
+            justRun { alluClient.addAttachment(alluId, any()) }
+            every { alluClient.sendSystemComment(alluId, any()) } returns 4
+            every { alluClient.getApplicationInformation(any()) } returns
+                AlluFactory.createAlluApplicationResponse(alluId)
+
+            hakemusService.sendHakemus(hakemus.id, paperDecisionReceiver, USERNAME)
+
+            verifySequence {
+                alluClient.create(any())
+                alluClient.addAttachment(alluId, any())
+                alluClient.sendSystemComment(
+                    alluId,
+                    "Asiakas haluaa päätöksen myös paperisena. Liitteessä " +
+                        "haitaton-form-data.pdf on päätöksen toimitukseen liittyvät osoitetiedot.")
                 alluClient.getApplicationInformation(alluId)
             }
         }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/AlluClient.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/AlluClient.kt
@@ -31,7 +31,7 @@ import reactor.core.publisher.Mono
 
 private val logger = KotlinLogging.logger {}
 
-const val HAITATON_SYSTEM = "Haitaton järjestelmä"
+const val HAITATON_SYSTEM = "Haitaton-järjestelmä"
 const val AUTH_TOKEN_SAFETY_MARGIN_SECONDS = 5L * 60L
 
 class AlluClient(

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/pdf/Formatters.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/pdf/Formatters.kt
@@ -2,6 +2,7 @@ package fi.hel.haitaton.hanke.pdf
 
 import fi.hel.haitaton.hanke.hakemus.Hakemusyhteyshenkilo
 import fi.hel.haitaton.hanke.hakemus.Hakemusyhteystieto
+import fi.hel.haitaton.hanke.hakemus.PaperDecisionReceiver
 import fi.hel.haitaton.hanke.hakemus.PostalAddress
 import java.time.ZoneId
 import java.time.ZonedDateTime
@@ -21,6 +22,14 @@ fun Hakemusyhteystieto.format(): String =
     listOfNotNull("$nimi\n", registryKey, sahkoposti, puhelinnumero, "\nYhteyshenkilöt\n")
         .filter { it.isNotBlank() }
         .joinToString("\n") + this.yhteyshenkilot.joinToString("\n") { "\n" + it.format() }
+
+fun PaperDecisionReceiver.format(): String =
+    """
+        $name
+        $streetAddress
+        $postalCode $city
+    """
+        .trimIndent()
 
 fun ZonedDateTime?.format(): String? =
     this?.withZoneSameInstant(ZoneId.of("Europe/Helsinki"))?.format(FINNISH_DATE_FORMAT)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/pdf/JohtoselvityshakemusPdfEncoder.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/pdf/JohtoselvityshakemusPdfEncoder.kt
@@ -74,17 +74,18 @@ object JohtoselvityshakemusPdfEncoder {
 
         document.section("Yhteystiedot") {
             if (data.customerWithContacts != null) {
-                row("Työstä vastaavat", data.customerWithContacts.format())
+                row("Työstä vastaava", data.customerWithContacts.format())
             }
             if (data.contractorWithContacts != null) {
-                row("Työn suorittajat", data.contractorWithContacts.format())
+                row("Työn suorittaja", data.contractorWithContacts.format())
             }
             if (data.propertyDeveloperWithContacts != null) {
-                row("Rakennuttajat", data.propertyDeveloperWithContacts.format())
+                row("Rakennuttaja", data.propertyDeveloperWithContacts.format())
             }
             if (data.representativeWithContacts != null) {
-                row("Asianhoitajat", data.representativeWithContacts.format())
+                row("Asianhoitaja", data.representativeWithContacts.format())
             }
+            data.paperDecisionReceiver?.let { row("Päätös tilattu paperisena", it.format()) }
         }
 
         document.newPage()

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/pdf/KaivuilmoitusPdfEncoder.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/pdf/KaivuilmoitusPdfEncoder.kt
@@ -72,6 +72,7 @@ object KaivuilmoitusPdfEncoder {
             data.contractorWithContacts?.let { row("Työn suorittaja", it.format()) }
             data.propertyDeveloperWithContacts?.let { row("Rakennuttaja", it.format()) }
             data.representativeWithContacts?.let { row("Asianhoitaja", it.format()) }
+            data.paperDecisionReceiver?.let { row("Päätös tilattu paperisena", it.format()) }
         }
         document.newPage()
 

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusFactory.kt
@@ -21,6 +21,7 @@ import fi.hel.haitaton.hanke.hakemus.JohtoselvityshakemusData
 import fi.hel.haitaton.hanke.hakemus.KaivuilmoitusAlue
 import fi.hel.haitaton.hanke.hakemus.KaivuilmoitusData
 import fi.hel.haitaton.hanke.hakemus.Laskutusyhteystieto
+import fi.hel.haitaton.hanke.hakemus.PaperDecisionReceiver
 import fi.hel.haitaton.hanke.hakemus.PostalAddress
 import fi.hel.haitaton.hanke.paatos.Paatos
 import fi.hel.haitaton.hanke.permissions.HankeKayttajaService
@@ -134,6 +135,7 @@ class HakemusFactory(
             pendingOnClient: Boolean = false,
             areas: List<JohtoselvitysHakemusalue>? =
                 listOf(ApplicationFactory.createCableReportApplicationArea()),
+            paperDecisionReceiver: PaperDecisionReceiver? = null,
             customerWithContacts: Hakemusyhteystieto? = null,
             contractorWithContacts: Hakemusyhteystieto? = null,
             representativeWithContacts: Hakemusyhteystieto? = null,
@@ -156,7 +158,7 @@ class HakemusFactory(
                 endTime = endTime,
                 pendingOnClient = pendingOnClient,
                 areas = areas,
-                paperDecisionReceiver = null,
+                paperDecisionReceiver = paperDecisionReceiver,
                 customerWithContacts = customerWithContacts,
                 contractorWithContacts = contractorWithContacts,
                 representativeWithContacts = representativeWithContacts,
@@ -179,6 +181,7 @@ class HakemusFactory(
             endTime: ZonedDateTime? = DateFactory.getEndDatetime(),
             areas: List<KaivuilmoitusAlue>? =
                 listOf(ApplicationFactory.createExcavationNotificationArea()),
+            paperDecisionReceiver: PaperDecisionReceiver? = null,
             customerWithContacts: Hakemusyhteystieto? = null,
             contractorWithContacts: Hakemusyhteystieto? = null,
             representativeWithContacts: Hakemusyhteystieto? = null,
@@ -201,7 +204,7 @@ class HakemusFactory(
                 startTime = startTime,
                 endTime = endTime,
                 areas = areas,
-                paperDecisionReceiver = null,
+                paperDecisionReceiver = paperDecisionReceiver,
                 customerWithContacts = customerWithContacts,
                 contractorWithContacts = contractorWithContacts,
                 representativeWithContacts = representativeWithContacts,

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/pdf/JohtoselvityshakemusPdfEncoderTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/pdf/JohtoselvityshakemusPdfEncoderTest.kt
@@ -12,6 +12,7 @@ import fi.hel.haitaton.hanke.factory.HakemusFactory
 import fi.hel.haitaton.hanke.factory.HakemusyhteyshenkiloFactory
 import fi.hel.haitaton.hanke.factory.HakemusyhteystietoFactory
 import fi.hel.haitaton.hanke.factory.HakemusyhteystietoFactory.withYhteyshenkilo
+import fi.hel.haitaton.hanke.factory.PaperDecisionReceiverFactory
 import fi.hel.haitaton.hanke.hakemus.JohtoselvitysHakemusalue
 import java.time.ZonedDateTime
 import org.geojson.Polygon
@@ -176,10 +177,10 @@ class JohtoselvityshakemusPdfEncoderTest {
                 JohtoselvityshakemusPdfEncoder.createPdf(hakemusData, 1f, listOf(), listOf())
 
             assertThat(getPdfAsText(pdfData)).all {
-                contains("Työstä vastaavat")
-                contains("Työn suorittajat")
-                contains("Rakennuttajat")
-                contains("Asianhoitajat")
+                contains("Työstä vastaava")
+                contains("Työn suorittaja")
+                contains("Rakennuttaja")
+                contains("Asianhoitaja")
                 contains("Yhteyshenkilöt")
             }
         }
@@ -198,26 +199,21 @@ class JohtoselvityshakemusPdfEncoderTest {
                 JohtoselvityshakemusPdfEncoder.createPdf(hakemusData, 614f, listOf(), listOf())
 
             assertThat(getPdfAsText(pdfData)).all {
-                contains("Työstä vastaavat")
-                contains("Työn suorittajat")
-                doesNotContain("Rakennuttajat")
-                doesNotContain("Asianhoitajat")
+                contains("Työstä vastaava")
+                contains("Työn suorittaja")
+                doesNotContain("Rakennuttaja")
+                doesNotContain("Asianhoitaja")
             }
         }
 
         @Test
         fun `created PDF contains contact information`() {
-            val hakija = createCompany()
-            val tyonSuorittaja = createContractor()
-            val asianhoitaja = createRepresentative()
-            val rakennuttaja = createDeveloper()
-
             val hakemusData =
                 HakemusFactory.createJohtoselvityshakemusData(
-                    customerWithContacts = hakija,
-                    contractorWithContacts = tyonSuorittaja,
-                    representativeWithContacts = asianhoitaja,
-                    propertyDeveloperWithContacts = rakennuttaja,
+                    customerWithContacts = createCompany(),
+                    contractorWithContacts = createContractor(),
+                    representativeWithContacts = createRepresentative(),
+                    propertyDeveloperWithContacts = createDeveloper(),
                 )
 
             val pdfData =
@@ -253,6 +249,34 @@ class JohtoselvityshakemusPdfEncoderTest {
                 contains("denise@developer.test")
                 contains("0502222222")
             }
+        }
+
+        @Test
+        fun `created PDF contains paper decision receiver when present on the application`() {
+            val hakemusData =
+                HakemusFactory.createJohtoselvityshakemusData(
+                    paperDecisionReceiver = PaperDecisionReceiverFactory.default)
+
+            val pdfData =
+                JohtoselvityshakemusPdfEncoder.createPdf(hakemusData, 614f, listOf(), listOf())
+
+            assertThat(getPdfAsText(pdfData)).all {
+                contains("Päätös tilattu paperisena")
+                contains("Pekka Paperinen")
+                contains("Paperipolku 3 A 4")
+                contains("00451 Helsinki")
+            }
+        }
+
+        @Test
+        fun `created PDF doesn't contain paper decision receiver header when not present on the application`() {
+            val hakemusData =
+                HakemusFactory.createJohtoselvityshakemusData(paperDecisionReceiver = null)
+
+            val pdfData =
+                JohtoselvityshakemusPdfEncoder.createPdf(hakemusData, 614f, listOf(), listOf())
+
+            assertThat(getPdfAsText(pdfData)).doesNotContain("Päätös tilattu paperisena")
         }
 
         @Test

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/pdf/KaivuilmoitusPdfEncoderTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/pdf/KaivuilmoitusPdfEncoderTest.kt
@@ -16,6 +16,7 @@ import fi.hel.haitaton.hanke.factory.GeometriaFactory
 import fi.hel.haitaton.hanke.factory.HakemusFactory
 import fi.hel.haitaton.hanke.factory.HakemusyhteystietoFactory
 import fi.hel.haitaton.hanke.factory.HakemusyhteystietoFactory.withYhteyshenkilo
+import fi.hel.haitaton.hanke.factory.PaperDecisionReceiverFactory
 import fi.hel.haitaton.hanke.hakemus.KaivuilmoitusAlue
 import fi.hel.haitaton.hanke.hakemus.Tyoalue
 import fi.hel.haitaton.hanke.tormaystarkastelu.AutoliikenteenKaistavaikutustenPituus
@@ -278,6 +279,31 @@ class KaivuilmoitusPdfEncoderTest {
                 contains("denise@developer.test")
                 contains("0502222222")
             }
+        }
+
+        @Test
+        fun `created PDF contains paper decision receiver when present on the application`() {
+            val hakemusData =
+                HakemusFactory.createKaivuilmoitusData(
+                    paperDecisionReceiver = PaperDecisionReceiverFactory.default)
+
+            val pdfData = KaivuilmoitusPdfEncoder.createPdf(hakemusData, 614f, listOf(), listOf())
+
+            assertThat(getPdfAsText(pdfData)).all {
+                contains("Päätös tilattu paperisena")
+                contains("Pekka Paperinen")
+                contains("Paperipolku 3 A 4")
+                contains("00451 Helsinki")
+            }
+        }
+
+        @Test
+        fun `created PDF doesn't contain paper decision receiver header when not present on the application`() {
+            val hakemusData = HakemusFactory.createKaivuilmoitusData(paperDecisionReceiver = null)
+
+            val pdfData = KaivuilmoitusPdfEncoder.createPdf(hakemusData, 614f, listOf(), listOf())
+
+            assertThat(getPdfAsText(pdfData)).doesNotContain("Päätös tilattu paperisena")
         }
 
         @Test


### PR DESCRIPTION
# Description

When the orderer asks for a paper of the decision to be sent to an address, send that address to Allu. The address is added to the form data PDF that's sent to Allu after every application.

To make the information easy to notice, add a system comment saying that a paper copy has been requested and that the address can be found in the PDF.

Also,
- Change the customer headers in johtoselvityshakemus PDF to singular, since there can be only one customer for each role.
- Fix the `as` keyword in the Dockerfiles. It should be capitalized.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2792

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
Create and send an application. Check Allu for the new comment and addition to the form-data PDF.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 