### PR TITLE
HAI-2703 Save a new information request to Haitaton

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/allu/AlluClientITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/allu/AlluClientITests.kt
@@ -74,7 +74,7 @@ class AlluClientITests {
         val properties = AlluProperties(baseUrl, "fake_username", "any_password", 2)
         val builder = WebClient.builder()
         // To fix the date formatting for the tests, customize ObjectMapper used by the WebClient.
-        // In production, when the client is build by Configuration, the builder is injected with an
+        // In production, when the client is built by Configuration, the builder is injected with an
         // object mapper with correct date handling.
         builder.codecs {
             it.defaultCodecs().jackson2JsonEncoder(Jackson2JsonEncoder(OBJECT_MAPPER))

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/allu/AlluClientITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/allu/AlluClientITests.kt
@@ -333,6 +333,42 @@ class AlluClientITests {
     }
 
     @Nested
+    inner class GetInformationRequest {
+        val alluid = 47188
+
+        @Test
+        fun `calls the correct address and returns the information request`() {
+
+            val body = AlluFactory.createInformationRequest(applicationAlluId = alluid)
+            val mockResponse =
+                MockResponse()
+                    .setHeader(CONTENT_TYPE, APPLICATION_JSON_VALUE)
+                    .setResponseCode(200)
+                    .setBody(body.toJsonString())
+            mockWebServer.enqueue(mockResponse)
+
+            val response = service.getInformationRequest(alluid)
+
+            val request = mockWebServer.takeRequest()
+            assertThat(request.method).isEqualTo("GET")
+            assertThat(request.path).isEqualTo("/v2/applications/$alluid/informationrequests")
+            assertThat(request.getHeader("Authorization")).isEqualTo("Bearer $authToken")
+
+            assertThat(response).isEqualTo(body)
+        }
+
+        @Test
+        fun `throws an exception when Allu returns an error`() {
+            val mockResponse = MockResponse().setResponseCode(500)
+            mockWebServer.enqueue(mockResponse)
+
+            val failure = assertFailure { service.getInformationRequest(alluid) }
+
+            failure.hasClass(WebClientResponseException.InternalServerError::class)
+        }
+    }
+
+    @Nested
     inner class GetDecisionPdf {
         @Test
         fun `returns PDF file as bytes`() {

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/allu/AlluClientITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/allu/AlluClientITests.kt
@@ -17,6 +17,7 @@ import assertk.assertions.messageContains
 import assertk.assertions.prop
 import com.auth0.jwt.JWT
 import com.auth0.jwt.algorithms.Algorithm
+import fi.hel.haitaton.hanke.OBJECT_MAPPER
 import fi.hel.haitaton.hanke.attachment.PDF_BYTES
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType
 import fi.hel.haitaton.hanke.configuration.Configuration.Companion.webClientWithLargeBuffer
@@ -44,6 +45,8 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.CsvSource
 import org.junit.jupiter.params.provider.MethodSource
+import org.skyscreamer.jsonassert.JSONAssert
+import org.skyscreamer.jsonassert.JSONCompareMode
 import org.springframework.http.HttpHeaders.CONTENT_DISPOSITION
 import org.springframework.http.HttpHeaders.CONTENT_TYPE
 import org.springframework.http.MediaType
@@ -51,6 +54,8 @@ import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
 import org.springframework.http.MediaType.APPLICATION_PDF
 import org.springframework.http.MediaType.APPLICATION_PDF_VALUE
 import org.springframework.http.MediaType.IMAGE_PNG
+import org.springframework.http.codec.json.Jackson2JsonDecoder
+import org.springframework.http.codec.json.Jackson2JsonEncoder
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.WebClientResponseException
 
@@ -67,7 +72,15 @@ class AlluClientITests {
 
         val baseUrl = mockWebServer.url("/").toUrl().toString()
         val properties = AlluProperties(baseUrl, "fake_username", "any_password", 2)
-        val webClient = webClientWithLargeBuffer(WebClient.builder())
+        val builder = WebClient.builder()
+        // To fix the date formatting for the tests, customize ObjectMapper used by the WebClient.
+        // In production, when the client is build by Configuration, the builder is injected with an
+        // object mapper with correct date handling.
+        builder.codecs {
+            it.defaultCodecs().jackson2JsonEncoder(Jackson2JsonEncoder(OBJECT_MAPPER))
+            it.defaultCodecs().jackson2JsonDecoder(Jackson2JsonDecoder(OBJECT_MAPPER))
+        }
+        val webClient = webClientWithLargeBuffer(builder)
         authToken = createMockToken()
         service = AlluClient(webClient, properties)
         service.authToken = authToken
@@ -365,6 +378,60 @@ class AlluClientITests {
             val failure = assertFailure { service.getInformationRequest(alluid) }
 
             failure.hasClass(WebClientResponseException.InternalServerError::class)
+        }
+    }
+
+    @Nested
+    inner class RespondToInformationRequest {
+        private val alluid = 47188
+        private val requestId = 9927
+
+        @Test
+        fun `calls the right address when the hakemus is a johtoselvityshakemus`() {
+            val applicationData = AlluFactory.createCableReportApplicationData()
+            val fields = listOf(InformationRequestFieldKey.AREA, InformationRequestFieldKey.OTHER)
+            mockWebServer.enqueue(MockResponse().setResponseCode(200))
+
+            service.respondToInformationRequest(
+                alluid,
+                requestId,
+                applicationData,
+                fields,
+            )
+
+            val request = mockWebServer.takeRequest()
+            assertThat(request.method).isEqualTo("POST")
+            assertThat(request.path)
+                .isEqualTo("/v2/cablereports/$alluid/informationrequests/$requestId/response")
+            val expectedBody = InformationRequestResponse(applicationData, fields).toJsonString()
+            val actualBody = request.body.readUtf8()
+            JSONAssert.assertEquals(expectedBody, actualBody, JSONCompareMode.NON_EXTENSIBLE)
+            assertThat(request.getHeader("Authorization")).isEqualTo("Bearer $authToken")
+        }
+
+        @Test
+        fun `calls the right address when the hakemus is a kaivuilmoitus`() {
+            val applicationData = AlluFactory.createExcavationNotificationData()
+            val fields =
+                listOf(InformationRequestFieldKey.START_TIME, InformationRequestFieldKey.END_TIME)
+            mockWebServer.enqueue(MockResponse().setResponseCode(200))
+
+            service.respondToInformationRequest(
+                alluid,
+                requestId,
+                applicationData,
+                fields,
+            )
+
+            val request = mockWebServer.takeRequest()
+            assertThat(request.method).isEqualTo("POST")
+            assertThat(request.path)
+                .isEqualTo(
+                    "/v2/excavationannouncements/$alluid/informationrequests/$requestId/response")
+            val expectedBody = InformationRequestResponse(applicationData, fields).toJsonString()
+            val actualBody = request.body.readUtf8()
+            JSONAssert.assertEquals(expectedBody, actualBody, JSONCompareMode.NON_EXTENSIBLE)
+            assertThat(request.getHeader("Authorization")).isEqualTo("Bearer $authToken")
         }
     }
 

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennysServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennysServiceITest.kt
@@ -1,0 +1,57 @@
+package fi.hel.haitaton.hanke.taydennys
+
+import assertk.all
+import assertk.assertThat
+import assertk.assertions.containsOnly
+import assertk.assertions.isEqualTo
+import assertk.assertions.prop
+import assertk.assertions.single
+import fi.hel.haitaton.hanke.IntegrationTest
+import fi.hel.haitaton.hanke.allu.AlluClient
+import fi.hel.haitaton.hanke.allu.InformationRequestFieldKey
+import fi.hel.haitaton.hanke.factory.AlluFactory
+import fi.hel.haitaton.hanke.factory.HakemusFactory
+import io.mockk.every
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+
+class TaydennysServiceITest(
+    @Autowired private val taydennysService: TaydennysService,
+    @Autowired private val taydennyspyyntoRepository: TaydennyspyyntoRepository,
+    @Autowired private val alluClient: AlluClient,
+    @Autowired private val hakemusFactory: HakemusFactory,
+) : IntegrationTest() {
+    private val alluId = 3464
+
+    @Nested
+    inner class SaveTaydennyspyyntoFromAllu {
+
+        @Test
+        fun `saves taydennyspyynto when Allu has one for the application`() {
+            val hakemus = hakemusFactory.builder().withStatus(alluId = alluId).save()
+            val kentat =
+                listOf(
+                    AlluFactory.createInformationRequestField(
+                        InformationRequestFieldKey.CUSTOMER, "Customer is missing"),
+                    AlluFactory.createInformationRequestField(
+                        InformationRequestFieldKey.ATTACHMENT, "Needs a letter of attorney"),
+                )
+            every { alluClient.getInformationRequest(hakemus.alluid!!) } returns
+                AlluFactory.createInformationRequest(applicationAlluId = alluId, fields = kentat)
+
+            taydennysService.saveTaydennyspyyntoFromAllu(hakemus)
+
+            assertThat(taydennyspyyntoRepository.findAll()).single().all {
+                prop(TaydennyspyyntoEntity::alluId)
+                    .isEqualTo(AlluFactory.DEFAULT_INFORMATION_REQUEST_ID)
+                prop(TaydennyspyyntoEntity::applicationId).isEqualTo(hakemus.id)
+                prop(TaydennyspyyntoEntity::kentat)
+                    .containsOnly(
+                        InformationRequestFieldKey.CUSTOMER to "Customer is missing",
+                        InformationRequestFieldKey.ATTACHMENT to "Needs a letter of attorney",
+                    )
+            }
+        }
+    }
+}

--- a/services/hanke-service/src/integrationTest/resources/clear-db.sql
+++ b/services/hanke-service/src/integrationTest/resources/clear-db.sql
@@ -18,6 +18,8 @@ TRUNCATE TABLE
     kayttajakutsu,
     paatos,
     permissions,
+    taydennyspyynnon_kentta,
+    taydennyspyynto,
     tormaystarkastelutulos,
     ui_notification_banner,
     valmistumisilmoitus;

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/AlluApplicationData.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/AlluApplicationData.kt
@@ -59,8 +59,8 @@ data class AlluCableReportApplicationData(
             .toMap()
 }
 
-data class CableReportInformationRequestResponse(
-    val applicationData: AlluCableReportApplicationData,
+data class InformationRequestResponse(
+    val applicationData: AlluApplicationData,
     val updatedFields: List<InformationRequestFieldKey>
 )
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
@@ -38,6 +38,7 @@ import fi.hel.haitaton.hanke.pdf.KaivuilmoitusPdfEncoder
 import fi.hel.haitaton.hanke.permissions.CurrentUserWithoutKayttajaException
 import fi.hel.haitaton.hanke.permissions.HankeKayttajaService
 import fi.hel.haitaton.hanke.permissions.PermissionCode
+import fi.hel.haitaton.hanke.taydennys.TaydennysService
 import fi.hel.haitaton.hanke.toJsonString
 import fi.hel.haitaton.hanke.tormaystarkastelu.TormaystarkasteluLaskentaService
 import fi.hel.haitaton.hanke.valmistumisilmoitus.ValmistumisilmoitusEntity
@@ -81,6 +82,7 @@ class HakemusService(
     private val paatosService: PaatosService,
     private val applicationEventPublisher: ApplicationEventPublisher,
     private val tormaystarkasteluLaskentaService: TormaystarkasteluLaskentaService,
+    private val taydennysService: TaydennysService,
 ) {
 
     @Transactional(readOnly = true)
@@ -604,6 +606,7 @@ class HakemusService(
             }
             ApplicationStatus.WAITING_INFORMATION -> {
                 updateStatus()
+                taydennysService.saveTaydennyspyyntoFromAllu(application)
                 sendInformationRequestEmails(application, event.applicationIdentifier)
             }
             else -> updateStatus()

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennysService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennysService.kt
@@ -1,0 +1,27 @@
+package fi.hel.haitaton.hanke.taydennys
+
+import fi.hel.haitaton.hanke.allu.AlluClient
+import fi.hel.haitaton.hanke.hakemus.HakemusIdentifier
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class TaydennysService(
+    private val taydennyspyyntoRepository: TaydennyspyyntoRepository,
+    private val alluClient: AlluClient,
+) {
+
+    @Transactional
+    fun saveTaydennyspyyntoFromAllu(hakemus: HakemusIdentifier) {
+        val request = alluClient.getInformationRequest(hakemus.alluid!!)
+
+        val entity =
+            TaydennyspyyntoEntity(
+                applicationId = hakemus.id,
+                alluId = request.informationRequestId,
+                kentat = request.fields.associate { it.fieldKey to it.requestDescription },
+            )
+
+        taydennyspyyntoRepository.save(entity)
+    }
+}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennyspyyntoEntity.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennyspyyntoEntity.kt
@@ -1,0 +1,32 @@
+package fi.hel.haitaton.hanke.taydennys
+
+import fi.hel.haitaton.hanke.allu.InformationRequestFieldKey
+import jakarta.persistence.CollectionTable
+import jakarta.persistence.Column
+import jakarta.persistence.ElementCollection
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.FetchType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.MapKeyColumn
+import jakarta.persistence.MapKeyEnumerated
+import jakarta.persistence.Table
+import java.util.UUID
+
+@Entity
+@Table(name = "taydennyspyynto")
+class TaydennyspyyntoEntity(
+    @Id val id: UUID = UUID.randomUUID(),
+    @Column(name = "application_id") val applicationId: Long,
+    @Column(name = "allu_id") val alluId: Int,
+    @ElementCollection(fetch = FetchType.EAGER)
+    @CollectionTable(
+        name = "taydennyspyynnon_kentta",
+        joinColumns = [JoinColumn(name = "taydennyspyynto_id", referencedColumnName = "id")],
+    )
+    @MapKeyColumn(name = "key")
+    @Column(name = "description")
+    @MapKeyEnumerated(EnumType.STRING)
+    val kentat: Map<InformationRequestFieldKey, String> = mutableMapOf(),
+)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennyspyyntoRepository.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennyspyyntoRepository.kt
@@ -1,0 +1,7 @@
+package fi.hel.haitaton.hanke.taydennys
+
+import java.util.UUID
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository interface TaydennyspyyntoRepository : JpaRepository<TaydennyspyyntoEntity, UUID>

--- a/services/hanke-service/src/main/resources/db/changelog/changesets/083-create-tables-for-taydennyspyynto.sql
+++ b/services/hanke-service/src/main/resources/db/changelog/changesets/083-create-tables-for-taydennyspyynto.sql
@@ -1,0 +1,37 @@
+--liquibase formatted sql
+--changeset Topias Heinonen:083-create-tables-for-taydennyspyynto
+--comment: Create tables for taydennyspyynto
+
+CREATE TABLE taydennyspyynto
+(
+    id             uuid                     NOT NULL PRIMARY KEY,
+    application_id bigint                   NOT NULL,
+    allu_id        integer                  NOT NULL,
+    created_at     timestamp with time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT fk_taydennyspyynto_applications FOREIGN KEY (application_id) REFERENCES applications (id) ON DELETE CASCADE,
+    CONSTRAINT uk_taydennyspyynto_application_id UNIQUE (application_id),
+    CONSTRAINT uk_taydennyspyynto_allu_id UNIQUE (allu_id)
+);
+
+COMMENT ON TABLE taydennyspyynto IS 'Information request sent from Allu. Content consists of rows in taydennyspyynnon_kentat.';
+COMMENT ON COLUMN taydennyspyynto.id IS 'The haitaton ID for this information request.';
+COMMENT ON COLUMN taydennyspyynto.application_id IS 'Application this information request is directed at.';
+COMMENT ON COLUMN taydennyspyynto.allu_id IS 'The ID this information request has in Allu.';
+COMMENT ON COLUMN taydennyspyynto.created_at IS 'The time this object was created.';
+
+
+CREATE TABLE taydennyspyynnon_kentta
+(
+    taydennyspyynto_id uuid                     NOT NULL,
+    key                text                     NOT NULL,
+    description        text                     NOT NULL,
+    created_at         timestamp with time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (taydennyspyynto_id, key),
+    CONSTRAINT fk_taydennyspyynnon_kentat_applications FOREIGN KEY (taydennyspyynto_id) REFERENCES taydennyspyynto (id) ON DELETE CASCADE
+);
+
+COMMENT ON TABLE taydennyspyynnon_kentta IS 'A comment on a single field set in the application. The taydennyspyynto consists of a bunch of these.';
+COMMENT ON COLUMN taydennyspyynnon_kentta.taydennyspyynto_id IS 'The taydennyspyynto this comment is a part of.';
+COMMENT ON COLUMN taydennyspyynnon_kentta.key IS 'The field set this comment is for. One of the values in InformationRequestFieldKey in the backend.';
+COMMENT ON COLUMN taydennyspyynnon_kentta.description IS 'The comment the handler in Allu has written concerning this field set.';
+COMMENT ON COLUMN taydennyspyynnon_kentta.created_at IS 'The time this object was created.';

--- a/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -193,3 +193,5 @@ databaseChangeLog:
       file: db/changelog/changesets/081-create-valmistumisilmoitukset.sql
   - include:
       file: db/changelog/changesets/082-rename-ytunnus-to-registry-key-for-hakemusyhteystieto.sql
+  - include:
+      file: db/changelog/changesets/083-create-tables-for-taydennyspyynto.sql

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/AlluFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/AlluFactory.kt
@@ -9,11 +9,17 @@ import fi.hel.haitaton.hanke.allu.Contact
 import fi.hel.haitaton.hanke.allu.Customer
 import fi.hel.haitaton.hanke.allu.CustomerType
 import fi.hel.haitaton.hanke.allu.CustomerWithContacts
+import fi.hel.haitaton.hanke.allu.InformationRequest
+import fi.hel.haitaton.hanke.allu.InformationRequestField
+import fi.hel.haitaton.hanke.allu.InformationRequestFieldKey
 import java.time.ZonedDateTime
 import org.geojson.GeometryCollection
 import org.springframework.http.MediaType
 
 object AlluFactory {
+    const val DEFAULT_INFORMATION_REQUEST_ID = 248765
+    const val DEFAULT_INFORMATION_REQUEST_DESCRIPTION = "Default change request for a field."
+
     fun createAlluApplicationResponse(
         id: Int = 42,
         status: ApplicationStatus = ApplicationStatus.PENDING,
@@ -122,6 +128,22 @@ object AlluFactory {
             trafficArrangements = null,
             trafficArrangementImpediment = null,
         )
+
+    fun createInformationRequest(
+        applicationAlluId: Int = 1,
+        informationRequestId: Int = DEFAULT_INFORMATION_REQUEST_ID,
+        fields: List<InformationRequestField> = listOf(createInformationRequestField()),
+    ): InformationRequest =
+        InformationRequest(
+            applicationId = applicationAlluId,
+            informationRequestId = informationRequestId,
+            fields = fields,
+        )
+
+    fun createInformationRequestField(
+        fieldKey: InformationRequestFieldKey = InformationRequestFieldKey.OTHER,
+        requestDescription: String = "Default change request for a field.",
+    ) = InformationRequestField(requestDescription, fieldKey)
 
     val customer =
         Customer(

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceTest.kt
@@ -43,6 +43,7 @@ import fi.hel.haitaton.hanke.logging.HankeLoggingService
 import fi.hel.haitaton.hanke.logging.Status
 import fi.hel.haitaton.hanke.paatos.PaatosService
 import fi.hel.haitaton.hanke.permissions.HankeKayttajaService
+import fi.hel.haitaton.hanke.taydennys.TaydennysService
 import fi.hel.haitaton.hanke.test.AlluException
 import fi.hel.haitaton.hanke.test.USERNAME
 import fi.hel.haitaton.hanke.tormaystarkastelu.TormaystarkasteluLaskentaService
@@ -93,6 +94,7 @@ class HakemusServiceTest {
     private val paatosService: PaatosService = mockk()
     private val publisher: ApplicationEventPublisher = mockk()
     private val tormaystarkasteluLaskentaService: TormaystarkasteluLaskentaService = mockk()
+    private val taydennysService: TaydennysService = mockk()
 
     private val hakemusService =
         HakemusService(
@@ -110,6 +112,7 @@ class HakemusServiceTest {
             paatosService,
             publisher,
             tormaystarkasteluLaskentaService,
+            taydennysService,
         )
 
     @BeforeEach


### PR DESCRIPTION
# Description
When the application status changes to WAITING_INFORMATION, get the information request from Allu and save it to Haitaton.

Create tables for storing the information requests. Change `getInformationRequest` to return a single request instead of a list. Add tests for it.

Also, refactor `AlluClient.respondToInformationRequest` to handle both cable reports and excavation notifications. This isn't used yet, but I needed it while experimenting.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2703

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
1. Send a hakemus to Allu.
2. Create an information request for the application in Allu.
3. After a minute, the database should have the information request info in the `taydennyspyynto` and `taydennyspyynnon_kentta` tables.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 