### PR TITLE
HAI-2812 Remove henkilotunnus from accompanying johtoselvitys

### DIFF
--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/Hakemus.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/Hakemus.kt
@@ -16,7 +16,7 @@ data class Hakemus(
     override val alluid: Int?,
     val alluStatus: ApplicationStatus?,
     override val applicationIdentifier: String?,
-    val applicationType: ApplicationType,
+    override val applicationType: ApplicationType,
     val applicationData: HakemusData,
     val hankeTunnus: String,
     val hankeId: Int,
@@ -180,8 +180,10 @@ interface HakemusIdentifier : HasId<Long> {
     override val id: Long
     val alluid: Int?
     val applicationIdentifier: String?
+    val applicationType: ApplicationType
 
-    fun logString() = "Hakemus: (id=$id, alluId=$alluid, identifier=$applicationIdentifier)"
+    fun logString() =
+        "Hakemus: (id=$id, alluId=$alluid, identifier=$applicationIdentifier, type=$applicationType)"
 }
 
 /** Without application data, just the identifiers and metadata. */
@@ -190,6 +192,6 @@ data class HakemusMetaData(
     override val alluid: Int?,
     val alluStatus: ApplicationStatus?,
     override val applicationIdentifier: String?,
-    val applicationType: ApplicationType,
+    override val applicationType: ApplicationType,
     val hankeTunnus: String,
 ) : HakemusIdentifier

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusEntity.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusEntity.kt
@@ -30,7 +30,7 @@ data class HakemusEntity(
     @Enumerated(EnumType.STRING) var alluStatus: ApplicationStatus?,
     override var applicationIdentifier: String?,
     var userId: String?,
-    @Enumerated(EnumType.STRING) val applicationType: ApplicationType,
+    @Enumerated(EnumType.STRING) override val applicationType: ApplicationType,
     @Type(JsonType::class)
     @Column(columnDefinition = "jsonb", name = "applicationdata")
     var hakemusEntityData: HakemusEntityData,

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
@@ -276,8 +276,7 @@ class HakemusService(
             hakemus.alluStatus = response.status
         }
 
-        logger.info(
-            "Sent hakemus ${hakemus.applicationType}. ${hakemus.logString()}, alluStatus = ${hakemus.alluStatus}")
+        logger.info("Sent hakemus. ${hakemus.logString()}, alluStatus = ${hakemus.alluStatus}")
         // Save only if sendApplicationToAllu didn't throw an exception
         return hakemusRepository.save(hakemus).toHakemus()
     }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
@@ -15,6 +15,7 @@ import fi.hel.haitaton.hanke.allu.ApplicationStatus
 import fi.hel.haitaton.hanke.allu.ApplicationStatusEvent
 import fi.hel.haitaton.hanke.allu.Attachment
 import fi.hel.haitaton.hanke.allu.AttachmentMetadata
+import fi.hel.haitaton.hanke.allu.CustomerType
 import fi.hel.haitaton.hanke.attachment.application.ApplicationAttachmentService
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType
 import fi.hel.haitaton.hanke.daysBetween
@@ -254,14 +255,10 @@ class HakemusService(
 
         // For excavation announcements, a cable report can be applied for at the same time.
         // If so, it should be sent before the excavation announcement.
-        val accompanyingJohtoselvityshakemus =
-            createAccompanyingJohtoselvityshakemus(hakemus, currentUserId)
-        if (accompanyingJohtoselvityshakemus != null) {
-            val sentJohtoselvityshakemus =
-                sendHakemus(
-                    accompanyingJohtoselvityshakemus.id, paperDecisionReceiver, currentUserId)
-            // add the application identifier of the cable report to the list of cable reports in
-            // the excavation announcement
+        createAccompanyingJohtoselvityshakemus(hakemus, currentUserId)?.let {
+            val sentJohtoselvityshakemus = sendHakemus(it.id, paperDecisionReceiver, currentUserId)
+            // Add the application identifier of the cable report to the list of cable reports
+            // in the excavation announcement
             val hakemusEntityData = hakemus.hakemusEntityData as KaivuilmoitusEntityData
             val cableReports = hakemusEntityData.cableReports ?: emptyList()
             hakemus.hakemusEntityData =
@@ -279,7 +276,8 @@ class HakemusService(
             hakemus.alluStatus = response.status
         }
 
-        logger.info("Sent hakemus. ${hakemus.logString()}, alluStatus = ${hakemus.alluStatus}")
+        logger.info(
+            "Sent hakemus ${hakemus.applicationType}. ${hakemus.logString()}, alluStatus = ${hakemus.alluStatus}")
         // Save only if sendApplicationToAllu didn't throw an exception
         return hakemusRepository.save(hakemus).toHakemus()
     }
@@ -321,8 +319,15 @@ class HakemusService(
                 hakemusEntityData = johtoselvityshakemusData,
                 hanke = hakemus.hanke,
             )
-        johtoselvityshakemus.yhteystiedot.putAll(
-            hakemus.yhteystiedot.mapValues { it.value.copyWithHakemus(johtoselvityshakemus) })
+        val yhteystiedot =
+            hakemus.yhteystiedot.mapValues { it.value.copyWithHakemus(johtoselvityshakemus) }
+        // In johtoselvityshakemus, person and other type customers don't need to have registry
+        // keys, so they should be removed.
+        yhteystiedot.values
+            .filter { it.tyyppi in listOf(CustomerType.PERSON, CustomerType.OTHER) }
+            .forEach { it.registryKey = null }
+        johtoselvityshakemus.yhteystiedot.putAll(yhteystiedot)
+
         val savedJohtoselvityshakemus = hakemusRepository.save(johtoselvityshakemus)
         copyOtherAttachments(hakemus, savedJohtoselvityshakemus)
         logger.info(


### PR DESCRIPTION
# Description

When a kaivuilmoitus has a person customer, henkilotunnus is mandatory for them. When an accompanying johtoselvityshakemus is created, the henkilotunnus has been copied to the created application. This causes problems when sending the application to Allu, because johtoselvityshakemus doesn't support registry keys for person customers.

Solve this dilemma by removing the registry keys from any person customers.

Johtoselvityshakemus isn't invoiced and doesn't have invoicing information, so we don't have to care about the registry key there.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2812

## Type of change

- [x] Bug fix 
- [ ] New feature 
- [ ] Other

# Instructions for testing
1. Create a kaivuilmoitus with the apply for cable report set on.
2. For the customer (työstä vastaava) select a person and give them a henkilötunnus.
3. Send the application to Allu.
4. The send should succeed.
5. The created johtoselvityshakemus doesn't have a registry key for the customer.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 