### PR TITLE
HAI Remove archaic hankeyhteystieto locking system

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
@@ -829,25 +829,6 @@ class HankeServiceITests(
         }"""
 
     /**
-     * Clear all information fields from the yhteystieto. Returns a copy.
-     *
-     * The fields are set to empty strings instead of nulls, since nulls are interpreted as "no
-     * change" in update operations.
-     *
-     * Follows [fi.hel.haitaton.hanke.domain.Yhteystieto.isAnyFieldSet] in which fields are emptied.
-     */
-    private fun clearYhteystieto(yhteystieto: HankeYhteystieto) =
-        yhteystieto.copy(
-            nimi = "",
-            email = "",
-            puhelinnumero = "",
-            organisaatioNimi = "",
-            osasto = "",
-            rooli = "",
-            ytunnus = "",
-        )
-
-    /**
      * Find all audit logs for a specific object type. Getting all and filtering would obviously not
      * be acceptable in production, but in tests we usually have a very limited number of entities
      * at any one test.

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeYhteystietoEntity.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeYhteystietoEntity.kt
@@ -47,10 +47,6 @@ class HankeYhteystietoEntity(
     /** For contacts with tyyppi other than YKSITYISHENKILO. */
     @JsonView(ChangeLogView::class) @Column(name = "y_tunnus") var ytunnus: String? = null,
 
-    // Personal data processing restriction (or other needs to prevent changes)
-    @JsonView(NotInChangeLogView::class) var dataLocked: Boolean? = false,
-    @JsonView(NotInChangeLogView::class) var dataLockInfo: String? = null,
-
     // NOTE: createdByUserId must be non-null for valid data, but to allow creating instances with
     // no-arg constructor and programming convenience, this class allows it to be null
     // (temporarily).
@@ -68,7 +64,7 @@ class HankeYhteystietoEntity(
         fetch = FetchType.LAZY,
         mappedBy = "hankeYhteystieto",
         cascade = [CascadeType.ALL],
-        orphanRemoval = true
+        orphanRemoval = true,
     )
     var yhteyshenkilot: MutableList<HankeYhteyshenkiloEntity> = mutableListOf(),
 ) {
@@ -156,8 +152,6 @@ class HankeYhteystietoEntity(
                 osasto = hankeYht.osasto,
                 rooli = hankeYht.rooli,
                 tyyppi = hankeYht.tyyppi,
-                dataLocked = false,
-                dataLockInfo = null,
                 createdByUserId = createdByUserId,
                 createdAt = getCurrentTimeUTCAsLocalTime(),
                 id = hankeYht.id,

--- a/services/hanke-service/src/main/resources/db/changelog/changesets/084-remove-datalock-from-hankeyhteystieto.sql
+++ b/services/hanke-service/src/main/resources/db/changelog/changesets/084-remove-datalock-from-hankeyhteystieto.sql
@@ -1,0 +1,7 @@
+--liquibase formatted sql
+--changeset Topias Heinonen:084-remove-datalock-from-hankeyhteystieto
+--comment: Remove the columns related to locking yhteystieto data
+
+ALTER TABLE hankeyhteystieto
+    DROP COLUMN datalocked,
+    DROP COLUMN datalockinfo;

--- a/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -195,3 +195,5 @@ databaseChangeLog:
       file: db/changelog/changesets/082-rename-ytunnus-to-registry-key-for-hakemusyhteystieto.sql
   - include:
       file: db/changelog/changesets/083-create-tables-for-taydennyspyynto.sql
+  - include:
+      file: db/changelog/changesets/084-remove-datalock-from-hankeyhteystieto.sql

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeYhteystietoFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeYhteystietoFactory.kt
@@ -66,8 +66,6 @@ object HankeYhteystietoFactory {
                     organisaatioNimi = organisaatioNimi,
                     osasto = osasto,
                     rooli = rooli,
-                    dataLocked = false,
-                    dataLockInfo = "info",
                     createdByUserId = createdBy,
                     createdAt = createdAt?.toLocalDateTime(),
                     modifiedByUserId = modifiedBy,
@@ -78,7 +76,7 @@ object HankeYhteystietoFactory {
                     yhteyshenkilot =
                         mutableListOf(
                             HankeYhteyshenkiloFactory.createEntity(id * 2, this),
-                            HankeYhteyshenkiloFactory.createEntity(id * 2 + 1, this)
+                            HankeYhteyshenkiloFactory.createEntity(id * 2 + 1, this),
                         )
                 }
         }


### PR DESCRIPTION
# Description

There's an old system for disabling edits to hankeyhteystieto. There's a `datalocked` boolean flag in the hankeyhteystieto database table. When it's set to true (by someone manually editing the database), updates to the hanke are refused if they try to change that yhteystieto.

It seems like this system has been born out of a misunderstanding of what data processing restrictions mean in GDPR. It's been interpreted that it means that personal information cannot be edited. In reality, it's a broader concept. If someone asks us to restrict the processing of their personal data, we can't even store it without a valid reason. The GDPR API and the Profiili UI handle this, if someone wants to remove their information, we remove it unless we have a reason why we can't do so.

Since the system is unused and fundamentally flawed, it's best to remove it so it doesn't have to be maintained in the future.

### Jira Issue: -

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [X] Other