### PR TITLE
HAI-2748 Refactor logging services

### DIFF
--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/ChangeLoggingService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/ChangeLoggingService.kt
@@ -1,0 +1,28 @@
+package fi.hel.haitaton.hanke.logging
+
+import fi.hel.haitaton.hanke.domain.HasId
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
+
+abstract class ChangeLoggingService<ID, T : HasId<ID>>(
+    private val auditLogService: AuditLogService
+) {
+    abstract val objectType: ObjectType
+
+    @Transactional(propagation = Propagation.MANDATORY)
+    open fun logCreate(saved: T, userId: String) {
+        auditLogService.create(AuditLogService.createEntry(userId, objectType, saved))
+    }
+
+    @Transactional(propagation = Propagation.MANDATORY)
+    open fun logUpdate(before: T, after: T, userId: String) {
+        AuditLogService.updateEntry(userId, objectType, before, after)?.let {
+            auditLogService.create(it)
+        }
+    }
+
+    @Transactional(propagation = Propagation.MANDATORY)
+    open fun logDelete(before: T, userId: String) {
+        auditLogService.create(AuditLogService.deleteEntry(userId, objectType, before))
+    }
+}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/HakemusLoggingService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/HakemusLoggingService.kt
@@ -2,30 +2,9 @@ package fi.hel.haitaton.hanke.logging
 
 import fi.hel.haitaton.hanke.hakemus.Hakemus
 import org.springframework.stereotype.Service
-import org.springframework.transaction.annotation.Propagation
-import org.springframework.transaction.annotation.Transactional
 
 @Service
-class HakemusLoggingService(private val auditLogService: AuditLogService) {
-
-    @Transactional(propagation = Propagation.MANDATORY)
-    fun logCreate(savedHakemus: Hakemus, userId: String) {
-        auditLogService.create(
-            AuditLogService.createEntry(userId, ObjectType.HAKEMUS, savedHakemus)
-        )
-    }
-
-    @Transactional(propagation = Propagation.MANDATORY)
-    fun logUpdate(hakemusBefore: Hakemus, hakemusAfter: Hakemus, userId: String) {
-        AuditLogService.updateEntry(userId, ObjectType.HAKEMUS, hakemusBefore, hakemusAfter)?.let {
-            auditLogService.create(it)
-        }
-    }
-
-    @Transactional(propagation = Propagation.MANDATORY)
-    fun logDelete(hakemusBefore: Hakemus, userId: String) {
-        auditLogService.create(
-            AuditLogService.deleteEntry(userId, ObjectType.HAKEMUS, hakemusBefore)
-        )
-    }
+class HakemusLoggingService(auditLogService: AuditLogService) :
+    ChangeLoggingService<Long, Hakemus>(auditLogService) {
+    override val objectType: ObjectType = ObjectType.HAKEMUS
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/HankeKayttajaLoggingService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/HankeKayttajaLoggingService.kt
@@ -2,12 +2,16 @@ package fi.hel.haitaton.hanke.logging
 
 import fi.hel.haitaton.hanke.permissions.HankeKayttaja
 import fi.hel.haitaton.hanke.permissions.KayttajaTunniste
+import java.util.UUID
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
 
 @Service
-class HankeKayttajaLoggingService(private val auditLogService: AuditLogService) {
+class HankeKayttajaLoggingService(private val auditLogService: AuditLogService) :
+    ChangeLoggingService<UUID, HankeKayttaja>(auditLogService) {
+
+    override val objectType: ObjectType = ObjectType.HANKE_KAYTTAJA
 
     @Transactional(propagation = Propagation.MANDATORY)
     fun logUpdate(
@@ -27,28 +31,12 @@ class HankeKayttajaLoggingService(private val auditLogService: AuditLogService) 
     @Transactional(propagation = Propagation.MANDATORY)
     fun logCreate(kayttajaTunniste: KayttajaTunniste, userId: String) {
         auditLogService.create(
-            AuditLogService.createEntry(userId, ObjectType.KAYTTAJA_TUNNISTE, kayttajaTunniste)
-        )
+            AuditLogService.createEntry(userId, ObjectType.KAYTTAJA_TUNNISTE, kayttajaTunniste))
     }
 
     @Transactional(propagation = Propagation.MANDATORY)
     fun logDelete(tunniste: KayttajaTunniste, currentUserId: String) {
         auditLogService.create(
-            AuditLogService.deleteEntry(currentUserId, ObjectType.KAYTTAJA_TUNNISTE, tunniste)
-        )
-    }
-
-    @Transactional(propagation = Propagation.MANDATORY)
-    fun logCreate(hankeKayttaja: HankeKayttaja, currentUser: String) {
-        auditLogService.create(
-            AuditLogService.createEntry(currentUser, ObjectType.HANKE_KAYTTAJA, hankeKayttaja)
-        )
-    }
-
-    @Transactional(propagation = Propagation.MANDATORY)
-    fun logDelete(hankeKayttaja: HankeKayttaja, currentUserId: String) {
-        auditLogService.create(
-            AuditLogService.deleteEntry(currentUserId, ObjectType.HANKE_KAYTTAJA, hankeKayttaja)
-        )
+            AuditLogService.deleteEntry(currentUserId, ObjectType.KAYTTAJA_TUNNISTE, tunniste))
     }
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/PermissionLoggingService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/PermissionLoggingService.kt
@@ -7,7 +7,10 @@ import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
 
 @Service
-class PermissionLoggingService(private val auditLogService: AuditLogService) {
+class PermissionLoggingService(private val auditLogService: AuditLogService) :
+    ChangeLoggingService<Int, Permission>(auditLogService) {
+    override val objectType: ObjectType = ObjectType.PERMISSION
+
     @Transactional(propagation = Propagation.MANDATORY)
     fun logUpdate(
         kayttooikeustasoBefore: Kayttooikeustaso,
@@ -17,25 +20,7 @@ class PermissionLoggingService(private val auditLogService: AuditLogService) {
         val permissionBefore = permissionAfter.copy(kayttooikeustaso = kayttooikeustasoBefore)
 
         AuditLogService.updateEntry(
-                userId,
-                ObjectType.PERMISSION,
-                permissionBefore,
-                permissionAfter,
-            )
+                userId, ObjectType.PERMISSION, permissionBefore, permissionAfter)
             ?.let { auditLogService.create(it) }
-    }
-
-    @Transactional(propagation = Propagation.MANDATORY)
-    fun logCreate(permission: Permission, userId: String) {
-        auditLogService.create(
-            AuditLogService.createEntry(userId, ObjectType.PERMISSION, permission)
-        )
-    }
-
-    @Transactional(propagation = Propagation.MANDATORY)
-    fun logDelete(permission: Permission, currentUserId: String) {
-        auditLogService.create(
-            AuditLogService.deleteEntry(currentUserId, ObjectType.PERMISSION, permission)
-        )
     }
 }


### PR DESCRIPTION
# Description

Create an abstract class for the change logging services. They have very similar methods with just a couple of changed parameters, so implementing them only once makes sense. Some have extra methods, so they are left in place. HankeLoggingService has a differing implementation for logging deletes, so it overrides the default.

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [X] Other