### PR TITLE
HAI-2770 Add täydennys to hakemus response

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennysServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennysServiceITest.kt
@@ -16,7 +16,9 @@ import fi.hel.haitaton.hanke.allu.AlluClient
 import fi.hel.haitaton.hanke.allu.ApplicationStatus
 import fi.hel.haitaton.hanke.allu.InformationRequestFieldKey
 import fi.hel.haitaton.hanke.factory.AlluFactory
+import fi.hel.haitaton.hanke.factory.AlluFactory.customer
 import fi.hel.haitaton.hanke.factory.HakemusFactory
+import fi.hel.haitaton.hanke.factory.TaydennysFactory
 import fi.hel.haitaton.hanke.factory.TaydennyspyyntoFactory
 import fi.hel.haitaton.hanke.findByType
 import fi.hel.haitaton.hanke.hakemus.HakemusData
@@ -53,6 +55,7 @@ class TaydennysServiceITest(
     @Autowired private val alluClient: AlluClient,
     @Autowired private val hakemusFactory: HakemusFactory,
     @Autowired private val taydennyspyyntoFactory: TaydennyspyyntoFactory,
+    @Autowired private val taydennysFactory: TaydennysFactory,
     @Autowired private val auditLogRepository: AuditLogRepository,
 ) : IntegrationTest() {
     private val alluId = 3464
@@ -86,6 +89,26 @@ class TaydennysServiceITest(
             val result = taydennysService.findTaydennyspyynto(hakemus.id)
 
             assertThat(result).isEqualTo(taydennyspyynto)
+        }
+    }
+
+    @Nested
+    inner class FindTaydennys {
+        @Test
+        fun `returns null when taydennys doesn't exist`() {
+            val result = taydennysService.findTaydennys(1L)
+
+            assertThat(result).isNull()
+        }
+
+        @Test
+        fun `returns taydennys when it exists`() {
+            val hakemus = hakemusFactory.builder().withStatus().save()
+            val taydennys = taydennysFactory.save(applicationId = hakemus.id)
+
+            val result = taydennysService.findTaydennys(hakemus.id)
+
+            assertThat(result).isEqualTo(taydennys)
         }
     }
 

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennysServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennysServiceITest.kt
@@ -16,7 +16,6 @@ import fi.hel.haitaton.hanke.allu.AlluClient
 import fi.hel.haitaton.hanke.allu.ApplicationStatus
 import fi.hel.haitaton.hanke.allu.InformationRequestFieldKey
 import fi.hel.haitaton.hanke.factory.AlluFactory
-import fi.hel.haitaton.hanke.factory.AlluFactory.customer
 import fi.hel.haitaton.hanke.factory.HakemusFactory
 import fi.hel.haitaton.hanke.factory.TaydennysFactory
 import fi.hel.haitaton.hanke.factory.TaydennyspyyntoFactory

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusController.kt
@@ -70,6 +70,9 @@ class HakemusController(
         logger.info { "Finding application $id" }
         val response = hakemusService.getWithExtras(id).toResponse()
         disclosureLogService.saveDisclosureLogsForHakemusResponse(response.hakemus, currentUserId())
+        response.taydennys?.let {
+            disclosureLogService.saveDisclosureLogsForTaydennys(it, currentUserId())
+        }
         return response
     }
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
@@ -84,7 +84,8 @@ class HakemusService(
         val hakemus = getById(hakemusId)
         val paatokset = paatosService.findByHakemusId(hakemusId)
         val taydennyspyynto = taydennysService.findTaydennyspyynto(hakemusId)
-        return HakemusWithExtras(hakemus, paatokset, taydennyspyynto)
+        val taydennys = taydennysService.findTaydennys(hakemusId)
+        return HakemusWithExtras(hakemus, paatokset, taydennyspyynto, taydennys)
     }
 
     @Transactional(readOnly = true)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusWithExtras.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusWithExtras.kt
@@ -3,6 +3,8 @@ package fi.hel.haitaton.hanke.hakemus
 import com.fasterxml.jackson.annotation.JsonUnwrapped
 import fi.hel.haitaton.hanke.paatos.Paatos
 import fi.hel.haitaton.hanke.paatos.PaatosResponse
+import fi.hel.haitaton.hanke.taydennys.Taydennys
+import fi.hel.haitaton.hanke.taydennys.TaydennysResponse
 import fi.hel.haitaton.hanke.taydennys.Taydennyspyynto
 import fi.hel.haitaton.hanke.taydennys.TaydennyspyyntoResponse
 
@@ -10,12 +12,14 @@ data class HakemusWithExtras(
     val hakemus: Hakemus,
     val paatokset: List<Paatos>,
     val taydennyspyynto: Taydennyspyynto?,
+    val taydennys: Taydennys?,
 ) {
     fun toResponse(): HakemusWithExtrasResponse =
         HakemusWithExtrasResponse(
             hakemus.toResponse(),
             paatokset.map { it.toResponse() }.groupBy { it.hakemustunnus },
             taydennyspyynto?.toResponse(),
+            taydennys?.toResponse(),
         )
 }
 
@@ -23,4 +27,5 @@ data class HakemusWithExtrasResponse(
     @JsonUnwrapped val hakemus: HakemusResponse,
     val paatokset: Map<String, List<PaatosResponse>>,
     val taydennyspyynto: TaydennyspyyntoResponse?,
+    val taydennys: TaydennysResponse?,
 )

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusFactory.kt
@@ -25,6 +25,7 @@ import fi.hel.haitaton.hanke.hakemus.PaperDecisionReceiver
 import fi.hel.haitaton.hanke.hakemus.PostalAddress
 import fi.hel.haitaton.hanke.paatos.Paatos
 import fi.hel.haitaton.hanke.permissions.HankeKayttajaService
+import fi.hel.haitaton.hanke.taydennys.Taydennys
 import fi.hel.haitaton.hanke.taydennys.Taydennyspyynto
 import fi.hel.haitaton.hanke.test.USERNAME
 import fi.hel.haitaton.hanke.valmistumisilmoitus.Valmistumisilmoitus
@@ -236,31 +237,10 @@ class HakemusFactory(
                 hanke = hanke,
             )
 
-        fun createWithPaatokset(
-            id: Long = 1,
-            alluid: Int? = null,
-            alluStatus: ApplicationStatus? = null,
-            applicationIdentifier: String? = null,
-            applicationType: ApplicationType = ApplicationType.CABLE_REPORT,
-            applicationData: HakemusData = createHakemusData(applicationType),
-            hankeTunnus: String = "HAI-1234",
-            hankeId: Int = 1,
-            paatokset: List<Paatos>,
+        fun Hakemus.withExtras(
+            paatokset: List<Paatos> = listOf(),
             taydennyspyynto: Taydennyspyynto? = null,
-        ) =
-            HakemusWithExtras(
-                create(
-                    id,
-                    alluid,
-                    alluStatus,
-                    applicationIdentifier,
-                    applicationType,
-                    applicationData,
-                    hankeTunnus,
-                    hankeId,
-                ),
-                paatokset,
-                taydennyspyynto,
-            )
+            taydennys: Taydennys? = null,
+        ) = HakemusWithExtras(this, paatokset, taydennyspyynto, taydennys)
     }
 }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/TaydennysFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/TaydennysFactory.kt
@@ -1,0 +1,38 @@
+package fi.hel.haitaton.hanke.factory
+
+import fi.hel.haitaton.hanke.hakemus.HakemusData
+import fi.hel.haitaton.hanke.hakemus.HakemusEntityData
+import fi.hel.haitaton.hanke.taydennys.Taydennys
+import fi.hel.haitaton.hanke.taydennys.TaydennysEntity
+import fi.hel.haitaton.hanke.taydennys.TaydennysRepository
+import fi.hel.haitaton.hanke.taydennys.TaydennyspyyntoEntity
+import java.util.UUID
+import org.springframework.stereotype.Component
+
+@Component
+class TaydennysFactory(
+    private val taydennysRepository: TaydennysRepository,
+    private val taydennyspyyntoFactory: TaydennyspyyntoFactory,
+) {
+    fun save(
+        id: UUID = DEFAULT_ID,
+        applicationId: Long? = null,
+        taydennyspyynto: TaydennyspyyntoEntity =
+            applicationId?.let { taydennyspyyntoFactory.saveEntity(it) }
+                ?: throw RuntimeException(),
+        hakemusData: HakemusEntityData = ApplicationFactory.createCableReportApplicationData()
+    ): Taydennys =
+        TaydennysEntity(id, taydennyspyynto, hakemusData)
+            .let { taydennysRepository.save(it) }
+            .toDomain()
+
+    companion object {
+        val DEFAULT_ID: UUID = UUID.fromString("49ee9168-a1e3-45a1-8fe0-9330cd5475d3")
+
+        fun create(
+            id: UUID = DEFAULT_ID,
+            taydennyspyyntoId: UUID = TaydennyspyyntoFactory.DEFAULT_ID,
+            hakemusData: HakemusData = HakemusFactory.createJohtoselvityshakemusData()
+        ) = Taydennys(id, taydennyspyyntoId, hakemusData)
+    }
+}

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/TaydennyspyyntoFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/TaydennyspyyntoFactory.kt
@@ -15,7 +15,14 @@ class TaydennyspyyntoFactory(private val taydennyspyyntoRepository: Taydennyspyy
         alluId: Int = DEFAULT_ALLU_ID,
         kentat: Map<InformationRequestFieldKey, String> = DEFAULT_KENTAT,
         mutator: TaydennyspyyntoEntity.() -> Unit = {},
-    ): Taydennyspyynto {
+    ): Taydennyspyynto = saveEntity(applicationId, alluId, kentat, mutator).toDomain()
+
+    fun saveEntity(
+        applicationId: Long,
+        alluId: Int = DEFAULT_ALLU_ID,
+        kentat: Map<InformationRequestFieldKey, String> = DEFAULT_KENTAT,
+        mutator: TaydennyspyyntoEntity.() -> Unit = {},
+    ): TaydennyspyyntoEntity {
         val entity =
             TaydennyspyyntoEntity(
                 applicationId = applicationId,
@@ -23,7 +30,7 @@ class TaydennyspyyntoFactory(private val taydennyspyyntoRepository: Taydennyspyy
                 kentat = kentat.toMutableMap(),
             )
         mutator(entity)
-        return taydennyspyyntoRepository.save(entity).toDomain()
+        return taydennyspyyntoRepository.save(entity)
     }
 
     companion object {


### PR DESCRIPTION
# Description

If a hakemus has a täydennys draft, return it with the hakemus data when querying for a single hakemus.

Add tests for `TaydennysService.findTaydennys()`, which was previously only needed in tests.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2770

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
1. Create a täydennys like in #848 
2. Check the return value of the single hakemus API, easiest with browser developer tools. It should have `taydennys` object with the created täydennys.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 