### PR TITLE
HAI-2770 Refactor disclosure logging using an aspect

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeControllerITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeControllerITests.kt
@@ -28,6 +28,7 @@ import fi.hel.haitaton.hanke.tormaystarkastelu.Meluhaitta
 import fi.hel.haitaton.hanke.tormaystarkastelu.Polyhaitta
 import fi.hel.haitaton.hanke.tormaystarkastelu.Tarinahaitta
 import fi.hel.haitaton.hanke.tormaystarkastelu.VaikutusAutoliikenteenKaistamaariin
+import io.mockk.Called
 import io.mockk.checkUnnecessaryStub
 import io.mockk.clearAllMocks
 import io.mockk.confirmVerified
@@ -125,7 +126,7 @@ class HankeControllerITests(@Autowired override val mockMvc: MockMvc) : Controll
             verifySequence {
                 authorizer.authorizeHankeTunnus(HANKE_TUNNUS, PermissionCode.VIEW.name)
                 hankeService.loadHanke(HANKE_TUNNUS)
-                disclosureLogService.saveDisclosureLogsForHanke(hanke, USERNAME)
+                disclosureLogService.saveForHanke(hanke, USERNAME)
             }
         }
 
@@ -141,8 +142,7 @@ class HankeControllerITests(@Autowired override val mockMvc: MockMvc) : Controll
                         autoliikenne = autoliikenne,
                         pyoraliikenneindeksi = pyoraliikenneindeksi,
                         linjaautoliikenneindeksi = linjaautoliikenneindeksi,
-                        raitioliikenneindeksi = raitioliikenneindeksi
-                    )
+                        raitioliikenneindeksi = raitioliikenneindeksi)
             every { hankeService.loadHanke(HANKE_TUNNUS) }.returns(hanke)
             every {
                 authorizer.authorizeHankeTunnus(HANKE_TUNNUS, PermissionCode.VIEW.name)
@@ -152,54 +152,43 @@ class HankeControllerITests(@Autowired override val mockMvc: MockMvc) : Controll
                 .andExpect(status().isOk)
                 .andExpect(
                     jsonPath("tormaystarkasteluTulos.autoliikenne.haitanKesto")
-                        .value(autoliikenne.haitanKesto)
-                )
+                        .value(autoliikenne.haitanKesto))
                 .andExpect(
                     jsonPath("tormaystarkasteluTulos.autoliikenne.katuluokka")
-                        .value(autoliikenne.katuluokka)
-                )
+                        .value(autoliikenne.katuluokka))
                 .andExpect(
                     jsonPath("tormaystarkasteluTulos.autoliikenne.liikennemaara")
-                        .value(autoliikenne.liikennemaara)
-                )
+                        .value(autoliikenne.liikennemaara))
                 .andExpect(
                     jsonPath("tormaystarkasteluTulos.autoliikenne.kaistahaitta")
-                        .value(autoliikenne.kaistahaitta)
-                )
+                        .value(autoliikenne.kaistahaitta))
                 .andExpect(
                     jsonPath("tormaystarkasteluTulos.autoliikenne.kaistapituushaitta")
-                        .value(autoliikenne.kaistapituushaitta)
-                )
+                        .value(autoliikenne.kaistapituushaitta))
                 .andExpect(
                     jsonPath("tormaystarkasteluTulos.autoliikenne.indeksi")
-                        .value(autoliikenne.indeksi)
-                )
+                        .value(autoliikenne.indeksi))
                 .andExpect(
                     jsonPath("tormaystarkasteluTulos.pyoraliikenneindeksi")
-                        .value(pyoraliikenneindeksi)
-                )
+                        .value(pyoraliikenneindeksi))
                 .andExpect(
                     jsonPath("tormaystarkasteluTulos.linjaautoliikenneindeksi")
-                        .value(linjaautoliikenneindeksi)
-                )
+                        .value(linjaautoliikenneindeksi))
                 .andExpect(
                     jsonPath("tormaystarkasteluTulos.raitioliikenneindeksi")
-                        .value(raitioliikenneindeksi)
-                )
+                        .value(raitioliikenneindeksi))
                 // In this case, raitioliikenneindeksi has the highest value
                 .andExpect(
                     jsonPath("tormaystarkasteluTulos.liikennehaittaindeksi.indeksi")
-                        .value(raitioliikenneindeksi)
-                )
+                        .value(raitioliikenneindeksi))
                 .andExpect(
                     jsonPath("tormaystarkasteluTulos.liikennehaittaindeksi.tyyppi")
-                        .value(IndeksiType.RAITIOLIIKENNEINDEKSI.name)
-                )
+                        .value(IndeksiType.RAITIOLIIKENNEINDEKSI.name))
 
             verifySequence {
                 authorizer.authorizeHankeTunnus(HANKE_TUNNUS, PermissionCode.VIEW.name)
                 hankeService.loadHanke(HANKE_TUNNUS)
-                disclosureLogService.saveDisclosureLogsForHanke(hanke, USERNAME)
+                disclosureLogService.saveForHanke(hanke, USERNAME)
             }
         }
 
@@ -214,7 +203,7 @@ class HankeControllerITests(@Autowired override val mockMvc: MockMvc) : Controll
                         3,
                         HankeYhteyshenkiloFactory.create(3),
                         HankeYhteyshenkiloFactory.create(5),
-                        HankeYhteyshenkiloFactory.create(6)
+                        HankeYhteyshenkiloFactory.create(6),
                     )
                     .withMuuYhteystieto(4, 4, HankeYhteyshenkiloFactory.create(4))
             every { hankeService.loadHanke(HANKE_TUNNUS) }.returns(hanke)
@@ -238,8 +227,7 @@ class HankeControllerITests(@Autowired override val mockMvc: MockMvc) : Controll
                     jsonPath(
                         "toteuttajat[0].yhteyshenkilot[*].etunimi",
                         containsInAnyOrder("Etu3", "Etu5", "Etu6"),
-                    )
-                )
+                    ))
                 .andExpect(jsonPath("muut.length()").value(1))
                 .andExpect(jsonPath("muut[0].yhteyshenkilot.length()").value(1))
                 .andExpect(jsonPath("muut[0].yhteyshenkilot[0].etunimi").value("Etu4"))
@@ -248,7 +236,7 @@ class HankeControllerITests(@Autowired override val mockMvc: MockMvc) : Controll
             verifySequence {
                 authorizer.authorizeHankeTunnus(HANKE_TUNNUS, PermissionCode.VIEW.name)
                 hankeService.loadHanke(HANKE_TUNNUS)
-                disclosureLogService.saveDisclosureLogsForHanke(hanke, USERNAME)
+                disclosureLogService.saveForHanke(hanke, USERNAME)
             }
         }
     }
@@ -267,6 +255,21 @@ class HankeControllerITests(@Autowired override val mockMvc: MockMvc) : Controll
         }
 
         @Test
+        fun `returns empty list when user has no hanke`() {
+            every { hankeService.loadHankkeetByIds(listOf()) }.returns(listOf())
+            every { permissionService.getAllowedHankeIds(USERNAME, PermissionCode.VIEW) }
+                .returns(listOf())
+
+            get(url).andExpect { status().isOk }.andExpect { content().string("[]") }
+
+            verifySequence {
+                permissionService.getAllowedHankeIds(USERNAME, PermissionCode.VIEW)
+                hankeService.loadHankkeetByIds(listOf())
+                disclosureLogService wasNot Called
+            }
+        }
+
+        @Test
         fun `Without parameters return all Hanke data without geometry`() {
             val hankeIds = listOf(123, 444)
             val hankkeet =
@@ -278,8 +281,7 @@ class HankeControllerITests(@Autowired override val mockMvc: MockMvc) : Controll
                         id = hankeIds[1],
                         hankeTunnus = "hanketunnus2",
                         nimi = "Esplanadin viemäröinti",
-                    )
-                )
+                    ))
             every { hankeService.loadHankkeetByIds(hankeIds) }.returns(hankkeet)
             every { permissionService.getAllowedHankeIds(USERNAME, PermissionCode.VIEW) }
                 .returns(hankeIds)
@@ -298,7 +300,7 @@ class HankeControllerITests(@Autowired override val mockMvc: MockMvc) : Controll
             verifySequence {
                 permissionService.getAllowedHankeIds(USERNAME, PermissionCode.VIEW)
                 hankeService.loadHankkeetByIds(hankeIds)
-                disclosureLogService.saveDisclosureLogsForHankkeet(hankkeet, USERNAME)
+                disclosureLogService.saveForHankkeet(hankkeet, USERNAME)
             }
         }
 
@@ -343,7 +345,7 @@ class HankeControllerITests(@Autowired override val mockMvc: MockMvc) : Controll
             verifySequence {
                 permissionService.getAllowedHankeIds(USERNAME, PermissionCode.VIEW)
                 hankeService.loadHankkeetByIds(hankeIds)
-                disclosureLogService.saveDisclosureLogsForHankkeet(hankkeet, USERNAME)
+                disclosureLogService.saveForHankkeet(hankkeet, USERNAME)
             }
         }
 
@@ -365,20 +367,18 @@ class HankeControllerITests(@Autowired override val mockMvc: MockMvc) : Controll
                 .andExpect(jsonPath("\$.[0].omistajat.length()").value(1))
                 .andExpect(jsonPath("\$.[0].omistajat[0].yhteyshenkilot.length()").value(1))
                 .andExpect(
-                    jsonPath("\$.[0].omistajat[0].yhteyshenkilot[0].etunimi").value("Etu122")
-                )
+                    jsonPath("\$.[0].omistajat[0].yhteyshenkilot[0].etunimi").value("Etu122"))
                 .andExpect(jsonPath("\$.[0].omistajat[0].yhteyshenkilot[0].id").isString)
                 .andExpect(jsonPath("\$.[1].omistajat.length()").value(1))
                 .andExpect(jsonPath("\$.[1].omistajat[0].yhteyshenkilot.length()").value(1))
                 .andExpect(
-                    jsonPath("\$.[1].omistajat[0].yhteyshenkilot[0].etunimi").value("Etu144")
-                )
+                    jsonPath("\$.[1].omistajat[0].yhteyshenkilot[0].etunimi").value("Etu144"))
                 .andExpect(jsonPath("\$.[1].omistajat[0].yhteyshenkilot[0].id").isString)
 
             verifySequence {
                 permissionService.getAllowedHankeIds(USERNAME, PermissionCode.VIEW)
                 hankeService.loadHankkeetByIds(hankeIds)
-                disclosureLogService.saveDisclosureLogsForHankkeet(hankkeet, USERNAME)
+                disclosureLogService.saveForHankkeet(hankkeet, USERNAME)
             }
         }
     }
@@ -417,7 +417,7 @@ class HankeControllerITests(@Autowired override val mockMvc: MockMvc) : Controll
 
             verifySequence {
                 hankeService.createHanke(request, any())
-                disclosureLogService.saveDisclosureLogsForHanke(createdHanke, USERNAME)
+                disclosureLogService.saveForHanke(createdHanke, USERNAME)
             }
         }
 
@@ -492,7 +492,7 @@ class HankeControllerITests(@Autowired override val mockMvc: MockMvc) : Controll
             verifySequence {
                 authorizer.authorizeHankeTunnus(HANKE_TUNNUS, PermissionCode.EDIT.name)
                 hankeService.updateHanke(hankeToBeUpdated.hankeTunnus, any())
-                disclosureLogService.saveDisclosureLogsForHanke(updatedHanke, USERNAME)
+                disclosureLogService.saveForHanke(updatedHanke, USERNAME)
             }
         }
 
@@ -503,7 +503,7 @@ class HankeControllerITests(@Autowired override val mockMvc: MockMvc) : Controll
             val modifiedHanke =
                 hankeToBeUpdated.copy(
                     modifiedBy = USERNAME,
-                    modifiedAt = DateFactory.getEndDatetime()
+                    modifiedAt = DateFactory.getEndDatetime(),
                 )
 
             every {
@@ -517,7 +517,7 @@ class HankeControllerITests(@Autowired override val mockMvc: MockMvc) : Controll
             verifySequence {
                 authorizer.authorizeHankeTunnus(HANKE_TUNNUS, PermissionCode.EDIT.name)
                 hankeService.updateHanke(hankeToBeUpdated.hankeTunnus, any())
-                disclosureLogService.saveDisclosureLogsForHanke(modifiedHanke, USERNAME)
+                disclosureLogService.saveForHanke(modifiedHanke, USERNAME)
             }
         }
 
@@ -574,21 +574,17 @@ class HankeControllerITests(@Autowired override val mockMvc: MockMvc) : Controll
                         .value(
                             VaikutusAutoliikenteenKaistamaariin
                                 .VAHENTAA_KAISTAN_YHDELLA_AJOSUUNNALLA
-                                .name
-                        )
-                ) // Note, here as string, not the enum.
+                                .name)) // Note, here as string, not the enum.
                 .andExpect(
                     jsonPath("$.alueet[0].haittojenhallintasuunnitelma.YLEINEN")
                         .value(
                             hankeToBeUpdated.alueet[0].haittojenhallintasuunnitelma!![
-                                Haittojenhallintatyyppi.YLEINEN]
-                        )
-                )
+                                Haittojenhallintatyyppi.YLEINEN]))
 
             verifySequence {
                 authorizer.authorizeHankeTunnus(HANKE_TUNNUS, PermissionCode.EDIT.name)
                 hankeService.updateHanke(hankeToBeUpdated.hankeTunnus, any())
-                disclosureLogService.saveDisclosureLogsForHanke(expectedHanke, USERNAME)
+                disclosureLogService.saveForHanke(expectedHanke, USERNAME)
             }
         }
     }

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/IntegrationTestConfiguration.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/IntegrationTestConfiguration.kt
@@ -16,6 +16,7 @@ import fi.hel.haitaton.hanke.hakemus.HakemusAuthorizer
 import fi.hel.haitaton.hanke.hakemus.HakemusService
 import fi.hel.haitaton.hanke.logging.AuditLogRepository
 import fi.hel.haitaton.hanke.logging.DisclosureLogService
+import fi.hel.haitaton.hanke.logging.DisclosureLoggingAspect
 import fi.hel.haitaton.hanke.paatos.PaatosAuthorizer
 import fi.hel.haitaton.hanke.paatos.PaatosService
 import fi.hel.haitaton.hanke.permissions.HankeKayttajaAuthorizer
@@ -33,9 +34,11 @@ import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.sentry.Sentry
 import io.sentry.protocol.SentryId
+import org.springframework.boot.autoconfigure.aop.AopAutoConfiguration
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.test.context.TestConfiguration
 import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Import
 import org.springframework.context.event.ContextRefreshedEvent
 import org.springframework.context.event.EventListener
 import org.springframework.jdbc.core.JdbcOperations
@@ -46,6 +49,7 @@ import org.springframework.security.web.SecurityFilterChain
 @TestConfiguration
 @EnableConfigurationProperties(GdprProperties::class, FeatureFlags::class)
 @EnableMethodSecurity(prePostEnabled = true)
+@Import(value = [AopAutoConfiguration::class, DisclosureLoggingAspect::class])
 class IntegrationTestConfiguration {
 
     @Bean fun applicationAttachmentMetadataService(): ApplicationAttachmentMetadataService = mockk()

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/gdpr/GdprControllerITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/gdpr/GdprControllerITests.kt
@@ -189,7 +189,7 @@ class GdprControllerITests(@Autowired var mockMvc: MockMvc) {
 
             verifySequence {
                 gdprService.findGdprInfo(USERNAME)
-                disclosureLogService.saveDisclosureLogsForProfiili(USERNAME, any<CollectionNode>())
+                disclosureLogService.saveForProfiili(any<CollectionNode>(), USERNAME)
             }
         }
     }

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusControllerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusControllerITest.kt
@@ -162,8 +162,7 @@ class HakemusControllerITest(@Autowired override val mockMvc: MockMvc) : Control
             verifySequence {
                 authorizer.authorizeHakemusId(id, PermissionCode.VIEW.name)
                 hakemusService.getWithExtras(id)
-                disclosureLogService.saveDisclosureLogsForHakemusResponse(
-                    hakemus.toResponse(), USERNAME)
+                disclosureLogService.saveForHakemusResponse(hakemus.toResponse(), USERNAME)
             }
         }
 
@@ -270,9 +269,8 @@ class HakemusControllerITest(@Autowired override val mockMvc: MockMvc) : Control
             verifySequence {
                 authorizer.authorizeHakemusId(id, PermissionCode.VIEW.name)
                 hakemusService.getWithExtras(id)
-                disclosureLogService.saveDisclosureLogsForHakemusResponse(any(), USERNAME)
-                disclosureLogService.saveDisclosureLogsForTaydennys(
-                    taydennys.toResponse(), USERNAME)
+                disclosureLogService.saveForHakemusResponse(any(), USERNAME)
+                disclosureLogService.saveForTaydennys(taydennys.toResponse(), USERNAME)
             }
         }
 
@@ -884,8 +882,7 @@ class HakemusControllerITest(@Autowired override val mockMvc: MockMvc) : Control
             verifySequence {
                 authorizer.authorizeHakemusId(id, PermissionCode.EDIT_APPLICATIONS.name)
                 hakemusService.updateHakemus(id, request, USERNAME)
-                disclosureLogService.saveDisclosureLogsForHakemusResponse(
-                    expectedResponse, USERNAME)
+                disclosureLogService.saveForHakemusResponse(expectedResponse, USERNAME)
             }
         }
 
@@ -911,8 +908,7 @@ class HakemusControllerITest(@Autowired override val mockMvc: MockMvc) : Control
             verifySequence {
                 authorizer.authorizeHakemusId(id, PermissionCode.EDIT_APPLICATIONS.name)
                 hakemusService.updateHakemus(id, request, USERNAME)
-                disclosureLogService.saveDisclosureLogsForHakemusResponse(
-                    hakemus.toResponse(), USERNAME)
+                disclosureLogService.saveForHakemusResponse(hakemus.toResponse(), USERNAME)
             }
         }
     }
@@ -1404,10 +1400,7 @@ class HakemusControllerITest(@Autowired override val mockMvc: MockMvc) : Control
                 authorizer.authorizeHakemusId(id, PermissionCode.VIEW.name)
                 hakemusService.downloadDecision(id)
                 hakemusService.getById(id)
-                disclosureLogService.saveDisclosureLogsForCableReport(
-                    hakemus.toMetadata(),
-                    USERNAME,
-                )
+                disclosureLogService.saveForCableReport(hakemus.toMetadata(), USERNAME)
             }
         }
     }

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/paatos/PaatosControllerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/paatos/PaatosControllerITest.kt
@@ -147,10 +147,7 @@ class PaatosControllerITest(
                 authorizer.authorizePaatosId(id, PermissionCode.VIEW.name)
                 paatosService.findById(id)
                 paatosService.downloadDecision(paatos)
-                disclosureLogService.saveDisclosureLogsForPaatos(
-                    paatos.toMetadata(),
-                    USERNAME,
-                )
+                disclosureLogService.saveForPaatos(paatos.toMetadata(), USERNAME)
             }
         }
     }

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/profiili/ProfiiliControllerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/profiili/ProfiiliControllerITest.kt
@@ -92,7 +92,7 @@ class ProfiiliControllerITest(@Autowired override val mockMvc: MockMvc) : Contro
         @Test
         fun `returns verified names`() {
             every { profiiliClient.getVerifiedName(any()) } returns ProfiiliFactory.DEFAULT_NAMES
-            every { disclosureLogService.saveDisclosureLogsForProfiiliNimi(any(), any()) } just Runs
+            every { disclosureLogService.saveForProfiiliNimi(any(), any()) } just Runs
 
             val names: Names =
                 get(url).andExpect(MockMvcResultMatchers.status().isOk).andReturnBody()
@@ -104,7 +104,7 @@ class ProfiiliControllerITest(@Autowired override val mockMvc: MockMvc) : Contro
             }
             verifyAll {
                 profiiliClient.getVerifiedName(any())
-                disclosureLogService.saveDisclosureLogsForProfiiliNimi(any(), any())
+                disclosureLogService.saveForProfiiliNimi(any(), any())
             }
         }
     }

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennysControllerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennysControllerITest.kt
@@ -152,7 +152,7 @@ class TaydennysControllerITest(@Autowired override val mockMvc: MockMvc) : Contr
                 hakemusAuthorizer.authorizeHakemusId(
                     hakemusId, PermissionCode.EDIT_APPLICATIONS.name)
                 taydennysService.create(hakemusId, USERNAME)
-                disclosureLogService.saveDisclosureLogsForTaydennys(response, USERNAME)
+                disclosureLogService.saveForTaydennys(response, USERNAME)
             }
         }
     }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/configuration/AspectConfig.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/configuration/AspectConfig.kt
@@ -1,0 +1,6 @@
+package fi.hel.haitaton.hanke.configuration
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.EnableAspectJAutoProxy
+
+@Configuration @EnableAspectJAutoProxy class AspectConfig

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/gdpr/GdprController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/gdpr/GdprController.kt
@@ -3,7 +3,6 @@ package fi.hel.haitaton.hanke.gdpr
 import com.fasterxml.jackson.databind.node.ObjectNode
 import fi.hel.haitaton.hanke.HankeError
 import fi.hel.haitaton.hanke.OBJECT_MAPPER
-import fi.hel.haitaton.hanke.logging.DisclosureLogService
 import fi.hel.haitaton.hanke.toJsonString
 import io.sentry.Sentry
 import io.swagger.v3.oas.annotations.Hidden
@@ -34,7 +33,6 @@ private val logger = KotlinLogging.logger {}
 @Validated
 class GdprController(
     private val gdprService: GdprService,
-    private val disclosureLogService: DisclosureLogService,
     private val gdprProperties: GdprProperties,
 ) {
 
@@ -86,7 +84,6 @@ class GdprController(
             return ResponseEntity.noContent().build()
         }
 
-        disclosureLogService.saveDisclosureLogsForProfiili(userId, gdprInfo)
         logger.info { "Returning GDPR information for user $userId" }
         return ResponseEntity.ok().body(gdprInfo)
     }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusController.kt
@@ -68,12 +68,7 @@ class HakemusController(
     @PreAuthorize("@hakemusAuthorizer.authorizeHakemusId(#id, 'VIEW')")
     fun getById(@PathVariable(name = "id") id: Long): HakemusWithExtrasResponse {
         logger.info { "Finding application $id" }
-        val response = hakemusService.getWithExtras(id).toResponse()
-        disclosureLogService.saveDisclosureLogsForHakemusResponse(response.hakemus, currentUserId())
-        response.taydennys?.let {
-            disclosureLogService.saveDisclosureLogsForTaydennys(it, currentUserId())
-        }
-        return response
+        return hakemusService.getWithExtras(id).toResponse()
     }
 
     @GetMapping("/hankkeet/{hankeTunnus}/hakemukset")
@@ -212,13 +207,8 @@ class HakemusController(
     @PreAuthorize("@hakemusAuthorizer.authorizeHakemusId(#id, 'EDIT_APPLICATIONS')")
     fun update(
         @PathVariable(name = "id") id: Long,
-        @ValidHakemusUpdateRequest @RequestBody request: HakemusUpdateRequest
-    ): HakemusResponse {
-        val userId = currentUserId()
-        val response = hakemusService.updateHakemus(id, request, userId).toResponse()
-        disclosureLogService.saveDisclosureLogsForHakemusResponse(response, userId)
-        return response
-    }
+        @ValidHakemusUpdateRequest @RequestBody request: HakemusUpdateRequest,
+    ): HakemusResponse = hakemusService.updateHakemus(id, request, currentUserId()).toResponse()
 
     @DeleteMapping("/hakemukset/{id}")
     @Operation(
@@ -417,7 +407,7 @@ The id needs to reference an excavation notification.
         val userId = currentUserId()
         val (filename, pdfBytes) = hakemusService.downloadDecision(id)
         val application = hakemusService.getById(id)
-        disclosureLogService.saveDisclosureLogsForCableReport(application.toMetadata(), userId)
+        disclosureLogService.saveForCableReport(application.toMetadata(), userId)
 
         val headers = HttpHeaders()
         headers.add("Content-Disposition", "inline; filename=$filename.pdf")

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
@@ -681,8 +681,7 @@ class HakemusService(
     ): T {
         try {
             val result = f()
-            disclosureLogService.saveDisclosureLogsForAllu(
-                applicationId, alluApplicationData, Status.SUCCESS)
+            disclosureLogService.saveForAllu(applicationId, alluApplicationData, Status.SUCCESS)
             return result
         } catch (e: AlluLoginException) {
             // Since the login failed we didn't send the application itself, so logging not needed.
@@ -691,7 +690,7 @@ class HakemusService(
             // There was an exception outside login, so there was at least an attempt to send the
             // application to Allu. Allu might have read it and rejected it, so we should log this
             // as a disclosure event.
-            disclosureLogService.saveDisclosureLogsForAllu(
+            disclosureLogService.saveForAllu(
                 applicationId, alluApplicationData, Status.FAILED, ALLU_APPLICATION_ERROR_MSG)
             throw e
         }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/DisclosureLoggingAspect.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/DisclosureLoggingAspect.kt
@@ -1,0 +1,119 @@
+package fi.hel.haitaton.hanke.logging
+
+import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentMetadataDto
+import fi.hel.haitaton.hanke.attachment.common.HankeAttachmentMetadataDto
+import fi.hel.haitaton.hanke.banners.BannerResponse
+import fi.hel.haitaton.hanke.currentUserId
+import fi.hel.haitaton.hanke.domain.Hanke
+import fi.hel.haitaton.hanke.domain.PublicHanke
+import fi.hel.haitaton.hanke.gdpr.CollectionNode
+import fi.hel.haitaton.hanke.hakemus.HakemusDeletionResultDto
+import fi.hel.haitaton.hanke.hakemus.HakemusResponse
+import fi.hel.haitaton.hanke.hakemus.HakemusWithExtrasResponse
+import fi.hel.haitaton.hanke.hakemus.HankkeenHakemuksetResponse
+import fi.hel.haitaton.hanke.permissions.HankeKayttajaController
+import fi.hel.haitaton.hanke.permissions.HankeKayttajaDto
+import fi.hel.haitaton.hanke.permissions.HankeKayttajaResponse
+import fi.hel.haitaton.hanke.permissions.HankekayttajaDeleteService
+import fi.hel.haitaton.hanke.permissions.WhoamiResponse
+import fi.hel.haitaton.hanke.profiili.Names
+import fi.hel.haitaton.hanke.taydennys.TaydennysResponse
+import fi.hel.haitaton.hanke.tormaystarkastelu.TormaystarkasteluTulos
+import kotlin.reflect.KClass
+import org.aspectj.lang.annotation.AfterReturning
+import org.aspectj.lang.annotation.Aspect
+import org.springframework.http.ResponseEntity
+import org.springframework.stereotype.Component
+
+@Aspect
+@Component
+class DisclosureLoggingAspect(private val disclosureLogService: DisclosureLogService) {
+    @AfterReturning(
+        pointcut = "@annotation(io.swagger.v3.oas.annotations.Operation)", returning = "result")
+    fun logResponse(result: Any?) {
+        if (result == null) {
+            return
+        }
+        logResult(result)
+    }
+
+    private fun logResult(result: Any) {
+        when (result) {
+            // For types that (can) contain personal information, log said information
+            is CollectionNode -> disclosureLogService.saveForProfiili(result, currentUserId())
+            is HakemusResponse ->
+                disclosureLogService.saveForHakemusResponse(result, currentUserId())
+            is HakemusWithExtrasResponse -> {
+                disclosureLogService.saveForHakemusResponse(result.hakemus, currentUserId())
+                result.taydennys?.let { disclosureLogService.saveForTaydennys(it, currentUserId()) }
+            }
+            is Hanke -> disclosureLogService.saveForHanke(result, currentUserId())
+            is HankeKayttajaDto ->
+                disclosureLogService.saveForHankeKayttaja(result, currentUserId())
+            is HankeKayttajaResponse ->
+                disclosureLogService.saveForHankeKayttajat(result.kayttajat, currentUserId())
+            is Names -> disclosureLogService.saveForProfiiliNimi(result, currentUserId())
+            is TaydennysResponse -> disclosureLogService.saveForTaydennys(result, currentUserId())
+
+            // Some classes cannot hold personal information, so they are skipped
+            is ApplicationAttachmentMetadataDto -> return
+            is HakemusDeletionResultDto -> return
+            is HankeAttachmentMetadataDto -> return
+            is HankeKayttajaController.TunnistautuminenResponse -> return
+            is HankekayttajaDeleteService.DeleteInfo -> return
+            is HankkeenHakemuksetResponse -> return
+            is TormaystarkasteluTulos -> return
+            is WhoamiResponse -> return
+
+            // We can't know if binary data contains personal information. These need to be handled
+            // in the respective controllers.
+            is ByteArray -> return
+
+            // Content is extracted from wrapper types and any non-null content is evaluated
+            is ResponseEntity<*> -> result.body?.let { logResult(it) }
+            is List<*> -> logResultList(result.filterNotNull())
+            is Map<*, *> -> logResultList(result.values.filterNotNull())
+
+            // Throw an exception if nothing matches. This will ensure we specify whether a new
+            // response type can contain personal information or not.
+            else -> throw UnknownResponseTypeException(result::class)
+        }
+    }
+
+    private fun logResultList(results: List<Any>) {
+        if (results.isEmpty()) return
+        when (val first = results.first()) {
+            is Hanke -> {
+                val hankkeet = checkAllElementsAreOfClass<Hanke>(results)
+                disclosureLogService.saveForHankkeet(hankkeet, currentUserId())
+            }
+
+            is ApplicationAttachmentMetadataDto -> return
+            is BannerResponse -> return
+            is HankeAttachmentMetadataDto -> return
+            is PublicHanke -> return
+            is String -> return
+            is WhoamiResponse -> return
+
+            else -> throw UnknownResponseListTypeException(first::class)
+        }
+    }
+
+    private inline fun <reified T> checkAllElementsAreOfClass(list: List<Any>): List<T> {
+        if (list.all { it is T }) {
+            return list.filterIsInstance<T>()
+        } else {
+            throw MixedElementsInResponseException(T::class, list.map { it::class }.toSet())
+        }
+    }
+}
+
+class UnknownResponseTypeException(kclass: KClass<*>) :
+    RuntimeException("Unknown response type: ${kclass.qualifiedName}")
+
+class UnknownResponseListTypeException(kclass: KClass<*>) :
+    RuntimeException("Unknown response type inside a list: ${kclass.qualifiedName}")
+
+class MixedElementsInResponseException(expected: KClass<*>, actual: Set<KClass<*>>) :
+    RuntimeException(
+        "Mixed types inside a list. Expected type: ${expected.qualifiedName} Actual types: ${actual.map { it.qualifiedName }.joinToString ()}")

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/paatos/PaatosController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/paatos/PaatosController.kt
@@ -59,7 +59,7 @@ class PaatosController(
     fun download(@PathVariable("id") id: UUID): ResponseEntity<ByteArray> {
         val paatos: Paatos = paatosService.findById(id)
         val (filename, pdfBytes) = paatosService.downloadDecision(paatos)
-        disclosureLogService.saveDisclosureLogsForPaatos(paatos.toMetadata(), currentUserId())
+        disclosureLogService.saveForPaatos(paatos.toMetadata(), currentUserId())
 
         val headers = HttpHeaders()
         headers.add("Content-Disposition", "inline; filename=$filename")

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaController.kt
@@ -3,7 +3,6 @@ package fi.hel.haitaton.hanke.permissions
 import fi.hel.haitaton.hanke.HankeError
 import fi.hel.haitaton.hanke.HankeService
 import fi.hel.haitaton.hanke.currentUserId
-import fi.hel.haitaton.hanke.logging.DisclosureLogService
 import fi.hel.haitaton.hanke.profiili.VerifiedNameNotFound
 import io.swagger.v3.oas.annotations.Hidden
 import io.swagger.v3.oas.annotations.Operation
@@ -39,22 +38,19 @@ class HankeKayttajaController(
     private val hankeKayttajaService: HankeKayttajaService,
     private val hankekayttajaDeleteService: HankekayttajaDeleteService,
     private val permissionService: PermissionService,
-    private val disclosureLogService: DisclosureLogService,
 ) {
     @GetMapping("/my-permissions")
     @Operation(
         summary = "Get your permissions for your own projects",
-        description = "Returns a map of current users Hanke identifiers and respective permissions."
-    )
+        description =
+            "Returns a map of current users Hanke identifiers and respective permissions.")
     @ApiResponses(
         value =
             [
                 ApiResponse(
                     description = "Permissions grouped by hankeTunnus.",
                     responseCode = "200",
-                )
-            ]
-    )
+                )])
     fun whoAmIByHanke(): Map<String, WhoamiResponse> {
         val permissions: List<HankePermission> =
             permissionService.permissionsByHanke(userId = currentUserId())
@@ -70,15 +66,12 @@ class HankeKayttajaController(
                 ApiResponse(
                     description = "Your permissions",
                     responseCode = "200",
-                    content = [Content(schema = Schema(implementation = WhoamiResponse::class))]
-                ),
+                    content = [Content(schema = Schema(implementation = WhoamiResponse::class))]),
                 ApiResponse(
                     description = "Hanke not found",
                     responseCode = "404",
-                    content = [Content(schema = Schema(implementation = HankeError::class))]
-                ),
-            ]
-    )
+                    content = [Content(schema = Schema(implementation = HankeError::class))]),
+            ])
     @PreAuthorize("@hankeKayttajaAuthorizer.authorizeHankeTunnus(#hankeTunnus, 'VIEW')")
     fun whoami(@PathVariable hankeTunnus: String): WhoamiResponse {
         val userId = currentUserId()
@@ -93,8 +86,7 @@ class HankeKayttajaController(
     @GetMapping("/kayttajat/{kayttajaId}")
     @Operation(
         summary = "Get a Hanke user",
-        description = "Returns a single user and their Hanke related information."
-    )
+        description = "Returns a single user and their Hanke related information.")
     @ApiResponses(
         value =
             [
@@ -102,26 +94,20 @@ class HankeKayttajaController(
                 ApiResponse(
                     description = "Invalid UUID",
                     responseCode = "400",
-                    content = [Content(schema = Schema(implementation = HankeError::class))]
-                ),
+                    content = [Content(schema = Schema(implementation = HankeError::class))]),
                 ApiResponse(
                     description = "Hanke or user not found",
                     responseCode = "404",
-                    content = [Content(schema = Schema(implementation = HankeError::class))]
-                ),
-            ]
-    )
+                    content = [Content(schema = Schema(implementation = HankeError::class))]),
+            ])
     @PreAuthorize("@hankeKayttajaAuthorizer.authorizeKayttajaId(#kayttajaId, 'VIEW')")
     fun getHankeKayttaja(@PathVariable kayttajaId: UUID): HankeKayttajaDto =
-        hankeKayttajaService.getKayttaja(kayttajaId).toDto().also {
-            disclosureLogService.saveDisclosureLogsForHankeKayttaja(it, currentUserId())
-        }
+        hankeKayttajaService.getKayttaja(kayttajaId).toDto()
 
     @GetMapping("/hankkeet/{hankeTunnus}/kayttajat")
     @Operation(
         summary = "Get Hanke users",
-        description = "Returns a list of users and their Hanke related information."
-    )
+        description = "Returns a list of users and their Hanke related information.")
     @ApiResponses(
         value =
             [
@@ -129,15 +115,12 @@ class HankeKayttajaController(
                     description = "Users in Hanke",
                     responseCode = "200",
                     content =
-                        [Content(schema = Schema(implementation = HankeKayttajaResponse::class))]
-                ),
+                        [Content(schema = Schema(implementation = HankeKayttajaResponse::class))]),
                 ApiResponse(
                     description = "Hanke not found",
                     responseCode = "404",
-                    content = [Content(schema = Schema(implementation = HankeError::class))]
-                ),
-            ]
-    )
+                    content = [Content(schema = Schema(implementation = HankeError::class))]),
+            ])
     @PreAuthorize("@hankeKayttajaAuthorizer.authorizeHankeTunnus(#hankeTunnus, 'VIEW')")
     fun getHankeKayttajat(@PathVariable hankeTunnus: String): HankeKayttajaResponse {
         logger.info { "Finding kayttajat for hanke $hankeTunnus" }
@@ -145,7 +128,6 @@ class HankeKayttajaController(
         val hankeIdentifier = hankeService.findIdentifier(hankeTunnus)!!
 
         val users = hankeKayttajaService.getKayttajatByHankeId(hankeIdentifier.id)
-        disclosureLogService.saveDisclosureLogsForHankeKayttajat(users, currentUserId())
 
         logger.info { "Found ${users.size} kayttajat for ${hankeIdentifier.logString()}" }
 
@@ -200,8 +182,7 @@ permissions.
 
 If removing or adding KAIKKI_OIKEUDET kayttooikeustaso, the caller needs to
 have those same permissions.
-"""
-    )
+""")
     @ApiResponses(
         value =
             [
@@ -209,31 +190,25 @@ have those same permissions.
                 ApiResponse(
                     description = "The request body was invalid",
                     responseCode = "400",
-                    content = [Content(schema = Schema(implementation = HankeError::class))]
-                ),
+                    content = [Content(schema = Schema(implementation = HankeError::class))]),
                 ApiResponse(
                     description = "Not authorized to change admin permissions",
                     responseCode = "403",
-                    content = [Content(schema = Schema(implementation = HankeError::class))]
-                ),
+                    content = [Content(schema = Schema(implementation = HankeError::class))]),
                 ApiResponse(
                     description = "Hanke by requested tunnus not found",
                     responseCode = "404",
-                    content = [Content(schema = Schema(implementation = HankeError::class))]
-                ),
+                    content = [Content(schema = Schema(implementation = HankeError::class))]),
                 ApiResponse(
                     description =
                         "User tried editing their own permissions or there would " +
                             "be no users with KAIKKI_OIKEUDET left.",
                     responseCode = "409",
-                    content = [Content(schema = Schema(implementation = HankeError::class))]
-                ),
-            ]
-    )
+                    content = [Content(schema = Schema(implementation = HankeError::class))]),
+            ])
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @PreAuthorize(
-        "@hankeKayttajaAuthorizer.authorizeHankeTunnus(#hankeTunnus, 'MODIFY_EDIT_PERMISSIONS')"
-    )
+        "@hankeKayttajaAuthorizer.authorizeHankeTunnus(#hankeTunnus, 'MODIFY_EDIT_PERMISSIONS')")
     fun updatePermissions(
         @RequestBody permissions: PermissionUpdate,
         @PathVariable hankeTunnus: String
@@ -244,17 +219,13 @@ have those same permissions.
 
         val deleteAdminPermission =
             permissionService.hasPermission(
-                hankeIdentifier.id,
-                userId,
-                PermissionCode.MODIFY_DELETE_PERMISSIONS
-            )
+                hankeIdentifier.id, userId, PermissionCode.MODIFY_DELETE_PERMISSIONS)
 
         hankeKayttajaService.updatePermissions(
             hankeIdentifier,
             permissions.kayttajat.associate { it.id to it.kayttooikeustaso },
             deleteAdminPermission,
-            userId
-        )
+            userId)
     }
 
     @PostMapping("/kayttajat")
@@ -269,8 +240,7 @@ the hanke the token was created for.
 Removes the token after a successful identification.
 
 Responds with information about the activated user and the hanke associated with it.
-"""
-    )
+""")
     @ApiResponses(
         value =
             [
@@ -281,31 +251,24 @@ Responds with information about the activated user and the hanke associated with
                 ApiResponse(
                     description = "Token not found or outdated",
                     responseCode = "404",
-                    content = [Content(schema = Schema(implementation = HankeError::class))]
-                ),
+                    content = [Content(schema = Schema(implementation = HankeError::class))]),
                 ApiResponse(
                     description =
                         "Token doesn't have a user associated with it or the verified name cannot be retrieved from Profiili",
                     responseCode = "500",
-                    content = [Content(schema = Schema(implementation = HankeError::class))]
-                ),
+                    content = [Content(schema = Schema(implementation = HankeError::class))]),
                 ApiResponse(
                     description = "Permission already exists",
                     responseCode = "409",
-                    content = [Content(schema = Schema(implementation = HankeError::class))]
-                ),
-            ]
-    )
+                    content = [Content(schema = Schema(implementation = HankeError::class))]),
+            ])
     fun identifyUser(
         @RequestBody tunnistautuminen: Tunnistautuminen,
         @Parameter(hidden = true) @CurrentSecurityContext securityContext: SecurityContext
     ): TunnistautuminenResponse {
         val kayttaja =
             hankeKayttajaService.createPermissionFromToken(
-                currentUserId(),
-                tunnistautuminen.tunniste,
-                securityContext
-            )
+                currentUserId(), tunnistautuminen.tunniste, securityContext)
 
         val hanke = hankeService.loadHankeById(kayttaja.hankeId)!!
         return TunnistautuminenResponse(kayttaja.id, hanke.hankeTunnus, hanke.nimi)
@@ -324,8 +287,7 @@ original email will not work anymore. It also means that the period of validity
 of the token and link will be reset.
 
 Returns the updated hankekayttaja.
-"""
-    )
+""")
     @ApiResponses(
         value =
             [
@@ -341,10 +303,8 @@ Returns the updated hankekayttaja.
                     description =
                         "User has already been activated or the current user doesn't have name and email registered.",
                     responseCode = "409",
-                    content = [Content(schema = Schema(implementation = HankeError::class))]
-                ),
-            ]
-    )
+                    content = [Content(schema = Schema(implementation = HankeError::class))]),
+            ])
     @PreAuthorize("@hankeKayttajaAuthorizer.authorizeKayttajaId(#kayttajaId, 'RESEND_INVITATION')")
     fun resendInvitations(@PathVariable kayttajaId: UUID): HankeKayttajaDto =
         hankeKayttajaService.resendInvitation(kayttajaId, currentUserId()).toDto()
@@ -359,8 +319,7 @@ Updates the contact information of the hankekayttaja the user has in the hanke.
 The sahkoposti and puhelinnumero are mandatory and can't be empty or blank.
 
 Returns the updated hankekayttaja.
-"""
-    )
+""")
     @ApiResponses(
         value =
             [
@@ -376,8 +335,7 @@ Returns the updated hankekayttaja.
                     description = "Hanke not found or not authorized",
                     responseCode = "404",
                 ),
-            ]
-    )
+            ])
     @PreAuthorize("@hankeKayttajaAuthorizer.authorizeHankeTunnus(#hankeTunnus, 'VIEW')")
     fun updateOwnContactInfo(
         @Valid @RequestBody update: ContactUpdate,
@@ -396,8 +354,7 @@ Returns the updated hankekayttaja.
 Updates the contact and (optionally) name information of the hankekayttaja.
 
 Returns the updated hankekayttaja.
-"""
-    )
+""")
     @ApiResponses(
         value =
             [
@@ -418,8 +375,7 @@ Returns the updated hankekayttaja.
                         "User has already been activated and therefore cannot update name",
                     responseCode = "409",
                 ),
-            ]
-    )
+            ])
     @PreAuthorize("@hankeKayttajaAuthorizer.authorizeHankeTunnus(#hankeTunnus, 'MODIFY_USER')")
     fun updateKayttajaInfo(
         @RequestBody @Valid update: KayttajaUpdate,
@@ -443,8 +399,7 @@ needs to show them when asking for confirmation.
 
 Does not check if the caller needs KAIKKI_OIKEUDET to delete this particular
 user.
-"""
-    )
+""")
     @ApiResponses(
         value =
             [
@@ -460,8 +415,7 @@ user.
                     description = "Hankekayttaja not found or not authorized",
                     responseCode = "404",
                 ),
-            ]
-    )
+            ])
     @PreAuthorize("@hankeKayttajaAuthorizer.authorizeKayttajaId(#kayttajaId, 'DELETE_USER')")
     fun checkForDelete(@PathVariable kayttajaId: UUID): HankekayttajaDeleteService.DeleteInfo =
         hankekayttajaDeleteService.checkForDelete(kayttajaId)
@@ -474,8 +428,7 @@ Deletes the given hankekayttaja (user) from the hanke.
 
 Check if there are active applications the user is a contact in or if the user is the only
 contact in the applicant customer role. If either is true, refuse to delete the kayttaja.
-"""
-    )
+""")
     @ApiResponses(
         value =
             [
@@ -498,8 +451,7 @@ contact in the applicant customer role. If either is true, refuse to delete the 
                             "there would be no admin users left.",
                     responseCode = "409",
                 ),
-            ]
-    )
+            ])
     @DeleteMapping("/kayttajat/{kayttajaId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @PreAuthorize("@hankeKayttajaAuthorizer.authorizeKayttajaId(#kayttajaId, 'DELETE_USER')")

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/profiili/ProfiiliController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/profiili/ProfiiliController.kt
@@ -1,8 +1,6 @@
 package fi.hel.haitaton.hanke.profiili
 
 import fi.hel.haitaton.hanke.HankeError
-import fi.hel.haitaton.hanke.logging.DisclosureLogService
-import fi.hel.haitaton.hanke.userId
 import io.sentry.Sentry
 import io.swagger.v3.oas.annotations.Hidden
 import io.swagger.v3.oas.annotations.Operation
@@ -28,7 +26,6 @@ private val logger = KotlinLogging.logger {}
 @SecurityRequirement(name = "bearerAuth")
 class ProfiiliController(
     private val profiiliClient: ProfiiliClient,
-    private val disclosureLogService: DisclosureLogService
 ) {
 
     @GetMapping("/verified-name")
@@ -37,18 +34,10 @@ class ProfiiliController(
     @ApiResponse(
         description = "Verification not found.",
         responseCode = "404",
-        content = [Content(schema = Schema(implementation = HankeError::class))]
-    )
+        content = [Content(schema = Schema(implementation = HankeError::class))])
     fun verifiedName(
-        @Parameter(hidden = true) @CurrentSecurityContext securityContext: SecurityContext
-    ): Names {
-        val verifiedName = profiiliClient.getVerifiedName(securityContext)
-        disclosureLogService.saveDisclosureLogsForProfiiliNimi(
-            securityContext.userId(),
-            verifiedName
-        )
-        return verifiedName
-    }
+        @Parameter(hidden = true) @CurrentSecurityContext securityContext: SecurityContext,
+    ): Names = profiiliClient.getVerifiedName(securityContext)
 
     @ExceptionHandler(VerifiedNameNotFound::class)
     @ResponseStatus(HttpStatus.NOT_FOUND)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennysController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennysController.kt
@@ -2,7 +2,6 @@ package fi.hel.haitaton.hanke.taydennys
 
 import fi.hel.haitaton.hanke.HankeError
 import fi.hel.haitaton.hanke.currentUserId
-import fi.hel.haitaton.hanke.logging.DisclosureLogService
 import io.swagger.v3.oas.annotations.Hidden
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
@@ -25,10 +24,7 @@ private val logger = KotlinLogging.logger {}
 @RestController
 @Validated
 @SecurityRequirement(name = "bearerAuth")
-class TaydennysController(
-    private val taydennysService: TaydennysService,
-    private val disclosureLogService: DisclosureLogService,
-) {
+class TaydennysController(private val taydennysService: TaydennysService) {
 
     @PostMapping("/hakemukset/{id}/taydennys")
     @Operation(
@@ -55,12 +51,8 @@ class TaydennysController(
                 ),
             ])
     @PreAuthorize("@hakemusAuthorizer.authorizeHakemusId(#id, 'EDIT_APPLICATIONS')")
-    fun create(@PathVariable id: Long): TaydennysResponse {
-        val userId = currentUserId()
-        val response = taydennysService.create(id, userId).toResponse()
-        disclosureLogService.saveDisclosureLogsForTaydennys(response, userId)
-        return response
-    }
+    fun create(@PathVariable id: Long): TaydennysResponse =
+        taydennysService.create(id, currentUserId()).toResponse()
 
     @ExceptionHandler(NoTaydennyspyyntoException::class)
     @ResponseStatus(HttpStatus.CONFLICT)

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/HankeControllerTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/HankeControllerTest.kt
@@ -22,11 +22,9 @@ import fi.hel.haitaton.hanke.logging.DisclosureLogService
 import fi.hel.haitaton.hanke.permissions.PermissionCode
 import fi.hel.haitaton.hanke.permissions.PermissionService
 import fi.hel.haitaton.hanke.test.USERNAME
-import io.mockk.Called
 import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
-import io.mockk.verify
 import jakarta.validation.ConstraintViolationException
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -65,12 +63,10 @@ class HankeControllerTest {
         fun hankeController(
             hankeService: HankeService,
             permissionService: PermissionService,
-            disclosureLogService: DisclosureLogService,
         ): HankeController =
             HankeController(
                 hankeService,
                 permissionService,
-                disclosureLogService,
             )
     }
 
@@ -79,7 +75,6 @@ class HankeControllerTest {
     @Autowired private lateinit var hankeService: HankeService
     @Autowired private lateinit var permissionService: PermissionService
     @Autowired private lateinit var hankeController: HankeController
-    @Autowired private lateinit var disclosureLogService: DisclosureLogService
     @Autowired private lateinit var hankeAuthorizer: HankeAuthorizer
 
     @BeforeEach
@@ -107,9 +102,8 @@ class HankeControllerTest {
                     getCurrentTimeUTC(),
                     null,
                     null,
-                    HankeStatus.DRAFT
-                )
-            )
+                    HankeStatus.DRAFT,
+                ))
         every {
             hankeAuthorizer.authorizeHankeTunnus(mockedHankeTunnus, PermissionCode.VIEW)
         } returns true
@@ -118,7 +112,6 @@ class HankeControllerTest {
 
         assertThat(response).isNotNull()
         assertThat(response.nimi).isNotEmpty()
-        verify { disclosureLogService.saveDisclosureLogsForHanke(any(), eq(USERNAME)) }
     }
 
     @Test
@@ -137,7 +130,7 @@ class HankeControllerTest {
                     getCurrentTimeUTC(),
                     null,
                     null,
-                    HankeStatus.DRAFT
+                    HankeStatus.DRAFT,
                 ),
                 Hanke(
                     50,
@@ -151,8 +144,8 @@ class HankeControllerTest {
                     getCurrentTimeUTC(),
                     null,
                     null,
-                    HankeStatus.DRAFT
-                )
+                    HankeStatus.DRAFT,
+                ),
             )
         every { permissionService.getAllowedHankeIds(USERNAME, PermissionCode.VIEW) }
             .returns(listOf(1234, 50))
@@ -164,7 +157,6 @@ class HankeControllerTest {
         assertThat(hankeList[1].nimi).isEqualTo("Hämeenlinnanväylän uudistus")
         assertThat(hankeList[0].alueet.geometriat()).isEmpty()
         assertThat(hankeList[1].alueet.geometriat()).isEmpty()
-        verify { disclosureLogService.saveDisclosureLogsForHankkeet(any(), eq(USERNAME)) }
     }
 
     @Test
@@ -183,7 +175,7 @@ class HankeControllerTest {
                 createdAt = getCurrentTimeUTC(),
                 modifiedBy = null,
                 modifiedAt = null,
-                status = HankeStatus.DRAFT
+                status = HankeStatus.DRAFT,
             )
         val request = partialHanke.toModifyRequest()
         every { hankeService.updateHanke(hanketunnus, request) }
@@ -194,7 +186,6 @@ class HankeControllerTest {
 
         assertThat(response).isNotNull()
         assertThat(response.nimi).isEqualTo("hankkeen nimi")
-        verify { disclosureLogService.saveDisclosureLogsForHanke(any(), eq(USERNAME)) }
     }
 
     @Test
@@ -213,7 +204,7 @@ class HankeControllerTest {
                 createdAt = null,
                 modifiedBy = null,
                 modifiedAt = null,
-                status = HankeStatus.DRAFT
+                status = HankeStatus.DRAFT,
             )
         val request = partialHanke.toModifyRequest()
         every { hankeService.loadHanke(hanketunnus) }.returns(HankeFactory.create())
@@ -225,6 +216,5 @@ class HankeControllerTest {
             hasClass(ConstraintViolationException::class)
             messageContains("updateHanke.hankeUpdate.nimi: " + HankeError.HAI1002.toString())
         }
-        verify { disclosureLogService wasNot Called }
     }
 }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceTest.kt
@@ -150,7 +150,7 @@ class HakemusServiceTest {
             justRun { attachmentService.sendInitialAttachments(alluId, any()) }
             val applicationCapturingSlot = slot<AlluCableReportApplicationData>()
             justRun {
-                disclosureLogService.saveDisclosureLogsForAllu(
+                disclosureLogService.saveForAllu(
                     3, capture(applicationCapturingSlot), Status.SUCCESS)
             }
 
@@ -233,7 +233,7 @@ class HakemusServiceTest {
                 attachmentService.getMetadataList(applicationEntity.id)
                 geometriatDao.calculateArea(any())
                 alluClient.create(any())
-                disclosureLogService.saveDisclosureLogsForAllu(3, any(), Status.SUCCESS)
+                disclosureLogService.saveForAllu(3, any(), Status.SUCCESS)
                 alluClient.addAttachment(alluId, any())
                 attachmentService.sendInitialAttachments(alluId, any())
                 alluClient.getApplicationInformation(alluId)
@@ -260,7 +260,7 @@ class HakemusServiceTest {
                 attachmentService.getMetadataList(applicationEntity.id)
                 geometriatDao.calculateArea(any())
                 alluClient.create(any())
-                disclosureLogService.saveDisclosureLogsForAllu(
+                disclosureLogService.saveForAllu(
                     3, any(), Status.FAILED, ALLU_APPLICATION_ERROR_MSG)
             }
         }
@@ -324,7 +324,7 @@ class HakemusServiceTest {
                 attachmentService.getMetadataList(applicationEntity.id)
                 geometriatDao.calculateArea(any())
                 alluClient.create(any())
-                disclosureLogService.saveDisclosureLogsForAllu(3, any(), Status.SUCCESS)
+                disclosureLogService.saveForAllu(3, any(), Status.SUCCESS)
                 alluClient.addAttachment(alluId, any())
                 attachmentService.sendInitialAttachments(alluId, any())
                 alluClient.getApplicationInformation(alluId)

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/logging/DisclosureLogServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/logging/DisclosureLogServiceTest.kt
@@ -97,7 +97,7 @@ internal class DisclosureLogServiceTest {
                     StringNode("puhelin", TEPPO_PHONE),
                 ))
 
-        disclosureLogService.saveDisclosureLogsForProfiili(userId, info)
+        disclosureLogService.saveForProfiili(info, userId)
 
         val expectedObject =
             """
@@ -126,7 +126,7 @@ internal class DisclosureLogServiceTest {
     fun `saveDisclosureLogsForHanke with hanke with no yhteystiedot doesn't do anything`() {
         val hanke = HankeFactory.create()
 
-        disclosureLogService.saveDisclosureLogsForHanke(hanke, userId)
+        disclosureLogService.saveForHanke(hanke, userId)
 
         verify { auditLogService wasNot Called }
     }
@@ -136,7 +136,7 @@ internal class DisclosureLogServiceTest {
         val hanke = HankeFactory.create().withYhteystiedot()
         val expectedLogs = AuditLogEntryFactory.createReadEntriesForHanke(hanke)
 
-        disclosureLogService.saveDisclosureLogsForHanke(hanke, userId)
+        disclosureLogService.saveForHanke(hanke, userId)
 
         verify { auditLogService.createAll(match(containsAll(expectedLogs))) }
     }
@@ -154,14 +154,14 @@ internal class DisclosureLogServiceTest {
         val expectedLogs =
             listOf(AuditLogEntryFactory.createReadEntry(objectBefore = yhteystieto.toJsonString()))
 
-        disclosureLogService.saveDisclosureLogsForHanke(hanke, userId)
+        disclosureLogService.saveForHanke(hanke, userId)
 
         verify { auditLogService.createAll(match(containsAll(expectedLogs))) }
     }
 
     @Test
     fun `saveDisclosureLogsForHankkeet without hankkeet does nothing`() {
-        disclosureLogService.saveDisclosureLogsForHankkeet(listOf(), userId)
+        disclosureLogService.saveForHankkeet(listOf(), userId)
 
         verify { auditLogService wasNot Called }
     }
@@ -170,7 +170,7 @@ internal class DisclosureLogServiceTest {
     fun `saveDisclosureLogsForHankkeet with hankkeet without yhteystiedot does nothing`() {
         val hankkeet = listOf(HankeFactory.create(), HankeFactory.create())
 
-        disclosureLogService.saveDisclosureLogsForHankkeet(hankkeet, userId)
+        disclosureLogService.saveForHankkeet(hankkeet, userId)
 
         verify { auditLogService wasNot Called }
     }
@@ -184,7 +184,7 @@ internal class DisclosureLogServiceTest {
             )
         val expectedLogs = hankkeet.flatMap { AuditLogEntryFactory.createReadEntriesForHanke(it) }
 
-        disclosureLogService.saveDisclosureLogsForHankkeet(hankkeet, userId)
+        disclosureLogService.saveForHankkeet(hankkeet, userId)
 
         verify { auditLogService.createAll(match(containsAll(expectedLogs))) }
     }
@@ -198,7 +198,7 @@ internal class DisclosureLogServiceTest {
             )
         val expectedLogs = AuditLogEntryFactory.createReadEntriesForHanke(hankkeet[0])
 
-        disclosureLogService.saveDisclosureLogsForHankkeet(hankkeet, userId)
+        disclosureLogService.saveForHankkeet(hankkeet, userId)
 
         verify { auditLogService.createAll(match(containsAll(expectedLogs))) }
     }
@@ -208,7 +208,7 @@ internal class DisclosureLogServiceTest {
         val hankeKayttaja = HankeKayttajaFactory.createDto()
         val expectedLogs = AuditLogEntryFactory.createReadEntryForHankeKayttaja(hankeKayttaja)
 
-        disclosureLogService.saveDisclosureLogsForHankeKayttaja(hankeKayttaja, userId)
+        disclosureLogService.saveForHankeKayttaja(hankeKayttaja, userId)
 
         verify { auditLogService.createAll(listOf(expectedLogs)) }
     }
@@ -218,7 +218,7 @@ internal class DisclosureLogServiceTest {
         val hankeKayttajat = HankeKayttajaFactory.createHankeKayttajat(amount = 2)
         val expectedLogs = AuditLogEntryFactory.createReadEntryForHankeKayttajat(hankeKayttajat)
 
-        disclosureLogService.saveDisclosureLogsForHankeKayttajat(hankeKayttajat, userId)
+        disclosureLogService.saveForHankeKayttajat(hankeKayttajat, userId)
 
         verify { auditLogService.createAll(match(containsAll(expectedLogs))) }
     }
@@ -241,7 +241,7 @@ internal class DisclosureLogServiceTest {
                     hankeTunnus = hankeTunnus,
                 )
 
-            disclosureLogService.saveDisclosureLogsForHakemusResponse(hakemusResponse, userId)
+            disclosureLogService.saveForHakemusResponse(hakemusResponse, userId)
 
             verify { auditLogService wasNot Called }
         }
@@ -263,7 +263,7 @@ internal class DisclosureLogServiceTest {
                     hankeTunnus = hankeTunnus,
                 )
 
-            disclosureLogService.saveDisclosureLogsForHakemusResponse(hakemusResponse, userId)
+            disclosureLogService.saveForHakemusResponse(hakemusResponse, userId)
 
             verify { auditLogService wasNot Called }
         }
@@ -284,7 +284,7 @@ internal class DisclosureLogServiceTest {
                     hankeTunnus = hankeTunnus,
                 )
 
-            disclosureLogService.saveDisclosureLogsForHakemusResponse(hakemusResponse, userId)
+            disclosureLogService.saveForHakemusResponse(hakemusResponse, userId)
 
             verify { auditLogService wasNot Called }
         }
@@ -305,7 +305,7 @@ internal class DisclosureLogServiceTest {
             val capturedLogs = slot<Collection<AuditLogEntry>>()
             every { auditLogService.createAll(capture(capturedLogs)) } returns mutableListOf()
 
-            disclosureLogService.saveDisclosureLogsForHakemusResponse(hakemusResponse, userId)
+            disclosureLogService.saveForHakemusResponse(hakemusResponse, userId)
 
             val expectedLogs =
                 listOf(HAKIJA, TYON_SUORITTAJA).map {
@@ -335,7 +335,7 @@ internal class DisclosureLogServiceTest {
             val capturedLogs = slot<Collection<AuditLogEntry>>()
             every { auditLogService.createAll(capture(capturedLogs)) } returns mutableListOf()
 
-            disclosureLogService.saveDisclosureLogsForHakemusResponse(application, userId)
+            disclosureLogService.saveForHakemusResponse(application, userId)
 
             assertThat(capturedLogs.captured)
                 .containsAtLeast(
@@ -377,7 +377,7 @@ internal class DisclosureLogServiceTest {
             val capturedLogs = slot<Collection<AuditLogEntry>>()
             every { auditLogService.createAll(capture(capturedLogs)) } returns mutableListOf()
 
-            disclosureLogService.saveDisclosureLogsForAllu(
+            disclosureLogService.saveForAllu(
                 applicationId,
                 hakemusData.toAlluCableReportData(hankeTunnus),
                 expectedStatus,
@@ -400,7 +400,7 @@ internal class DisclosureLogServiceTest {
             val capturedLogs = slot<Collection<AuditLogEntry>>()
             every { auditLogService.createAll(capture(capturedLogs)) } returns mutableListOf()
 
-            disclosureLogService.saveDisclosureLogsForAllu(
+            disclosureLogService.saveForAllu(
                 applicationId,
                 hakemusData.toAlluCableReportData(hankeTunnus),
                 Status.SUCCESS,
@@ -431,7 +431,7 @@ internal class DisclosureLogServiceTest {
                     contractorWithContacts = companyCustomer,
                 )
 
-            disclosureLogService.saveDisclosureLogsForAllu(
+            disclosureLogService.saveForAllu(
                 applicationId,
                 hakemusData.toAlluCableReportData(hankeTunnus),
                 Status.SUCCESS,
@@ -464,7 +464,7 @@ internal class DisclosureLogServiceTest {
             val capturedLogs = slot<Collection<AuditLogEntry>>()
             every { auditLogService.createAll(capture(capturedLogs)) } returns mutableListOf()
 
-            disclosureLogService.saveDisclosureLogsForAllu(
+            disclosureLogService.saveForAllu(
                 applicationId,
                 hakemusData.toAlluExcavationNotificationData(hankeTunnus),
                 Status.SUCCESS,
@@ -489,7 +489,7 @@ internal class DisclosureLogServiceTest {
             val capturedLogs = slot<Collection<AuditLogEntry>>()
             every { auditLogService.createAll(capture(capturedLogs)) } returns mutableListOf()
 
-            disclosureLogService.saveDisclosureLogsForAllu(
+            disclosureLogService.saveForAllu(
                 applicationId,
                 hakemusData.toAlluExcavationNotificationData(hankeTunnus),
                 Status.SUCCESS,
@@ -536,7 +536,7 @@ internal class DisclosureLogServiceTest {
                     objectBefore = expectedObject,
                 )
 
-            disclosureLogService.saveDisclosureLogsForCableReport(hakemus.toMetadata(), userId)
+            disclosureLogService.saveForCableReport(hakemus.toMetadata(), userId)
 
             verify { auditLogService.create(expectedLog) }
         }
@@ -568,7 +568,7 @@ internal class DisclosureLogServiceTest {
                     objectBefore = expectedObject)
             val metadata = PaatosMetadata(paatosId, hakemusId, hakemustunnus, tyyppi, tila)
 
-            disclosureLogService.saveDisclosureLogsForPaatos(metadata, userId)
+            disclosureLogService.saveForPaatos(metadata, userId)
 
             verifySequence { auditLogService.create(expectedLog) }
         }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/logging/DisclosureLoggingAspectTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/logging/DisclosureLoggingAspectTest.kt
@@ -1,0 +1,205 @@
+package fi.hel.haitaton.hanke.logging
+
+import assertk.all
+import assertk.assertFailure
+import assertk.assertions.hasClass
+import assertk.assertions.messageContains
+import fi.hel.haitaton.hanke.domain.Hanke
+import fi.hel.haitaton.hanke.factory.HankeFactory
+import fi.hel.haitaton.hanke.factory.ProfiiliFactory
+import fi.hel.haitaton.hanke.hakemus.HakemusDeletionResultDto
+import fi.hel.haitaton.hanke.test.USERNAME
+import io.mockk.checkUnnecessaryStub
+import io.mockk.clearAllMocks
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verifySequence
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.Authentication
+import org.springframework.security.core.context.SecurityContext
+import org.springframework.security.core.context.SecurityContextHolder
+
+class DisclosureLoggingAspectTest {
+
+    private val disclosureLogService: DisclosureLogService = mockk(relaxUnitFun = true)
+    private val disclosureLoggingAspect = DisclosureLoggingAspect(disclosureLogService)
+
+    @BeforeEach
+    fun cleanup() {
+        clearAllMocks()
+    }
+
+    @AfterEach
+    fun checkMocks() {
+        checkUnnecessaryStub()
+        confirmVerified(disclosureLogService)
+    }
+
+    @Nested
+    inner class LogResponse {
+
+        private fun mockAuthentication() {
+            val authentication: Authentication = mockk()
+            every { authentication.name } returns USERNAME
+            val context: SecurityContext = mockk()
+            every { context.authentication } returns authentication
+            SecurityContextHolder.setContext(context)
+        }
+
+        @Test
+        fun `does nothing when called with null`() {
+            disclosureLoggingAspect.logResponse(null)
+        }
+
+        @Test
+        fun `throws an exception when called with an unspecified type`() {
+            val failure = assertFailure { disclosureLoggingAspect.logResponse(5.toShort()) }
+
+            failure.all {
+                hasClass(UnknownResponseTypeException::class)
+                messageContains("Unknown response type")
+                messageContains("kotlin.Short")
+            }
+        }
+
+        @Test
+        fun `does nothing when called with a type that just returns`() {
+            disclosureLoggingAspect.logResponse(HakemusDeletionResultDto(false))
+        }
+
+        @Test
+        fun `calls disclosure service for logging when necessary`() {
+            mockAuthentication()
+
+            disclosureLoggingAspect.logResponse(ProfiiliFactory.DEFAULT_NAMES)
+
+            verifySequence {
+                disclosureLogService.saveForProfiiliNimi(ProfiiliFactory.DEFAULT_NAMES, USERNAME)
+            }
+        }
+
+        @Test
+        fun `does nothing when called with an empty list`() {
+            disclosureLoggingAspect.logResponse(listOf<Hanke>())
+        }
+
+        @Test
+        fun `throws an exception when called with a list of unknown types`() {
+            val failure = assertFailure { disclosureLoggingAspect.logResponse(listOf<Short>(4)) }
+
+            failure.all {
+                hasClass(UnknownResponseListTypeException::class)
+                messageContains("Unknown response type inside a list")
+                messageContains("kotlin.Short")
+            }
+        }
+
+        @Test
+        fun `throws an exception when called with a list of mixed types`() {
+            val list = listOf(HankeFactory.create(), "", "", 3, 4, "other string")
+
+            val failure = assertFailure { disclosureLoggingAspect.logResponse(list) }
+
+            failure.all {
+                hasClass(MixedElementsInResponseException::class)
+                messageContains("Mixed types inside a list")
+                messageContains("Expected type: fi.hel.haitaton.hanke.domain.Hanke")
+                messageContains(
+                    "Actual types: fi.hel.haitaton.hanke.domain.Hanke, kotlin.String, kotlin.Int")
+            }
+        }
+
+        @Test
+        fun `does nothing when response is a list of types that don't need logging`() {
+            disclosureLoggingAspect.logResponse(listOf(""))
+        }
+
+        @Test
+        fun `does nothing when response is a list where first element is not logged`() {
+            disclosureLoggingAspect.logResponse(listOf("", HankeFactory.create()))
+        }
+
+        @Test
+        fun `calls disclosure service for lists when list has loggable types`() {
+            mockAuthentication()
+            val list = listOf(HankeFactory.create(), HankeFactory.create(4))
+
+            disclosureLoggingAspect.logResponse(list)
+
+            verifySequence { disclosureLogService.saveForHankkeet(list, USERNAME) }
+        }
+
+        @Test
+        fun `calls disclosure service when response is a ResponseEntity wrapping a logged type`() {
+            mockAuthentication()
+
+            disclosureLoggingAspect.logResponse(
+                ResponseEntity.ofNullable(ProfiiliFactory.DEFAULT_NAMES))
+
+            verifySequence {
+                disclosureLogService.saveForProfiiliNimi(ProfiiliFactory.DEFAULT_NAMES, USERNAME)
+            }
+        }
+
+        @Test
+        fun `does nothing when called with an empty map`() {
+            disclosureLoggingAspect.logResponse(mapOf<Int, Hanke>())
+        }
+
+        @Test
+        fun `throws an exception when called with a map of unknown values`() {
+            val failure = assertFailure {
+                disclosureLoggingAspect.logResponse(mapOf<Int, Short>(4 to 4))
+            }
+
+            failure.all {
+                hasClass(UnknownResponseListTypeException::class)
+                messageContains("Unknown response type inside a list")
+                messageContains("kotlin.Short")
+            }
+        }
+
+        @Test
+        fun `throws an exception when called with a map of mixed type values`() {
+            val list =
+                listOf(HankeFactory.create(), "", "", 3, 4, "other string")
+                    .mapIndexed { i, v -> i to v }
+                    .toMap()
+
+            val failure = assertFailure { disclosureLoggingAspect.logResponse(list) }
+
+            failure.all {
+                hasClass(MixedElementsInResponseException::class)
+                messageContains("Mixed types inside a list")
+                messageContains("Expected type: fi.hel.haitaton.hanke.domain.Hanke")
+                messageContains(
+                    "Actual types: fi.hel.haitaton.hanke.domain.Hanke, kotlin.String, kotlin.Int")
+            }
+        }
+
+        @Test
+        fun `does nothing when response is a map with values of types that don't need logging`() {
+            disclosureLoggingAspect.logResponse(mapOf(1 to ""))
+        }
+
+        @Test
+        fun `does nothing when response is a map where first value is not logged`() {
+            disclosureLoggingAspect.logResponse(mapOf(1 to "", 2 to HankeFactory.create()))
+        }
+
+        @Test
+        fun `calls disclosure service with values when map has values with loggable types`() {
+            mockAuthentication()
+            val map = mapOf(1 to HankeFactory.create(), 2 to HankeFactory.create(4))
+
+            disclosureLoggingAspect.logResponse(map)
+
+            verifySequence { disclosureLogService.saveForHankkeet(map.values.toList(), USERNAME) }
+        }
+    }
+}


### PR DESCRIPTION
# Description

Use an `@Aspect` to handle disclosure logging instead of calling it explicitly from controller methods.

I'm worried we haven't always remembered to save the disclosure logs when writing new APIs. It's easy to forget since we need to add an explicit call to `disclosureService` to the controller method. There's also a lot of deduction involved, e.g. we don't run the logging for the return value of create hakemus endpoint, because the endpoint doesn't accept any personal information, so the response can't have any either. But if this assumption changes in the future, it's easy to miss the need to add the logging.

This PR adds an aspect to returning from controller methods to make it implicit. After returning, the return value is checked, and if it's a type that can contain personal information, the value is logged appropriately. The return value is, after all, the deciding factor on what should be logged.

The aspect is attached to any method annotated with `@Operation`. This seemed like the best distinction to find the actual controller methods. We could add it to every public method in classes named `*Controller`, but I think that would include extra things like exception handlers.

To make it impossible to forget, an exception is thrown on unknown types. So when implementing something with a new return value, you have to add it to the logging aspect, either with the logging or without it.

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [X] Other