### PR TITLE
HAI-2820 Add query param for retrieving application areas

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusControllerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusControllerITest.kt
@@ -479,10 +479,12 @@ class HakemusControllerITest(@Autowired override val mockMvc: MockMvc) : Control
             val response: HankkeenHakemuksetResponse =
                 get("$url?areas=true").andExpect(status().isOk).andReturnBody()
 
-            assertThat(response.applications).isNotEmpty()
-            val expected =
-                HankkeenHakemuksetResponse(hakemukset.map { HankkeenHakemusResponse(it, true) })
-            assertThat(response).isEqualTo(expected)
+            for (i in 0..3) {
+                assertThat(response.applications[i].applicationData.areas)
+                    .isNotNull()
+                    .single()
+                    .isEqualTo(hakemukset[i].applicationData.areas?.single())
+            }
             verifySequence {
                 authorizer.authorizeHankeTunnus(HANKE_TUNNUS, PermissionCode.VIEW.name)
                 hakemusService.hankkeenHakemukset(HANKE_TUNNUS)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusController.kt
@@ -35,6 +35,7 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 
@@ -95,12 +96,26 @@ class HakemusController(
                 ),
             ])
     @PreAuthorize("@hakemusAuthorizer.authorizeHankeTunnus(#hankeTunnus, 'VIEW')")
-    fun getHankkeenHakemukset(@PathVariable hankeTunnus: String): HankkeenHakemuksetResponse {
-        logger.info { "Finding applications for hanke $hankeTunnus" }
+    fun getHankkeenHakemukset(
+        @PathVariable hankeTunnus: String,
+        @Parameter(
+            description =
+                """Boolean flag indicating whether endpoint should return application areas. 
+                    Areas field will be null if false.""",
+            schema = Schema(type = "boolean", defaultValue = "false"),
+            required = false,
+            example = "false",
+        )
+        @RequestParam
+        areas: Boolean = false,
+    ): HankkeenHakemuksetResponse {
+        logger.info {
+            "Finding applications for hanke $hankeTunnus with areas ${if (areas) "included" else "excluded"}"
+        }
         val hakemukset = hakemusService.hankkeenHakemukset(hankeTunnus)
         logger.info { "Found ${hakemukset.size} applications for hanke $hankeTunnus" }
         return HankkeenHakemuksetResponse(
-            hakemukset.map { hakemus -> HankkeenHakemusResponse(hakemus) })
+            hakemukset.map { hakemus -> HankkeenHakemusResponse(hakemus, areas) })
     }
 
     @PostMapping("/hakemukset")

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HankkeenHakemuksetResponse.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HankkeenHakemuksetResponse.kt
@@ -14,7 +14,8 @@ data class HankkeenHakemusResponse(
     val applicationData: HankkeenHakemusDataResponse,
 ) {
     constructor(
-        hakemus: Hakemus
+        hakemus: Hakemus,
+        includeAreas: Boolean = false,
     ) : this(
         hakemus.id,
         hakemus.alluid,
@@ -22,8 +23,10 @@ data class HankkeenHakemusResponse(
         hakemus.applicationIdentifier,
         hakemus.applicationType,
         when (hakemus.applicationData) {
-            is JohtoselvityshakemusData -> HankkeenHakemusDataResponse(hakemus.applicationData)
-            is KaivuilmoitusData -> HankkeenHakemusDataResponse(hakemus.applicationData)
+            is JohtoselvityshakemusData ->
+                HankkeenHakemusDataResponse(hakemus.applicationData, includeAreas)
+            is KaivuilmoitusData ->
+                HankkeenHakemusDataResponse(hakemus.applicationData, includeAreas)
         },
     )
 }
@@ -33,22 +36,27 @@ data class HankkeenHakemusDataResponse(
     val startTime: ZonedDateTime?,
     val endTime: ZonedDateTime?,
     val pendingOnClient: Boolean,
+    val areas: List<Hakemusalue>?,
 ) {
     constructor(
-        cableReportApplicationData: JohtoselvityshakemusData
+        cableReportApplicationData: JohtoselvityshakemusData,
+        includeAreas: Boolean,
     ) : this(
         cableReportApplicationData.name,
         cableReportApplicationData.startTime,
         cableReportApplicationData.endTime,
         cableReportApplicationData.pendingOnClient,
+        if (includeAreas) cableReportApplicationData.areas else null,
     )
 
     constructor(
-        kaivuilmoitusEntityData: KaivuilmoitusData
+        kaivuilmoitusEntityData: KaivuilmoitusData,
+        includeAreas: Boolean,
     ) : this(
         kaivuilmoitusEntityData.name,
         kaivuilmoitusEntityData.startTime,
         kaivuilmoitusEntityData.endTime,
         kaivuilmoitusEntityData.pendingOnClient,
+        if (includeAreas) kaivuilmoitusEntityData.areas else null,
     )
 }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/HankkeenHakemuksetResponseDeserializer.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/HankkeenHakemuksetResponseDeserializer.kt
@@ -1,0 +1,84 @@
+package fi.hel.haitaton.hanke.hakemus
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.JsonDeserializer
+import com.fasterxml.jackson.databind.node.ObjectNode
+import fi.hel.haitaton.hanke.OBJECT_MAPPER
+import fi.hel.haitaton.hanke.allu.ApplicationStatus
+import java.time.ZonedDateTime
+
+class HankkeenHakemuksetResponseDeserializer : JsonDeserializer<HankkeenHakemuksetResponse>() {
+    override fun deserialize(
+        jsonParser: JsonParser,
+        deserializationContext: DeserializationContext
+    ): HankkeenHakemuksetResponse {
+        val root = jsonParser.readValueAsTree<ObjectNode>()
+        val applicationsNode = root.path("applications")
+        val applications =
+            applicationsNode.map { appNode ->
+                val basicApplication = OBJECT_MAPPER.treeToValue(appNode, BasicResponse::class.java)
+                val dataNode = appNode.path("applicationData") as ObjectNode
+                val basicApplicationData =
+                    OBJECT_MAPPER.treeToValue(dataNode, BasicDataResponse::class.java)
+                val areasNode = dataNode.path("areas")
+                val areas =
+                    areasNode.map { areaNode ->
+                        deserializeHakemusalue(
+                            areaNode as ObjectNode, basicApplication.applicationType)
+                    }
+                basicApplication.toHankkeenHakemusResponse(
+                    basicApplicationData.toHankkeenHakemusDataResponse(areas))
+            }
+        return HankkeenHakemuksetResponse(applications)
+    }
+
+    private fun deserializeHakemusalue(
+        areaNode: ObjectNode,
+        applicationType: ApplicationType
+    ): Hakemusalue {
+        return when (applicationType) {
+            ApplicationType.CABLE_REPORT ->
+                OBJECT_MAPPER.treeToValue(areaNode, JohtoselvitysHakemusalue::class.java)
+            ApplicationType.EXCAVATION_NOTIFICATION ->
+                OBJECT_MAPPER.treeToValue(areaNode, KaivuilmoitusAlue::class.java)
+        }
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    data class BasicResponse(
+        val id: Long,
+        val alluid: Int?,
+        val alluStatus: ApplicationStatus?,
+        val applicationIdentifier: String?,
+        val applicationType: ApplicationType,
+    ) {
+        fun toHankkeenHakemusResponse(hakemusData: HankkeenHakemusDataResponse) =
+            HankkeenHakemusResponse(
+                id,
+                alluid,
+                alluStatus,
+                applicationIdentifier,
+                applicationType,
+                hakemusData,
+            )
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    data class BasicDataResponse(
+        val name: String,
+        val startTime: ZonedDateTime?,
+        val endTime: ZonedDateTime?,
+        val pendingOnClient: Boolean,
+    ) {
+        fun toHankkeenHakemusDataResponse(areas: List<Hakemusalue>) =
+            HankkeenHakemusDataResponse(
+                name,
+                startTime,
+                endTime,
+                pendingOnClient,
+                if (areas.isNotEmpty()) areas else null,
+            )
+    }
+}

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/HankkeenHakemusResponseDeserializer.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/HankkeenHakemusResponseDeserializer.kt
@@ -9,29 +9,23 @@ import fi.hel.haitaton.hanke.OBJECT_MAPPER
 import fi.hel.haitaton.hanke.allu.ApplicationStatus
 import java.time.ZonedDateTime
 
-class HankkeenHakemuksetResponseDeserializer : JsonDeserializer<HankkeenHakemuksetResponse>() {
+class HankkeenHakemusResponseDeserializer : JsonDeserializer<HankkeenHakemusResponse>() {
     override fun deserialize(
         jsonParser: JsonParser,
         deserializationContext: DeserializationContext
-    ): HankkeenHakemuksetResponse {
+    ): HankkeenHakemusResponse {
         val root = jsonParser.readValueAsTree<ObjectNode>()
-        val applicationsNode = root.path("applications")
-        val applications =
-            applicationsNode.map { appNode ->
-                val basicApplication = OBJECT_MAPPER.treeToValue(appNode, BasicResponse::class.java)
-                val dataNode = appNode.path("applicationData") as ObjectNode
-                val basicApplicationData =
-                    OBJECT_MAPPER.treeToValue(dataNode, BasicDataResponse::class.java)
-                val areasNode = dataNode.path("areas")
-                val areas =
-                    areasNode.map { areaNode ->
-                        deserializeHakemusalue(
-                            areaNode as ObjectNode, basicApplication.applicationType)
-                    }
-                basicApplication.toHankkeenHakemusResponse(
-                    basicApplicationData.toHankkeenHakemusDataResponse(areas))
+        val basicApplication = OBJECT_MAPPER.treeToValue(root, BasicResponse::class.java)
+        val dataNode = root.path("applicationData") as ObjectNode
+        val basicApplicationData =
+            OBJECT_MAPPER.treeToValue(dataNode, BasicDataResponse::class.java)
+        val areasNode = dataNode.path("areas")
+        val areas =
+            areasNode.map { areaNode ->
+                deserializeHakemusalue(areaNode as ObjectNode, basicApplication.applicationType)
             }
-        return HankkeenHakemuksetResponse(applications)
+        return basicApplication.toHankkeenHakemusResponse(
+            basicApplicationData.toHankkeenHakemusDataResponse(areas))
     }
 
     private fun deserializeHakemusalue(

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/test/JacksonTestExtension.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/test/JacksonTestExtension.kt
@@ -6,6 +6,8 @@ import fi.hel.haitaton.hanke.hakemus.Hakemus
 import fi.hel.haitaton.hanke.hakemus.HakemusDeserializer
 import fi.hel.haitaton.hanke.hakemus.HakemusResponse
 import fi.hel.haitaton.hanke.hakemus.HakemusResponseDeserializer
+import fi.hel.haitaton.hanke.hakemus.HankkeenHakemuksetResponse
+import fi.hel.haitaton.hanke.hakemus.HankkeenHakemuksetResponseDeserializer
 import fi.hel.haitaton.hanke.taydennys.Taydennys
 import fi.hel.haitaton.hanke.taydennys.TaydennysDeserializer
 import fi.hel.haitaton.hanke.taydennys.TaydennysResponse
@@ -34,6 +36,8 @@ class JacksonTestExtension : BeforeAllCallback {
         module.addDeserializer(HakemusResponse::class.java, HakemusResponseDeserializer())
         module.addDeserializer(Taydennys::class.java, TaydennysDeserializer())
         module.addDeserializer(TaydennysResponse::class.java, TaydennysResponseDeserializer())
+        module.addDeserializer(
+            HankkeenHakemuksetResponse::class.java, HankkeenHakemuksetResponseDeserializer())
         OBJECT_MAPPER.registerModule(module)
     }
 

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/test/JacksonTestExtension.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/test/JacksonTestExtension.kt
@@ -6,8 +6,8 @@ import fi.hel.haitaton.hanke.hakemus.Hakemus
 import fi.hel.haitaton.hanke.hakemus.HakemusDeserializer
 import fi.hel.haitaton.hanke.hakemus.HakemusResponse
 import fi.hel.haitaton.hanke.hakemus.HakemusResponseDeserializer
-import fi.hel.haitaton.hanke.hakemus.HankkeenHakemuksetResponse
-import fi.hel.haitaton.hanke.hakemus.HankkeenHakemuksetResponseDeserializer
+import fi.hel.haitaton.hanke.hakemus.HankkeenHakemusResponse
+import fi.hel.haitaton.hanke.hakemus.HankkeenHakemusResponseDeserializer
 import fi.hel.haitaton.hanke.taydennys.Taydennys
 import fi.hel.haitaton.hanke.taydennys.TaydennysDeserializer
 import fi.hel.haitaton.hanke.taydennys.TaydennysResponse
@@ -37,7 +37,7 @@ class JacksonTestExtension : BeforeAllCallback {
         module.addDeserializer(Taydennys::class.java, TaydennysDeserializer())
         module.addDeserializer(TaydennysResponse::class.java, TaydennysResponseDeserializer())
         module.addDeserializer(
-            HankkeenHakemuksetResponse::class.java, HankkeenHakemuksetResponseDeserializer())
+            HankkeenHakemusResponse::class.java, HankkeenHakemusResponseDeserializer())
         OBJECT_MAPPER.registerModule(module)
     }
 


### PR DESCRIPTION
# Description

Add query param 'areas=true/false' for retrieving application areas for all project applications.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2820

## Type of change

- [ ] Bug fix 
- [x] New feature 
- [ ] Other

# Instructions for testing
With Swagger UI call GET `/hankkeet/{hankeTunnus}/hakemukset` with and without new query parameter `areas`

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 

# Other relevant info
Please describe here if there is e.g. some requirements for this change or
 other info that the tester/user needs to know.