### PR TITLE
HAI-2749 Use data instead of entity for hakemus update change check

### DIFF
--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
@@ -181,7 +181,7 @@ class HakemusService(
         assertNotSent(applicationEntity)
         assertCompatibility(applicationEntity, request)
 
-        if (!request.hasChanges(applicationEntity)) {
+        if (!request.hasChanges(hakemus.applicationData)) {
             logger.info("Not updating unchanged hakemus data. ${applicationEntity.logString()}")
             return hakemus
         }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusUpdateRequest.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusUpdateRequest.kt
@@ -30,9 +30,9 @@ sealed interface HakemusUpdateRequest {
 
     /**
      * Returns true if this application update request has changes compared to the given
-     * [hakemusEntity].
+     * [hakemusData].
      */
-    fun hasChanges(hakemusEntity: HakemusEntity): Boolean
+    fun hasChanges(hakemusData: HakemusData): Boolean
 
     /**
      * Converts this update request to an [HakemusEntityData] object using the given [hakemusEntity]
@@ -85,28 +85,25 @@ data class JohtoselvityshakemusUpdateRequest(
     // 5. sivu Yhteenveto (no input data)
 ) : HakemusUpdateRequest {
 
-    override fun hasChanges(hakemusEntity: HakemusEntity): Boolean {
-        val applicationData = hakemusEntity.hakemusEntityData as JohtoselvityshakemusEntityData
-        return name != applicationData.name ||
+    override fun hasChanges(hakemusData: HakemusData): Boolean {
+        hakemusData as JohtoselvityshakemusData
+
+        return name != hakemusData.name ||
             (postalAddress?.streetAddress?.streetName ?: "") !=
-                (applicationData.postalAddress?.streetAddress?.streetName ?: "") ||
-            constructionWork != applicationData.constructionWork ||
-            maintenanceWork != applicationData.maintenanceWork ||
-            propertyConnectivity != applicationData.propertyConnectivity ||
-            emergencyWork != applicationData.emergencyWork ||
-            rockExcavation != applicationData.rockExcavation ||
-            workDescription != applicationData.workDescription ||
-            startTime != applicationData.startTime ||
-            endTime != applicationData.endTime ||
-            areas != applicationData.areas ||
-            customerWithContacts.hasChanges(
-                hakemusEntity.yhteystiedot[ApplicationContactType.HAKIJA]) ||
-            contractorWithContacts.hasChanges(
-                hakemusEntity.yhteystiedot[ApplicationContactType.TYON_SUORITTAJA]) ||
-            propertyDeveloperWithContacts.hasChanges(
-                hakemusEntity.yhteystiedot[ApplicationContactType.RAKENNUTTAJA]) ||
-            representativeWithContacts.hasChanges(
-                hakemusEntity.yhteystiedot[ApplicationContactType.ASIANHOITAJA])
+                (hakemusData.postalAddress?.streetAddress?.streetName ?: "") ||
+            constructionWork != hakemusData.constructionWork ||
+            maintenanceWork != hakemusData.maintenanceWork ||
+            propertyConnectivity != hakemusData.propertyConnectivity ||
+            emergencyWork != hakemusData.emergencyWork ||
+            rockExcavation != hakemusData.rockExcavation ||
+            workDescription != hakemusData.workDescription ||
+            startTime != hakemusData.startTime ||
+            endTime != hakemusData.endTime ||
+            areas != hakemusData.areas ||
+            customerWithContacts.hasChanges(hakemusData.customerWithContacts) ||
+            contractorWithContacts.hasChanges(hakemusData.contractorWithContacts) ||
+            propertyDeveloperWithContacts.hasChanges(hakemusData.propertyDeveloperWithContacts) ||
+            representativeWithContacts.hasChanges(hakemusData.propertyDeveloperWithContacts)
     }
 
     override fun toEntityData(hakemusEntity: HakemusEntity) =
@@ -186,34 +183,31 @@ data class KaivuilmoitusUpdateRequest(
     // 5. sivu Yhteenveto (no input data)
 ) : HakemusUpdateRequest {
 
-    override fun hasChanges(hakemusEntity: HakemusEntity): Boolean {
-        val applicationData = hakemusEntity.hakemusEntityData as KaivuilmoitusEntityData
+    override fun hasChanges(hakemusData: HakemusData): Boolean {
+        hakemusData as KaivuilmoitusData
+
         val areas = areas?.map { it.withoutTormaystarkastelut() }
-        val newAreas = applicationData.areas?.map { it.withoutTormaystarkastelut() }
-        return name != applicationData.name ||
-            workDescription != applicationData.workDescription ||
-            constructionWork != applicationData.constructionWork ||
-            maintenanceWork != applicationData.maintenanceWork ||
-            emergencyWork != applicationData.emergencyWork ||
-            cableReportDone != applicationData.cableReportDone ||
-            rockExcavation != applicationData.rockExcavation ||
-            cableReports != applicationData.cableReports ||
-            placementContracts != applicationData.placementContracts ||
-            requiredCompetence != applicationData.requiredCompetence ||
-            startTime != applicationData.startTime ||
-            endTime != applicationData.endTime ||
+        val newAreas = hakemusData.areas?.map { it.withoutTormaystarkastelut() }
+
+        return name != hakemusData.name ||
+            workDescription != hakemusData.workDescription ||
+            constructionWork != hakemusData.constructionWork ||
+            maintenanceWork != hakemusData.maintenanceWork ||
+            emergencyWork != hakemusData.emergencyWork ||
+            cableReportDone != hakemusData.cableReportDone ||
+            rockExcavation != hakemusData.rockExcavation ||
+            cableReports != hakemusData.cableReports ||
+            placementContracts != hakemusData.placementContracts ||
+            requiredCompetence != hakemusData.requiredCompetence ||
+            startTime != hakemusData.startTime ||
+            endTime != hakemusData.endTime ||
             areas != newAreas ||
-            customerWithContacts.hasChanges(
-                hakemusEntity.yhteystiedot[ApplicationContactType.HAKIJA]) ||
-            contractorWithContacts.hasChanges(
-                hakemusEntity.yhteystiedot[ApplicationContactType.TYON_SUORITTAJA]) ||
-            propertyDeveloperWithContacts.hasChanges(
-                hakemusEntity.yhteystiedot[ApplicationContactType.RAKENNUTTAJA]) ||
-            representativeWithContacts.hasChanges(
-                hakemusEntity.yhteystiedot[ApplicationContactType.ASIANHOITAJA]) ||
-            invoicingCustomer.hasChanges(
-                applicationData.invoicingCustomer, applicationData.customerReference) ||
-            additionalInfo != applicationData.additionalInfo
+            customerWithContacts.hasChanges(hakemusData.customerWithContacts) ||
+            contractorWithContacts.hasChanges(hakemusData.contractorWithContacts) ||
+            propertyDeveloperWithContacts.hasChanges(hakemusData.propertyDeveloperWithContacts) ||
+            representativeWithContacts.hasChanges(hakemusData.representativeWithContacts) ||
+            invoicingCustomer.hasChanges(hakemusData.invoicingCustomer) ||
+            additionalInfo != hakemusData.additionalInfo
     }
 
     override fun toEntityData(hakemusEntity: HakemusEntity) =
@@ -269,15 +263,13 @@ data class CustomerRequest(
     /** Value is false when read from JSON with null or empty value. */
     val registryKeyHidden: Boolean = false,
 ) {
-    /**
-     * Returns true if this customer has changes compared to the given [hakemusyhteystietoEntity].
-     */
-    fun hasChanges(hakemusyhteystietoEntity: HakemusyhteystietoEntity): Boolean =
-        type != hakemusyhteystietoEntity.tyyppi ||
-            name != hakemusyhteystietoEntity.nimi ||
-            email != hakemusyhteystietoEntity.sahkoposti ||
-            phone != hakemusyhteystietoEntity.puhelinnumero ||
-            (!registryKeyHidden && registryKey != hakemusyhteystietoEntity.registryKey)
+    /** Returns true if this customer has changes compared to the given [hakemusyhteystieto]. */
+    fun hasChanges(hakemusyhteystieto: Hakemusyhteystieto): Boolean =
+        type != hakemusyhteystieto.tyyppi ||
+            name != hakemusyhteystieto.nimi ||
+            email != hakemusyhteystieto.sahkoposti ||
+            phone != hakemusyhteystieto.puhelinnumero ||
+            (!registryKeyHidden && registryKey != hakemusyhteystieto.registryKey)
 }
 
 /** For referencing [fi.hel.haitaton.hanke.permissions.HankeKayttaja] by its id. */
@@ -307,49 +299,42 @@ data class InvoicingPostalAddressRequest(
     val city: String?,
 )
 
-fun CustomerWithContactsRequest?.hasChanges(
-    hakemusyhteystietoEntity: HakemusyhteystietoEntity?
-): Boolean {
+fun CustomerWithContactsRequest?.hasChanges(hakemusyhteystieto: Hakemusyhteystieto?): Boolean {
     if (this == null) {
-        return hakemusyhteystietoEntity != null
+        return hakemusyhteystieto != null
     }
-    if (hakemusyhteystietoEntity == null) {
+    if (hakemusyhteystieto == null) {
         return true
     }
-    return this.customer.hasChanges(hakemusyhteystietoEntity) ||
-        this.contacts.hasChanges(hakemusyhteystietoEntity.yhteyshenkilot)
+    return customer.hasChanges(hakemusyhteystieto) ||
+        contacts.hasChanges(hakemusyhteystieto.yhteyshenkilot)
 }
 
-fun List<ContactRequest>?.hasChanges(
-    hakemusyhteyshenkilot: List<HakemusyhteyshenkiloEntity>
-): Boolean {
+fun List<ContactRequest>?.hasChanges(hakemusyhteyshenkilot: List<Hakemusyhteyshenkilo>): Boolean {
     if (this == null) {
         return hakemusyhteyshenkilot.isNotEmpty()
     }
     val requestIds = this.map { it.hankekayttajaId }.toSet()
-    val existingIds = hakemusyhteyshenkilot.map { it.hankekayttaja.id }.toSet()
+    val existingIds = hakemusyhteyshenkilot.map { it.hankekayttajaId }.toSet()
     return requestIds != existingIds
 }
 
-fun InvoicingCustomerRequest?.hasChanges(
-    invoicingCustomer: InvoicingCustomer?,
-    customerReference: String?
-): Boolean {
+fun InvoicingCustomerRequest?.hasChanges(laskutusyhteystieto: Laskutusyhteystieto?): Boolean {
     if (this == null) {
-        return invoicingCustomer != null
+        return laskutusyhteystieto != null
     }
-    if (invoicingCustomer == null) {
+    if (laskutusyhteystieto == null) {
         return true
     }
-    return type != invoicingCustomer.type ||
-        name != invoicingCustomer.name ||
-        registryKey != invoicingCustomer.registryKey ||
-        ovt != invoicingCustomer.ovt ||
-        invoicingOperator != invoicingCustomer.invoicingOperator ||
-        this.customerReference != customerReference ||
-        postalAddress.hasChanges(invoicingCustomer.postalAddress) ||
-        email != invoicingCustomer.email ||
-        phone != invoicingCustomer.phone
+    return type != laskutusyhteystieto.tyyppi ||
+        name != laskutusyhteystieto.nimi ||
+        registryKey != laskutusyhteystieto.registryKey ||
+        ovt != laskutusyhteystieto.ovttunnus ||
+        invoicingOperator != laskutusyhteystieto.valittajanTunnus ||
+        customerReference != laskutusyhteystieto.asiakkaanViite ||
+        postalAddress.hasChanges(laskutusyhteystieto.postalAddress()) ||
+        email != laskutusyhteystieto.sahkoposti ||
+        phone != laskutusyhteystieto.puhelinnumero
 }
 
 fun InvoicingPostalAddressRequest?.hasChanges(postalAddress: PostalAddress?): Boolean {

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/Hakemusyhteystieto.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/Hakemusyhteystieto.kt
@@ -69,10 +69,13 @@ data class Laskutusyhteystieto(
             ovttunnus,
             valittajanTunnus,
             asiakkaanViite,
-            PostalAddress(StreetAddress(katuosoite), postinumero ?: "", postitoimipaikka ?: ""),
+            postalAddress(),
             sahkoposti,
             puhelinnumero,
         )
+
+    fun postalAddress(): PostalAddress =
+        PostalAddress(StreetAddress(katuosoite), postinumero ?: "", postitoimipaikka ?: "")
 
     private fun hideRegistryKey(): Boolean =
         registryKey != null && (tyyppi == CustomerType.PERSON || tyyppi == CustomerType.OTHER)

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusyhteyshenkiloFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusyhteyshenkiloFactory.kt
@@ -20,6 +20,8 @@ object HakemusyhteyshenkiloFactory {
     val DEFAULT_HANKEKAYTTAJA_ID = UUID.fromString("db92aa0e-5a32-4ffd-83b3-9bff28700cfc")
 
     fun create(
+        id: UUID = DEFAULT_ID,
+        hankekayttajaId: UUID = DEFAULT_HANKEKAYTTAJA_ID,
         etunimi: String = DEFAULT_ETUNIMI,
         sukunimi: String = DEFAULT_SUKUNIMI,
         sahkoposti: String = DEFAULT_SAHKOPOSTI,
@@ -27,13 +29,13 @@ object HakemusyhteyshenkiloFactory {
         tilaaja: Boolean = DEFAULT_TILAAJA,
     ) =
         Hakemusyhteyshenkilo(
-            DEFAULT_ID,
-            DEFAULT_HANKEKAYTTAJA_ID,
-            etunimi,
-            sukunimi,
-            sahkoposti,
-            puhelin,
-            tilaaja
+            id = id,
+            hankekayttajaId = hankekayttajaId,
+            etunimi = etunimi,
+            sukunimi = sukunimi,
+            sahkoposti = sahkoposti,
+            puhelin = puhelin,
+            tilaaja = tilaaja,
         )
 
     fun createEntity(
@@ -59,7 +61,7 @@ object HakemusyhteyshenkiloFactory {
                     puhelin = puhelin,
                     permission = permission,
                 ),
-            tilaaja = tilaaja
+            tilaaja = tilaaja,
         )
 
     fun createEntity(
@@ -70,7 +72,7 @@ object HakemusyhteyshenkiloFactory {
         HakemusyhteyshenkiloEntity(
             hakemusyhteystieto = hakemusyhteystieto,
             hankekayttaja = hankekayttaja,
-            tilaaja = tilaaja
+            tilaaja = tilaaja,
         )
 
     fun HakemusyhteystietoEntity.withYhteyshenkilo(

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusyhteystietoFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusyhteystietoFactory.kt
@@ -93,7 +93,13 @@ object HakemusyhteystietoFactory {
         tilaaja: Boolean = HakemusyhteyshenkiloFactory.DEFAULT_TILAAJA,
     ): Hakemusyhteystieto {
         val yhteyshenkilo =
-            HakemusyhteyshenkiloFactory.create(etunimi, sukunimi, sahkoposti, puhelin, tilaaja)
+            HakemusyhteyshenkiloFactory.create(
+                etunimi = etunimi,
+                sukunimi = sukunimi,
+                sahkoposti = sahkoposti,
+                puhelin = puhelin,
+                tilaaja = tilaaja,
+            )
         return copy(yhteyshenkilot = yhteyshenkilot + yhteyshenkilo)
     }
 

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusUpdateRequestTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusUpdateRequestTest.kt
@@ -5,15 +5,12 @@ import assertk.assertions.isFalse
 import assertk.assertions.isTrue
 import fi.hel.haitaton.hanke.allu.CustomerType
 import fi.hel.haitaton.hanke.factory.ApplicationFactory
-import fi.hel.haitaton.hanke.factory.ApplicationFactory.Companion.createApplicationEntity
 import fi.hel.haitaton.hanke.factory.ApplicationFactory.Companion.createBlankExcavationNotificationData
 import fi.hel.haitaton.hanke.factory.ApplicationFactory.Companion.createExcavationNotificationArea
 import fi.hel.haitaton.hanke.factory.ApplicationFactory.Companion.createTyoalue
 import fi.hel.haitaton.hanke.factory.HakemusUpdateRequestFactory
 import fi.hel.haitaton.hanke.factory.HakemusyhteyshenkiloFactory
 import fi.hel.haitaton.hanke.factory.HakemusyhteystietoFactory
-import fi.hel.haitaton.hanke.factory.HankeFactory
-import fi.hel.haitaton.hanke.factory.HankeKayttajaFactory
 import fi.hel.haitaton.hanke.factory.HankealueFactory.TORMAYSTARKASTELU_DEFAULT_AUTOLIIKENNELUOKITTELU
 import fi.hel.haitaton.hanke.tormaystarkastelu.TormaystarkasteluTulos
 import java.util.UUID
@@ -21,60 +18,46 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 class HakemusUpdateRequestTest {
+    private val blankOriginal =
+        ApplicationFactory.createBlankCableReportApplicationData()
+            .toHakemusData(yhteystiedot = mapOf())
+
+    private val blankRequest =
+        HakemusUpdateRequestFactory.createBlankJohtoselvityshakemusUpdateRequest()
 
     @Nested
     inner class HasChanges {
 
         @Test
         fun `returns false when nothing has changed`() {
-            val original =
-                ApplicationFactory.createApplicationEntity(
-                    hakemusEntityData = ApplicationFactory.createBlankCableReportApplicationData(),
-                    hanke = HankeFactory.createMinimalEntity(),
-                )
-            val request = HakemusUpdateRequestFactory.createBlankJohtoselvityshakemusUpdateRequest()
+            val original = blankOriginal
+            val request = blankRequest
 
             assertThat(request.hasChanges(original)).isFalse()
         }
 
         @Test
         fun `returns true when name is changed`() {
-            val original =
-                ApplicationFactory.createApplicationEntity(
-                    hakemusEntityData = ApplicationFactory.createBlankCableReportApplicationData(),
-                    hanke = HankeFactory.createMinimalEntity(),
-                )
-            val request =
-                HakemusUpdateRequestFactory.createBlankJohtoselvityshakemusUpdateRequest()
-                    .copy(name = "Testihakemus")
+            val original = blankOriginal
+            val request = blankRequest.copy(name = "Testihakemus")
 
             assertThat(request.hasChanges(original)).isTrue()
         }
 
         @Test
         fun `returns true when work description is changed`() {
-            val original =
-                ApplicationFactory.createApplicationEntity(
-                    hakemusEntityData = ApplicationFactory.createBlankCableReportApplicationData(),
-                    hanke = HankeFactory.createMinimalEntity(),
-                )
+            val original = blankOriginal
             val request =
-                HakemusUpdateRequestFactory.createBlankJohtoselvityshakemusUpdateRequest()
-                    .copy(
-                        workDescription =
-                            "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
-                    )
+                blankRequest.copy(
+                    workDescription = "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+                )
 
             assertThat(request.hasChanges(original)).isTrue()
         }
 
         @Test
         fun `returns true when a customer is added`() {
-            val original =
-                ApplicationFactory.createApplicationEntity(
-                    hakemusEntityData = ApplicationFactory.createBlankCableReportApplicationData(),
-                    hanke = HankeFactory.createMinimalEntity(),
-                )
+            val original = blankOriginal
             val request =
                 createJohtoselvityshakemusUpdateRequestWithCustomerWithContacts(
                     "cd1d4d2f-526b-4ee5-a1fa-97b14d25a11f",
@@ -86,7 +69,7 @@ class HakemusUpdateRequestTest {
         @Test
         fun `returns true when new customer contact is added`() {
             val original =
-                createApplicationEntityWithYhteystiedot(
+                createHakemusDataWithYhteystiedot(
                     Pair("cd1d4d2f-526b-4ee5-a1fa-97b14d25a11f", true),
                 )
             val request =
@@ -101,7 +84,7 @@ class HakemusUpdateRequestTest {
         @Test
         fun `returns false when customer contacts are the same`() {
             val original =
-                createApplicationEntityWithYhteystiedot(
+                createHakemusDataWithYhteystiedot(
                     Pair("cd1d4d2f-526b-4ee5-a1fa-97b14d25a11f", true),
                     Pair("3047a6fc-5a2b-41cb-bb99-1f907fef2101", false),
                 )
@@ -117,7 +100,7 @@ class HakemusUpdateRequestTest {
         @Test
         fun `returns true when customer contacts are removed`() {
             val original =
-                createApplicationEntityWithYhteystiedot(
+                createHakemusDataWithYhteystiedot(
                     Pair("cd1d4d2f-526b-4ee5-a1fa-97b14d25a11f", true),
                     Pair("3047a6fc-5a2b-41cb-bb99-1f907fef2101", false),
                 )
@@ -128,64 +111,52 @@ class HakemusUpdateRequestTest {
 
         @Test
         fun `returns false when only tormaystarkastelu is missing in request`() {
-            val original = createApplicationEntityWithTormaystarkastelu()
+            val original = createHakemusDataWithTormaystarkastelu()
             val request = createKaivuilmoitusUpdateRequestWithoutTormaystarkastelu()
             assertThat(request.hasChanges(original)).isFalse()
         }
     }
 
-    private fun createApplicationEntityWithYhteystiedot(
-        vararg hakemusyhteyshenkilot: Pair<String, Boolean>
-    ): HakemusEntity =
-        ApplicationFactory.createApplicationEntity(
-                hakemusEntityData = ApplicationFactory.createBlankCableReportApplicationData(),
-                hanke = HankeFactory.createMinimalEntity(),
-            )
-            .apply {
-                yhteystiedot[ApplicationContactType.HAKIJA] =
-                    HakemusyhteystietoFactory.createEntity(
-                            tyyppi = CustomerType.COMPANY,
-                            rooli = ApplicationContactType.HAKIJA,
-                            nimi = "Testiyritys",
-                            sahkoposti = "info@testiyritys.fi",
-                            puhelinnumero = "0401234567",
-                            ytunnus = "1234567-8",
-                            application = this,
-                        )
-                        .apply {
-                            yhteyshenkilot.addAll(
-                                hakemusyhteyshenkilot.map {
-                                    HakemusyhteyshenkiloFactory.createEntity(
-                                        this,
-                                        HankeKayttajaFactory.createEntity(
-                                            id = UUID.fromString(it.first),
-                                        ),
-                                        it.second,
-                                    )
-                                },
-                            )
-                        }
+    private fun createHakemusDataWithYhteystiedot(
+        vararg hankekayttajat: Pair<String, Boolean>
+    ): HakemusData {
+        val yhteyshenkilot =
+            hankekayttajat.map { (hankekayttajaId, tilaaja) ->
+                HakemusyhteyshenkiloFactory.create(
+                    hankekayttajaId = UUID.fromString(hankekayttajaId), tilaaja = tilaaja)
             }
 
-    private fun createJohtoselvityshakemusUpdateRequestWithCustomerWithContacts(
-        vararg yhteyshenkilot: String
-    ): JohtoselvityshakemusUpdateRequest =
-        HakemusUpdateRequestFactory.createBlankJohtoselvityshakemusUpdateRequest()
-            .copy(
-                customerWithContacts =
-                    CustomerWithContactsRequest(
-                        CustomerRequest(
-                            type = CustomerType.COMPANY,
-                            name = "Testiyritys",
-                            email = "info@testiyritys.fi",
-                            phone = "0401234567",
-                            registryKey = "1234567-8",
-                        ),
-                        yhteyshenkilot.map { ContactRequest(UUID.fromString(it)) },
-                    ),
+        val yhteystieto =
+            HakemusyhteystietoFactory.create(
+                tyyppi = CustomerType.COMPANY,
+                rooli = ApplicationContactType.HAKIJA,
+                nimi = "Testiyritys",
+                sahkoposti = "info@testiyritys.fi",
+                puhelinnumero = "0401234567",
+                registryKey = "1234567-8",
+                yhteyshenkilot = yhteyshenkilot,
             )
 
-    private fun createApplicationEntityWithTormaystarkastelu(): HakemusEntity {
+        return blankOriginal.copy(customerWithContacts = yhteystieto)
+    }
+
+    private fun createJohtoselvityshakemusUpdateRequestWithCustomerWithContacts(
+        vararg hankekayttajaIds: String
+    ): JohtoselvityshakemusUpdateRequest {
+        val customer =
+            CustomerRequest(
+                type = CustomerType.COMPANY,
+                name = "Testiyritys",
+                email = "info@testiyritys.fi",
+                phone = "0401234567",
+                registryKey = "1234567-8",
+            )
+        val contacts = hankekayttajaIds.map { ContactRequest(UUID.fromString(it)) }
+        val customerWithContacts = CustomerWithContactsRequest(customer, contacts)
+        return blankRequest.copy(customerWithContacts = customerWithContacts)
+    }
+
+    private fun createHakemusDataWithTormaystarkastelu(): HakemusData {
         val tormaystarkasteluTulos =
             TormaystarkasteluTulos(
                 TORMAYSTARKASTELU_DEFAULT_AUTOLIIKENNELUOKITTELU,
@@ -195,12 +166,9 @@ class HakemusUpdateRequestTest {
             )
         val tyoalue = createTyoalue(tormaystarkasteluTulos = tormaystarkasteluTulos)
         val area = createExcavationNotificationArea(tyoalueet = listOf(tyoalue))
-        val hakemusEntityData = createBlankExcavationNotificationData().copy(areas = listOf(area))
-        return createApplicationEntity(
-            applicationType = ApplicationType.EXCAVATION_NOTIFICATION,
-            hakemusEntityData = hakemusEntityData,
-            hanke = HankeFactory.createMinimalEntity(),
-        )
+        return createBlankExcavationNotificationData()
+            .copy(areas = listOf(area))
+            .toHakemusData(mapOf())
     }
 
     private fun createKaivuilmoitusUpdateRequestWithoutTormaystarkastelu():


### PR DESCRIPTION
# Description

Compare the hakemus update to a ` HakemusData` instead of an `ApplicationEntity` when checking if the update has any changes.

This allows the same method to be used to check if a täydennys has any changes over the original hakemus or the previously saved täydennys.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2749

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [X] Other

# Instructions for testing
Should work like before.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 