### PR TITLE
HAI-2749 Add API for updating täydennys

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/IntegrationTestConfiguration.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/IntegrationTestConfiguration.kt
@@ -25,6 +25,7 @@ import fi.hel.haitaton.hanke.permissions.HankekayttajaDeleteService
 import fi.hel.haitaton.hanke.permissions.PermissionService
 import fi.hel.haitaton.hanke.profiili.ProfiiliClient
 import fi.hel.haitaton.hanke.security.AccessRules
+import fi.hel.haitaton.hanke.taydennys.TaydennysAuthorizer
 import fi.hel.haitaton.hanke.taydennys.TaydennysService
 import fi.hel.haitaton.hanke.testdata.TestDataService
 import fi.hel.haitaton.hanke.tormaystarkastelu.TormaystarkasteluLaskentaService
@@ -105,6 +106,8 @@ class IntegrationTestConfiguration {
     @Bean fun permissionService(): PermissionService = mockk()
 
     @Bean fun profiiliClient(): ProfiiliClient = mockk()
+
+    @Bean fun taydennysAuthorizer(): TaydennysAuthorizer = mockk()
 
     @Bean fun taydennysService(): TaydennysService = mockk()
 

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennysControllerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennysControllerITest.kt
@@ -6,29 +6,53 @@ import assertk.assertions.isEqualTo
 import assertk.assertions.prop
 import fi.hel.haitaton.hanke.ControllerTest
 import fi.hel.haitaton.hanke.HankeError
+import fi.hel.haitaton.hanke.HankeErrorDetail
 import fi.hel.haitaton.hanke.IntegrationTestConfiguration
 import fi.hel.haitaton.hanke.allu.ApplicationStatus
+import fi.hel.haitaton.hanke.allu.CustomerType
 import fi.hel.haitaton.hanke.andReturnBody
+import fi.hel.haitaton.hanke.andReturnContent
+import fi.hel.haitaton.hanke.factory.GeometriaFactory
 import fi.hel.haitaton.hanke.factory.HakemusFactory
+import fi.hel.haitaton.hanke.factory.HakemusUpdateRequestFactory
+import fi.hel.haitaton.hanke.factory.HakemusUpdateRequestFactory.withRegistryKey
+import fi.hel.haitaton.hanke.factory.HakemusUpdateRequestFactory.withTimes
+import fi.hel.haitaton.hanke.factory.HakemusUpdateRequestFactory.withWorkDescription
+import fi.hel.haitaton.hanke.factory.TaydennysFactory
 import fi.hel.haitaton.hanke.factory.TaydennyspyyntoFactory
+import fi.hel.haitaton.hanke.geometria.GeometriatDao
+import fi.hel.haitaton.hanke.hakemus.ApplicationType
 import fi.hel.haitaton.hanke.hakemus.HakemusAuthorizer
 import fi.hel.haitaton.hanke.hakemus.HakemusDataResponse
+import fi.hel.haitaton.hanke.hakemus.HakemusGeometryException
+import fi.hel.haitaton.hanke.hakemus.HakemusGeometryNotInsideHankeException
 import fi.hel.haitaton.hanke.hakemus.HakemusInWrongStatusException
 import fi.hel.haitaton.hanke.hakemus.HakemusNotFoundException
+import fi.hel.haitaton.hanke.hakemus.InvalidHakemusyhteyshenkiloException
+import fi.hel.haitaton.hanke.hakemus.InvalidHakemusyhteystietoException
+import fi.hel.haitaton.hanke.hakemus.InvalidHiddenRegistryKey
+import fi.hel.haitaton.hanke.hakemus.andVerifyRegistryKeys
 import fi.hel.haitaton.hanke.hankeError
 import fi.hel.haitaton.hanke.logging.DisclosureLogService
 import fi.hel.haitaton.hanke.permissions.PermissionCode
 import fi.hel.haitaton.hanke.test.USERNAME
+import fi.hel.haitaton.hanke.toJsonString
+import io.mockk.Called
 import io.mockk.checkUnnecessaryStub
 import io.mockk.clearAllMocks
 import io.mockk.confirmVerified
 import io.mockk.every
 import io.mockk.verifySequence
+import java.time.ZonedDateTime
 import java.util.UUID
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+import org.skyscreamer.jsonassert.JSONAssert
+import org.skyscreamer.jsonassert.JSONCompareMode
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.context.annotation.Import
@@ -44,10 +68,12 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 @WithMockUser(USERNAME)
 class TaydennysControllerITest(@Autowired override val mockMvc: MockMvc) : ControllerTest {
     @Autowired private lateinit var taydennysService: TaydennysService
+    @Autowired private lateinit var taydennysAuthorizer: TaydennysAuthorizer
     @Autowired private lateinit var hakemusAuthorizer: HakemusAuthorizer
     @Autowired private lateinit var disclosureLogService: DisclosureLogService
 
     private val hakemusId = 24050L
+    private val id = UUID.fromString("130ee6a4-01c1-4222-8f6f-3baefb133468")
 
     @BeforeEach
     fun clearMocks() {
@@ -68,7 +94,8 @@ class TaydennysControllerITest(@Autowired override val mockMvc: MockMvc) : Contr
             Taydennys(
                 UUID.fromString("90b67df3-cd13-4dca-bd30-9dda424d1260"),
                 TaydennyspyyntoFactory.DEFAULT_ID,
-                HakemusFactory.createJohtoselvityshakemusData(name = "Täydennettävä hakemus"))
+                HakemusFactory.createJohtoselvityshakemusData(name = "Täydennettävä hakemus"),
+            )
 
         @Test
         @WithAnonymousUser
@@ -80,14 +107,18 @@ class TaydennysControllerITest(@Autowired override val mockMvc: MockMvc) : Contr
         fun `returns 404 when application does not exist`() {
             every {
                 hakemusAuthorizer.authorizeHakemusId(
-                    hakemusId, PermissionCode.EDIT_APPLICATIONS.name)
+                    hakemusId,
+                    PermissionCode.EDIT_APPLICATIONS.name,
+                )
             } throws HakemusNotFoundException(hakemusId)
 
             post(url).andExpect(status().isNotFound)
 
             verifySequence {
                 hakemusAuthorizer.authorizeHakemusId(
-                    hakemusId, PermissionCode.EDIT_APPLICATIONS.name)
+                    hakemusId,
+                    PermissionCode.EDIT_APPLICATIONS.name,
+                )
             }
         }
 
@@ -95,7 +126,9 @@ class TaydennysControllerITest(@Autowired override val mockMvc: MockMvc) : Contr
         fun `returns 409 when hakemus doesn't have an open taydennyspyynto`() {
             every {
                 hakemusAuthorizer.authorizeHakemusId(
-                    hakemusId, PermissionCode.EDIT_APPLICATIONS.name)
+                    hakemusId,
+                    PermissionCode.EDIT_APPLICATIONS.name,
+                )
             } returns true
             every { taydennysService.create(hakemusId, USERNAME) } throws
                 NoTaydennyspyyntoException(hakemusId)
@@ -104,7 +137,9 @@ class TaydennysControllerITest(@Autowired override val mockMvc: MockMvc) : Contr
 
             verifySequence {
                 hakemusAuthorizer.authorizeHakemusId(
-                    hakemusId, PermissionCode.EDIT_APPLICATIONS.name)
+                    hakemusId,
+                    PermissionCode.EDIT_APPLICATIONS.name,
+                )
                 taydennysService.create(hakemusId, USERNAME)
             }
         }
@@ -113,20 +148,25 @@ class TaydennysControllerITest(@Autowired override val mockMvc: MockMvc) : Contr
         fun `returns 409 when the hakemus is not in WAITING_INFORMATION status`() {
             every {
                 hakemusAuthorizer.authorizeHakemusId(
-                    hakemusId, PermissionCode.EDIT_APPLICATIONS.name)
+                    hakemusId,
+                    PermissionCode.EDIT_APPLICATIONS.name,
+                )
             } returns true
             val hakemus = HakemusFactory.create(hakemusId, alluStatus = ApplicationStatus.HANDLING)
             every { taydennysService.create(hakemusId, USERNAME) } throws
                 HakemusInWrongStatusException(
                     hakemus,
                     ApplicationStatus.HANDLING,
-                    listOf(ApplicationStatus.WAITING_INFORMATION))
+                    listOf(ApplicationStatus.WAITING_INFORMATION),
+                )
 
             post(url).andExpect(status().isConflict).andExpect(hankeError(HankeError.HAI2015))
 
             verifySequence {
                 hakemusAuthorizer.authorizeHakemusId(
-                    hakemusId, PermissionCode.EDIT_APPLICATIONS.name)
+                    hakemusId,
+                    PermissionCode.EDIT_APPLICATIONS.name,
+                )
                 taydennysService.create(hakemusId, USERNAME)
             }
         }
@@ -135,7 +175,9 @@ class TaydennysControllerITest(@Autowired override val mockMvc: MockMvc) : Contr
         fun `returns the created taydennys and writes the access to disclosure logs`() {
             every {
                 hakemusAuthorizer.authorizeHakemusId(
-                    hakemusId, PermissionCode.EDIT_APPLICATIONS.name)
+                    hakemusId,
+                    PermissionCode.EDIT_APPLICATIONS.name,
+                )
             } returns true
             every { taydennysService.create(hakemusId, USERNAME) } returns taydennys
 
@@ -150,9 +192,283 @@ class TaydennysControllerITest(@Autowired override val mockMvc: MockMvc) : Contr
             }
             verifySequence {
                 hakemusAuthorizer.authorizeHakemusId(
-                    hakemusId, PermissionCode.EDIT_APPLICATIONS.name)
+                    hakemusId,
+                    PermissionCode.EDIT_APPLICATIONS.name,
+                )
                 taydennysService.create(hakemusId, USERNAME)
                 disclosureLogService.saveForTaydennys(response, USERNAME)
+            }
+        }
+    }
+
+    @Nested
+    inner class Update {
+        private val url = "/taydennykset/$id"
+
+        @Test
+        @WithAnonymousUser
+        fun `returns 401 when unknown user`() {
+            put(url, HakemusUpdateRequestFactory.createBlankJohtoselvityshakemusUpdateRequest())
+                .andExpect(status().isUnauthorized)
+
+            verifySequence { taydennysService wasNot Called }
+        }
+
+        @Test
+        fun `returns 400 when no request body`() {
+            put(url).andExpect(status().isBadRequest)
+
+            verifySequence { taydennysService wasNot Called }
+        }
+
+        @Test
+        fun `returns 400 when end date before start date`() {
+            val request =
+                HakemusUpdateRequestFactory.createBlankJohtoselvityshakemusUpdateRequest()
+                    .withTimes(
+                        startTime = ZonedDateTime.now(),
+                        endTime = ZonedDateTime.now().minusDays(1),
+                    )
+            every {
+                taydennysAuthorizer.authorize(id, PermissionCode.EDIT_APPLICATIONS.name)
+            } returns true
+
+            val response = put(url, request).andExpect(status().isBadRequest).andReturnContent()
+
+            assertThat(response)
+                .isEqualTo(HankeErrorDetail(HankeError.HAI2008, listOf("endTime")).toJsonString())
+            verifySequence {
+                taydennysAuthorizer.authorize(id, PermissionCode.EDIT_APPLICATIONS.name)
+                taydennysService wasNot Called
+            }
+        }
+
+        @Test
+        fun `returns 400 when invalid y-tunnus`() {
+            val request =
+                HakemusUpdateRequestFactory.createFilledJohtoselvityshakemusUpdateRequest()
+                    .withRegistryKey("281192-937W")
+            every {
+                taydennysAuthorizer.authorize(id, PermissionCode.EDIT_APPLICATIONS.name)
+            } returns true
+
+            put(url, request).andExpect(status().isBadRequest)
+
+            verifySequence {
+                taydennysAuthorizer.authorize(id, PermissionCode.EDIT_APPLICATIONS.name)
+                taydennysService wasNot Called
+            }
+        }
+
+        @Test
+        fun `returns 400 when missing required data`() {
+            val mockErrorPaths = listOf("workDescription")
+            val request =
+                HakemusUpdateRequestFactory.createFilledJohtoselvityshakemusUpdateRequest()
+                    .withWorkDescription(" ")
+            every {
+                taydennysAuthorizer.authorize(id, PermissionCode.EDIT_APPLICATIONS.name)
+            } returns true
+
+            val response = put(url, request).andExpect(status().isBadRequest).andReturnContent()
+
+            assertThat(response)
+                .isEqualTo(HankeErrorDetail(HankeError.HAI2008, mockErrorPaths).toJsonString())
+            verifySequence {
+                taydennysAuthorizer.authorize(id, PermissionCode.EDIT_APPLICATIONS.name)
+                taydennysService wasNot Called
+            }
+        }
+
+        @Test
+        fun `returns 404 when no taydennys`() {
+            val request =
+                HakemusUpdateRequestFactory.createFilledJohtoselvityshakemusUpdateRequest()
+            every {
+                taydennysAuthorizer.authorize(id, PermissionCode.EDIT_APPLICATIONS.name)
+            } throws TaydennysNotFoundException(id)
+
+            put(url, request)
+                .andExpect(status().isNotFound)
+                .andExpect(hankeError(HankeError.HAI6001))
+
+            verifySequence {
+                taydennysAuthorizer.authorize(id, PermissionCode.EDIT_APPLICATIONS.name)
+            }
+        }
+
+        @Test
+        fun `returns 400 when request is not of the same type as the application`() {
+            val request =
+                HakemusUpdateRequestFactory.createFilledJohtoselvityshakemusUpdateRequest()
+            every {
+                taydennysAuthorizer.authorize(id, PermissionCode.EDIT_APPLICATIONS.name)
+            } returns true
+            every { taydennysService.updateTaydennys(id, request, USERNAME) } throws
+                IncompatibleTaydennysUpdateException(
+                    TaydennysFactory.createEntity(id = id),
+                    ApplicationType.EXCAVATION_NOTIFICATION,
+                    ApplicationType.CABLE_REPORT,
+                )
+
+            put(url, request)
+                .andExpect(status().isBadRequest)
+                .andExpect(hankeError(HankeError.HAI2002))
+
+            verifySequence {
+                taydennysAuthorizer.authorize(id, PermissionCode.EDIT_APPLICATIONS.name)
+                taydennysService.updateTaydennys(id, request, USERNAME)
+            }
+        }
+
+        @Test
+        fun `returns 400 when request areas contain invalid geometry`() {
+            val request =
+                HakemusUpdateRequestFactory.createFilledJohtoselvityshakemusUpdateRequest()
+            every {
+                taydennysAuthorizer.authorize(id, PermissionCode.EDIT_APPLICATIONS.name)
+            } returns true
+            every { taydennysService.updateTaydennys(id, request, USERNAME) } throws
+                HakemusGeometryException(GeometriatDao.InvalidDetail("", ""))
+
+            put(url, request)
+                .andExpect(status().isBadRequest)
+                .andExpect(hankeError(HankeError.HAI2005))
+
+            verifySequence {
+                taydennysAuthorizer.authorize(id, PermissionCode.EDIT_APPLICATIONS.name)
+                taydennysService.updateTaydennys(id, request, USERNAME)
+            }
+        }
+
+        @Test
+        fun `returns 400 when request areas outside hankealueet`() {
+            val request =
+                HakemusUpdateRequestFactory.createFilledJohtoselvityshakemusUpdateRequest()
+            every {
+                taydennysAuthorizer.authorize(id, PermissionCode.EDIT_APPLICATIONS.name)
+            } returns true
+            every { taydennysService.updateTaydennys(id, request, USERNAME) } throws
+                HakemusGeometryNotInsideHankeException(GeometriaFactory.polygon())
+
+            put(url, request)
+                .andExpect(status().isBadRequest)
+                .andExpect(hankeError(HankeError.HAI2007))
+
+            verifySequence {
+                taydennysAuthorizer.authorize(id, PermissionCode.EDIT_APPLICATIONS.name)
+                taydennysService.updateTaydennys(id, request, USERNAME)
+            }
+        }
+
+        @Test
+        fun `returns 400 when request contain invalid customer`() {
+            val request =
+                HakemusUpdateRequestFactory.createFilledJohtoselvityshakemusUpdateRequest()
+            every {
+                taydennysAuthorizer.authorize(id, PermissionCode.EDIT_APPLICATIONS.name)
+            } returns true
+            every { taydennysService.updateTaydennys(id, request, USERNAME) } throws
+                InvalidHakemusyhteystietoException(
+                    UUID.fromString("c47d2b42-0c79-410e-a3e4-40e023d98a2f"),
+                    UUID.fromString("45efa6f5-6d94-473b-9739-6eb40ec4e7d0"),
+                )
+
+            put(url, request)
+                .andExpect(status().isBadRequest)
+                .andExpect(hankeError(HankeError.HAI2010))
+
+            verifySequence {
+                taydennysAuthorizer.authorize(id, PermissionCode.EDIT_APPLICATIONS.name)
+                taydennysService.updateTaydennys(id, request, USERNAME)
+            }
+        }
+
+        @Test
+        fun `returns 400 when request contain invalid use of hidden registry key`() {
+            val request = HakemusUpdateRequestFactory.createFilledKaivuilmoitusUpdateRequest()
+            every {
+                taydennysAuthorizer.authorize(id, PermissionCode.EDIT_APPLICATIONS.name)
+            } returns true
+            every { taydennysService.updateTaydennys(id, request, USERNAME) } throws
+                InvalidHiddenRegistryKey(
+                    "Reason for error",
+                    CustomerType.COMPANY,
+                    CustomerType.PERSON,
+                )
+
+            put(url, request)
+                .andExpect(status().isBadRequest)
+                .andExpect(hankeError(HankeError.HAI2010))
+
+            verifySequence {
+                taydennysAuthorizer.authorize(id, PermissionCode.EDIT_APPLICATIONS.name)
+                taydennysService.updateTaydennys(id, request, USERNAME)
+            }
+        }
+
+        @Test
+        fun `returns 400 when request contain invalid contact`() {
+            val request =
+                HakemusUpdateRequestFactory.createFilledJohtoselvityshakemusUpdateRequest()
+            every {
+                taydennysAuthorizer.authorize(id, PermissionCode.EDIT_APPLICATIONS.name)
+            } returns true
+            every { taydennysService.updateTaydennys(id, request, USERNAME) } throws
+                InvalidHakemusyhteyshenkiloException(setOf())
+
+            put(url, request)
+                .andExpect(status().isBadRequest)
+                .andExpect(hankeError(HankeError.HAI2011))
+
+            verifySequence {
+                taydennysAuthorizer.authorize(id, PermissionCode.EDIT_APPLICATIONS.name)
+                taydennysService.updateTaydennys(id, request, USERNAME)
+            }
+        }
+
+        @ParameterizedTest
+        @EnumSource(ApplicationType::class)
+        fun `returns taydennys when it exists`(hakemusType: ApplicationType) {
+            val taydennys = TaydennysFactory.create(hakemusType = hakemusType)
+            val request = HakemusUpdateRequestFactory.createFilledUpdateRequest(hakemusType)
+            every {
+                taydennysAuthorizer.authorize(id, PermissionCode.EDIT_APPLICATIONS.name)
+            } returns true
+            every { taydennysService.updateTaydennys(id, request, USERNAME) } returns taydennys
+
+            val response = put(url, request).andExpect(status().isOk).andReturnContent()
+
+            val expectedResponse = taydennys.toResponse()
+            JSONAssert.assertEquals(
+                expectedResponse.toJsonString(),
+                response,
+                JSONCompareMode.NON_EXTENSIBLE,
+            )
+            verifySequence {
+                taydennysAuthorizer.authorize(id, PermissionCode.EDIT_APPLICATIONS.name)
+                taydennysService.updateTaydennys(id, request, USERNAME)
+                disclosureLogService.saveForTaydennys(expectedResponse, USERNAME)
+            }
+        }
+
+        @ParameterizedTest
+        @EnumSource(CustomerType::class, names = ["PERSON", "OTHER"])
+        fun `hides the registry key of person customers when it's not null`(tyyppi: CustomerType) {
+            val hakemusdata = HakemusFactory.hakemusDataForRegistryKeyTest(tyyppi)
+            val taydennys = TaydennysFactory.create(id = id, hakemusData = hakemusdata)
+            val request = HakemusUpdateRequestFactory.createFilledKaivuilmoitusUpdateRequest()
+            every {
+                taydennysAuthorizer.authorize(id, PermissionCode.EDIT_APPLICATIONS.name)
+            } returns true
+            every { taydennysService.updateTaydennys(id, request, USERNAME) } returns taydennys
+
+            put(url, request).andExpect(status().isOk).andVerifyRegistryKeys()
+
+            verifySequence {
+                taydennysAuthorizer.authorize(id, PermissionCode.EDIT_APPLICATIONS.name)
+                taydennysService.updateTaydennys(id, request, USERNAME)
+                disclosureLogService.saveForTaydennys(taydennys.toResponse(), USERNAME)
             }
         }
     }

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennysServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennysServiceITest.kt
@@ -144,7 +144,7 @@ class TaydennysServiceITest(
     }
 
     @Nested
-    inner class CreateFromHakemus {
+    inner class Create {
         private val fixedUUID = UUID.fromString("789b38cf-5345-4889-a5b8-2711c47559c8")
 
         private fun builder() =

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/taydennys/UpdateTaydennysITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/taydennys/UpdateTaydennysITest.kt
@@ -1,0 +1,857 @@
+package fi.hel.haitaton.hanke.taydennys
+
+import assertk.all
+import assertk.assertFailure
+import assertk.assertThat
+import assertk.assertions.contains
+import assertk.assertions.containsExactly
+import assertk.assertions.containsExactlyInAnyOrder
+import assertk.assertions.extracting
+import assertk.assertions.hasClass
+import assertk.assertions.hasSize
+import assertk.assertions.isEmpty
+import assertk.assertions.isEqualTo
+import assertk.assertions.isInstanceOf
+import assertk.assertions.isNotNull
+import assertk.assertions.isNull
+import assertk.assertions.isTrue
+import assertk.assertions.messageContains
+import assertk.assertions.prop
+import assertk.assertions.single
+import com.icegreen.greenmail.configuration.GreenMailConfiguration
+import com.icegreen.greenmail.junit5.GreenMailExtension
+import com.icegreen.greenmail.util.ServerSetupTest
+import fi.hel.haitaton.hanke.HankeEntity
+import fi.hel.haitaton.hanke.HankeRepository
+import fi.hel.haitaton.hanke.IntegrationTest
+import fi.hel.haitaton.hanke.allu.AlluClient
+import fi.hel.haitaton.hanke.allu.CustomerType
+import fi.hel.haitaton.hanke.asJsonResource
+import fi.hel.haitaton.hanke.email.textBody
+import fi.hel.haitaton.hanke.factory.ApplicationFactory
+import fi.hel.haitaton.hanke.factory.ApplicationFactory.Companion.createExcavationNotificationArea
+import fi.hel.haitaton.hanke.factory.ApplicationFactory.Companion.createTyoalue
+import fi.hel.haitaton.hanke.factory.GeometriaFactory
+import fi.hel.haitaton.hanke.factory.HakemusFactory
+import fi.hel.haitaton.hanke.factory.HakemusUpdateRequestFactory
+import fi.hel.haitaton.hanke.factory.HakemusUpdateRequestFactory.withArea
+import fi.hel.haitaton.hanke.factory.HakemusUpdateRequestFactory.withAreas
+import fi.hel.haitaton.hanke.factory.HakemusUpdateRequestFactory.withContractor
+import fi.hel.haitaton.hanke.factory.HakemusUpdateRequestFactory.withCustomer
+import fi.hel.haitaton.hanke.factory.HakemusUpdateRequestFactory.withCustomerWithContactsRequest
+import fi.hel.haitaton.hanke.factory.HakemusUpdateRequestFactory.withDates
+import fi.hel.haitaton.hanke.factory.HakemusUpdateRequestFactory.withInvoicingCustomer
+import fi.hel.haitaton.hanke.factory.HakemusUpdateRequestFactory.withName
+import fi.hel.haitaton.hanke.factory.HakemusUpdateRequestFactory.withRequiredCompetence
+import fi.hel.haitaton.hanke.factory.HakemusUpdateRequestFactory.withWorkDescription
+import fi.hel.haitaton.hanke.factory.HakemusyhteystietoFactory
+import fi.hel.haitaton.hanke.factory.HankeFactory
+import fi.hel.haitaton.hanke.factory.HankeKayttajaFactory
+import fi.hel.haitaton.hanke.factory.TaydennysFactory
+import fi.hel.haitaton.hanke.factory.TaydennysFactory.Companion.toUpdateRequest
+import fi.hel.haitaton.hanke.findByType
+import fi.hel.haitaton.hanke.firstReceivedMessage
+import fi.hel.haitaton.hanke.hakemus.ApplicationContactType.TYON_SUORITTAJA
+import fi.hel.haitaton.hanke.hakemus.ApplicationType
+import fi.hel.haitaton.hanke.hakemus.HakemusGeometryException
+import fi.hel.haitaton.hanke.hakemus.HakemusGeometryNotInsideHankeException
+import fi.hel.haitaton.hanke.hakemus.HakemusRepository
+import fi.hel.haitaton.hanke.hakemus.Hakemusyhteystieto
+import fi.hel.haitaton.hanke.hakemus.InvalidHakemusyhteyshenkiloException
+import fi.hel.haitaton.hanke.hakemus.InvalidHakemusyhteystietoException
+import fi.hel.haitaton.hanke.hakemus.InvalidHiddenRegistryKey
+import fi.hel.haitaton.hanke.hakemus.JohtoselvityshakemusData
+import fi.hel.haitaton.hanke.hakemus.KaivuilmoitusAlue
+import fi.hel.haitaton.hanke.hakemus.KaivuilmoitusData
+import fi.hel.haitaton.hanke.hakemus.KaivuilmoitusUpdateRequest
+import fi.hel.haitaton.hanke.hakemus.Laskutusyhteystieto
+import fi.hel.haitaton.hanke.hakemus.Tyoalue
+import fi.hel.haitaton.hanke.logging.AuditLogRepository
+import fi.hel.haitaton.hanke.logging.ObjectType
+import fi.hel.haitaton.hanke.permissions.HankekayttajaRepository
+import fi.hel.haitaton.hanke.permissions.PermissionService
+import fi.hel.haitaton.hanke.test.USERNAME
+import fi.hel.haitaton.hanke.toJsonString
+import fi.hel.haitaton.hanke.tormaystarkastelu.Autoliikenneluokittelu
+import fi.hel.haitaton.hanke.tormaystarkastelu.TormaystarkasteluTulos
+import io.mockk.checkUnnecessaryStub
+import io.mockk.clearAllMocks
+import io.mockk.confirmVerified
+import java.time.ZonedDateTime
+import java.util.UUID
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+import org.junit.jupiter.params.provider.NullSource
+import org.junit.jupiter.params.provider.ValueSource
+import org.springframework.beans.factory.annotation.Autowired
+
+class UpdateTaydennysITest(
+    @Autowired private val taydennysService: TaydennysService,
+    @Autowired private val permissionService: PermissionService,
+    @Autowired private val hakemusRepository: HakemusRepository,
+    @Autowired private val hankekayttajaRepository: HankekayttajaRepository,
+    @Autowired private val hankeRepository: HankeRepository,
+    @Autowired private val auditLogRepository: AuditLogRepository,
+    @Autowired private val taydennysFactory: TaydennysFactory,
+    @Autowired private val hakemusFactory: HakemusFactory,
+    @Autowired private val hankeFactory: HankeFactory,
+    @Autowired private val hankeKayttajaFactory: HankeKayttajaFactory,
+    @Autowired private val alluClient: AlluClient,
+) : IntegrationTest() {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val greenMail: GreenMailExtension =
+            GreenMailExtension(ServerSetupTest.SMTP)
+                .withConfiguration(GreenMailConfiguration.aConfig().withDisabledAuthentication())
+    }
+
+    @BeforeEach
+    fun clearMocks() {
+        clearAllMocks()
+    }
+
+    @AfterEach
+    fun checkMocks() {
+        checkUnnecessaryStub()
+        confirmVerified(alluClient)
+    }
+
+    @ParameterizedTest
+    @EnumSource(ApplicationType::class)
+    fun `throws exception when the taydennys does not exist`(type: ApplicationType) {
+        val request = HakemusUpdateRequestFactory.createFilledUpdateRequest(type)
+        val taydennysId = UUID.fromString("21404863-edc8-4c28-8d14-35ffc06c04eb")
+
+        val exception = assertFailure {
+            taydennysService.updateTaydennys(taydennysId, request, USERNAME)
+        }
+
+        exception.all {
+            hasClass(TaydennysNotFoundException::class)
+            messageContains("Id=21404863-edc8-4c28-8d14-35ffc06c04eb")
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(ApplicationType::class)
+    fun `does not create a new audit log entry when the taydennys has not changed`(
+        type: ApplicationType
+    ) {
+        val taydennys = taydennysFactory.saveWithHakemus(type)
+        // The saved hakemus has null in areas, but the response replaces it with an empty
+        // list, so set the value back to null in the request.
+        val request = taydennys.toUpdateRequest().withAreas(null)
+        auditLogRepository.deleteAll()
+
+        taydennysService.updateTaydennys(taydennys.id, request, USERNAME)
+
+        assertThat(auditLogRepository.findByType(ObjectType.TAYDENNYS)).isEmpty()
+    }
+
+    @ParameterizedTest
+    @EnumSource(ApplicationType::class)
+    fun `throws exception when the request has a persisted contact but the taydennys does not`(
+        type: ApplicationType
+    ) {
+        val taydennys = taydennysFactory.saveWithHakemus(type)
+        val requestYhteystietoId = UUID.randomUUID()
+        val request =
+            taydennys
+                .toUpdateRequest()
+                .withCustomerWithContactsRequest(CustomerType.COMPANY, requestYhteystietoId)
+
+        val exception = assertFailure {
+            taydennysService.updateTaydennys(taydennys.id, request, USERNAME)
+        }
+
+        exception.all {
+            hasClass(InvalidHakemusyhteystietoException::class)
+            messageContains("Invalid hakemusyhteystieto received when updating hakemus")
+            messageContains("yhteystietoId=null")
+            messageContains("newId=$requestYhteystietoId")
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(ApplicationType::class)
+    fun `throws exception when the request has different persisted contact than the application`(
+        type: ApplicationType
+    ) {
+        val taydennys = taydennysFactory.saveWithHakemus(type) { it.hakija() }
+        val originalYhteystietoId = taydennys.hakemusData.yhteystiedot().single().id
+        val requestYhteystietoId = UUID.fromString("ad2173c5-eda4-43e2-8457-7974d74319e8")
+        val request =
+            taydennys.toUpdateRequest().withCustomer(CustomerType.COMPANY, requestYhteystietoId)
+
+        val exception = assertFailure {
+            taydennysService.updateTaydennys(taydennys.id, request, USERNAME)
+        }
+
+        exception.all {
+            hasClass(InvalidHakemusyhteystietoException::class)
+            messageContains("Invalid hakemusyhteystieto received when updating hakemus")
+            messageContains("yhteystietoId=$originalYhteystietoId")
+            messageContains("newId=$requestYhteystietoId")
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(ApplicationType::class)
+    fun `throws exception when the request has a contact that is not a user on hanke`(
+        type: ApplicationType
+    ) {
+        val taydennys = taydennysFactory.saveWithHakemus(type) { it.hakija() }
+        val originalYhteystietoId = taydennys.hakemusData.yhteystiedot().single().id
+        val requestHankekayttajaId = UUID.fromString("598e1383-0720-4fd4-8449-21fd759aa457")
+        val request =
+            taydennys
+                .toUpdateRequest()
+                .withCustomer(CustomerType.COMPANY, originalYhteystietoId, requestHankekayttajaId)
+
+        val exception = assertFailure {
+            taydennysService.updateTaydennys(taydennys.id, request, USERNAME)
+        }
+
+        exception.all {
+            hasClass(InvalidHakemusyhteyshenkiloException::class)
+            messageContains("Invalid hanke user/users received when updating hakemus")
+            messageContains("invalidHankeKayttajaIds=[$requestHankekayttajaId]")
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(ApplicationType::class)
+    fun `doesn't send email when the caller adds themself as contact`(type: ApplicationType) {
+        val hanke = hankeFactory.builder(USERNAME).withHankealue().saveEntity()
+        val taydennys = taydennysFactory.saveWithHakemus(type, hanke)
+        val permission = permissionService.findPermission(hanke.id, USERNAME)!!
+        val founder = hankekayttajaRepository.findByPermissionId(permission.id)!!
+        val request =
+            taydennys
+                .toUpdateRequest()
+                .withCustomer(CustomerType.COMPANY, null, founder.id)
+                .withContractor(CustomerType.COMPANY, null, founder.id)
+
+        taydennysService.updateTaydennys(taydennys.id, request, USERNAME)
+
+        assertThat(greenMail.receivedMessages).isEmpty()
+    }
+
+    @Nested
+    inner class WithJohtoselvitys {
+
+        private val intersectingArea =
+            ApplicationFactory.createCableReportApplicationArea(
+                name = "area",
+                geometry =
+                    "/fi/hel/haitaton/hanke/geometria/intersecting-polygon.json".asJsonResource(),
+            )
+
+        private val notInHankeArea =
+            ApplicationFactory.createCableReportApplicationArea(
+                name = "area", geometry = GeometriaFactory.polygon())
+
+        @Test
+        fun `throws exception when there are invalid geometry in areas`() {
+            val taydennys = taydennysFactory.saveWithHakemus()
+            val request = taydennys.toUpdateRequest().withArea(intersectingArea)
+
+            val exception = assertFailure {
+                taydennysService.updateTaydennys(taydennys.id, request, USERNAME)
+            }
+
+            exception.all {
+                hasClass(HakemusGeometryException::class)
+                messageContains("Invalid geometry received when updating hakemus")
+                messageContains("reason=Self-intersection")
+                messageContains(
+                    "location={\"type\":\"Point\",\"coordinates\":[25494009.65639264,6679886.142116806]}")
+            }
+        }
+
+        @Test
+        fun `throws exception when area is not inside hanke area`() {
+            val taydennys = taydennysFactory.saveWithHakemus()
+            val request = taydennys.toUpdateRequest().withArea(notInHankeArea)
+
+            val exception = assertFailure {
+                taydennysService.updateTaydennys(taydennys.id, request, USERNAME)
+            }
+
+            exception.all {
+                hasClass(HakemusGeometryNotInsideHankeException::class)
+                messageContains("Hakemus geometry doesn't match any hankealue")
+                messageContains("geometry=${notInHankeArea.geometry.toJsonString()}")
+            }
+        }
+
+        @Test
+        fun `saves updated data and creates an audit log`() {
+            val taydennys =
+                taydennysFactory.saveWithHakemus {
+                    it.hakija().withWorkDescription("Old work description")
+                }
+            val yhteystieto = taydennys.hakemusData.yhteystiedot().single()
+            val perustajaId = yhteystieto.yhteyshenkilot.single().hankekayttajaId
+            val hanke = hankeRepository.findAll().single()
+            val newKayttaja = hankeKayttajaFactory.saveUser(hanke.id)
+            val request =
+                taydennys
+                    .toUpdateRequest()
+                    .withCustomer(CustomerType.COMPANY, yhteystieto.id, perustajaId, newKayttaja.id)
+                    .withWorkDescription("New work description")
+            auditLogRepository.deleteAll()
+
+            val updatedTaydennys = taydennysService.updateTaydennys(taydennys.id, request, USERNAME)
+
+            assertThat(updatedTaydennys.hakemusData)
+                .isInstanceOf(JohtoselvityshakemusData::class)
+                .all {
+                    prop(JohtoselvityshakemusData::workDescription)
+                        .isEqualTo("New work description")
+                    prop(JohtoselvityshakemusData::customerWithContacts)
+                        .isNotNull()
+                        .prop(Hakemusyhteystieto::yhteyshenkilot)
+                        .extracting { it.hankekayttajaId }
+                        .containsExactlyInAnyOrder(perustajaId, newKayttaja.id)
+                }
+            val applicationLogs = auditLogRepository.findByType(ObjectType.TAYDENNYS)
+            assertThat(applicationLogs).hasSize(1)
+
+            val hakemus = hakemusRepository.findAll().single()
+            val persistedTaydennys = taydennysService.findTaydennys(hakemus.id)!!
+            assertThat(persistedTaydennys.hakemusData)
+                .isInstanceOf(JohtoselvityshakemusData::class)
+                .all {
+                    prop(JohtoselvityshakemusData::workDescription)
+                        .isEqualTo("New work description")
+                    prop(JohtoselvityshakemusData::customerWithContacts)
+                        .isNotNull()
+                        .prop(Hakemusyhteystieto::yhteyshenkilot)
+                        .extracting { it.hankekayttajaId }
+                        .containsExactlyInAnyOrder(perustajaId, newKayttaja.id)
+                }
+        }
+
+        @Test
+        fun `removes existing yhteyshenkilot from an yhteystieto`() {
+            val hanke = hankeFactory.builder(USERNAME).withHankealue().saveEntity()
+            val kayttaja1 = hankeKayttajaFactory.saveUser(hanke.id)
+            val kayttaja2 = hankeKayttajaFactory.saveUser(hanke.id, sahkoposti = "other@email")
+            val taydennys =
+                taydennysFactory.saveWithHakemus(hanke = hanke) {
+                    it.hakija().tyonSuorittaja(kayttaja1, kayttaja2)
+                }
+            val tyonSuorittajaId =
+                taydennys.hakemusData.yhteystiedot().first { it.rooli == TYON_SUORITTAJA }.id
+            val request =
+                taydennys
+                    .toUpdateRequest()
+                    .withContractor(
+                        CustomerType.COMPANY, tyonSuorittajaId, hankekayttajaIds = arrayOf())
+
+            val updatedTaydennys = taydennysService.updateTaydennys(taydennys.id, request, USERNAME)
+
+            assertThat(updatedTaydennys.hakemusData)
+                .isInstanceOf(JohtoselvityshakemusData::class)
+                .prop(JohtoselvityshakemusData::contractorWithContacts)
+                .isNotNull()
+                .prop(Hakemusyhteystieto::yhteyshenkilot)
+                .isEmpty()
+
+            val hakemus = hakemusRepository.findAll().single()
+            val persistedTaydennys = taydennysService.findTaydennys(hakemus.id)!!
+            assertThat(persistedTaydennys.hakemusData)
+                .isInstanceOf(JohtoselvityshakemusData::class)
+                .prop(JohtoselvityshakemusData::contractorWithContacts)
+                .isNotNull()
+                .prop(Hakemusyhteystieto::yhteyshenkilot)
+                .isEmpty()
+        }
+
+        @Test
+        fun `adds a new yhteystieto and an yhteyshenkilo for it at the same time`() {
+            val hanke = hankeFactory.builder(USERNAME).withHankealue().saveEntity()
+            val newKayttaja = hankeKayttajaFactory.saveUser(hanke.id)
+            val taydennys =
+                taydennysFactory.saveWithHakemus(hanke = hanke) {
+                    it.withWorkDescription("Old work description")
+                }
+            assertThat(taydennys.hakemusData.customerWithContacts).isNull()
+            val request =
+                taydennys
+                    .toUpdateRequest()
+                    .withCustomer(
+                        CustomerType.COMPANY,
+                        yhteystietoId = null,
+                        hankekayttajaIds = arrayOf(newKayttaja.id))
+
+            val updatedTaydennys = taydennysService.updateTaydennys(taydennys.id, request, USERNAME)
+
+            assertThat(updatedTaydennys.hakemusData)
+                .isInstanceOf(JohtoselvityshakemusData::class)
+                .prop(JohtoselvityshakemusData::customerWithContacts)
+                .isNotNull()
+                .prop(Hakemusyhteystieto::yhteyshenkilot)
+                .extracting { it.hankekayttajaId }
+                .containsExactly(newKayttaja.id)
+
+            val hakemus = hakemusRepository.findAll().single()
+            val persistedTaydennys = taydennysService.findTaydennys(hakemus.id)!!
+            assertThat(persistedTaydennys.hakemusData)
+                .isInstanceOf(JohtoselvityshakemusData::class)
+                .prop(JohtoselvityshakemusData::customerWithContacts)
+                .isNotNull()
+                .prop(Hakemusyhteystieto::yhteyshenkilot)
+                .extracting { it.hankekayttajaId }
+                .containsExactly(newKayttaja.id)
+        }
+
+        @Test
+        fun `sends email to new contacts`() {
+            val hanke = hankeFactory.builder(USERNAME).withHankealue().saveEntity()
+            val taydennys = taydennysFactory.saveWithHakemus(hanke = hanke) { it.hakija() }
+            val yhteystietoId = taydennys.hakemusData.yhteystiedot().single().id
+            val newKayttaja = hankeKayttajaFactory.saveUser(hanke.id)
+            val request =
+                taydennys
+                    .toUpdateRequest()
+                    .withCustomer(CustomerType.COMPANY, yhteystietoId, newKayttaja.id)
+                    .withContractor(CustomerType.COMPANY, null, newKayttaja.id)
+
+            taydennysService.updateTaydennys(taydennys.id, request, USERNAME)
+
+            val email = greenMail.firstReceivedMessage()
+            assertThat(email.allRecipients.single().toString()).isEqualTo(newKayttaja.sahkoposti)
+            assertThat(email.subject)
+                .isEqualTo(
+                    "Haitaton: Sinut on lisätty hakemukselle / Du har lagts till i en ansökan / You have been added to an application")
+            assertThat(email.textBody())
+                .contains(
+                    "laatimassa johtoselvityshakemusta hankkeelle \"${hanke.nimi}\" (${hanke.hankeTunnus})")
+        }
+
+        @Test
+        fun `doesn't change project name when application name is changed`() {
+            val hakemus =
+                hakemusFactory.builderWithGeneratedHanke(nimi = "An application").saveEntity()
+            val taydennys = taydennysFactory.saveForHakemus(hakemus)
+            val request = taydennys.toUpdateRequest().withName("New name")
+
+            taydennysService.updateTaydennys(taydennys.id, request, USERNAME)
+
+            assertThat(hankeRepository.findAll().single()).all {
+                prop(HankeEntity::nimi).isEqualTo("An application")
+            }
+        }
+    }
+
+    @Nested
+    inner class WithKaivuilmoitus {
+
+        private val notInHankeArea =
+            createExcavationNotificationArea(
+                name = "area",
+                tyoalueet = listOf(createTyoalue(GeometriaFactory.polygon())),
+            )
+
+        @Test
+        fun `throws exception when area is not inside hanke area`() {
+            val hanke = hankeFactory.builder(USERNAME).withHankealue().save()
+            val hankeEntity = hankeRepository.findAll().single()
+            val taydennys =
+                taydennysFactory.saveWithHakemus(
+                    ApplicationType.EXCAVATION_NOTIFICATION, hankeEntity)
+            val hankealueId = hanke.alueet.single().id!!
+            val area = notInHankeArea.copy(hankealueId = hankealueId)
+            val request = taydennys.toUpdateRequest().withArea(area)
+
+            val exception = assertFailure {
+                taydennysService.updateTaydennys(taydennys.id, request, USERNAME)
+            }
+
+            exception.all {
+                hasClass(HakemusGeometryNotInsideHankeException::class)
+                messageContains("Hakemus geometry is outside the associated hankealue")
+                messageContains(
+                    "geometry=${notInHankeArea.tyoalueet.single().geometry.toJsonString()}")
+            }
+        }
+
+        @Test
+        fun `throws exception when area references non-existent hankealue`() {
+            val hanke = hankeFactory.builder(USERNAME).withHankealue().save()
+            val hankeEntity = hankeRepository.findAll().single()
+            val taydennys =
+                taydennysFactory.saveWithHakemus(
+                    ApplicationType.EXCAVATION_NOTIFICATION, hankeEntity)
+            val hankealueId = hanke.alueet.single().id!! + 1000
+            val area = createExcavationNotificationArea(hankealueId = hankealueId)
+            val request = taydennys.toUpdateRequest().withArea(area)
+
+            val exception = assertFailure {
+                taydennysService.updateTaydennys(taydennys.id, request, USERNAME)
+            }
+
+            exception.all {
+                hasClass(HakemusGeometryNotInsideHankeException::class)
+                messageContains("Hakemus geometry is outside the associated hankealue")
+                messageContains("hankealue=$hankealueId")
+                messageContains("geometry=${area.tyoalueet.single().geometry.toJsonString()}")
+            }
+        }
+
+        @Test
+        fun `saves updated data and creates an audit log`() {
+            val hanke = hankeFactory.builder(USERNAME).withHankealue().save()
+            val hankeEntity = hankeRepository.findAll().single()
+            val taydennys =
+                taydennysFactory.saveWithHakemus(
+                    ApplicationType.EXCAVATION_NOTIFICATION, hankeEntity) {
+                        it.hakija().withWorkDescription("Old work description")
+                    }
+            val yhteystieto = taydennys.hakemusData.yhteystiedot().single()
+            val kayttajaId = yhteystieto.yhteyshenkilot.single().hankekayttajaId
+            val newKayttaja = hankeKayttajaFactory.saveUser(hanke.id)
+            val area = createExcavationNotificationArea(hankealueId = hanke.alueet.single().id!!)
+            val request =
+                taydennys
+                    .toUpdateRequest()
+                    .withCustomerWithContactsRequest(
+                        CustomerType.COMPANY, yhteystieto.id, kayttajaId, newKayttaja.id)
+                    .withWorkDescription("New work description")
+                    .withRequiredCompetence(true)
+                    .withDates(ZonedDateTime.now(), ZonedDateTime.now().plusDays(1))
+                    .withArea(area)
+            auditLogRepository.deleteAll()
+
+            val updatedTaydennys = taydennysService.updateTaydennys(taydennys.id, request, USERNAME)
+
+            assertThat(updatedTaydennys.hakemusData).isInstanceOf(KaivuilmoitusData::class).all {
+                prop(KaivuilmoitusData::workDescription).isEqualTo("New work description")
+                prop(KaivuilmoitusData::requiredCompetence).isTrue()
+                prop(KaivuilmoitusData::customerWithContacts)
+                    .isNotNull()
+                    .prop(Hakemusyhteystieto::yhteyshenkilot)
+                    .extracting { it.hankekayttajaId }
+                    .containsExactlyInAnyOrder(kayttajaId, newKayttaja.id)
+                prop(KaivuilmoitusData::areas)
+                    .isNotNull()
+                    .single()
+                    .transform { it.withoutTormaystarkastelut() }
+                    .isEqualTo(area.withoutTormaystarkastelut())
+            }
+
+            assertThat(auditLogRepository.findByType(ObjectType.TAYDENNYS)).hasSize(1)
+
+            val hakemus = hakemusRepository.findAll().single()
+            val persistedTaydennys = taydennysService.findTaydennys(hakemus.id)!!
+            assertThat(persistedTaydennys.hakemusData).isInstanceOf(KaivuilmoitusData::class).all {
+                prop(KaivuilmoitusData::workDescription).isEqualTo("New work description")
+                prop(KaivuilmoitusData::requiredCompetence).isTrue()
+                prop(KaivuilmoitusData::customerWithContacts)
+                    .isNotNull()
+                    .prop(Hakemusyhteystieto::yhteyshenkilot)
+                    .extracting { it.hankekayttajaId }
+                    .containsExactlyInAnyOrder(kayttajaId, newKayttaja.id)
+                prop(KaivuilmoitusData::areas)
+                    .isNotNull()
+                    .single()
+                    .transform { it.withoutTormaystarkastelut() }
+                    .isEqualTo(area.withoutTormaystarkastelut())
+            }
+        }
+
+        @Test
+        fun `removes existing yhteyshenkilot from an yhteystieto`() {
+            val hanke = hankeFactory.builder(USERNAME).withHankealue().saveEntity()
+            val kayttaja1 = hankeKayttajaFactory.saveUser(hanke.id)
+            val kayttaja2 = hankeKayttajaFactory.saveUser(hanke.id, sahkoposti = "other@email")
+            val taydennys =
+                taydennysFactory.saveWithHakemus(ApplicationType.EXCAVATION_NOTIFICATION, hanke) {
+                    it.hakija().tyonSuorittaja(kayttaja1, kayttaja2)
+                }
+            val tyonSuorittajaId =
+                taydennys.hakemusData.yhteystiedot().first { it.rooli == TYON_SUORITTAJA }.id
+            val request =
+                taydennys
+                    .toUpdateRequest()
+                    .withContractor(
+                        CustomerType.COMPANY, tyonSuorittajaId, hankekayttajaIds = arrayOf())
+
+            val updatedTaydennys = taydennysService.updateTaydennys(taydennys.id, request, USERNAME)
+
+            assertThat(updatedTaydennys.hakemusData)
+                .isInstanceOf(KaivuilmoitusData::class)
+                .prop(KaivuilmoitusData::contractorWithContacts)
+                .isNotNull()
+                .prop(Hakemusyhteystieto::yhteyshenkilot)
+                .isEmpty()
+        }
+
+        @Test
+        fun `adds a new yhteystieto and an yhteyshenkilo for it at the same time`() {
+            val hanke = hankeFactory.builder(USERNAME).withHankealue().saveEntity()
+            val newKayttaja = hankeKayttajaFactory.saveUser(hanke.id)
+            val taydennys =
+                taydennysFactory.saveWithHakemus(ApplicationType.EXCAVATION_NOTIFICATION, hanke) {
+                    it.withWorkDescription("Old work description")
+                }
+            assertThat(taydennys.hakemusData.customerWithContacts).isNull()
+            val request =
+                taydennys
+                    .toUpdateRequest()
+                    .withCustomer(
+                        CustomerType.COMPANY,
+                        yhteystietoId = null,
+                        hankekayttajaIds = arrayOf(newKayttaja.id))
+
+            val updatedTaydennys = taydennysService.updateTaydennys(taydennys.id, request, USERNAME)
+
+            assertThat(updatedTaydennys.hakemusData)
+                .isInstanceOf(KaivuilmoitusData::class)
+                .prop(KaivuilmoitusData::customerWithContacts)
+                .isNotNull()
+                .prop(Hakemusyhteystieto::yhteyshenkilot)
+                .extracting { it.hankekayttajaId }
+                .containsExactly(newKayttaja.id)
+
+            val hakemus = hakemusRepository.findAll().single()
+            val persistedTaydennys = taydennysService.findTaydennys(hakemus.id)!!
+            assertThat(persistedTaydennys.hakemusData)
+                .isInstanceOf(KaivuilmoitusData::class)
+                .prop(KaivuilmoitusData::customerWithContacts)
+                .isNotNull()
+                .prop(Hakemusyhteystieto::yhteyshenkilot)
+                .extracting { it.hankekayttajaId }
+                .containsExactly(newKayttaja.id)
+        }
+
+        @Test
+        fun `throws exception when an existing yhteystieto has registry key hidden but different type in the request`() {
+            val taydennys =
+                taydennysFactory.saveWithHakemus(ApplicationType.EXCAVATION_NOTIFICATION) {
+                    it.hakija(HakemusyhteystietoFactory.create(tyyppi = CustomerType.COMPANY))
+                }
+            val yhteystietoId = taydennys.hakemusData.customerWithContacts!!.id
+            val request =
+                taydennys
+                    .toUpdateRequest()
+                    .withCustomer(
+                        CustomerType.PERSON,
+                        yhteystietoId,
+                        registryKey = null,
+                        registryKeyHidden = true,
+                    )
+
+            val failure = assertFailure {
+                taydennysService.updateTaydennys(taydennys.id, request, USERNAME)
+            }
+
+            failure.all {
+                hasClass(InvalidHiddenRegistryKey::class)
+                messageContains("RegistryKeyHidden used in an incompatible way")
+                messageContains("New customer type doesn't match the old")
+                messageContains("New=PERSON")
+                messageContains("Old=COMPANY")
+            }
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = ["Something completely different"])
+        @NullSource
+        fun `keeps old customer registry key when registry key hidden is true`(
+            newRegistryKey: String?
+        ) {
+            val henkilotunnus = "090626-885W"
+            val taydennys =
+                taydennysFactory.saveWithHakemus(ApplicationType.EXCAVATION_NOTIFICATION) {
+                    it.hakija(
+                        HakemusyhteystietoFactory.create(
+                            tyyppi = CustomerType.PERSON, registryKey = henkilotunnus))
+                }
+            val yhteystietoId = taydennys.hakemusData.customerWithContacts!!.id
+            val request =
+                taydennys
+                    .toUpdateRequest()
+                    .withCustomer(
+                        CustomerType.PERSON,
+                        yhteystietoId,
+                        registryKey = newRegistryKey,
+                        registryKeyHidden = true,
+                    )
+
+            val result = taydennysService.updateTaydennys(taydennys.id, request, USERNAME)
+
+            assertThat(result.hakemusData)
+                .isInstanceOf(KaivuilmoitusData::class)
+                .prop(KaivuilmoitusData::customerWithContacts)
+                .isNotNull()
+                .prop(Hakemusyhteystieto::registryKey)
+                .isEqualTo(henkilotunnus)
+
+            val hakemus = hakemusRepository.findAll().single()
+            val persistedTaydennys = taydennysService.findTaydennys(hakemus.id)!!
+            assertThat(persistedTaydennys.hakemusData)
+                .isInstanceOf(KaivuilmoitusData::class)
+                .prop(KaivuilmoitusData::customerWithContacts)
+                .isNotNull()
+                .prop(Hakemusyhteystieto::registryKey)
+                .isEqualTo(henkilotunnus)
+        }
+
+        @Test
+        fun `throws exception when an existing laskutusyhteystieto has registry key hidden but different type in the request`() {
+            val taydennys =
+                taydennysFactory.saveWithHakemus(ApplicationType.EXCAVATION_NOTIFICATION) {
+                    it.withInvoicingCustomer(ApplicationFactory.createCompanyInvoicingCustomer())
+                }
+            val request =
+                (taydennys.toUpdateRequest() as KaivuilmoitusUpdateRequest).withInvoicingCustomer(
+                    CustomerType.PERSON,
+                    registryKey = null,
+                    registryKeyHidden = true,
+                )
+
+            val failure = assertFailure {
+                taydennysService.updateTaydennys(taydennys.id, request, USERNAME)
+            }
+
+            failure.all {
+                hasClass(InvalidHiddenRegistryKey::class)
+                messageContains("RegistryKeyHidden used in an incompatible way")
+                messageContains("New invoicing customer type doesn't match the old")
+                messageContains("New=PERSON")
+                messageContains("Old=COMPANY")
+            }
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = ["Something completely different"])
+        @NullSource
+        fun `keeps old invoicing customer registry key when registry key hidden is true`(
+            newRegistryKey: String?
+        ) {
+            val henkilotunnus = ApplicationFactory.DEFAULT_HENKILOTUNNUS
+            val taydennys =
+                taydennysFactory.saveWithHakemus(ApplicationType.EXCAVATION_NOTIFICATION) {
+                    it.withInvoicingCustomer(ApplicationFactory.createPersonInvoicingCustomer())
+                }
+            val request =
+                (taydennys.toUpdateRequest() as KaivuilmoitusUpdateRequest).withInvoicingCustomer(
+                    CustomerType.PERSON,
+                    registryKey = newRegistryKey,
+                    registryKeyHidden = true,
+                )
+
+            val result = taydennysService.updateTaydennys(taydennys.id, request, USERNAME)
+
+            assertThat(result.hakemusData)
+                .isInstanceOf(KaivuilmoitusData::class)
+                .prop(KaivuilmoitusData::invoicingCustomer)
+                .isNotNull()
+                .prop(Laskutusyhteystieto::registryKey)
+                .isEqualTo(henkilotunnus)
+            val hakemus = hakemusRepository.findAll().single()
+            val persistedTaydennys = taydennysService.findTaydennys(hakemus.id)!!
+            assertThat(persistedTaydennys.hakemusData)
+                .isInstanceOf(KaivuilmoitusData::class)
+                .prop(KaivuilmoitusData::invoicingCustomer)
+                .isNotNull()
+                .prop(Laskutusyhteystieto::registryKey)
+                .isEqualTo(henkilotunnus)
+        }
+
+        @Test
+        fun `sends email for new contacts`() {
+            val hanke = hankeFactory.builder(USERNAME).withHankealue().saveEntity()
+            val taydennys =
+                taydennysFactory.saveWithHakemus(ApplicationType.EXCAVATION_NOTIFICATION, hanke) {
+                    it.hakija()
+                }
+            val yhteystietoId = taydennys.hakemusData.yhteystiedot().single().id
+            val newKayttaja = hankeKayttajaFactory.saveUser(hanke.id)
+            val request =
+                taydennys
+                    .toUpdateRequest()
+                    .withCustomer(CustomerType.COMPANY, yhteystietoId, newKayttaja.id)
+                    .withContractor(CustomerType.COMPANY, null, newKayttaja.id)
+
+            taydennysService.updateTaydennys(taydennys.id, request, USERNAME)
+
+            val email = greenMail.firstReceivedMessage()
+            assertThat(email.allRecipients.single().toString()).isEqualTo(newKayttaja.sahkoposti)
+            assertThat(email.subject)
+                .isEqualTo(
+                    "Haitaton: Sinut on lisätty hakemukselle / Du har lagts till i en ansökan / You have been added to an application")
+            assertThat(email.textBody())
+                .contains(
+                    "laatimassa kaivuilmoitusta hankkeelle \"${hanke.nimi}\" (${hanke.hankeTunnus})")
+        }
+
+        @Test
+        fun `calculates tormaystarkastelu for work areas`() {
+            val hanke = hankeFactory.builder(USERNAME).withHankealue().save()
+            val hankeEntity = hankeRepository.findAll().single()
+            val taydennys =
+                taydennysFactory.saveWithHakemus(
+                    ApplicationType.EXCAVATION_NOTIFICATION, hankeEntity)
+            val area = createExcavationNotificationArea(hankealueId = hanke.alueet.single().id!!)
+            val request =
+                taydennys
+                    .toUpdateRequest()
+                    .withDates(ZonedDateTime.now(), ZonedDateTime.now().plusDays(1))
+                    .withArea(area)
+            val expectedTormaystarkasteluTulos =
+                TormaystarkasteluTulos(
+                    autoliikenne =
+                        Autoliikenneluokittelu(
+                            indeksi = 3.1f,
+                            haitanKesto = 1,
+                            katuluokka = 4,
+                            liikennemaara = 5,
+                            kaistahaitta = 2,
+                            kaistapituushaitta = 2,
+                        ),
+                    pyoraliikenneindeksi = 3.0f,
+                    linjaautoliikenneindeksi = 3.0f,
+                    raitioliikenneindeksi = 5.0f,
+                )
+
+            val result = taydennysService.updateTaydennys(taydennys.id, request, USERNAME)
+
+            assertThat(result.hakemusData)
+                .isInstanceOf(KaivuilmoitusData::class)
+                .prop(KaivuilmoitusData::areas)
+                .isNotNull()
+                .single()
+                .prop(KaivuilmoitusAlue::tyoalueet)
+                .isNotNull()
+                .single()
+                .prop(Tyoalue::tormaystarkasteluTulos)
+                .isNotNull()
+                .isEqualTo(expectedTormaystarkasteluTulos)
+
+            val hakemus = hakemusRepository.findAll().single()
+            val persistedTaydennys = taydennysService.findTaydennys(hakemus.id)!!
+            assertThat(persistedTaydennys.hakemusData)
+                .isInstanceOf(KaivuilmoitusData::class)
+                .prop(KaivuilmoitusData::areas)
+                .isNotNull()
+                .single()
+                .prop(KaivuilmoitusAlue::tyoalueet)
+                .isNotNull()
+                .single()
+                .prop(Tyoalue::tormaystarkasteluTulos)
+                .isNotNull()
+                .isEqualTo(expectedTormaystarkasteluTulos)
+        }
+    }
+}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennysAuthorizer.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennysAuthorizer.kt
@@ -1,0 +1,25 @@
+package fi.hel.haitaton.hanke.taydennys
+
+import fi.hel.haitaton.hanke.HankeRepository
+import fi.hel.haitaton.hanke.hakemus.HakemusAuthorizer
+import fi.hel.haitaton.hanke.permissions.Authorizer
+import fi.hel.haitaton.hanke.permissions.PermissionService
+import java.util.UUID
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+class TaydennysAuthorizer(
+    permissionService: PermissionService,
+    hankeRepository: HankeRepository,
+    private val taydennysRepository: TaydennysRepository,
+    private val hakemusAuthorizer: HakemusAuthorizer,
+) : Authorizer(permissionService, hankeRepository) {
+
+    @Transactional(readOnly = true)
+    fun authorize(id: UUID, permissionCode: String): Boolean =
+        taydennysRepository.findByIdOrNull(id)?.taydennyspyynto?.applicationId?.let {
+            hakemusAuthorizer.authorizeHakemusId(it, permissionCode)
+        } ?: false
+}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennysController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennysController.kt
@@ -1,14 +1,20 @@
 package fi.hel.haitaton.hanke.taydennys
 
 import fi.hel.haitaton.hanke.HankeError
+import fi.hel.haitaton.hanke.HankeErrorDetail
 import fi.hel.haitaton.hanke.currentUserId
+import fi.hel.haitaton.hanke.hakemus.HakemusUpdateRequest
+import fi.hel.haitaton.hanke.hakemus.InvalidHakemusDataException
+import fi.hel.haitaton.hanke.hakemus.ValidHakemusUpdateRequest
 import io.swagger.v3.oas.annotations.Hidden
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.ExampleObject
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
+import java.util.UUID
 import mu.KotlinLogging
 import org.springframework.http.HttpStatus
 import org.springframework.security.access.prepost.PreAuthorize
@@ -16,6 +22,8 @@ import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 
@@ -54,11 +62,85 @@ class TaydennysController(private val taydennysService: TaydennysService) {
     fun create(@PathVariable id: Long): TaydennysResponse =
         taydennysService.create(id, currentUserId()).toResponse()
 
+    @RequestMapping("/taydennykset/{id}")
+    @Operation(
+        summary = "Update a täydennys",
+        description =
+            """
+               Returns the updated täydennys.
+               The täydennys can be updated until it has been sent to Allu.
+               If the täydennys hasn't changed since the last update, nothing more is done.
+            """,
+    )
+    @ApiResponses(
+        value =
+            [
+                ApiResponse(description = "The updated täydennys", responseCode = "200"),
+                ApiResponse(
+                    description = "Request contains invalid data",
+                    responseCode = "400",
+                    content =
+                        [
+                            Content(
+                                schema =
+                                    Schema(oneOf = [HankeErrorDetail::class, HankeError::class]),
+                                examples =
+                                    [
+                                        ExampleObject(
+                                            name = "Validation error",
+                                            summary = "Validation error example",
+                                            value = "{hankeError: 'HAI2008', errorPaths: ['name']}",
+                                        ),
+                                        ExampleObject(
+                                            name = "Incompatible request",
+                                            summary = "Incompatible request example",
+                                            value = "{hankeError: 'HAI2002'}",
+                                        ),
+                                    ],
+                            )],
+                ),
+                ApiResponse(
+                    description = "A täydennys was not found with the given id",
+                    responseCode = "404",
+                    content = [Content(schema = Schema(implementation = HankeError::class))],
+                ),
+            ])
+    @PreAuthorize("@taydennysAuthorizer.authorize(#id, 'EDIT_APPLICATIONS')")
+    fun update(
+        @PathVariable id: UUID,
+        @ValidHakemusUpdateRequest @RequestBody request: HakemusUpdateRequest,
+    ): TaydennysResponse =
+        taydennysService.updateTaydennys(id, request, currentUserId()).toResponse()
+
+    @ExceptionHandler(InvalidHakemusDataException::class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @Hidden
+    fun invalidHakemusDataException(ex: InvalidHakemusDataException): HankeErrorDetail {
+        logger.warn(ex) { ex.message }
+        return HankeErrorDetail(hankeError = HankeError.HAI2008, errorPaths = ex.errorPaths)
+    }
+
     @ExceptionHandler(NoTaydennyspyyntoException::class)
     @ResponseStatus(HttpStatus.CONFLICT)
     @Hidden
     fun noTaydennyspyyntoException(ex: NoTaydennyspyyntoException): HankeError {
         logger.warn(ex) { ex.message }
         return HankeError.HAI2015
+    }
+
+    @ExceptionHandler(TaydennysNotFoundException::class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    @Hidden
+    fun taydennysNotFoundException(ex: TaydennysNotFoundException): HankeError {
+        logger.warn(ex) { ex.message }
+        return HankeError.HAI6001
+    }
+
+    @ExceptionHandler(IncompatibleTaydennysUpdateException::class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @Hidden
+    fun incompatibleTaydennysUpdateException(ex: IncompatibleTaydennysUpdateException): HankeError {
+        logger.warn(ex) { ex.message }
+        return HankeError.HAI2002
     }
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennysIdentifier.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennysIdentifier.kt
@@ -1,0 +1,28 @@
+package fi.hel.haitaton.hanke.taydennys
+
+import fi.hel.haitaton.hanke.domain.HasId
+import fi.hel.haitaton.hanke.hakemus.ApplicationType
+import java.util.UUID
+
+interface TaydennysIdentifier : HasId<UUID> {
+    override val id: UUID
+
+    fun taydennyspyyntoId(): UUID
+
+    fun taydennyspyyntoAlluId(): Int
+
+    fun hakemusId(): Long
+
+    fun hakemustyyppi(): ApplicationType
+
+    fun logString() =
+        "Täydennys: (" +
+            listOf(
+                    "id=$id",
+                    "täydennyspyyntö=${taydennyspyyntoId()}",
+                    "täydennyspyyntöAlluId=${taydennyspyyntoAlluId()}",
+                    "hakemusId=${hakemusId()}",
+                    "hakemustyyppi=${hakemustyyppi()}")
+                .joinToString() +
+            ")"
+}

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/TaydennysFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/TaydennysFactory.kt
@@ -1,11 +1,22 @@
 package fi.hel.haitaton.hanke.factory
 
+import fi.hel.haitaton.hanke.HankeEntity
+import fi.hel.haitaton.hanke.allu.ApplicationStatus
+import fi.hel.haitaton.hanke.hakemus.ApplicationContactType
+import fi.hel.haitaton.hanke.hakemus.ApplicationType
 import fi.hel.haitaton.hanke.hakemus.HakemusData
+import fi.hel.haitaton.hanke.hakemus.HakemusEntity
 import fi.hel.haitaton.hanke.hakemus.HakemusEntityData
+import fi.hel.haitaton.hanke.hakemus.HakemusUpdateRequest
+import fi.hel.haitaton.hanke.parseJson
 import fi.hel.haitaton.hanke.taydennys.Taydennys
 import fi.hel.haitaton.hanke.taydennys.TaydennysEntity
 import fi.hel.haitaton.hanke.taydennys.TaydennysRepository
 import fi.hel.haitaton.hanke.taydennys.TaydennyspyyntoEntity
+import fi.hel.haitaton.hanke.taydennys.TaydennysyhteyshenkiloEntity
+import fi.hel.haitaton.hanke.taydennys.TaydennysyhteystietoEntity
+import fi.hel.haitaton.hanke.test.USERNAME
+import fi.hel.haitaton.hanke.toJsonString
 import java.util.UUID
 import org.springframework.stereotype.Component
 
@@ -13,18 +24,67 @@ import org.springframework.stereotype.Component
 class TaydennysFactory(
     private val taydennysRepository: TaydennysRepository,
     private val taydennyspyyntoFactory: TaydennyspyyntoFactory,
+    private val hakemusFactory: HakemusFactory,
 ) {
     fun save(
-        id: UUID = DEFAULT_ID,
         applicationId: Long? = null,
         taydennyspyynto: TaydennyspyyntoEntity =
             applicationId?.let { taydennyspyyntoFactory.saveEntity(it) }
                 ?: throw RuntimeException(),
         hakemusData: HakemusEntityData = ApplicationFactory.createCableReportApplicationData()
     ): Taydennys =
-        TaydennysEntity(id, taydennyspyynto, hakemusData)
+        TaydennysEntity(taydennyspyynto = taydennyspyynto, hakemusData = hakemusData)
             .let { taydennysRepository.save(it) }
             .toDomain()
+
+    fun saveForHakemus(hakemus: HakemusEntity): Taydennys {
+        val taydennyspyynto = taydennyspyyntoFactory.saveEntity(hakemus.id)
+        val entity =
+            TaydennysEntity(
+                taydennyspyynto = taydennyspyynto, hakemusData = hakemus.hakemusEntityData)
+        entity.yhteystiedot =
+            hakemus.yhteystiedot
+                .mapValues { (_, hakemusyhteystieto) ->
+                    val taydennysyhteystieto =
+                        TaydennysyhteystietoEntity(
+                            tyyppi = hakemusyhteystieto.tyyppi,
+                            rooli = hakemusyhteystieto.rooli,
+                            nimi = hakemusyhteystieto.nimi,
+                            sahkoposti = hakemusyhteystieto.sahkoposti,
+                            puhelinnumero = hakemusyhteystieto.puhelinnumero,
+                            registryKey = hakemusyhteystieto.registryKey,
+                            taydennys = entity,
+                            yhteyshenkilot = mutableListOf(),
+                        )
+                    taydennysyhteystieto.yhteyshenkilot =
+                        hakemusyhteystieto.yhteyshenkilot
+                            .map {
+                                TaydennysyhteyshenkiloEntity(
+                                    taydennysyhteystieto = taydennysyhteystieto,
+                                    hankekayttaja = it.hankekayttaja,
+                                    tilaaja = it.tilaaja)
+                            }
+                            .toMutableList()
+                    taydennysyhteystieto
+                }
+                .toMutableMap()
+        return taydennysRepository.save(entity).toDomain()
+    }
+
+    fun saveWithHakemus(
+        type: ApplicationType = ApplicationType.CABLE_REPORT,
+        hanke: HankeEntity? = null,
+        f: (HakemusBuilder) -> HakemusBuilder = { it }
+    ): Taydennys {
+        val hakemusBuilder =
+            if (hanke != null) hakemusFactory.builder(USERNAME, hanke, type)
+            else {
+                hakemusFactory.builder(type)
+            }
+        val hakemus =
+            f(hakemusBuilder.withStatus(ApplicationStatus.WAITING_INFORMATION)).saveEntity()
+        return saveForHakemus(hakemus)
+    }
 
     companion object {
         val DEFAULT_ID: UUID = UUID.fromString("49ee9168-a1e3-45a1-8fe0-9330cd5475d3")
@@ -32,7 +92,19 @@ class TaydennysFactory(
         fun create(
             id: UUID = DEFAULT_ID,
             taydennyspyyntoId: UUID = TaydennyspyyntoFactory.DEFAULT_ID,
-            hakemusData: HakemusData = HakemusFactory.createJohtoselvityshakemusData()
+            hakemusType: ApplicationType = ApplicationType.CABLE_REPORT,
+            hakemusData: HakemusData = HakemusFactory.createHakemusData(hakemusType),
         ) = Taydennys(id, taydennyspyyntoId, hakemusData)
+
+        fun createEntity(
+            id: UUID = DEFAULT_ID,
+            taydennyspyynto: TaydennyspyyntoEntity = TaydennyspyyntoFactory.createEntity(),
+            hakemusData: HakemusEntityData =
+                ApplicationFactory.createBlankCableReportApplicationData(),
+            yhteystiedot: Map<ApplicationContactType, TaydennysyhteystietoEntity> = mapOf(),
+        ) = TaydennysEntity(id, taydennyspyynto, hakemusData, yhteystiedot.toMutableMap())
+
+        fun Taydennys.toUpdateRequest(): HakemusUpdateRequest =
+            this.toResponse().applicationData.toJsonString().parseJson()
     }
 }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/TaydennyspyyntoFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/TaydennyspyyntoFactory.kt
@@ -53,5 +53,12 @@ class TaydennyspyyntoFactory(private val taydennyspyyntoRepository: Taydennyspyy
         fun TaydennyspyyntoEntity.clearKentat() {
             kentat.clear()
         }
+
+        fun createEntity(
+            id: UUID = DEFAULT_ID,
+            applicationId: Long = ApplicationFactory.DEFAULT_APPLICATION_ID,
+            alluId: Int = DEFAULT_ALLU_ID,
+            kentat: Map<InformationRequestFieldKey, String> = DEFAULT_KENTAT,
+        ) = TaydennyspyyntoEntity(id, applicationId, alluId, kentat.toMutableMap())
     }
 }


### PR DESCRIPTION
# Description

Add API for updating a täydennys. The API has most of the same checks and functionalities as the hakemus update. I tried to reuse as much of the code in HakemusService as I could. However, some methods that alter the database entities have to access a specific entity, so they can't be shared easily.

One check removed from the täydennys update is checking if the hakemus has been sent to Allu. It always has. We don't check the hakemus status at all, since the täydennys shouldn't exist unless the hakemus is in a compatible state. Even if it's not due to a bug, there's no harm in updating the täydennys. When sending the täydennys and merging the data back to the hakemus we need to be more careful with the status.

Updating the name of a generated hanke will be done when the täydennys is sent and merged to the hakemus.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2770

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
1. Create a täydennys.
2. Call the update endpoint in Swagger UI (http://localhost:3001/api/swagger-ui/index.html#/hakemus-controller/update) with different kinds of updates.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 