### PR TITLE
HAI-2749 Refactor hakemus service for reusability

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceITest.kt
@@ -782,8 +782,7 @@ class HakemusServiceITest(
 
             failure.all {
                 hasClass(HakemusGeometryNotInsideHankeException::class)
-                messageContains(hakemus.logString())
-                messageContains(hanke.logString())
+                messageContains("Hakemus geometry doesn't match any hankealue")
                 messageContains(
                     "hakemus geometry=${areaOutsideDefaultHanke.geometry.toJsonString()}")
             }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeError.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeError.kt
@@ -57,10 +57,10 @@ enum class HankeError(val errorMessage: String) {
     HAI4006("Duplicate hankekayttaja"),
     HAI4007("Verified name not found in Profiili"),
     HAI5001("Decision not found"),
+    HAI6001("Taydennys not found"),
     ;
 
-    val errorCode: String
-        get() = name
+    fun getErrorCode(): String = name
 
     companion object {
         fun valueOf(violation: ConstraintViolation<*>): HankeError {
@@ -77,7 +77,7 @@ enum class HankeError(val errorMessage: String) {
 
 data class HankeErrorDetail(
     @JsonUnwrapped val hankeError: HankeError,
-    val errorPaths: List<String>
+    val errorPaths: List<String>,
 )
 
 class HankeNotFoundException(val hankeTunnus: String?) :

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/gdpr/GdprController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/gdpr/GdprController.kt
@@ -229,7 +229,7 @@ data class GdprError(val code: String, val message: LocalizedMessage) {
     companion object {
         fun fromSentApplication(applicationIdentifier: String?) =
             GdprError(
-                HankeError.HAI2003.errorCode,
+                HankeError.HAI2003.name,
                 LocalizedMessage(
                     "Keskeneräinen hakemus tunnuksella $applicationIdentifier. Ota yhteyttä alueidenkaytto@hel.fi hakemuksen poistamiseksi.",
                     "Pågående ansökan med koden $applicationIdentifier. Kontakta alueidenkaytto@hel.fi för att ta bort ansökan.",

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusController.kt
@@ -173,7 +173,8 @@ class HakemusController(
     @Operation(
         summary = "Update an application",
         description =
-            """Returns the updated application.
+            """
+               Returns the updated application.
                The application can be updated until it has been sent to Allu.
                If the application hasn't changed since the last update, nothing more is done.
                The pendingOnClient value can't be changed with this endpoint.
@@ -456,48 +457,6 @@ The id needs to reference an excavation notification.
     ): HankeError {
         logger.warn(ex) { ex.message }
         return HankeError.HAI2002
-    }
-
-    @ExceptionHandler(HakemusGeometryException::class)
-    @ResponseStatus(HttpStatus.BAD_REQUEST)
-    @Hidden
-    fun applicationGeometryException(ex: HakemusGeometryException): HankeError {
-        logger.warn(ex) { ex.message }
-        return HankeError.HAI2005
-    }
-
-    @ExceptionHandler(HakemusGeometryNotInsideHankeException::class)
-    @ResponseStatus(HttpStatus.BAD_REQUEST)
-    @Hidden
-    fun applicationGeometryNotInsideHankeException(
-        ex: HakemusGeometryNotInsideHankeException
-    ): HankeError {
-        logger.warn(ex) { ex.message }
-        return HankeError.HAI2007
-    }
-
-    @ExceptionHandler(InvalidHakemusyhteystietoException::class)
-    @ResponseStatus(HttpStatus.BAD_REQUEST)
-    @Hidden
-    fun invalidHakemusyhteystietoException(ex: InvalidHakemusyhteystietoException): HankeError {
-        logger.warn(ex) { ex.message }
-        return HankeError.HAI2010
-    }
-
-    @ExceptionHandler(InvalidHiddenRegistryKey::class)
-    @ResponseStatus(HttpStatus.BAD_REQUEST)
-    @Hidden
-    fun invalidHiddenRegistryKey(ex: InvalidHiddenRegistryKey): HankeError {
-        logger.warn(ex) { ex.message }
-        return HankeError.HAI2010
-    }
-
-    @ExceptionHandler(InvalidHakemusyhteyshenkiloException::class)
-    @ResponseStatus(HttpStatus.BAD_REQUEST)
-    @Hidden
-    fun invalidHakemusyhteyshenkiloException(ex: InvalidHakemusyhteyshenkiloException): HankeError {
-        logger.warn(ex) { ex.message }
-        return HankeError.HAI2011
     }
 
     @ResponseStatus(HttpStatus.BAD_REQUEST)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusUpdateRequest.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusUpdateRequest.kt
@@ -35,10 +35,10 @@ sealed interface HakemusUpdateRequest {
     fun hasChanges(hakemusData: HakemusData): Boolean
 
     /**
-     * Converts this update request to an [HakemusEntityData] object using the given [hakemusEntity]
-     * as a basis.
+     * Converts this update request to an [HakemusEntityData] object using the given
+     * [hakemusEntityData] as a basis.
      */
-    fun toEntityData(hakemusEntity: HakemusEntity): HakemusEntityData
+    fun toEntityData(hakemusEntityData: HakemusEntityData): HakemusEntityData
 
     fun customersByRole(): Map<ApplicationContactType, CustomerWithContactsRequest?>
 }
@@ -106,8 +106,8 @@ data class JohtoselvityshakemusUpdateRequest(
             representativeWithContacts.hasChanges(hakemusData.propertyDeveloperWithContacts)
     }
 
-    override fun toEntityData(hakemusEntity: HakemusEntity) =
-        (hakemusEntity.hakemusEntityData as JohtoselvityshakemusEntityData).copy(
+    override fun toEntityData(hakemusEntityData: HakemusEntityData) =
+        (hakemusEntityData as JohtoselvityshakemusEntityData).copy(
             name = this.name,
             postalAddress =
                 PostalAddress(StreetAddress(this.postalAddress?.streetAddress?.streetName), "", ""),
@@ -210,8 +210,8 @@ data class KaivuilmoitusUpdateRequest(
             additionalInfo != hakemusData.additionalInfo
     }
 
-    override fun toEntityData(hakemusEntity: HakemusEntity) =
-        (hakemusEntity.hakemusEntityData as KaivuilmoitusEntityData).copy(
+    override fun toEntityData(hakemusEntityData: HakemusEntityData) =
+        (hakemusEntityData as KaivuilmoitusEntityData).copy(
             name = this.name,
             workDescription = this.workDescription,
             constructionWork = this.constructionWork,
@@ -225,7 +225,7 @@ data class KaivuilmoitusUpdateRequest(
             startTime = this.startTime,
             endTime = this.endTime,
             areas = this.areas,
-            invoicingCustomer = this.invoicingCustomer.toCustomer(hakemusEntity),
+            invoicingCustomer = this.invoicingCustomer.toCustomer(hakemusEntityData),
             customerReference = this.invoicingCustomer?.customerReference,
             additionalInfo = this.additionalInfo,
         )
@@ -349,15 +349,15 @@ fun InvoicingPostalAddressRequest?.hasChanges(postalAddress: PostalAddress?): Bo
         city != postalAddress.city
 }
 
-fun InvoicingCustomerRequest?.toCustomer(hakemus: HakemusEntity): InvoicingCustomer? {
+fun InvoicingCustomerRequest?.toCustomer(hakemusEntityData: HakemusEntityData): InvoicingCustomer? {
     return this?.let {
-        val baseData = (hakemus.hakemusEntityData as KaivuilmoitusEntityData).invoicingCustomer
+        val baseData = (hakemusEntityData as KaivuilmoitusEntityData).invoicingCustomer
         if (baseData != null && type != baseData.type && registryKeyHidden) {
             // If new invoicing customer type doesn't match the old one, the type of registry key
             // will be wrong, but it will be retained if the key is hidden.
             // Validation only checks the new type.
             throw InvalidHiddenRegistryKey(
-                hakemus, "New invoicing customer type doesn't match the old.")
+                "New invoicing customer type doesn't match the old.", type, baseData.type)
         }
 
         InvoicingCustomer(

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/HankeErrorResultMatcher.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/HankeErrorResultMatcher.kt
@@ -15,6 +15,6 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPat
  * ```
  */
 fun hankeError(error: HankeError) = ResultMatcher { result: MvcResult ->
-    jsonPath("$.errorCode").value(error.errorCode).match(result)
+    jsonPath("$.errorCode").value(error.getErrorCode()).match(result)
     jsonPath("$.errorMessage").value(error.errorMessage).match(result)
 }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/HankeErrorTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/HankeErrorTest.kt
@@ -9,8 +9,8 @@ class HankeErrorTest {
     @Test
     fun testJacksonSerialization() {
         val err = HankeError.HAI0002
-        val expected = """{"errorMessage":"${err.errorMessage}","errorCode":"${err.errorCode}"}"""
+        val expected =
+            """{"errorMessage":"${err.errorMessage}","errorCode":"${err.getErrorCode()}"}"""
         assertThat(err.toJsonString()).isEqualTo(expected)
     }
-
 }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusFactory.kt
@@ -3,6 +3,7 @@ package fi.hel.haitaton.hanke.factory
 import fi.hel.haitaton.hanke.HankeEntity
 import fi.hel.haitaton.hanke.HankeRepository
 import fi.hel.haitaton.hanke.allu.ApplicationStatus
+import fi.hel.haitaton.hanke.allu.CustomerType
 import fi.hel.haitaton.hanke.domain.CreateHankeRequest
 import fi.hel.haitaton.hanke.domain.HankePerustaja
 import fi.hel.haitaton.hanke.hakemus.ApplicationType
@@ -124,7 +125,7 @@ class HakemusFactory(
         fun createSeveral(n: Long, applicationType: ApplicationType) =
             (1..n).map { i -> create(id = i, applicationType = applicationType) }
 
-        private fun createHakemusData(type: ApplicationType): HakemusData =
+        fun createHakemusData(type: ApplicationType): HakemusData =
             when (type) {
                 ApplicationType.CABLE_REPORT -> createJohtoselvityshakemusData()
                 ApplicationType.EXCAVATION_NOTIFICATION -> createKaivuilmoitusData()
@@ -223,11 +224,11 @@ class HakemusFactory(
             alluid: Int? = null,
             alluStatus: ApplicationStatus? = null,
             applicationIdentifier: String? = null,
-            userId: String,
+            userId: String = USERNAME,
             applicationType: ApplicationType = ApplicationType.CABLE_REPORT,
             hakemusEntityData: HakemusEntityData =
                 ApplicationFactory.createBlankApplicationData(applicationType),
-            hanke: HankeEntity,
+            hanke: HankeEntity = HankeFactory.createEntity(),
         ): HakemusEntity =
             HakemusEntity(
                 id = id,
@@ -245,5 +246,26 @@ class HakemusFactory(
             taydennyspyynto: Taydennyspyynto? = null,
             taydennys: Taydennys? = null,
         ) = HakemusWithExtras(this, paatokset, taydennyspyynto, taydennys)
+
+        fun hakemusDataForRegistryKeyTest(tyyppi: CustomerType): KaivuilmoitusData {
+            val hakija =
+                HakemusyhteystietoFactory.createPerson(tyyppi = tyyppi, registryKey = "280341-912F")
+            val suorittaja =
+                HakemusyhteystietoFactory.createPerson(tyyppi = tyyppi, registryKey = null)
+            val rakennuttaja = HakemusyhteystietoFactory.create(registryKey = "5425233-4")
+            val asianhoitaja = HakemusyhteystietoFactory.create(registryKey = null)
+            val laskutusyhteystieto =
+                HakemusyhteystietoFactory.createLaskutusyhteystieto(
+                    tyyppi = tyyppi, registryKey = "280341-912F")
+            val hakemusdata =
+                createKaivuilmoitusData(
+                    customerWithContacts = hakija,
+                    contractorWithContacts = suorittaja,
+                    propertyDeveloperWithContacts = rakennuttaja,
+                    representativeWithContacts = asianhoitaja,
+                    invoicingCustomer = laskutusyhteystieto,
+                )
+            return hakemusdata
+        }
     }
 }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusUpdateRequestFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusUpdateRequestFactory.kt
@@ -36,12 +36,6 @@ object HakemusUpdateRequestFactory {
         InvoicingPostalAddressRequest(StreetAddress("Testikatu 1"), "00100", "Helsinki")
     internal const val DEFAULT_OVT = "003734741376"
 
-    fun createBlankUpdateRequest(type: ApplicationType): HakemusUpdateRequest =
-        when (type) {
-            ApplicationType.CABLE_REPORT -> createBlankJohtoselvityshakemusUpdateRequest()
-            ApplicationType.EXCAVATION_NOTIFICATION -> createBlankKaivuilmoitusUpdateRequest()
-        }
-
     fun createBlankJohtoselvityshakemusUpdateRequest(): JohtoselvityshakemusUpdateRequest =
         JohtoselvityshakemusUpdateRequest(
             name = "",
@@ -317,33 +311,6 @@ object HakemusUpdateRequestFactory {
                 this.copy(areas = areas?.map { it as JohtoselvitysHakemusalue })
             is KaivuilmoitusUpdateRequest ->
                 this.copy(areas = areas?.map { it as KaivuilmoitusAlue })
-        }
-
-    fun HakemusUpdateRequest.withTimes(startTime: ZonedDateTime?, endTime: ZonedDateTime?) =
-        when (this) {
-            is JohtoselvityshakemusUpdateRequest ->
-                this.copy(startTime = startTime, endTime = endTime)
-            is KaivuilmoitusUpdateRequest -> this.copy(startTime = startTime, endTime = endTime)
-        }
-
-    fun HakemusUpdateRequest.withRegistryKey(registryKey: String) =
-        when (this) {
-            is JohtoselvityshakemusUpdateRequest ->
-                this.copy(
-                    customerWithContacts =
-                        this.customerWithContacts?.copy(
-                            customer =
-                                this.customerWithContacts!!
-                                    .customer
-                                    .copy(registryKey = registryKey)))
-            is KaivuilmoitusUpdateRequest ->
-                this.copy(
-                    customerWithContacts =
-                        this.customerWithContacts?.copy(
-                            customer =
-                                this.customerWithContacts!!
-                                    .customer
-                                    .copy(registryKey = registryKey)))
         }
 
     fun KaivuilmoitusUpdateRequest.withInvoicingCustomer(

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceTest.kt
@@ -36,7 +36,8 @@ import fi.hel.haitaton.hanke.logging.HankeLoggingService
 import fi.hel.haitaton.hanke.logging.Status
 import fi.hel.haitaton.hanke.paatos.PaatosService
 import fi.hel.haitaton.hanke.permissions.HankeKayttajaService
-import fi.hel.haitaton.hanke.taydennys.TaydennysService
+import fi.hel.haitaton.hanke.taydennys.TaydennysRepository
+import fi.hel.haitaton.hanke.taydennys.TaydennyspyyntoRepository
 import fi.hel.haitaton.hanke.test.AlluException
 import fi.hel.haitaton.hanke.test.USERNAME
 import fi.hel.haitaton.hanke.tormaystarkastelu.TormaystarkasteluLaskentaService
@@ -71,6 +72,8 @@ import org.springframework.context.ApplicationEventPublisher
 class HakemusServiceTest {
     private val hakemusRepository: HakemusRepository = mockk()
     private val hankeRepository: HankeRepository = mockk()
+    private val taydennysRepository: TaydennysRepository = mockk()
+    private val taydennyspyyntoRepository: TaydennyspyyntoRepository = mockk()
     private val geometriatDao: GeometriatDao = mockk()
     private val hankealueService: HankealueService = mockk()
     private val loggingService: HakemusLoggingService = mockk(relaxUnitFun = true)
@@ -82,12 +85,13 @@ class HakemusServiceTest {
     private val paatosService: PaatosService = mockk()
     private val publisher: ApplicationEventPublisher = mockk()
     private val tormaystarkasteluLaskentaService: TormaystarkasteluLaskentaService = mockk()
-    private val taydennysService: TaydennysService = mockk()
 
     private val hakemusService =
         HakemusService(
             hakemusRepository,
             hankeRepository,
+            taydennyspyyntoRepository,
+            taydennysRepository,
             geometriatDao,
             hankealueService,
             loggingService,
@@ -99,7 +103,6 @@ class HakemusServiceTest {
             paatosService,
             publisher,
             tormaystarkasteluLaskentaService,
-            taydennysService,
         )
 
     @BeforeEach

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/KaivuilmoitusSendValidationTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/KaivuilmoitusSendValidationTest.kt
@@ -634,7 +634,7 @@ class KaivuilmoitusSendValidationTest {
     companion object {
         private const val BLANK = "   \t\n\t   "
 
-        val hakemus =
+        private val hakemus =
             HakemusFactory.createKaivuilmoitusData(
                 constructionWork = true,
                 requiredCompetence = true,


### PR DESCRIPTION
# Description

Make several methods in HankeService public and change their parameters from hakemus-specific objects to more generic data, but only the data they need. E.g., take `HakemusEntityData` instead of a `HakemusEntity`. Or use the generic interface `YhteystietoEntity<H>` to handle customer updates in a compatible way.

These changes allow us to reuse the same methods for validating and executing updates for täydennykset and hopefully for muutosilmoitukset.

Simplify exceptions in hakemus update. Don't worry about passing a hakemusIdentfier through the validating functions. Info about the hakemus we're updating is logged as an info-level log, so it doesn't need to be logged every time there's an error. When examining a problem, the reader can look at the previous lines to find the identifying info about the hakemus.

Otherwise, we would need a new set of exceptions for täydennys and some complex logic for passing the type of exception in the method parameters.

The `errorCode` value in HankeError made ktfmt crash after there were any changes in the file. I changed it to a getter function so that Jackson still serializes it as an `errorCode` field.

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [X] Other