### PR TITLE
HAI-2699 Remove täydennyspyyntö when cancelled in Allu

### DIFF
--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusHistoryService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusHistoryService.kt
@@ -118,6 +118,13 @@ class HakemusHistoryService(
                 taydennysService.saveTaydennyspyyntoFromAllu(application)
                 sendInformationRequestEmails(application, event.applicationIdentifier)
             }
+            ApplicationStatus.HANDLING -> {
+                logger.info {
+                    "A hakemus has has entered handling. Checking if there's a täydennyspyyntö for the hakemus."
+                }
+                taydennysService.removeTaydennyspyyntoIfItExists(application)
+                updateStatus()
+            }
             else -> updateStatus()
         }
     }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusHistoryServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusHistoryServiceTest.kt
@@ -155,7 +155,7 @@ class HakemusHistoryServiceTest {
                         alluid,
                         ApplicationHistoryFactory.createEvent(
                             applicationIdentifier = identifier,
-                            newStatus = ApplicationStatus.HANDLING)),
+                            newStatus = ApplicationStatus.DECISIONMAKING)),
                 )
 
             historyService.handleHakemusUpdates(histories, updateTime)


### PR DESCRIPTION
# Description

When the hakemus moves to a status of handling, check if it has a täydennyspyyntö. If it does, delete it. This will also delete any täydennys the user might have started drafting.

If the hakemus moves to a status of handling from an unexpected status and the hakemus has a täydennyspyyntö, something has gone wrong so log an error. This won't stop the deletion of the hakemus or updating the status.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2699

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
1. Make a täydennyspyyntö for a hakemus in Allu.
2. Wait until you see it in Haitaton.
3. Cancel the täydennyspyyntö in Allu.
4. It disappears in Haitaton.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 