### PR TITLE
HAI-2759 Remove pendingOnClient from Haitaton side

### DIFF
--- a/services/hanke-service/build.gradle.kts
+++ b/services/hanke-service/build.gradle.kts
@@ -43,7 +43,7 @@ spotless {
     ratchetFrom("origin/dev") // only format files which have changed since origin/dev
 
     kotlin {
-        ktfmt("0.51").kotlinlangStyle()
+        ktfmt("0.53").kotlinlangStyle()
         toggleOffOn()
     }
 }

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/testdata/TestDataServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/testdata/TestDataServiceITest.kt
@@ -4,12 +4,14 @@ import assertk.assertThat
 import assertk.assertions.each
 import assertk.assertions.hasSize
 import assertk.assertions.isNull
-import assertk.assertions.isTrue
+import assertk.assertions.prop
 import fi.hel.haitaton.hanke.IntegrationTest
 import fi.hel.haitaton.hanke.allu.ApplicationStatus
 import fi.hel.haitaton.hanke.factory.ApplicationFactory
 import fi.hel.haitaton.hanke.factory.HankeFactory
 import fi.hel.haitaton.hanke.factory.PaperDecisionReceiverFactory
+import fi.hel.haitaton.hanke.hakemus.HakemusEntity
+import fi.hel.haitaton.hanke.hakemus.HakemusEntityData
 import fi.hel.haitaton.hanke.hakemus.HakemusRepository
 import fi.hel.haitaton.hanke.test.USERNAME
 import org.junit.jupiter.api.Nested
@@ -42,9 +44,9 @@ class TestDataServiceITest : IntegrationTest() {
                     alluId = i,
                     applicationIdentifier = "JS00$i",
                     hakemusEntityData =
-                        applicationData
-                            .copy(pendingOnClient = false)
-                            .copy(paperDecisionReceiver = PaperDecisionReceiverFactory.default),
+                        applicationData.copy(
+                            paperDecisionReceiver = PaperDecisionReceiverFactory.default
+                        ),
                 )
 
                 applicationFactory.saveApplicationEntity(
@@ -53,7 +55,7 @@ class TestDataServiceITest : IntegrationTest() {
                     alluStatus = null,
                     alluId = null,
                     applicationIdentifier = null,
-                    hakemusEntityData = applicationData.copy(pendingOnClient = true),
+                    hakemusEntityData = applicationData,
                 )
             }
 
@@ -62,11 +64,13 @@ class TestDataServiceITest : IntegrationTest() {
             val applications = hakemusRepository.findAll()
             assertThat(applications).hasSize(8)
             assertThat(applications).each { application ->
-                application.transform { it.alluid }.isNull()
-                application.transform { it.applicationIdentifier }.isNull()
-                application.transform { it.alluStatus }.isNull()
-                application.transform { it.hakemusEntityData.pendingOnClient }.isTrue()
-                application.transform { it.hakemusEntityData.paperDecisionReceiver }.isNull()
+                application.prop(HakemusEntity::alluid).isNull()
+                application.prop(HakemusEntity::applicationIdentifier).isNull()
+                application.prop(HakemusEntity::alluStatus).isNull()
+                application
+                    .prop(HakemusEntity::hakemusEntityData)
+                    .prop(HakemusEntityData::paperDecisionReceiver)
+                    .isNull()
             }
         }
     }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/Hakemus.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/Hakemus.kt
@@ -38,7 +38,8 @@ data class Hakemus(
                     }
                 } else {
                     null
-                })
+                },
+        )
 
     fun toMetadata(): HakemusMetaData =
         HakemusMetaData(
@@ -54,7 +55,6 @@ data class Hakemus(
 sealed interface HakemusData {
     val applicationType: ApplicationType
     val name: String
-    val pendingOnClient: Boolean
     val startTime: ZonedDateTime?
     val endTime: ZonedDateTime?
     val areas: List<Hakemusalue>?
@@ -78,7 +78,6 @@ data class JohtoselvityshakemusData(
     val workDescription: String? = null,
     override val startTime: ZonedDateTime? = null,
     override val endTime: ZonedDateTime? = null,
-    override val pendingOnClient: Boolean,
     override val areas: List<JohtoselvitysHakemusalue>? = null,
     override val paperDecisionReceiver: PaperDecisionReceiver?,
     override val customerWithContacts: Hakemusyhteystieto? = null,
@@ -89,7 +88,6 @@ data class JohtoselvityshakemusData(
     override fun toResponse(): JohtoselvitysHakemusDataResponse =
         JohtoselvitysHakemusDataResponse(
             applicationType = ApplicationType.CABLE_REPORT,
-            pendingOnClient = pendingOnClient,
             name = name,
             postalAddress = postalAddress,
             constructionWork = constructionWork,
@@ -119,7 +117,6 @@ data class JohtoselvityshakemusData(
 
 data class KaivuilmoitusData(
     override val applicationType: ApplicationType = ApplicationType.EXCAVATION_NOTIFICATION,
-    override val pendingOnClient: Boolean,
     override val name: String,
     val workDescription: String,
     val constructionWork: Boolean,
@@ -144,7 +141,6 @@ data class KaivuilmoitusData(
     override fun toResponse(): KaivuilmoitusDataResponse =
         KaivuilmoitusDataResponse(
             applicationType = ApplicationType.EXCAVATION_NOTIFICATION,
-            pendingOnClient = pendingOnClient,
             name = name,
             workDescription = workDescription,
             constructionWork = constructionWork,

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusDataMapper.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusDataMapper.kt
@@ -29,7 +29,8 @@ object HakemusDataMapper {
         val description = workDescription()
         return AlluCableReportApplicationData(
             identificationNumber = hankeTunnus,
-            pendingOnClient = pendingOnClient,
+            // We don't send drafts to Allu
+            pendingOnClient = false,
             name = name,
             postalAddress = postalAddress?.toAlluData(),
             constructionWork = constructionWork,
@@ -61,7 +62,8 @@ object HakemusDataMapper {
     ): AlluExcavationNotificationData =
         AlluExcavationNotificationData(
             identificationNumber = hankeTunnus,
-            pendingOnClient = pendingOnClient,
+            // We don't send drafts to Allu
+            pendingOnClient = false,
             name = name,
             workPurpose = workDescription,
             clientApplicationKind = workDescription,
@@ -136,7 +138,8 @@ object HakemusDataMapper {
                 invoicingOperator = null,
                 sapCustomerNumber = null,
             ),
-            yhteyshenkilot.map { it.toAlluContact() })
+            yhteyshenkilot.map { it.toAlluContact() },
+        )
 
     fun Hakemusyhteyshenkilo.toAlluContact() =
         Contact("$etunimi $sukunimi".trim(), sahkoposti, puhelin, tilaaja)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusResponse.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusResponse.kt
@@ -23,7 +23,6 @@ data class HakemusResponse(
 
 sealed interface HakemusDataResponse {
     val applicationType: ApplicationType
-    val pendingOnClient: Boolean
     val name: String
     val startTime: ZonedDateTime?
     val endTime: ZonedDateTime?
@@ -36,7 +35,6 @@ sealed interface HakemusDataResponse {
 
 data class JohtoselvitysHakemusDataResponse(
     override val applicationType: ApplicationType = ApplicationType.CABLE_REPORT,
-    override val pendingOnClient: Boolean,
     /** Työn nimi */
     override val name: String,
     /** Katuosoite */
@@ -84,7 +82,6 @@ data class JohtoselvitysHakemusDataResponse(
 
 data class KaivuilmoitusDataResponse(
     override val applicationType: ApplicationType = ApplicationType.EXCAVATION_NOTIFICATION,
-    override val pendingOnClient: Boolean,
     /** Työn nimi */
     override val name: String,
     /** Työn kuvaus */

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HankkeenHakemuksetResponse.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HankkeenHakemuksetResponse.kt
@@ -35,7 +35,6 @@ data class HankkeenHakemusDataResponse(
     val name: String,
     val startTime: ZonedDateTime?,
     val endTime: ZonedDateTime?,
-    val pendingOnClient: Boolean,
     val areas: List<Hakemusalue>?,
 ) {
     constructor(
@@ -45,7 +44,6 @@ data class HankkeenHakemusDataResponse(
         cableReportApplicationData.name,
         cableReportApplicationData.startTime,
         cableReportApplicationData.endTime,
-        cableReportApplicationData.pendingOnClient,
         if (includeAreas) cableReportApplicationData.areas else null,
     )
 
@@ -56,7 +54,6 @@ data class HankkeenHakemusDataResponse(
         kaivuilmoitusEntityData.name,
         kaivuilmoitusEntityData.startTime,
         kaivuilmoitusEntityData.endTime,
-        kaivuilmoitusEntityData.pendingOnClient,
         if (includeAreas) kaivuilmoitusEntityData.areas else null,
     )
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/testdata/TestDataService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/testdata/TestDataService.kt
@@ -10,9 +10,7 @@ private val logger = KotlinLogging.logger {}
 
 @Service
 @ConditionalOnProperty(name = ["haitaton.testdata.enabled"], havingValue = "true")
-class TestDataService(
-    private val hakemusRepository: HakemusRepository,
-) {
+class TestDataService(private val hakemusRepository: HakemusRepository) {
     @Transactional
     fun unlinkApplicationsFromAllu() {
         logger.warn { "Unlinking all applications from Allu." }
@@ -21,8 +19,7 @@ class TestDataService(
             it.alluid = null
             it.alluStatus = null
             it.applicationIdentifier = null
-            it.hakemusEntityData =
-                it.hakemusEntityData.copy(pendingOnClient = true).copy(paperDecisionReceiver = null)
+            it.hakemusEntityData = it.hakemusEntityData.copy(paperDecisionReceiver = null)
         }
     }
 }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/ApplicationFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/ApplicationFactory.kt
@@ -133,14 +133,12 @@ class ApplicationFactory(
             areas: List<JohtoselvitysHakemusalue>? = listOf(createCableReportApplicationArea()),
             startTime: ZonedDateTime? = DateFactory.getStartDatetime(),
             endTime: ZonedDateTime? = DateFactory.getEndDatetime(),
-            pendingOnClient: Boolean = false,
             workDescription: String = DEFAULT_WORK_DESCRIPTION,
             rockExcavation: Boolean = false,
             postalAddress: PostalAddress? = null,
         ): JohtoselvityshakemusEntityData =
             JohtoselvityshakemusEntityData(
                 applicationType = ApplicationType.CABLE_REPORT,
-                pendingOnClient = pendingOnClient,
                 name = name,
                 postalAddress = postalAddress,
                 rockExcavation = rockExcavation,
@@ -157,13 +155,12 @@ class ApplicationFactory(
                 areas = null,
                 startTime = null,
                 endTime = null,
-                pendingOnClient = false,
                 workDescription = "",
                 rockExcavation = false,
-                postalAddress = PostalAddress(StreetAddress(""), "", ""))
+                postalAddress = PostalAddress(StreetAddress(""), "", ""),
+            )
 
         fun createExcavationNotificationData(
-            pendingOnClient: Boolean = false,
             name: String = DEFAULT_APPLICATION_NAME,
             workDescription: String = "Työn kuvaus.",
             maintenanceWork: Boolean = false,
@@ -182,7 +179,6 @@ class ApplicationFactory(
         ): KaivuilmoitusEntityData =
             KaivuilmoitusEntityData(
                 applicationType = ApplicationType.EXCAVATION_NOTIFICATION,
-                pendingOnClient = pendingOnClient,
                 name = name,
                 workDescription = workDescription,
                 maintenanceWork = maintenanceWork,

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusBuilder.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusBuilder.kt
@@ -72,21 +72,12 @@ data class HakemusBuilder(
     fun inHandling(alluId: Int = 1) = withStatus(ApplicationStatus.HANDLING, alluId)
 
     fun withName(name: String): HakemusBuilder =
-        updateApplicationData(
-            { copy(name = name) },
-            { copy(name = name) },
-        )
+        updateApplicationData({ copy(name = name) }, { copy(name = name) })
 
     fun withWorkDescription(workDescription: String): HakemusBuilder =
         updateApplicationData(
             { copy(workDescription = workDescription) },
             { copy(workDescription = workDescription) },
-        )
-
-    fun withPendingOnClient(pendingOnClient: Boolean) =
-        updateApplicationData(
-            { copy(pendingOnClient = pendingOnClient) },
-            { copy(pendingOnClient = pendingOnClient) },
         )
 
     fun withArea(area: JohtoselvitysHakemusalue): HakemusBuilder {
@@ -112,21 +103,17 @@ data class HakemusBuilder(
                 copy(
                     areas =
                         (areas ?: listOf()).plus(
-                            createExcavationNotificationArea(hankealueId = hankealueId ?: 0)))
+                            createExcavationNotificationArea(hankealueId = hankealueId ?: 0)
+                        )
+                )
             },
         )
 
     fun withStartTime(time: ZonedDateTime? = DateFactory.getStartDatetime()) =
-        updateApplicationData(
-            { copy(startTime = time) },
-            { copy(startTime = time) },
-        )
+        updateApplicationData({ copy(startTime = time) }, { copy(startTime = time) })
 
     fun withEndTime(time: ZonedDateTime? = DateFactory.getEndDatetime()) =
-        updateApplicationData(
-            { copy(endTime = time) },
-            { copy(endTime = time) },
-        )
+        updateApplicationData({ copy(endTime = time) }, { copy(endTime = time) })
 
     fun withoutCableReports() =
         updateApplicationData(
@@ -149,7 +136,7 @@ data class HakemusBuilder(
     fun withWorkInvolves(
         constructionWork: Boolean = true,
         maintenanceWork: Boolean = false,
-        emergencyWork: Boolean = false
+        emergencyWork: Boolean = false,
     ): HakemusBuilder =
         updateApplicationData(
             { throw InvalidParameterException("Not available for cable reports.") },
@@ -212,7 +199,8 @@ data class HakemusBuilder(
                     .withEndTime()
                     .withArea(hankealue?.id)
                     .withCableReports(
-                        listOf(ApplicationFactory.DEFAULT_CABLE_REPORT_APPLICATION_IDENTIFIER))
+                        listOf(ApplicationFactory.DEFAULT_CABLE_REPORT_APPLICATION_IDENTIFIER)
+                    )
                     .withWorkInvolves()
                     .withRequiredCompetence()
                     .hakija()
@@ -228,7 +216,7 @@ data class HakemusBuilder(
         status: ApplicationStatus? = ApplicationStatus.PENDING,
         alluId: Int? = 1,
         identifier: String? = defaultIdentifier(alluId),
-        hankealue: SavedHankealue? = null
+        hankealue: SavedHankealue? = null,
     ) = this.withMandatoryFields(hankealue).withStatus(status, alluId, identifier)
 
     private fun founder(): HankekayttajaEntity =
@@ -237,13 +225,10 @@ data class HakemusBuilder(
     fun hakija(
         yhteystieto: Hakemusyhteystieto = HakemusyhteystietoFactory.create(),
         vararg yhteyshenkilot: HankekayttajaEntity =
-            arrayOf(kayttaja(HankeKayttajaFactory.KAYTTAJA_INPUT_HAKIJA))
+            arrayOf(kayttaja(HankeKayttajaFactory.KAYTTAJA_INPUT_HAKIJA)),
     ): HakemusBuilder = yhteystieto(ApplicationContactType.HAKIJA, yhteystieto, *yhteyshenkilot)
 
-    fun hakija(
-        kayttooikeustaso: Kayttooikeustaso,
-        tilaaja: Boolean = true,
-    ): HakemusBuilder =
+    fun hakija(kayttooikeustaso: Kayttooikeustaso, tilaaja: Boolean = true): HakemusBuilder =
         yhteystieto(
             kayttooikeustaso,
             tilaaja,
@@ -253,13 +238,13 @@ data class HakemusBuilder(
 
     fun hakija(
         first: HankekayttajaEntity,
-        vararg yhteyshenkilot: HankekayttajaEntity
+        vararg yhteyshenkilot: HankekayttajaEntity,
     ): HakemusBuilder = hakija(yhteyshenkilot = arrayOf(first) + yhteyshenkilot)
 
     fun tyonSuorittaja(
         yhteystieto: Hakemusyhteystieto = HakemusyhteystietoFactory.create(),
         vararg yhteyshenkilot: HankekayttajaEntity =
-            arrayOf(kayttaja(HankeKayttajaFactory.KAYTTAJA_INPUT_SUORITTAJA))
+            arrayOf(kayttaja(HankeKayttajaFactory.KAYTTAJA_INPUT_SUORITTAJA)),
     ): HakemusBuilder =
         yhteystieto(ApplicationContactType.TYON_SUORITTAJA, yhteystieto, *yhteyshenkilot)
 
@@ -276,20 +261,17 @@ data class HakemusBuilder(
 
     fun tyonSuorittaja(
         first: HankekayttajaEntity,
-        vararg yhteyshenkilot: HankekayttajaEntity
+        vararg yhteyshenkilot: HankekayttajaEntity,
     ): HakemusBuilder = tyonSuorittaja(yhteyshenkilot = arrayOf(first) + yhteyshenkilot)
 
     fun rakennuttaja(
         yhteystieto: Hakemusyhteystieto = HakemusyhteystietoFactory.create(),
         vararg yhteyshenkilot: HankekayttajaEntity =
-            arrayOf(kayttaja(HankeKayttajaFactory.KAYTTAJA_INPUT_RAKENNUTTAJA))
+            arrayOf(kayttaja(HankeKayttajaFactory.KAYTTAJA_INPUT_RAKENNUTTAJA)),
     ): HakemusBuilder =
         yhteystieto(ApplicationContactType.RAKENNUTTAJA, yhteystieto, *yhteyshenkilot)
 
-    fun rakennuttaja(
-        kayttooikeustaso: Kayttooikeustaso,
-        tilaaja: Boolean = false,
-    ): HakemusBuilder =
+    fun rakennuttaja(kayttooikeustaso: Kayttooikeustaso, tilaaja: Boolean = false): HakemusBuilder =
         yhteystieto(
             kayttooikeustaso,
             tilaaja,
@@ -299,20 +281,17 @@ data class HakemusBuilder(
 
     fun rakennuttaja(
         first: HankekayttajaEntity,
-        vararg yhteyshenkilot: HankekayttajaEntity
+        vararg yhteyshenkilot: HankekayttajaEntity,
     ): HakemusBuilder = rakennuttaja(yhteyshenkilot = arrayOf(first) + yhteyshenkilot)
 
     fun asianhoitaja(
         yhteystieto: Hakemusyhteystieto = HakemusyhteystietoFactory.create(),
         vararg yhteyshenkilot: HankekayttajaEntity =
-            arrayOf(kayttaja(HankeKayttajaFactory.KAYTTAJA_INPUT_ASIANHOITAJA))
+            arrayOf(kayttaja(HankeKayttajaFactory.KAYTTAJA_INPUT_ASIANHOITAJA)),
     ): HakemusBuilder =
         yhteystieto(ApplicationContactType.ASIANHOITAJA, yhteystieto, *yhteyshenkilot)
 
-    fun asianhoitaja(
-        kayttooikeustaso: Kayttooikeustaso,
-        tilaaja: Boolean = false,
-    ): HakemusBuilder =
+    fun asianhoitaja(kayttooikeustaso: Kayttooikeustaso, tilaaja: Boolean = false): HakemusBuilder =
         yhteystieto(
             kayttooikeustaso,
             tilaaja,
@@ -322,13 +301,13 @@ data class HakemusBuilder(
 
     fun asianhoitaja(
         first: HankekayttajaEntity,
-        vararg yhteyshenkilot: HankekayttajaEntity
+        vararg yhteyshenkilot: HankekayttajaEntity,
     ): HakemusBuilder = asianhoitaja(yhteyshenkilot = arrayOf(first) + yhteyshenkilot)
 
     /** Creates each customer and saves the given hankekayttaja as contacts to all of them. */
     fun withEachCustomer(
         first: HankekayttajaEntity,
-        vararg yhteyshenkilot: HankekayttajaEntity
+        vararg yhteyshenkilot: HankekayttajaEntity,
     ): HakemusBuilder =
         hakija(first, *yhteyshenkilot)
             .tyonSuorittaja(first, *yhteyshenkilot)
@@ -338,7 +317,7 @@ data class HakemusBuilder(
     private fun yhteystieto(
         rooli: ApplicationContactType,
         yhteystieto: Hakemusyhteystieto = HakemusyhteystietoFactory.create(),
-        vararg yhteyshenkilot: HankekayttajaEntity
+        vararg yhteyshenkilot: HankekayttajaEntity,
     ): HakemusBuilder {
         val yhteystietoEntity = createYhteystietoEntity(rooli, yhteystieto)
         val yhteyshenkiloEntities =
@@ -353,7 +332,7 @@ data class HakemusBuilder(
         kayttooikeustaso: Kayttooikeustaso,
         tilaaja: Boolean,
         rooli: ApplicationContactType,
-        kayttajaInput: HankekayttajaInput
+        kayttajaInput: HankekayttajaInput,
     ): HakemusBuilder {
         val yhteystietoEntity = createYhteystietoEntity(rooli, HakemusyhteystietoFactory.create())
         val kayttaja = kayttaja(kayttajaInput, kayttooikeustaso)
@@ -376,7 +355,7 @@ data class HakemusBuilder(
 
     private fun createYhteystietoEntity(
         rooli: ApplicationContactType,
-        yhteystieto: Hakemusyhteystieto
+        yhteystieto: Hakemusyhteystieto,
     ): HakemusyhteystietoEntity =
         HakemusyhteystietoEntity(
             tyyppi = yhteystieto.tyyppi,
@@ -391,10 +370,13 @@ data class HakemusBuilder(
     private fun createYhteyshenkiloEntity(
         yhteystietoEntity: HakemusyhteystietoEntity,
         kayttaja: HankekayttajaEntity,
-        tilaaja: Boolean = false
+        tilaaja: Boolean = false,
     ) =
         HakemusyhteyshenkiloEntity(
-            hankekayttaja = kayttaja, hakemusyhteystieto = yhteystietoEntity, tilaaja = tilaaja)
+            hankekayttaja = kayttaja,
+            hakemusyhteystieto = yhteystietoEntity,
+            tilaaja = tilaaja,
+        )
 
     private fun defaultIdentifier(alluId: Int?) =
         when (hakemusEntity.applicationType) {

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusFactory.kt
@@ -60,7 +60,10 @@ class HakemusFactory(
 
     fun builder(applicationType: ApplicationType) =
         builder(
-            USERNAME, hankeFactory.builder(USERNAME).withHankealue().saveEntity(), applicationType)
+            USERNAME,
+            hankeFactory.builder(USERNAME).withHankealue().saveEntity(),
+            applicationType,
+        )
 
     private fun builder(
         userId: String,
@@ -138,7 +141,6 @@ class HakemusFactory(
             workDescription: String = ApplicationFactory.DEFAULT_WORK_DESCRIPTION,
             startTime: ZonedDateTime? = DateFactory.getStartDatetime(),
             endTime: ZonedDateTime? = DateFactory.getEndDatetime(),
-            pendingOnClient: Boolean = false,
             areas: List<JohtoselvitysHakemusalue>? =
                 listOf(ApplicationFactory.createCableReportApplicationArea()),
             paperDecisionReceiver: PaperDecisionReceiver? = null,
@@ -162,7 +164,6 @@ class HakemusFactory(
                 workDescription = workDescription,
                 startTime = startTime,
                 endTime = endTime,
-                pendingOnClient = pendingOnClient,
                 areas = areas,
                 paperDecisionReceiver = paperDecisionReceiver,
                 customerWithContacts = customerWithContacts,
@@ -172,7 +173,6 @@ class HakemusFactory(
             )
 
         fun createKaivuilmoitusData(
-            pendingOnClient: Boolean = false,
             name: String = ApplicationFactory.DEFAULT_APPLICATION_NAME,
             workDescription: String = ApplicationFactory.DEFAULT_WORK_DESCRIPTION,
             constructionWork: Boolean = false,
@@ -196,7 +196,6 @@ class HakemusFactory(
             additionalInfo: String? = null,
         ): KaivuilmoitusData =
             KaivuilmoitusData(
-                pendingOnClient = pendingOnClient,
                 name = name,
                 workDescription = workDescription,
                 constructionWork = constructionWork,
@@ -256,7 +255,9 @@ class HakemusFactory(
             val asianhoitaja = HakemusyhteystietoFactory.create(registryKey = null)
             val laskutusyhteystieto =
                 HakemusyhteystietoFactory.createLaskutusyhteystieto(
-                    tyyppi = tyyppi, registryKey = "280341-912F")
+                    tyyppi = tyyppi,
+                    registryKey = "280341-912F",
+                )
             val hakemusdata =
                 createKaivuilmoitusData(
                     customerWithContacts = hakija,

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusResponseFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusResponseFactory.kt
@@ -51,7 +51,6 @@ object HakemusResponseFactory {
         }
 
     fun createJohtoselvitysHakemusDataResponse(
-        pendingOnClient: Boolean = false,
         name: String = ApplicationFactory.DEFAULT_APPLICATION_NAME,
         postalAddress: PostalAddress = PostalAddress(StreetAddress(DEFAULT_STREET_NAME), "", ""),
         rockExcavation: Boolean = false,
@@ -61,20 +60,13 @@ object HakemusResponseFactory {
         areas: List<JohtoselvitysHakemusalue> =
             listOf(ApplicationFactory.createCableReportApplicationArea()),
         customerWithContacts: CustomerWithContactsResponse? =
-            CustomerWithContactsResponse(
-                companyCustomer(),
-                listOf(createContactResponse()),
-            ),
+            CustomerWithContactsResponse(companyCustomer(), listOf(createContactResponse())),
         contractorWithContacts: CustomerWithContactsResponse? =
-            CustomerWithContactsResponse(
-                personCustomer(),
-                listOf(createContactResponse()),
-            ),
+            CustomerWithContactsResponse(personCustomer(), listOf(createContactResponse())),
         representativeWithContacts: CustomerWithContactsResponse? = null,
         propertyDeveloperWithContacts: CustomerWithContactsResponse? = null,
     ): JohtoselvitysHakemusDataResponse =
         JohtoselvitysHakemusDataResponse(
-            pendingOnClient = pendingOnClient,
             name = name,
             postalAddress = postalAddress,
             constructionWork = true,
@@ -94,7 +86,6 @@ object HakemusResponseFactory {
         )
 
     private fun createKaivuilmoitusDataResponse(
-        pendingOnClient: Boolean = false,
         name: String = ApplicationFactory.DEFAULT_APPLICATION_NAME,
         workDescription: String = "Work description.",
         cableReportDone: Boolean = false,
@@ -107,22 +98,15 @@ object HakemusResponseFactory {
         areas: List<KaivuilmoitusAlue> =
             listOf(ApplicationFactory.createExcavationNotificationArea()),
         customerWithContacts: CustomerWithContactsResponse? =
-            CustomerWithContactsResponse(
-                companyCustomer(),
-                listOf(createContactResponse()),
-            ),
+            CustomerWithContactsResponse(companyCustomer(), listOf(createContactResponse())),
         contractorWithContacts: CustomerWithContactsResponse? =
-            CustomerWithContactsResponse(
-                personCustomer(),
-                listOf(createContactResponse()),
-            ),
+            CustomerWithContactsResponse(personCustomer(), listOf(createContactResponse())),
         representativeWithContacts: CustomerWithContactsResponse? = null,
         propertyDeveloperWithContacts: CustomerWithContactsResponse? = null,
         invoicingCustomer: InvoicingCustomerResponse? = createInvoicingCustomerResponse(),
         additionalInfo: String? = null,
     ): KaivuilmoitusDataResponse =
         KaivuilmoitusDataResponse(
-            pendingOnClient = pendingOnClient,
             name = name,
             workDescription = workDescription,
             constructionWork = true,
@@ -190,7 +174,7 @@ object HakemusResponseFactory {
         lastName: String = "Testihenkilö",
         email: String = ApplicationFactory.TEPPO_EMAIL,
         phone: String = "04012345678",
-        orderer: Boolean = false
+        orderer: Boolean = false,
     ) = ContactResponse(hankekayttajaId, firstName, lastName, email, phone, orderer)
 
     private fun createInvoicingCustomerResponse(

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusDataMapperTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusDataMapperTest.kt
@@ -95,13 +95,13 @@ class HakemusDataMapperTest {
             val expected =
                 AlluCableReportApplicationData(
                     identificationNumber = "HAI23-9",
-                    pendingOnClient = hakemus.pendingOnClient,
+                    pendingOnClient = false,
                     name = hakemus.name,
                     postalAddress =
                         AlluPostalAddress(
                             AlluStreetAddress(hakemus.postalAddress!!.streetAddress.streetName),
-                            hakemus.postalAddress!!.postalCode,
-                            hakemus.postalAddress!!.city,
+                            hakemus.postalAddress.postalCode,
+                            hakemus.postalAddress.city,
                         ),
                     constructionWork = hakemus.constructionWork,
                     maintenanceWork = hakemus.maintenanceWork,
@@ -180,7 +180,7 @@ class HakemusDataMapperTest {
         private val expectedResult =
             AlluExcavationNotificationData(
                 identificationNumber = "HAI23-0045",
-                pendingOnClient = hakemus.pendingOnClient,
+                pendingOnClient = false,
                 name = hakemus.name,
                 workPurpose = hakemus.workDescription,
                 clientApplicationKind = hakemus.workDescription,
@@ -245,21 +245,9 @@ class HakemusDataMapperTest {
                     "contractorWithContacts",
                     AlluDataError.NULL,
                 ),
-                Arguments.of(
-                    hakemus.copy(startTime = null),
-                    "startTime",
-                    AlluDataError.NULL,
-                ),
-                Arguments.of(
-                    hakemus.copy(endTime = null),
-                    "endTime",
-                    AlluDataError.NULL,
-                ),
-                Arguments.of(
-                    hakemus.copy(areas = null),
-                    "areas",
-                    AlluDataError.EMPTY_OR_NULL,
-                ),
+                Arguments.of(hakemus.copy(startTime = null), "startTime", AlluDataError.NULL),
+                Arguments.of(hakemus.copy(endTime = null), "endTime", AlluDataError.NULL),
+                Arguments.of(hakemus.copy(areas = null), "areas", AlluDataError.EMPTY_OR_NULL),
             )
 
         @ParameterizedTest
@@ -300,7 +288,8 @@ class HakemusDataMapperTest {
                                 katuosoite = null,
                                 postinumero = null,
                                 postitoimipaikka = null,
-                            )),
+                            )
+                    ),
                     expectedResult.copy(
                         invoicingCustomer =
                             Customer(
@@ -316,7 +305,8 @@ class HakemusDataMapperTest {
                                 sapCustomerNumber = null,
                             ),
                         customerReference = null,
-                    )),
+                    ),
+                ),
                 Arguments.of(
                     hakemus.copy(
                         invoicingCustomer =
@@ -324,14 +314,17 @@ class HakemusDataMapperTest {
                                 katuosoite = "Katu 1",
                                 postinumero = null,
                                 postitoimipaikka = null,
-                            )),
+                            )
+                    ),
                     expectedResult.copy(
                         invoicingCustomer =
                             expectedResult.invoicingCustomer!!.copy(
                                 postalAddress =
-                                    AlluPostalAddress(AlluStreetAddress("Katu 1"), "", "")),
+                                    AlluPostalAddress(AlluStreetAddress("Katu 1"), "", "")
+                            ),
                         customerReference = null,
-                    )),
+                    ),
+                ),
                 Arguments.of(
                     hakemus.copy(
                         invoicingCustomer =
@@ -339,10 +332,11 @@ class HakemusDataMapperTest {
                                 katuosoite = null,
                                 postinumero = "00410",
                                 postitoimipaikka = "Helsinki",
-                            )),
+                            )
+                    ),
                     expectedResult.copy(
                         invoicingCustomer =
-                            expectedResult.invoicingCustomer!!.copy(postalAddress = null),
+                            expectedResult.invoicingCustomer.copy(postalAddress = null),
                         customerReference = null,
                     ),
                 ),
@@ -382,7 +376,8 @@ class HakemusDataMapperTest {
             area.geometry.crs.properties["name"] = "Wrong geometry"
             val hakemus =
                 hakemus.copy(
-                    areas = listOf(area, ApplicationFactory.createCableReportApplicationArea()))
+                    areas = listOf(area, ApplicationFactory.createCableReportApplicationArea())
+                )
 
             val failure = assertFailure { hakemus.getGeometries() }
 
@@ -398,9 +393,11 @@ class HakemusDataMapperTest {
             val areas =
                 listOf(
                     ApplicationFactory.createCableReportApplicationArea(
-                        geometry = GeometriaFactory.secondPolygon()),
+                        geometry = GeometriaFactory.secondPolygon()
+                    ),
                     ApplicationFactory.createCableReportApplicationArea(
-                        geometry = GeometriaFactory.thirdPolygon()),
+                        geometry = GeometriaFactory.thirdPolygon()
+                    ),
                 )
             val hakemus = hakemus.copy(areas = areas)
 
@@ -416,9 +413,11 @@ class HakemusDataMapperTest {
             val areas =
                 listOf(
                     ApplicationFactory.createCableReportApplicationArea(
-                        geometry = GeometriaFactory.secondPolygon()),
+                        geometry = GeometriaFactory.secondPolygon()
+                    ),
                     ApplicationFactory.createCableReportApplicationArea(
-                        geometry = GeometriaFactory.thirdPolygon()),
+                        geometry = GeometriaFactory.thirdPolygon()
+                    ),
                 )
             val hakemus = hakemus.copy(areas = areas)
 

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/HankkeenHakemusResponseDeserializer.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/HankkeenHakemusResponseDeserializer.kt
@@ -12,7 +12,7 @@ import java.time.ZonedDateTime
 class HankkeenHakemusResponseDeserializer : JsonDeserializer<HankkeenHakemusResponse>() {
     override fun deserialize(
         jsonParser: JsonParser,
-        deserializationContext: DeserializationContext
+        deserializationContext: DeserializationContext,
     ): HankkeenHakemusResponse {
         val root = jsonParser.readValueAsTree<ObjectNode>()
         val basicApplication = OBJECT_MAPPER.treeToValue(root, BasicResponse::class.java)
@@ -25,12 +25,13 @@ class HankkeenHakemusResponseDeserializer : JsonDeserializer<HankkeenHakemusResp
                 deserializeHakemusalue(areaNode as ObjectNode, basicApplication.applicationType)
             }
         return basicApplication.toHankkeenHakemusResponse(
-            basicApplicationData.toHankkeenHakemusDataResponse(areas))
+            basicApplicationData.toHankkeenHakemusDataResponse(areas)
+        )
     }
 
     private fun deserializeHakemusalue(
         areaNode: ObjectNode,
-        applicationType: ApplicationType
+        applicationType: ApplicationType,
     ): Hakemusalue {
         return when (applicationType) {
             ApplicationType.CABLE_REPORT ->
@@ -71,7 +72,6 @@ class HankkeenHakemusResponseDeserializer : JsonDeserializer<HankkeenHakemusResp
                 name,
                 startTime,
                 endTime,
-                pendingOnClient,
                 if (areas.isNotEmpty()) areas else null,
             )
     }


### PR DESCRIPTION
# Description

We don't send application drafts to Allu at this time, so we don't need to keep track of whether the application is a draft or not. Currently, it's a draft until it's sent to Allu.

Remove the pendingOnClient value from hakemus entity data and related places. In AlluApplicationData we set it to false when sending the hakemus since we never send drafts to Allu.

Also, upgrade the `ktfmt` version to 0.53. This causes most of the changes in this commit since the handling of closing parentheses has been changed again. They also added automatic handling of trailing commas, freeing us from thinking about them completely.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2759

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [X] Other