### PR TITLE
HAI-2759 Add changes in täydennys to hakemus response

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/taydennys/UpdateTaydennysITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/taydennys/UpdateTaydennysITest.kt
@@ -256,7 +256,9 @@ class UpdateTaydennysITest(
 
         private val notInHankeArea =
             ApplicationFactory.createCableReportApplicationArea(
-                name = "area", geometry = GeometriaFactory.polygon())
+                name = "area",
+                geometry = GeometriaFactory.polygon(),
+            )
 
         @Test
         fun `throws exception when there are invalid geometry in areas`() {
@@ -272,7 +274,8 @@ class UpdateTaydennysITest(
                 messageContains("Invalid geometry received when updating hakemus")
                 messageContains("reason=Self-intersection")
                 messageContains(
-                    "location={\"type\":\"Point\",\"coordinates\":[25494009.65639264,6679886.142116806]}")
+                    "location={\"type\":\"Point\",\"coordinates\":[25494009.65639264,6679886.142116806]}"
+                )
             }
         }
 
@@ -355,7 +358,10 @@ class UpdateTaydennysITest(
                 taydennys
                     .toUpdateRequest()
                     .withContractor(
-                        CustomerType.COMPANY, tyonSuorittajaId, hankekayttajaIds = arrayOf())
+                        CustomerType.COMPANY,
+                        tyonSuorittajaId,
+                        hankekayttajaIds = arrayOf(),
+                    )
 
             val updatedTaydennys = taydennysService.updateTaydennys(taydennys.id, request, USERNAME)
 
@@ -391,7 +397,8 @@ class UpdateTaydennysITest(
                     .withCustomer(
                         CustomerType.COMPANY,
                         yhteystietoId = null,
-                        hankekayttajaIds = arrayOf(newKayttaja.id))
+                        hankekayttajaIds = arrayOf(newKayttaja.id),
+                    )
 
             val updatedTaydennys = taydennysService.updateTaydennys(taydennys.id, request, USERNAME)
 
@@ -432,10 +439,12 @@ class UpdateTaydennysITest(
             assertThat(email.allRecipients.single().toString()).isEqualTo(newKayttaja.sahkoposti)
             assertThat(email.subject)
                 .isEqualTo(
-                    "Haitaton: Sinut on lisätty hakemukselle / Du har lagts till i en ansökan / You have been added to an application")
+                    "Haitaton: Sinut on lisätty hakemukselle / Du har lagts till i en ansökan / You have been added to an application"
+                )
             assertThat(email.textBody())
                 .contains(
-                    "laatimassa johtoselvityshakemusta hankkeelle \"${hanke.nimi}\" (${hanke.hankeTunnus})")
+                    "laatimassa johtoselvityshakemusta hankkeelle \"${hanke.nimi}\" (${hanke.hankeTunnus})"
+                )
         }
 
         @Test
@@ -468,7 +477,9 @@ class UpdateTaydennysITest(
             val hankeEntity = hankeRepository.findAll().single()
             val taydennys =
                 taydennysFactory.saveWithHakemus(
-                    ApplicationType.EXCAVATION_NOTIFICATION, hankeEntity)
+                    ApplicationType.EXCAVATION_NOTIFICATION,
+                    hankeEntity,
+                )
             val hankealueId = hanke.alueet.single().id!!
             val area = notInHankeArea.copy(hankealueId = hankealueId)
             val request = taydennys.toUpdateRequest().withArea(area)
@@ -481,7 +492,8 @@ class UpdateTaydennysITest(
                 hasClass(HakemusGeometryNotInsideHankeException::class)
                 messageContains("Hakemus geometry is outside the associated hankealue")
                 messageContains(
-                    "geometry=${notInHankeArea.tyoalueet.single().geometry.toJsonString()}")
+                    "geometry=${notInHankeArea.tyoalueet.single().geometry.toJsonString()}"
+                )
             }
         }
 
@@ -491,7 +503,9 @@ class UpdateTaydennysITest(
             val hankeEntity = hankeRepository.findAll().single()
             val taydennys =
                 taydennysFactory.saveWithHakemus(
-                    ApplicationType.EXCAVATION_NOTIFICATION, hankeEntity)
+                    ApplicationType.EXCAVATION_NOTIFICATION,
+                    hankeEntity,
+                )
             val hankealueId = hanke.alueet.single().id!! + 1000
             val area = createExcavationNotificationArea(hankealueId = hankealueId)
             val request = taydennys.toUpdateRequest().withArea(area)
@@ -514,9 +528,11 @@ class UpdateTaydennysITest(
             val hankeEntity = hankeRepository.findAll().single()
             val taydennys =
                 taydennysFactory.saveWithHakemus(
-                    ApplicationType.EXCAVATION_NOTIFICATION, hankeEntity) {
-                        it.hakija().withWorkDescription("Old work description")
-                    }
+                    ApplicationType.EXCAVATION_NOTIFICATION,
+                    hankeEntity,
+                ) {
+                    it.hakija().withWorkDescription("Old work description")
+                }
             val yhteystieto = taydennys.hakemusData.yhteystiedot().single()
             val kayttajaId = yhteystieto.yhteyshenkilot.single().hankekayttajaId
             val newKayttaja = hankeKayttajaFactory.saveUser(hanke.id)
@@ -525,7 +541,11 @@ class UpdateTaydennysITest(
                 taydennys
                     .toUpdateRequest()
                     .withCustomerWithContactsRequest(
-                        CustomerType.COMPANY, yhteystieto.id, kayttajaId, newKayttaja.id)
+                        CustomerType.COMPANY,
+                        yhteystieto.id,
+                        kayttajaId,
+                        newKayttaja.id,
+                    )
                     .withWorkDescription("New work description")
                     .withRequiredCompetence(true)
                     .withDates(ZonedDateTime.now(), ZonedDateTime.now().plusDays(1))
@@ -584,7 +604,10 @@ class UpdateTaydennysITest(
                 taydennys
                     .toUpdateRequest()
                     .withContractor(
-                        CustomerType.COMPANY, tyonSuorittajaId, hankekayttajaIds = arrayOf())
+                        CustomerType.COMPANY,
+                        tyonSuorittajaId,
+                        hankekayttajaIds = arrayOf(),
+                    )
 
             val updatedTaydennys = taydennysService.updateTaydennys(taydennys.id, request, USERNAME)
 
@@ -611,7 +634,8 @@ class UpdateTaydennysITest(
                     .withCustomer(
                         CustomerType.COMPANY,
                         yhteystietoId = null,
-                        hankekayttajaIds = arrayOf(newKayttaja.id))
+                        hankekayttajaIds = arrayOf(newKayttaja.id),
+                    )
 
             val updatedTaydennys = taydennysService.updateTaydennys(taydennys.id, request, USERNAME)
 
@@ -675,7 +699,10 @@ class UpdateTaydennysITest(
                 taydennysFactory.saveWithHakemus(ApplicationType.EXCAVATION_NOTIFICATION) {
                     it.hakija(
                         HakemusyhteystietoFactory.create(
-                            tyyppi = CustomerType.PERSON, registryKey = henkilotunnus))
+                            tyyppi = CustomerType.PERSON,
+                            registryKey = henkilotunnus,
+                        )
+                    )
                 }
             val yhteystietoId = taydennys.hakemusData.customerWithContacts!!.id
             val request =
@@ -790,10 +817,12 @@ class UpdateTaydennysITest(
             assertThat(email.allRecipients.single().toString()).isEqualTo(newKayttaja.sahkoposti)
             assertThat(email.subject)
                 .isEqualTo(
-                    "Haitaton: Sinut on lisätty hakemukselle / Du har lagts till i en ansökan / You have been added to an application")
+                    "Haitaton: Sinut on lisätty hakemukselle / Du har lagts till i en ansökan / You have been added to an application"
+                )
             assertThat(email.textBody())
                 .contains(
-                    "laatimassa kaivuilmoitusta hankkeelle \"${hanke.nimi}\" (${hanke.hankeTunnus})")
+                    "laatimassa kaivuilmoitusta hankkeelle \"${hanke.nimi}\" (${hanke.hankeTunnus})"
+                )
         }
 
         @Test
@@ -802,7 +831,9 @@ class UpdateTaydennysITest(
             val hankeEntity = hankeRepository.findAll().single()
             val taydennys =
                 taydennysFactory.saveWithHakemus(
-                    ApplicationType.EXCAVATION_NOTIFICATION, hankeEntity)
+                    ApplicationType.EXCAVATION_NOTIFICATION,
+                    hankeEntity,
+                )
             val area = createExcavationNotificationArea(hankealueId = hanke.alueet.single().id!!)
             val request =
                 taydennys

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeError.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeError.kt
@@ -57,10 +57,10 @@ enum class HankeError(val errorMessage: String) {
     HAI4006("Duplicate hankekayttaja"),
     HAI4007("Verified name not found in Profiili"),
     HAI5001("Decision not found"),
-    HAI6001("Taydennys not found"),
-    ;
+    HAI6001("Taydennys not found");
 
-    fun getErrorCode(): String = name
+    val errorCode: String
+        get() = name
 
     companion object {
         fun valueOf(violation: ConstraintViolation<*>): HankeError {
@@ -87,7 +87,8 @@ class HankeArgumentException(message: String) : RuntimeException(message)
 
 class HankeYhteystietoNotFoundException(val hanke: HankeIdentifier, ytId: Int) :
     RuntimeException(
-        "HankeYhteystieto not found for Hanke, yhteystieto: $ytId, ${hanke.logString()}")
+        "HankeYhteystieto not found for Hanke, yhteystieto: $ytId, ${hanke.logString()}"
+    )
 
 class HankeAlluConflictException(message: String) : RuntimeException(message)
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/Hakemus.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/Hakemus.kt
@@ -5,11 +5,16 @@ import fi.hel.haitaton.hanke.domain.HasId
 import fi.hel.haitaton.hanke.valmistumisilmoitus.Valmistumisilmoitus
 import fi.hel.haitaton.hanke.valmistumisilmoitus.ValmistumisilmoitusType
 import java.time.ZonedDateTime
+import java.util.UUID
+import kotlin.reflect.KClass
+import kotlin.reflect.KProperty1
 
 enum class ApplicationType {
     CABLE_REPORT,
     EXCAVATION_NOTIFICATION,
 }
+
+private val ZERO_UUID = UUID(0, 0)
 
 data class Hakemus(
     override val id: Long,
@@ -52,6 +57,33 @@ data class Hakemus(
         )
 }
 
+private fun <D : HakemusData> D.checkChange(property: KProperty1<D, Any?>, second: D): String? =
+    checkChange(property.get(this), property.get(second)) { property.name }
+
+private fun <D : HakemusData> D.checkChangeInYhteystieto(
+    property: KProperty1<D, Hakemusyhteystieto?>,
+    second: D,
+): String? =
+    if (hasChanges(property.get(this), property.get(second))) {
+        property.name
+    } else null
+
+/** Compare two yhteystieto ignoring differences IDs and yhteyshenkilo IDs. */
+private fun hasChanges(first: Hakemusyhteystieto?, second: Hakemusyhteystieto?): Boolean {
+    fun Hakemusyhteystieto.resetIds() =
+        copy(id = ZERO_UUID, yhteyshenkilot = yhteyshenkilot.map { it.copy(id = ZERO_UUID) })
+
+    if (first == null && second == null) return false
+    if (first == null || second == null) return true
+
+    return first.resetIds() != second.resetIds()
+}
+
+private fun checkChange(first: Any?, second: Any?, name: () -> String): String? =
+    if (first != second) {
+        name()
+    } else null
+
 sealed interface HakemusData {
     val applicationType: ApplicationType
     val name: String
@@ -64,12 +96,43 @@ sealed interface HakemusData {
     fun toResponse(): HakemusDataResponse
 
     fun yhteystiedot(): List<Hakemusyhteystieto>
+
+    fun listChanges(other: HakemusData): List<String> {
+        if (this::class != other::class) {
+            throw IncompatibleHakemusDataException(this::class, other::class)
+        }
+
+        val changes = mutableListOf<String>()
+        checkChange(HakemusData::applicationType, other)?.let { changes.add(it) }
+        checkChange(HakemusData::name, other)?.let { changes.add(it) }
+        checkChange(HakemusData::startTime, other)?.let { changes.add(it) }
+        checkChange(HakemusData::endTime, other)?.let { changes.add(it) }
+        checkChange(HakemusData::paperDecisionReceiver, other)?.let { changes.add(it) }
+        checkChangeInYhteystieto(HakemusData::customerWithContacts, other)?.let { changes.add(it) }
+
+        val areas = areas
+        val otherAreas = other.areas
+        areas?.withIndex()?.forEach { (i, area) ->
+            checkChange(area, otherAreas?.getOrNull(i)) { "areas[$i]" }?.let { changes.add(it) }
+        }
+        if (otherAreas != null) {
+            if (areas == null) {
+                changes.addAll(otherAreas.withIndex().map { (i, _) -> "areas[$i]" })
+            } else {
+                otherAreas.withIndex().drop(areas.size).forEach { (i, area) ->
+                    checkChange(area, areas.getOrNull(i)) { "areas[$i]" }?.let { changes.add(it) }
+                }
+            }
+        }
+
+        return changes
+    }
 }
 
 data class JohtoselvityshakemusData(
     override val applicationType: ApplicationType = ApplicationType.CABLE_REPORT,
     override val name: String,
-    val postalAddress: PostalAddress? = null,
+    val postalAddress: PostalAddress?,
     val constructionWork: Boolean = false,
     val maintenanceWork: Boolean = false,
     val propertyConnectivity: Boolean = false,
@@ -113,6 +176,29 @@ data class JohtoselvityshakemusData(
             propertyDeveloperWithContacts,
             representativeWithContacts,
         )
+
+    override fun listChanges(other: HakemusData): List<String> {
+        val changes = super.listChanges(other).toMutableList()
+
+        other as JohtoselvityshakemusData
+        checkChange(JohtoselvityshakemusData::postalAddress, other)?.let { changes.add(it) }
+        checkChange(JohtoselvityshakemusData::constructionWork, other)?.let { changes.add(it) }
+        checkChange(JohtoselvityshakemusData::maintenanceWork, other)?.let { changes.add(it) }
+        checkChange(JohtoselvityshakemusData::propertyConnectivity, other)?.let { changes.add(it) }
+        checkChange(JohtoselvityshakemusData::emergencyWork, other)?.let { changes.add(it) }
+        checkChange(JohtoselvityshakemusData::rockExcavation, other)?.let { changes.add(it) }
+        checkChange(JohtoselvityshakemusData::workDescription, other)?.let { changes.add(it) }
+        checkChangeInYhteystieto(JohtoselvityshakemusData::contractorWithContacts, other)?.let {
+            changes.add(it)
+        }
+        checkChangeInYhteystieto(JohtoselvityshakemusData::propertyDeveloperWithContacts, other)
+            ?.let { changes.add(it) }
+        checkChangeInYhteystieto(JohtoselvityshakemusData::representativeWithContacts, other)?.let {
+            changes.add(it)
+        }
+
+        return changes
+    }
 }
 
 data class KaivuilmoitusData(
@@ -170,6 +256,30 @@ data class KaivuilmoitusData(
             propertyDeveloperWithContacts,
             representativeWithContacts,
         )
+
+    override fun listChanges(other: HakemusData): List<String> {
+        val changes = mutableListOf<String>()
+
+        other as KaivuilmoitusData
+        checkChange(KaivuilmoitusData::workDescription, other)?.let { changes.add(it) }
+        checkChange(KaivuilmoitusData::constructionWork, other)?.let { changes.add(it) }
+        checkChange(KaivuilmoitusData::maintenanceWork, other)?.let { changes.add(it) }
+        checkChange(KaivuilmoitusData::emergencyWork, other)?.let { changes.add(it) }
+        checkChange(KaivuilmoitusData::cableReportDone, other)?.let { changes.add(it) }
+        checkChange(KaivuilmoitusData::rockExcavation, other)?.let { changes.add(it) }
+        checkChange(KaivuilmoitusData::cableReports, other)?.let { changes.add(it) }
+        checkChange(KaivuilmoitusData::placementContracts, other)?.let { changes.add(it) }
+        checkChange(KaivuilmoitusData::requiredCompetence, other)?.let { changes.add(it) }
+        checkChange(KaivuilmoitusData::contractorWithContacts, other)?.let { changes.add(it) }
+        checkChange(KaivuilmoitusData::propertyDeveloperWithContacts, other)?.let {
+            changes.add(it)
+        }
+        checkChange(KaivuilmoitusData::representativeWithContacts, other)?.let { changes.add(it) }
+        checkChange(KaivuilmoitusData::invoicingCustomer, other)?.let { changes.add(it) }
+        checkChange(KaivuilmoitusData::additionalInfo, other)?.let { changes.add(it) }
+
+        return changes
+    }
 }
 
 interface HakemusIdentifier : HasId<Long> {
@@ -191,3 +301,8 @@ data class HakemusMetaData(
     override val applicationType: ApplicationType,
     val hankeTunnus: String,
 ) : HakemusIdentifier
+
+class IncompatibleHakemusDataException(firstClass: KClass<*>, secondClass: KClass<*>) :
+    RuntimeException(
+        "Incompatible hakemus data when retrieving changes. firstClass=${firstClass.simpleName}, secondClass=${secondClass.simpleName}"
+    )

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
@@ -87,7 +87,12 @@ class HakemusService(
         val hakemus = getById(hakemusId)
         val paatokset = paatosService.findByHakemusId(hakemusId)
         val taydennyspyynto = taydennyspyyntoRepository.findByApplicationId(hakemusId)?.toDomain()
-        val taydennys = taydennysRepository.findByApplicationId(hakemusId)?.toDomain()
+        val taydennys =
+            taydennysRepository
+                .findByApplicationId(hakemusId)
+                ?.toDomain()
+                ?.withMuutokset(hakemus.applicationData)
+
         return HakemusWithExtras(hakemus, paatokset, taydennyspyynto, taydennys)
     }
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusWithExtras.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusWithExtras.kt
@@ -3,8 +3,8 @@ package fi.hel.haitaton.hanke.hakemus
 import com.fasterxml.jackson.annotation.JsonUnwrapped
 import fi.hel.haitaton.hanke.paatos.Paatos
 import fi.hel.haitaton.hanke.paatos.PaatosResponse
-import fi.hel.haitaton.hanke.taydennys.Taydennys
-import fi.hel.haitaton.hanke.taydennys.TaydennysResponse
+import fi.hel.haitaton.hanke.taydennys.TaydennysWithMuutokset
+import fi.hel.haitaton.hanke.taydennys.TaydennysWithMuutoksetResponse
 import fi.hel.haitaton.hanke.taydennys.Taydennyspyynto
 import fi.hel.haitaton.hanke.taydennys.TaydennyspyyntoResponse
 
@@ -12,7 +12,7 @@ data class HakemusWithExtras(
     val hakemus: Hakemus,
     val paatokset: List<Paatos>,
     val taydennyspyynto: Taydennyspyynto?,
-    val taydennys: Taydennys?,
+    val taydennys: TaydennysWithMuutokset?,
 ) {
     fun toResponse(): HakemusWithExtrasResponse =
         HakemusWithExtrasResponse(
@@ -27,5 +27,5 @@ data class HakemusWithExtrasResponse(
     @JsonUnwrapped val hakemus: HakemusResponse,
     val paatokset: Map<String, List<PaatosResponse>>,
     val taydennyspyynto: TaydennyspyyntoResponse?,
-    val taydennys: TaydennysResponse?,
+    val taydennys: TaydennysWithMuutoksetResponse?,
 )

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/DisclosureLoggingAspect.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/DisclosureLoggingAspect.kt
@@ -29,7 +29,9 @@ import org.springframework.stereotype.Component
 @Component
 class DisclosureLoggingAspect(private val disclosureLogService: DisclosureLogService) {
     @AfterReturning(
-        pointcut = "@annotation(io.swagger.v3.oas.annotations.Operation)", returning = "result")
+        pointcut = "@annotation(io.swagger.v3.oas.annotations.Operation)",
+        returning = "result",
+    )
     fun logResponse(result: Any?) {
         if (result == null) {
             return
@@ -45,7 +47,9 @@ class DisclosureLoggingAspect(private val disclosureLogService: DisclosureLogSer
                 disclosureLogService.saveForHakemusResponse(result, currentUserId())
             is HakemusWithExtrasResponse -> {
                 disclosureLogService.saveForHakemusResponse(result.hakemus, currentUserId())
-                result.taydennys?.let { disclosureLogService.saveForTaydennys(it, currentUserId()) }
+                result.taydennys?.let {
+                    disclosureLogService.saveForTaydennys(it.taydennys, currentUserId())
+                }
             }
             is Hanke -> disclosureLogService.saveForHanke(result, currentUserId())
             is HankeKayttajaDto ->
@@ -116,4 +120,5 @@ class UnknownResponseListTypeException(kclass: KClass<*>) :
 
 class MixedElementsInResponseException(expected: KClass<*>, actual: Set<KClass<*>>) :
     RuntimeException(
-        "Mixed types inside a list. Expected type: ${expected.qualifiedName} Actual types: ${actual.map { it.qualifiedName }.joinToString ()}")
+        "Mixed types inside a list. Expected type: ${expected.qualifiedName} Actual types: ${actual.map { it.qualifiedName }.joinToString ()}"
+    )

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/taydennys/Taydennys.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/taydennys/Taydennys.kt
@@ -1,5 +1,6 @@
 package fi.hel.haitaton.hanke.taydennys
 
+import com.fasterxml.jackson.annotation.JsonUnwrapped
 import fi.hel.haitaton.hanke.domain.HasId
 import fi.hel.haitaton.hanke.hakemus.HakemusData
 import fi.hel.haitaton.hanke.hakemus.HakemusDataResponse
@@ -11,7 +12,33 @@ data class Taydennys(
     val hakemusData: HakemusData,
 ) : HasId<UUID> {
     fun toResponse() = TaydennysResponse(id, hakemusData.toResponse())
+
+    fun withMuutokset(hakemusData: HakemusData): TaydennysWithMuutokset {
+        return TaydennysWithMuutokset(
+            id = id,
+            taydennyspyyntoId = taydennyspyyntoId,
+            hakemusData = hakemusData,
+            muutokset = hakemusData.listChanges(this.hakemusData),
+        )
+    }
 }
 
 data class TaydennysResponse(override val id: UUID, val applicationData: HakemusDataResponse) :
-    HasId<UUID>
+    HasId<UUID> {
+    fun withMuutokset(muutokset: List<String>): TaydennysWithMuutoksetResponse =
+        TaydennysWithMuutoksetResponse(this, muutokset)
+}
+
+data class TaydennysWithMuutokset(
+    override val id: UUID,
+    val taydennyspyyntoId: UUID,
+    val hakemusData: HakemusData,
+    val muutokset: List<String>,
+) : HasId<UUID> {
+    fun toResponse() = TaydennysResponse(id, hakemusData.toResponse()).withMuutokset(muutokset)
+}
+
+data class TaydennysWithMuutoksetResponse(
+    @JsonUnwrapped val taydennys: TaydennysResponse,
+    val muutokset: List<String>,
+)

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/HankeErrorResultMatcher.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/HankeErrorResultMatcher.kt
@@ -15,6 +15,6 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPat
  * ```
  */
 fun hankeError(error: HankeError) = ResultMatcher { result: MvcResult ->
-    jsonPath("$.errorCode").value(error.getErrorCode()).match(result)
+    jsonPath("$.errorCode").value(error.errorCode).match(result)
     jsonPath("$.errorMessage").value(error.errorMessage).match(result)
 }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/HankeErrorTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/HankeErrorTest.kt
@@ -9,8 +9,7 @@ class HankeErrorTest {
     @Test
     fun testJacksonSerialization() {
         val err = HankeError.HAI0002
-        val expected =
-            """{"errorMessage":"${err.errorMessage}","errorCode":"${err.getErrorCode()}"}"""
+        val expected = """{"errorMessage":"${err.errorMessage}","errorCode":"${err.errorCode}"}"""
         assertThat(err.toJsonString()).isEqualTo(expected)
     }
 }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusFactory.kt
@@ -26,7 +26,7 @@ import fi.hel.haitaton.hanke.hakemus.PaperDecisionReceiver
 import fi.hel.haitaton.hanke.hakemus.PostalAddress
 import fi.hel.haitaton.hanke.paatos.Paatos
 import fi.hel.haitaton.hanke.permissions.HankeKayttajaService
-import fi.hel.haitaton.hanke.taydennys.Taydennys
+import fi.hel.haitaton.hanke.taydennys.TaydennysWithMuutokset
 import fi.hel.haitaton.hanke.taydennys.Taydennyspyynto
 import fi.hel.haitaton.hanke.test.USERNAME
 import fi.hel.haitaton.hanke.valmistumisilmoitus.Valmistumisilmoitus
@@ -243,7 +243,7 @@ class HakemusFactory(
         fun Hakemus.withExtras(
             paatokset: List<Paatos> = listOf(),
             taydennyspyynto: Taydennyspyynto? = null,
-            taydennys: Taydennys? = null,
+            taydennys: TaydennysWithMuutokset? = null,
         ) = HakemusWithExtras(this, paatokset, taydennyspyynto, taydennys)
 
         fun hakemusDataForRegistryKeyTest(tyyppi: CustomerType): KaivuilmoitusData {

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusDataTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusDataTest.kt
@@ -1,0 +1,312 @@
+package fi.hel.haitaton.hanke.hakemus
+
+import assertk.all
+import assertk.assertFailure
+import assertk.assertThat
+import assertk.assertions.containsExactly
+import assertk.assertions.hasClass
+import assertk.assertions.isEmpty
+import assertk.assertions.messageContains
+import fi.hel.haitaton.hanke.factory.ApplicationFactory
+import fi.hel.haitaton.hanke.factory.HakemusFactory
+import fi.hel.haitaton.hanke.factory.HakemusyhteyshenkiloFactory
+import fi.hel.haitaton.hanke.factory.HakemusyhteystietoFactory
+import fi.hel.haitaton.hanke.factory.PaperDecisionReceiverFactory
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.EmptySource
+import org.junit.jupiter.params.provider.MethodSource
+import org.junit.jupiter.params.provider.NullSource
+
+class HakemusDataTest {
+
+    @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    inner class ListChanges {
+        val base: JohtoselvityshakemusData = HakemusFactory.createJohtoselvityshakemusData()
+
+        @Test
+        fun `throws exception when classes don't match`() {
+            val updated = HakemusFactory.createKaivuilmoitusData()
+
+            val failure = assertFailure { base.listChanges(updated) }
+
+            failure.all {
+                hasClass(IncompatibleHakemusDataException::class)
+                messageContains("Incompatible hakemus data when retrieving changes")
+                messageContains("firstClass=JohtoselvityshakemusData")
+                messageContains("secondClass=KaivuilmoitusData")
+            }
+        }
+
+        @Test
+        fun `returns empty when there are no changes`() {
+            val updated = HakemusFactory.createJohtoselvityshakemusData()
+
+            val result = base.listChanges(updated)
+
+            assertThat(result).isEmpty()
+        }
+
+        @Test
+        fun `returns all changes when there are several`() {
+            val updated = base.copy(name = "Other name", startTime = base.startTime!!.plusDays(3))
+
+            val result = base.listChanges(updated)
+
+            assertThat(result).containsExactly("name", "startTime")
+        }
+
+        private fun commonFieldCases(): List<Arguments> =
+            listOf(
+                Arguments.of(
+                    base.copy(applicationType = ApplicationType.EXCAVATION_NOTIFICATION),
+                    "applicationType",
+                ),
+                Arguments.of(base.copy(startTime = base.startTime!!.minusDays(2)), "startTime"),
+                Arguments.of(base.copy(endTime = base.endTime!!.plusDays(2)), "endTime"),
+                Arguments.of(
+                    base.copy(paperDecisionReceiver = PaperDecisionReceiverFactory.default),
+                    "paperDecisionReceiver",
+                ),
+                Arguments.of(
+                    base.copy(customerWithContacts = HakemusyhteystietoFactory.create()),
+                    "customerWithContacts",
+                ),
+            )
+
+        @ParameterizedTest(name = "{displayName} {1}")
+        @MethodSource("commonFieldCases")
+        fun `returns changes when common fields have changes`(updated: HakemusData, name: String) {
+            val changes = base.listChanges(updated)
+
+            assertThat(changes).containsExactly(name)
+        }
+
+        @Nested
+        inner class YhteystietoChanges {
+            private val yhteyshenkilo1 = HakemusyhteyshenkiloFactory.create()
+            private val yhteyshenkilo2 =
+                HakemusyhteyshenkiloFactory.create(
+                    etunimi = "Joku",
+                    sukunimi = "Toinen",
+                    sahkoposti = "joku.toinen@email",
+                )
+            private val base: JohtoselvityshakemusData =
+                this@ListChanges.base.copy(
+                    customerWithContacts =
+                        HakemusyhteystietoFactory.create(
+                            yhteyshenkilot = listOf(yhteyshenkilo1, yhteyshenkilo2)
+                        )
+                )
+
+            private val withOneHenkilo =
+                base.copy(
+                    customerWithContacts =
+                        base.customerWithContacts!!.copy(yhteyshenkilot = listOf(yhteyshenkilo1))
+                )
+
+            @Test
+            fun `returns a change when yhteyshenkilo removed from yhteystieto`() {
+                val result = base.listChanges(withOneHenkilo)
+
+                assertThat(result).containsExactly("customerWithContacts")
+            }
+
+            @Test
+            fun `returns a change when yhteyshenkilo added to yhteystieto`() {
+                val result = withOneHenkilo.listChanges(base)
+
+                assertThat(result).containsExactly("customerWithContacts")
+            }
+
+            @Test
+            fun `returns a change when yhteyshenkilo changed in yhteystieto`() {
+                val updatedYhteyshenkilo = yhteyshenkilo1.copy(etunimi = "Muutettu")
+                val updated =
+                    base.copy(
+                        customerWithContacts =
+                            base.customerWithContacts!!.copy(
+                                yhteyshenkilot = listOf(yhteyshenkilo1, updatedYhteyshenkilo)
+                            )
+                    )
+
+                val result = base.listChanges(updated)
+
+                assertThat(result).containsExactly("customerWithContacts")
+            }
+        }
+
+        @Nested
+        inner class AreaChanges {
+            private val dataWithTwoAreas =
+                base.copy(
+                    areas =
+                        listOf(
+                            ApplicationFactory.createCableReportApplicationArea(name = "first"),
+                            ApplicationFactory.createCableReportApplicationArea(name = "second"),
+                        )
+                )
+
+            @ParameterizedTest
+            @EmptySource
+            @NullSource
+            fun `returns a change when areas were empty but new ones are added`(
+                areas: List<JohtoselvitysHakemusalue>?
+            ) {
+                val base = base.copy(areas = areas)
+
+                val result = base.listChanges(dataWithTwoAreas)
+
+                assertThat(result).containsExactly("areas[0]", "areas[1]")
+            }
+
+            @ParameterizedTest
+            @EmptySource
+            @NullSource
+            fun `returns a change when there were areas but now they are empty`(
+                areas: List<JohtoselvitysHakemusalue>?
+            ) {
+                val updated = base.copy(areas = areas)
+
+                val result = dataWithTwoAreas.listChanges(updated)
+
+                assertThat(result).containsExactly("areas[0]", "areas[1]")
+            }
+
+            @Test
+            fun `returns several changes when an area is removed from the middle`() {
+                val base =
+                    base.copy(
+                        areas =
+                            listOf(
+                                ApplicationFactory.createCableReportApplicationArea(name = "first"),
+                                ApplicationFactory.createCableReportApplicationArea(
+                                    name = "removed1"
+                                ),
+                                ApplicationFactory.createCableReportApplicationArea(
+                                    name = "removed2"
+                                ),
+                                ApplicationFactory.createCableReportApplicationArea(name = "second"),
+                            )
+                    )
+
+                val result = base.listChanges(dataWithTwoAreas)
+
+                assertThat(result).containsExactly("areas[1]", "areas[2]", "areas[3]")
+            }
+
+            @Test
+            fun `returns several changes when an area is added to the middle`() {
+                val updated =
+                    base.copy(
+                        areas =
+                            listOf(
+                                ApplicationFactory.createCableReportApplicationArea(name = "first"),
+                                ApplicationFactory.createCableReportApplicationArea(
+                                    name = "added1"
+                                ),
+                                ApplicationFactory.createCableReportApplicationArea(
+                                    name = "added2"
+                                ),
+                                ApplicationFactory.createCableReportApplicationArea(name = "second"),
+                            )
+                    )
+
+                val result = dataWithTwoAreas.listChanges(updated)
+
+                assertThat(result).containsExactly("areas[1]", "areas[2]", "areas[3]")
+            }
+        }
+
+        private fun johtoselvitysCases(): List<Arguments> =
+            listOf(
+                Arguments.of(
+                    base.copy(postalAddress = ApplicationFactory.createPostalAddress()),
+                    "postalAddress",
+                ),
+                Arguments.of(base.copy(constructionWork = true), "constructionWork"),
+                Arguments.of(base.copy(maintenanceWork = true), "maintenanceWork"),
+                Arguments.of(base.copy(propertyConnectivity = true), "propertyConnectivity"),
+                Arguments.of(base.copy(emergencyWork = true), "emergencyWork"),
+                Arguments.of(base.copy(rockExcavation = true), "rockExcavation"),
+                Arguments.of(base.copy(workDescription = "New description"), "workDescription"),
+                Arguments.of(
+                    base.copy(contractorWithContacts = HakemusyhteystietoFactory.create()),
+                    "contractorWithContacts",
+                ),
+                Arguments.of(
+                    base.copy(propertyDeveloperWithContacts = HakemusyhteystietoFactory.create()),
+                    "propertyDeveloperWithContacts",
+                ),
+                Arguments.of(
+                    base.copy(representativeWithContacts = HakemusyhteystietoFactory.create()),
+                    "representativeWithContacts",
+                ),
+            )
+
+        @ParameterizedTest(name = "{displayName} {1}")
+        @MethodSource("johtoselvitysCases")
+        fun `returns changes when johtoselvityshakemus fields have changes`(
+            updated: JohtoselvityshakemusData,
+            name: String,
+        ) {
+            val changes = base.listChanges(updated)
+
+            assertThat(changes).containsExactly(name)
+        }
+
+        private fun kaivuilmoitusCases(): List<Arguments> {
+            val base = HakemusFactory.createKaivuilmoitusData()
+            return listOf(
+                Arguments.of(base.copy(workDescription = "New description."), "workDescription"),
+                Arguments.of(base.copy(constructionWork = true), "constructionWork"),
+                Arguments.of(base.copy(maintenanceWork = true), "maintenanceWork"),
+                Arguments.of(base.copy(emergencyWork = true), "emergencyWork"),
+                Arguments.of(base.copy(cableReportDone = !base.cableReportDone), "cableReportDone"),
+                Arguments.of(base.copy(rockExcavation = true), "rockExcavation"),
+                Arguments.of(base.copy(cableReports = listOf("JS2400001")), "cableReports"),
+                Arguments.of(
+                    base.copy(placementContracts = listOf("tunnus")),
+                    "placementContracts",
+                ),
+                Arguments.of(base.copy(requiredCompetence = true), "requiredCompetence"),
+                Arguments.of(
+                    base.copy(contractorWithContacts = HakemusyhteystietoFactory.create()),
+                    "contractorWithContacts",
+                ),
+                Arguments.of(
+                    base.copy(propertyDeveloperWithContacts = HakemusyhteystietoFactory.create()),
+                    "propertyDeveloperWithContacts",
+                ),
+                Arguments.of(
+                    base.copy(representativeWithContacts = HakemusyhteystietoFactory.create()),
+                    "representativeWithContacts",
+                ),
+                Arguments.of(
+                    base.copy(
+                        invoicingCustomer = HakemusyhteystietoFactory.createLaskutusyhteystieto()
+                    ),
+                    "invoicingCustomer",
+                ),
+                Arguments.of(base.copy(additionalInfo = "Uutta lisätietoa"), "additionalInfo"),
+            )
+        }
+
+        @ParameterizedTest(name = "{displayName} {1}")
+        @MethodSource("kaivuilmoitusCases")
+        fun `returns changes when kaivuilmoitus fields have changes`(
+            updated: KaivuilmoitusData,
+            name: String,
+        ) {
+            val base = HakemusFactory.createKaivuilmoitusData()
+
+            val changes = base.listChanges(updated)
+
+            assertThat(changes).containsExactly(name)
+        }
+    }
+}


### PR DESCRIPTION
# Description

If there are changes in the täydennys when compared to the original hakemus, return the changed fields. The changes are only checked at the top level so any change in e.g. an yhteystieto or in any of it's yhteyshenkilot will tag the yhteystieto as having changed.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2759

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
1. Create a täydennys and make changes to it.
2. Check that the response for the GET /hakemukset/:id endpoint contains the changed fields.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 