### PR TITLE
HAI-2815 Adjust enum values for kaistahaitta and kaistapituushaitta.

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeControllerITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeControllerITests.kt
@@ -142,7 +142,8 @@ class HankeControllerITests(@Autowired override val mockMvc: MockMvc) : Controll
                         autoliikenne = autoliikenne,
                         pyoraliikenneindeksi = pyoraliikenneindeksi,
                         linjaautoliikenneindeksi = linjaautoliikenneindeksi,
-                        raitioliikenneindeksi = raitioliikenneindeksi)
+                        raitioliikenneindeksi = raitioliikenneindeksi,
+                    )
             every { hankeService.loadHanke(HANKE_TUNNUS) }.returns(hanke)
             every {
                 authorizer.authorizeHankeTunnus(HANKE_TUNNUS, PermissionCode.VIEW.name)
@@ -152,38 +153,49 @@ class HankeControllerITests(@Autowired override val mockMvc: MockMvc) : Controll
                 .andExpect(status().isOk)
                 .andExpect(
                     jsonPath("tormaystarkasteluTulos.autoliikenne.haitanKesto")
-                        .value(autoliikenne.haitanKesto))
+                        .value(autoliikenne.haitanKesto)
+                )
                 .andExpect(
                     jsonPath("tormaystarkasteluTulos.autoliikenne.katuluokka")
-                        .value(autoliikenne.katuluokka))
+                        .value(autoliikenne.katuluokka)
+                )
                 .andExpect(
                     jsonPath("tormaystarkasteluTulos.autoliikenne.liikennemaara")
-                        .value(autoliikenne.liikennemaara))
+                        .value(autoliikenne.liikennemaara)
+                )
                 .andExpect(
                     jsonPath("tormaystarkasteluTulos.autoliikenne.kaistahaitta")
-                        .value(autoliikenne.kaistahaitta))
+                        .value(autoliikenne.kaistahaitta)
+                )
                 .andExpect(
                     jsonPath("tormaystarkasteluTulos.autoliikenne.kaistapituushaitta")
-                        .value(autoliikenne.kaistapituushaitta))
+                        .value(autoliikenne.kaistapituushaitta)
+                )
                 .andExpect(
                     jsonPath("tormaystarkasteluTulos.autoliikenne.indeksi")
-                        .value(autoliikenne.indeksi))
+                        .value(autoliikenne.indeksi)
+                )
                 .andExpect(
                     jsonPath("tormaystarkasteluTulos.pyoraliikenneindeksi")
-                        .value(pyoraliikenneindeksi))
+                        .value(pyoraliikenneindeksi)
+                )
                 .andExpect(
                     jsonPath("tormaystarkasteluTulos.linjaautoliikenneindeksi")
-                        .value(linjaautoliikenneindeksi))
+                        .value(linjaautoliikenneindeksi)
+                )
                 .andExpect(
                     jsonPath("tormaystarkasteluTulos.raitioliikenneindeksi")
-                        .value(raitioliikenneindeksi))
+                        .value(raitioliikenneindeksi)
+                )
                 // In this case, raitioliikenneindeksi has the highest value
                 .andExpect(
                     jsonPath("tormaystarkasteluTulos.liikennehaittaindeksi.indeksi")
-                        .value(raitioliikenneindeksi))
+                        .value(raitioliikenneindeksi)
+                )
                 .andExpect(
                     jsonPath("tormaystarkasteluTulos.liikennehaittaindeksi.tyyppi")
-                        .value(IndeksiType.RAITIOLIIKENNEINDEKSI.name))
+                        .value(IndeksiType.RAITIOLIIKENNEINDEKSI.name)
+                )
 
             verifySequence {
                 authorizer.authorizeHankeTunnus(HANKE_TUNNUS, PermissionCode.VIEW.name)
@@ -227,7 +239,8 @@ class HankeControllerITests(@Autowired override val mockMvc: MockMvc) : Controll
                     jsonPath(
                         "toteuttajat[0].yhteyshenkilot[*].etunimi",
                         containsInAnyOrder("Etu3", "Etu5", "Etu6"),
-                    ))
+                    )
+                )
                 .andExpect(jsonPath("muut.length()").value(1))
                 .andExpect(jsonPath("muut[0].yhteyshenkilot.length()").value(1))
                 .andExpect(jsonPath("muut[0].yhteyshenkilot[0].etunimi").value("Etu4"))
@@ -274,14 +287,13 @@ class HankeControllerITests(@Autowired override val mockMvc: MockMvc) : Controll
             val hankeIds = listOf(123, 444)
             val hankkeet =
                 listOf(
-                    HankeFactory.create(
-                        id = hankeIds[0],
-                    ),
+                    HankeFactory.create(id = hankeIds[0]),
                     HankeFactory.create(
                         id = hankeIds[1],
                         hankeTunnus = "hanketunnus2",
                         nimi = "Esplanadin viemäröinti",
-                    ))
+                    ),
+                )
             every { hankeService.loadHankkeetByIds(hankeIds) }.returns(hankkeet)
             every { permissionService.getAllowedHankeIds(USERNAME, PermissionCode.VIEW) }
                 .returns(hankeIds)
@@ -367,12 +379,14 @@ class HankeControllerITests(@Autowired override val mockMvc: MockMvc) : Controll
                 .andExpect(jsonPath("\$.[0].omistajat.length()").value(1))
                 .andExpect(jsonPath("\$.[0].omistajat[0].yhteyshenkilot.length()").value(1))
                 .andExpect(
-                    jsonPath("\$.[0].omistajat[0].yhteyshenkilot[0].etunimi").value("Etu122"))
+                    jsonPath("\$.[0].omistajat[0].yhteyshenkilot[0].etunimi").value("Etu122")
+                )
                 .andExpect(jsonPath("\$.[0].omistajat[0].yhteyshenkilot[0].id").isString)
                 .andExpect(jsonPath("\$.[1].omistajat.length()").value(1))
                 .andExpect(jsonPath("\$.[1].omistajat[0].yhteyshenkilot.length()").value(1))
                 .andExpect(
-                    jsonPath("\$.[1].omistajat[0].yhteyshenkilot[0].etunimi").value("Etu144"))
+                    jsonPath("\$.[1].omistajat[0].yhteyshenkilot[0].etunimi").value("Etu144")
+                )
                 .andExpect(jsonPath("\$.[1].omistajat[0].yhteyshenkilot[0].id").isString)
 
             verifySequence {
@@ -532,8 +546,7 @@ class HankeControllerITests(@Autowired override val mockMvc: MockMvc) : Controll
                     nimi = "$HANKEALUE_DEFAULT_NAME 1",
                     haittaAlkuPvm = DateFactory.getStartDatetime(),
                     haittaLoppuPvm = DateFactory.getEndDatetime(),
-                    kaistaHaitta =
-                        VaikutusAutoliikenteenKaistamaariin.VAHENTAA_KAISTAN_YHDELLA_AJOSUUNNALLA,
+                    kaistaHaitta = VaikutusAutoliikenteenKaistamaariin.YKSI_KAISTA_VAHENEE,
                     kaistaPituusHaitta =
                         AutoliikenteenKaistavaikutustenPituus.PITUUS_100_499_METRIA,
                     meluHaitta = Meluhaitta.SATUNNAINEN_MELUHAITTA,
@@ -571,15 +584,15 @@ class HankeControllerITests(@Autowired override val mockMvc: MockMvc) : Controll
                 .andExpect(jsonPath("$.tyomaaKatuosoite").value("Testikatu 1"))
                 .andExpect(
                     jsonPath("$.alueet[0].kaistaHaitta")
-                        .value(
-                            VaikutusAutoliikenteenKaistamaariin
-                                .VAHENTAA_KAISTAN_YHDELLA_AJOSUUNNALLA
-                                .name)) // Note, here as string, not the enum.
+                        .value(VaikutusAutoliikenteenKaistamaariin.YKSI_KAISTA_VAHENEE.name)
+                ) // Note, here as string, not the enum.
                 .andExpect(
                     jsonPath("$.alueet[0].haittojenhallintasuunnitelma.YLEINEN")
                         .value(
                             hankeToBeUpdated.alueet[0].haittojenhallintasuunnitelma!![
-                                Haittojenhallintatyyppi.YLEINEN]))
+                                Haittojenhallintatyyppi.YLEINEN]
+                        )
+                )
 
             verifySequence {
                 authorizer.authorizeHankeTunnus(HANKE_TUNNUS, PermissionCode.EDIT.name)

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/UpdateHankeITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/UpdateHankeITests.kt
@@ -67,7 +67,6 @@ import fi.hel.haitaton.hanke.tormaystarkastelu.Polyhaitta
 import fi.hel.haitaton.hanke.tormaystarkastelu.Tarinahaitta
 import fi.hel.haitaton.hanke.tormaystarkastelu.TormaystarkasteluTulos
 import fi.hel.haitaton.hanke.tormaystarkastelu.VaikutusAutoliikenteenKaistamaariin
-import fi.hel.haitaton.hanke.tormaystarkastelu.VaikutusAutoliikenteenKaistamaariin.VAHENTAA_SAMANAIKAISESTI_USEITA_KAISTOJA_LIITTYMIEN_ERI_SUUNNILLA
 import java.time.Duration
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
@@ -513,7 +512,7 @@ class UpdateHankeITests(
                     omistajat = listOf(omistaja),
                     rakennuttajat = listOf(rakennuttaja1, rakennuttaja2),
                     toteuttajat = listOf(toteuttaja),
-                    muut = listOf(muu)
+                    muut = listOf(muu),
                 )
 
         val result = hankeService.updateHanke(hanke.hankeTunnus, request)
@@ -566,8 +565,7 @@ class UpdateHankeITests(
                 haittaAlkuPvm = alkuPvm,
                 haittaLoppuPvm = loppuPvm,
                 kaistaHaitta =
-                    VaikutusAutoliikenteenKaistamaariin
-                        .VAHENTAA_SAMANAIKAISESTI_KAISTAN_KAHDELLA_AJOSUUNNALLA,
+                    VaikutusAutoliikenteenKaistamaariin.YKSI_KAISTA_VAHENEE_KAHDELLA_AJOSUUNNALLA,
                 kaistaPituusHaitta = AutoliikenteenKaistavaikutustenPituus.PITUUS_10_99_METRIA,
                 meluHaitta = Meluhaitta.JATKUVA_MELUHAITTA,
                 polyHaitta = Polyhaitta.TOISTUVA_POLYHAITTA,
@@ -586,8 +584,7 @@ class UpdateHankeITests(
             .isEqualTo(loppuPvm.format(DateTimeFormatter.BASIC_ISO_DATE))
         assertThat(alue.kaistaHaitta)
             .isEqualTo(
-                VaikutusAutoliikenteenKaistamaariin
-                    .VAHENTAA_SAMANAIKAISESTI_KAISTAN_KAHDELLA_AJOSUUNNALLA
+                VaikutusAutoliikenteenKaistamaariin.YKSI_KAISTA_VAHENEE_KAHDELLA_AJOSUUNNALLA
             )
         assertThat(alue.kaistaPituusHaitta)
             .isEqualTo(AutoliikenteenKaistavaikutustenPituus.PITUUS_10_99_METRIA)
@@ -604,14 +601,7 @@ class UpdateHankeITests(
         assertThat(hankealue.nimi).isEqualTo("Hankealue 1")
         val request = createdHanke.toModifyRequest()
         val updatedRequest =
-            request.copy(
-                alueet =
-                    listOf(
-                        request.alueet[0].copy(
-                            nimi = "Changed Name",
-                        )
-                    )
-            )
+            request.copy(alueet = listOf(request.alueet[0].copy(nimi = "Changed Name")))
 
         val updateHankeResult = hankeService.updateHanke(createdHanke.hankeTunnus, updatedRequest)
 
@@ -620,12 +610,7 @@ class UpdateHankeITests(
             .isEqualTo(createdHanke.copy(version = 2, modifiedAt = null))
         assertThat(updateHankeResult.alueet).single().all {
             transform { it.copy(geometriat = null) }
-                .isEqualTo(
-                    hankealue.copy(
-                        geometriat = null,
-                        nimi = "Changed Name",
-                    )
-                )
+                .isEqualTo(hankealue.copy(geometriat = null, nimi = "Changed Name"))
             prop(SavedHankealue::geometriat)
                 .isNotNull()
                 .prop(Geometriat::featureCollection)
@@ -711,8 +696,7 @@ class UpdateHankeITests(
                 haittaAlkuPvm = alkuPvm,
                 haittaLoppuPvm = loppuPvm,
                 kaistaHaitta =
-                    VaikutusAutoliikenteenKaistamaariin
-                        .VAHENTAA_SAMANAIKAISESTI_KAISTAN_KAHDELLA_AJOSUUNNALLA,
+                    VaikutusAutoliikenteenKaistamaariin.YKSI_KAISTA_VAHENEE_KAHDELLA_AJOSUUNNALLA,
                 kaistaPituusHaitta = AutoliikenteenKaistavaikutustenPituus.PITUUS_10_99_METRIA,
                 meluHaitta = Meluhaitta.SATUNNAINEN_MELUHAITTA,
                 polyHaitta = Polyhaitta.TOISTUVA_POLYHAITTA,
@@ -735,8 +719,7 @@ class UpdateHankeITests(
             prop(SavedHankealue::haittaLoppuPvm).isEqualTo(loppuPvm.truncatedTo(ChronoUnit.DAYS))
             prop(SavedHankealue::kaistaHaitta)
                 .isEqualTo(
-                    VaikutusAutoliikenteenKaistamaariin
-                        .VAHENTAA_SAMANAIKAISESTI_KAISTAN_KAHDELLA_AJOSUUNNALLA
+                    VaikutusAutoliikenteenKaistamaariin.YKSI_KAISTA_VAHENEE_KAHDELLA_AJOSUUNNALLA
                 )
             prop(SavedHankealue::kaistaPituusHaitta)
                 .isEqualTo(AutoliikenteenKaistavaikutustenPituus.PITUUS_10_99_METRIA)
@@ -770,9 +753,9 @@ class UpdateHankeITests(
                     prop(Autoliikenneluokittelu::haitanKesto).isEqualTo(1)
                     prop(Autoliikenneluokittelu::katuluokka).isEqualTo(4)
                     prop(Autoliikenneluokittelu::liikennemaara).isEqualTo(5)
-                    prop(Autoliikenneluokittelu::kaistahaitta).isEqualTo(2)
+                    prop(Autoliikenneluokittelu::kaistahaitta).isEqualTo(1)
                     prop(Autoliikenneluokittelu::kaistapituushaitta).isEqualTo(2)
-                    prop(Autoliikenneluokittelu::indeksi).isEqualTo(3.1f)
+                    prop(Autoliikenneluokittelu::indeksi).isEqualTo(2.8f)
                 }
                 prop(TormaystarkasteluTulos::pyoraliikenneindeksi).isEqualTo(3.0f)
                 prop(TormaystarkasteluTulos::linjaautoliikenneindeksi).isEqualTo(3.0f)
@@ -791,11 +774,12 @@ class UpdateHankeITests(
         val hanke = hankeFactory.builder(USERNAME).withHankealue().save()
         val originalTormaystarkasteluTulos = hanke.alueet[0].tormaystarkasteluTulos!!
         val originalAutoliikenteenIndeksi = originalTormaystarkasteluTulos.autoliikenne.indeksi
-        assertThat(originalTormaystarkasteluTulos.autoliikenne.kaistahaitta).isEqualTo(2)
+        assertThat(originalTormaystarkasteluTulos.autoliikenne.kaistahaitta).isEqualTo(1)
         assertThat(originalTormaystarkasteluTulos.autoliikenne.kaistapituushaitta).isEqualTo(2)
         hanke.alueet[0] =
             HankealueFactory.create(
-                kaistaHaitta = VAHENTAA_SAMANAIKAISESTI_USEITA_KAISTOJA_LIITTYMIEN_ERI_SUUNNILLA,
+                kaistaHaitta =
+                    VaikutusAutoliikenteenKaistamaariin.USEITA_AJOSUUNTIA_POISTUU_KAYTOSTA,
                 kaistaPituusHaitta = PITUUS_500_METRIA_TAI_ENEMMAN,
             )
         val request = hanke.toModifyRequest()
@@ -879,7 +863,7 @@ class UpdateHankeITests(
                 hanke,
                 hanke.alueet[0],
                 hankeVersion = 1,
-                tormaystarkasteluTulos = true
+                tormaystarkasteluTulos = true,
             )
         val expectedLogAfter =
             expectedHankeLogObject(
@@ -999,6 +983,6 @@ class UpdateHankeITests(
     private fun haittojenhallintasuunnitelmaCount(): Int? =
         jdbcTemplate.queryForObject(
             "SELECT count(*) from hankkeen_haittojenhallintasuunnitelma",
-            Int::class.java
+            Int::class.java,
         )
 }

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/UpdateHakemusITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/UpdateHakemusITest.kt
@@ -258,11 +258,13 @@ class UpdateHakemusITest(
         assertThat(email.allRecipients.single().toString()).isEqualTo(newKayttaja.sahkoposti)
         assertThat(email.subject)
             .isEqualTo(
-                "Haitaton: Sinut on lisätty hakemukselle / Du har lagts till i en ansökan / You have been added to an application")
+                "Haitaton: Sinut on lisätty hakemukselle / Du har lagts till i en ansökan / You have been added to an application"
+            )
         val typeTranslation = type.translations().fi
         assertThat(email.textBody())
             .contains(
-                "laatimassa $typeTranslation hankkeelle \"${hanke.nimi}\" (${hanke.hankeTunnus})")
+                "laatimassa $typeTranslation hankkeelle \"${hanke.nimi}\" (${hanke.hankeTunnus})"
+            )
     }
 
     @Nested
@@ -295,7 +297,8 @@ class UpdateHakemusITest(
                 messageContains("Invalid geometry received when updating hakemus")
                 messageContains("reason=Self-intersection")
                 messageContains(
-                    "location={\"type\":\"Point\",\"coordinates\":[25494009.65639264,6679886.142116806]}")
+                    "location={\"type\":\"Point\",\"coordinates\":[25494009.65639264,6679886.142116806]}"
+                )
             }
         }
 
@@ -467,7 +470,9 @@ class UpdateHakemusITest(
                     listOf(
                         createTyoalue(
                             "/fi/hel/haitaton/hanke/geometria/intersecting-polygon.json"
-                                .asJsonResource())),
+                                .asJsonResource()
+                        )
+                    ),
             )
 
         private val notInHankeArea =
@@ -496,7 +501,8 @@ class UpdateHakemusITest(
                 messageContains("Invalid geometry received when updating hakemus")
                 messageContains("reason=Self-intersection")
                 messageContains(
-                    "location={\"type\":\"Point\",\"coordinates\":[25494009.65639264,6679886.142116806]}")
+                    "location={\"type\":\"Point\",\"coordinates\":[25494009.65639264,6679886.142116806]}"
+                )
             }
         }
 
@@ -521,7 +527,8 @@ class UpdateHakemusITest(
                 messageContains("Hakemus geometry is outside the associated hankealue")
                 messageContains("hankealue=$hankealueId")
                 messageContains(
-                    "geometry=${notInHankeArea.tyoalueet.single().geometry.toJsonString()}")
+                    "geometry=${notInHankeArea.tyoalueet.single().geometry.toJsonString()}"
+                )
             }
         }
 
@@ -733,7 +740,8 @@ class UpdateHakemusITest(
                         HakemusyhteystietoFactory.create(
                             tyyppi = CustomerType.PERSON,
                             registryKey = henkilotunnus,
-                        ))
+                        )
+                    )
                     .save()
             val yhteystietoId = hakemus.applicationData.customerWithContacts!!.id
             val request =
@@ -844,11 +852,11 @@ class UpdateHakemusITest(
                 TormaystarkasteluTulos(
                     autoliikenne =
                         Autoliikenneluokittelu(
-                            indeksi = 3.1f,
+                            indeksi = 2.8f,
                             haitanKesto = 1,
                             katuluokka = 4,
                             liikennemaara = 5,
-                            kaistahaitta = 2,
+                            kaistahaitta = 1,
                             kaistapituushaitta = 2,
                         ),
                     pyoraliikenneindeksi = 3.0f,

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/taydennys/UpdateTaydennysITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/taydennys/UpdateTaydennysITest.kt
@@ -844,11 +844,11 @@ class UpdateTaydennysITest(
                 TormaystarkasteluTulos(
                     autoliikenne =
                         Autoliikenneluokittelu(
-                            indeksi = 3.1f,
+                            indeksi = 2.8f,
                             haitanKesto = 1,
                             katuluokka = 4,
                             liikennemaara = 5,
-                            kaistahaitta = 2,
+                            kaistahaitta = 1,
                             kaistapituushaitta = 2,
                         ),
                     pyoraliikenneindeksi = 3.0f,

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluControllerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluControllerITest.kt
@@ -104,11 +104,11 @@ class TormaystarkasteluControllerITest(
                 [
                     "2025-02-20T23:45:56Z,2025-02-20T23:45:55Z",
                     "2025-02-20T23:45:56Z,2025-02-19T23:47:56Z",
-                ],
+                ]
         )
         fun `returns 400 when start time is after end time`(
             startDate: ZonedDateTime,
-            endDate: ZonedDateTime
+            endDate: ZonedDateTime,
         ) {
             val request = createRequest(startDate, endDate)
 
@@ -125,7 +125,7 @@ class TormaystarkasteluControllerITest(
                     "2025-02-20T23:45:56Z,2025-02-20T23:45:56Z,1",
                     "2025-02-20T00:45:56Z,2025-02-20T23:12:34Z,1",
                     "2025-02-20T23:45:56Z,2025-02-21T23:45:56Z,2",
-                ],
+                ]
         )
         fun `calls the service with the right length in days`(
             startDate: ZonedDateTime,
@@ -137,7 +137,7 @@ class TormaystarkasteluControllerITest(
                 laskentaService.calculateTormaystarkastelu(
                     any<FeatureCollection>(),
                     days,
-                    VaikutusAutoliikenteenKaistamaariin.VAHENTAA_KAISTAN_YHDELLA_AJOSUUNNALLA,
+                    VaikutusAutoliikenteenKaistamaariin.YKSI_KAISTA_VAHENEE,
                     AutoliikenteenKaistavaikutustenPituus.PITUUS_10_99_METRIA,
                 )
             } returns createTulos()
@@ -148,7 +148,7 @@ class TormaystarkasteluControllerITest(
                 laskentaService.calculateTormaystarkastelu(
                     any<FeatureCollection>(),
                     days,
-                    VaikutusAutoliikenteenKaistamaariin.VAHENTAA_KAISTAN_YHDELLA_AJOSUUNNALLA,
+                    VaikutusAutoliikenteenKaistamaariin.YKSI_KAISTA_VAHENEE,
                     AutoliikenteenKaistavaikutustenPituus.PITUUS_10_99_METRIA,
                 )
             }
@@ -184,7 +184,7 @@ class TormaystarkasteluControllerITest(
             haittaAlkuPvm: ZonedDateTime = DateFactory.getStartDatetime(),
             haittaLoppuPvm: ZonedDateTime = DateFactory.getEndDatetime(),
             kaistaHaitta: VaikutusAutoliikenteenKaistamaariin =
-                VaikutusAutoliikenteenKaistamaariin.VAHENTAA_KAISTAN_YHDELLA_AJOSUUNNALLA,
+                VaikutusAutoliikenteenKaistamaariin.YKSI_KAISTA_VAHENEE,
             kaistaPituusHaitta: AutoliikenteenKaistavaikutustenPituus =
                 AutoliikenteenKaistavaikutustenPituus.PITUUS_10_99_METRIA,
         ): TormaystarkasteluRequest {

--- a/services/hanke-service/src/integrationTest/resources/fi/hel/haitaton/hanke/logging/expectedHankeWithPolygon.json.mustache
+++ b/services/hanke-service/src/integrationTest/resources/fi/hel/haitaton/hanke/logging/expectedHankeWithPolygon.json.mustache
@@ -86,7 +86,7 @@
         },
         "version": {{geometriaVersion}}
       },
-      "kaistaHaitta": "VAHENTAA_KAISTAN_YHDELLA_AJOSUUNNALLA",
+      "kaistaHaitta": "YKSI_KAISTA_VAHENEE",
       "kaistaPituusHaitta": "PITUUS_ALLE_10_METRIA",
       "meluHaitta": "SATUNNAINEN_MELUHAITTA",
       "polyHaitta": "TOISTUVA_POLYHAITTA",
@@ -97,9 +97,9 @@
           "haitanKesto": 1,
           "katuluokka": 4,
           "liikennemaara": 5,
-          "kaistahaitta": 2,
+          "kaistahaitta": 1,
           "kaistapituushaitta": 2,
-          "indeksi": 3.1
+          "indeksi": 2.8
         },
         "pyoraliikenneindeksi": 3.0,
         "linjaautoliikenneindeksi": 3.0,

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/pdf/Translations.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/pdf/Translations.kt
@@ -33,7 +33,7 @@ fun Tarinahaitta.format(): String =
 
 fun VaikutusAutoliikenteenKaistamaariin.format(): String =
     when (this) {
-        VaikutusAutoliikenteenKaistamaariin.EI_VAIKUTA -> "Ei vaikuta autoliikenteen kaistamääriin"
+        VaikutusAutoliikenteenKaistamaariin.EI_VAIKUTA -> "Ei vaikuta"
         VaikutusAutoliikenteenKaistamaariin.YKSI_KAISTA_VAHENEE ->
             "Yksi autokaista vähenee - ajosuunta vielä käytössä"
         VaikutusAutoliikenteenKaistamaariin.YKSI_KAISTA_VAHENEE_KAHDELLA_AJOSUUNNALLA ->
@@ -48,16 +48,11 @@ fun VaikutusAutoliikenteenKaistamaariin.format(): String =
 
 fun AutoliikenteenKaistavaikutustenPituus.format(): String =
     when (this) {
-        AutoliikenteenKaistavaikutustenPituus.EI_VAIKUTA_KAISTAJARJESTELYIHIN ->
-            "Ei vaikuta autoliikenteen kaistajärjestelyihin"
-        AutoliikenteenKaistavaikutustenPituus.PITUUS_ALLE_10_METRIA ->
-            "Kaistavaikutusten pituus alle 10 m"
-        AutoliikenteenKaistavaikutustenPituus.PITUUS_10_99_METRIA ->
-            "Kaistavaikutusten pituus 10-99 m"
-        AutoliikenteenKaistavaikutustenPituus.PITUUS_100_499_METRIA ->
-            "Kaistavaikutusten pituus 100-499 m"
-        AutoliikenteenKaistavaikutustenPituus.PITUUS_500_METRIA_TAI_ENEMMAN ->
-            "Kaistavaikutusten pituus 500 m tai enemmän"
+        AutoliikenteenKaistavaikutustenPituus.EI_VAIKUTA_KAISTAJARJESTELYIHIN -> "Ei vaikuta"
+        AutoliikenteenKaistavaikutustenPituus.PITUUS_ALLE_10_METRIA -> "Alle 10 m"
+        AutoliikenteenKaistavaikutustenPituus.PITUUS_10_99_METRIA -> "10-99 m"
+        AutoliikenteenKaistavaikutustenPituus.PITUUS_100_499_METRIA -> "100-499 m"
+        AutoliikenteenKaistavaikutustenPituus.PITUUS_500_METRIA_TAI_ENEMMAN -> "500 m tai enemmän"
     }
 
 fun TyomaaTyyppi.format(): String =

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/pdf/Translations.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/pdf/Translations.kt
@@ -33,7 +33,7 @@ fun Tarinahaitta.format(): String =
 
 fun VaikutusAutoliikenteenKaistamaariin.format(): String =
     when (this) {
-        VaikutusAutoliikenteenKaistamaariin.EI_VAIKUTA -> "Ei vaikuta"
+        VaikutusAutoliikenteenKaistamaariin.EI_VAIKUTA -> "Ei vaikuta autoliikenteen kaistamääriin"
         VaikutusAutoliikenteenKaistamaariin.YKSI_KAISTA_VAHENEE ->
             "Yksi autokaista vähenee - ajosuunta vielä käytössä"
         VaikutusAutoliikenteenKaistamaariin.YKSI_KAISTA_VAHENEE_KAHDELLA_AJOSUUNNALLA ->
@@ -48,11 +48,16 @@ fun VaikutusAutoliikenteenKaistamaariin.format(): String =
 
 fun AutoliikenteenKaistavaikutustenPituus.format(): String =
     when (this) {
-        AutoliikenteenKaistavaikutustenPituus.EI_VAIKUTA_KAISTAJARJESTELYIHIN -> "Ei vaikuta"
-        AutoliikenteenKaistavaikutustenPituus.PITUUS_ALLE_10_METRIA -> "Alle 10 m"
-        AutoliikenteenKaistavaikutustenPituus.PITUUS_10_99_METRIA -> "10-99 m"
-        AutoliikenteenKaistavaikutustenPituus.PITUUS_100_499_METRIA -> "100-499 m"
-        AutoliikenteenKaistavaikutustenPituus.PITUUS_500_METRIA_TAI_ENEMMAN -> "500 m tai enemmän"
+        AutoliikenteenKaistavaikutustenPituus.EI_VAIKUTA_KAISTAJARJESTELYIHIN ->
+            "Ei vaikuta autoliikenteen kaistajärjestelyihin"
+        AutoliikenteenKaistavaikutustenPituus.PITUUS_ALLE_10_METRIA ->
+            "Kaistavaikutusten pituus alle 10 m"
+        AutoliikenteenKaistavaikutustenPituus.PITUUS_10_99_METRIA ->
+            "Kaistavaikutusten pituus 10-99 m"
+        AutoliikenteenKaistavaikutustenPituus.PITUUS_100_499_METRIA ->
+            "Kaistavaikutusten pituus 100-499 m"
+        AutoliikenteenKaistavaikutustenPituus.PITUUS_500_METRIA_TAI_ENEMMAN ->
+            "Kaistavaikutusten pituus 500 m tai enemmän"
     }
 
 fun TyomaaTyyppi.format(): String =

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/pdf/Translations.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/pdf/Translations.kt
@@ -34,20 +34,16 @@ fun Tarinahaitta.format(): String =
 fun VaikutusAutoliikenteenKaistamaariin.format(): String =
     when (this) {
         VaikutusAutoliikenteenKaistamaariin.EI_VAIKUTA -> "Ei vaikuta"
-        VaikutusAutoliikenteenKaistamaariin.VAHENTAA_KAISTAN_YHDELLA_AJOSUUNNALLA ->
-            "Vähentää kaistan yhdellä ajosuunnalla"
-
-        VaikutusAutoliikenteenKaistamaariin
-            .VAHENTAA_SAMANAIKAISESTI_KAISTAN_KAHDELLA_AJOSUUNNALLA ->
-            "Vähentää samanaikaisesti kaistan kahdella ajosuunnalla"
-
-        VaikutusAutoliikenteenKaistamaariin
-            .VAHENTAA_SAMANAIKAISESTI_USEITA_KAISTOJA_KAHDELLA_AJOSUUNNALLA ->
-            "Vähentää samanaikaisesti useita kaistoja kahdella ajosuunnalla"
-
-        VaikutusAutoliikenteenKaistamaariin
-            .VAHENTAA_SAMANAIKAISESTI_USEITA_KAISTOJA_LIITTYMIEN_ERI_SUUNNILLA ->
-            "Vähentää samanaikaisesti useita kaistoja liittymän eri suunnilla"
+        VaikutusAutoliikenteenKaistamaariin.YKSI_KAISTA_VAHENEE ->
+            "Yksi autokaista vähenee - ajosuunta vielä käytössä"
+        VaikutusAutoliikenteenKaistamaariin.YKSI_KAISTA_VAHENEE_KAHDELLA_AJOSUUNNALLA ->
+            "Yksi autokaista vähenee kahdella ajosuunnalla - ajosuunnat vielä käytössä"
+        VaikutusAutoliikenteenKaistamaariin.USEITA_KAISTOJA_VAHENEE_AJOSUUNNILLA ->
+            "Useita autokaistoja vähenee ajosuunnilla - ajosuunnat vielä käytössä"
+        VaikutusAutoliikenteenKaistamaariin.YKSI_AJOSUUNTA_POISTUU_KAYTOSTA ->
+            "Yksi autoliikenteen ajosuunta poistuu käytöstä"
+        VaikutusAutoliikenteenKaistamaariin.USEITA_AJOSUUNTIA_POISTUU_KAYTOSTA ->
+            "Useita autoliikenteen ajosuuntia poistuu käytöstä"
     }
 
 fun AutoliikenteenKaistavaikutustenPituus.format(): String =

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluLuokittelu.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluLuokittelu.kt
@@ -6,20 +6,21 @@ interface Luokittelu {
 
 /** NOTE Järjestys täytyy olla pienimmästä suurimpaan */
 enum class VaikutusAutoliikenteenKaistamaariin(override val value: Int) : Luokittelu {
-    EI_VAIKUTA(1),
-    VAHENTAA_KAISTAN_YHDELLA_AJOSUUNNALLA(2),
-    VAHENTAA_SAMANAIKAISESTI_KAISTAN_KAHDELLA_AJOSUUNNALLA(3),
-    VAHENTAA_SAMANAIKAISESTI_USEITA_KAISTOJA_KAHDELLA_AJOSUUNNALLA(4),
-    VAHENTAA_SAMANAIKAISESTI_USEITA_KAISTOJA_LIITTYMIEN_ERI_SUUNNILLA(5)
+    EI_VAIKUTA(0),
+    YKSI_KAISTA_VAHENEE(1),
+    YKSI_KAISTA_VAHENEE_KAHDELLA_AJOSUUNNALLA(2),
+    USEITA_KAISTOJA_VAHENEE_AJOSUUNNILLA(3),
+    YKSI_AJOSUUNTA_POISTUU_KAYTOSTA(4),
+    USEITA_AJOSUUNTIA_POISTUU_KAYTOSTA(5),
 }
 
 /** NOTE Järjestys täytyy olla pienimmästä suurimpaan */
 enum class AutoliikenteenKaistavaikutustenPituus(override val value: Int) : Luokittelu {
-    EI_VAIKUTA_KAISTAJARJESTELYIHIN(1),
+    EI_VAIKUTA_KAISTAJARJESTELYIHIN(0),
     PITUUS_ALLE_10_METRIA(2),
     PITUUS_10_99_METRIA(3),
     PITUUS_100_499_METRIA(4),
-    PITUUS_500_METRIA_TAI_ENEMMAN(5)
+    PITUUS_500_METRIA_TAI_ENEMMAN(5),
 }
 
 /** NOTE Järjestys täytyy olla pienimmästä suurimpaan */
@@ -49,7 +50,7 @@ enum class Tarinahaitta(override val value: Int) : Luokittelu {
 enum class HaittaAjanKestoLuokittelu(override val value: Int) : Luokittelu {
     YLI_KOLME_KUUKAUTTA(5),
     KAKSI_VIIKKOA_VIIVA_KOLME_KUUKAUTTA(3),
-    ALLE_KAKSI_VIIKKOA(1)
+    ALLE_KAKSI_VIIKKOA(1),
 }
 
 enum class Liikennemaaraluokittelu(override val value: Int) : Luokittelu {
@@ -58,7 +59,7 @@ enum class Liikennemaaraluokittelu(override val value: Int) : Luokittelu {
     LIIKENNEMAARA_1500_4999(3),
     LIIKENNEMAARA_500_1499(2),
     LIIKENNEMAARA_ALLE_500(1),
-    EI_LIIKENNETTA(0)
+    EI_LIIKENNETTA(0),
 }
 
 enum class Linjaautoliikenneluokittelu(override val value: Int) : Luokittelu {
@@ -81,7 +82,7 @@ enum class Linjaautoliikenneluokittelu(override val value: Int) : Luokittelu {
     MAHDOLLINEN_POIKKEUSREITTI(1),
 
     /** No regular bus traffic */
-    EI_VAIKUTA_LINJAAUTOLIIKENTEESEEN(0)
+    EI_VAIKUTA_LINJAAUTOLIIKENTEESEEN(0),
 }
 
 enum class Raitioliikenneluokittelu(override val value: Int) : Luokittelu {

--- a/services/hanke-service/src/main/resources/db/changelog/changesets/086-change-car-lane-nuisance-enum.sql
+++ b/services/hanke-service/src/main/resources/db/changelog/changesets/086-change-car-lane-nuisance-enum.sql
@@ -1,0 +1,134 @@
+--liquibase formatted sql
+--changeset Teemu Hiltunen:086-change-car-lane-nuisance-enum
+--comment: Change 'hankealue.kaistahaitta' enum values and 'tormaystarkastelutulos.kaistapituushaitta' and 'applications.applicationData.areas[n].tyoalueet[m].tormaystarkastelutulos.kaistapituushaitta' index values
+
+-- update hankealue.kaistahaitta enum values
+ALTER TABLE hankealue
+    ADD COLUMN kaistahaitta_temp VARCHAR;
+
+UPDATE hankealue
+    SET kaistahaitta_temp =
+        CASE
+            WHEN kaistahaitta = 'VAHENTAA_KAISTAN_YHDELLA_AJOSUUNNALLA' THEN 'YKSI_KAISTA_VAHENEE'
+            WHEN kaistahaitta = 'VAHENTAA_SAMANAIKAISESTI_KAISTAN_KAHDELLA_AJOSUUNNALLA' THEN 'YKSI_KAISTA_VAHENEE_KAHDELLA_AJOSUUNNALLA'
+            WHEN kaistahaitta = 'VAHENTAA_SAMANAIKAISESTI_USEITA_KAISTOJA_KAHDELLA_AJOSUUNNALLA' THEN 'USEITA_KAISTOJA_VAHENEE_AJOSUUNNILLA'
+            WHEN kaistahaitta = 'VAHENTAA_SAMANAIKAISESTI_USEITA_KAISTOJA_LIITTYMIEN_ERI_SUUNNILLA' THEN 'USEITA_AJOSUUNTIA_POISTUU_KAYTOSTA'
+        END;
+
+ALTER TABLE hankealue
+    DROP COLUMN kaistahaitta;
+
+ALTER TABLE hankealue
+    RENAME COLUMN kaistahaitta_temp TO kaistahaitta;
+
+-- update tormaystarkastelutulos.kaistapituushaitta
+UPDATE tormaystarkastelutulos
+    SET kaistapituushaitta=0
+    WHERE kaistapituushaitta=1;
+
+-- update tormaystarkastelutulos.kaistahaitta
+UPDATE tormaystarkastelutulos
+    SET kaistahaitta =
+        CASE kaistahaitta
+            WHEN 1 THEN 0
+            WHEN 2 THEN 1
+            WHEN 3 THEN 2
+            WHEN 4 THEN 3
+            ELSE kaistahaitta
+        END;
+
+-- update applications.applicationData.areas
+WITH RECURSIVE areas_array AS (
+    SELECT id,
+        CASE
+            WHEN (applicationData #>> '{areas}') IS NOT NULL AND jsonb_typeof(applicationData->'areas') = 'array' THEN
+                jsonb_set(
+                    applicationData,
+                    '{areas}',
+                    (
+                        SELECT jsonb_agg(
+                            CASE
+                                WHEN (area #>> '{tyoalueet}') IS NOT NULL AND jsonb_typeof(area->'tyoalueet') = 'array' THEN
+                                    -- Update area level kaistahaitta first
+                                    jsonb_set(
+                                        jsonb_set(
+                                            area,
+                                            '{tyoalueet}',
+                                            (
+                                                SELECT jsonb_agg(
+                                                    CASE
+                                                        WHEN (tyoalue #>> '{tormaystarkasteluTulos}') IS NOT NULL AND
+                                                            (tyoalue #>> '{tormaystarkasteluTulos,autoliikenne}') IS NOT NULL THEN
+                                                            CASE
+                                                                -- First update kaistapituushaitta if it's 1
+                                                                WHEN tyoalue->'tormaystarkasteluTulos'->'autoliikenne'->>'kaistapituushaitta' = '1' THEN
+                                                                    jsonb_set(
+                                                                        jsonb_set(
+                                                                            tyoalue,
+                                                                            '{tormaystarkasteluTulos,autoliikenne,kaistapituushaitta}',
+                                                                            '0'::jsonb
+                                                                        ),
+                                                                        '{tormaystarkasteluTulos,autoliikenne,kaistahaitta}',
+                                                                        (
+                                                                            CASE tyoalue->'tormaystarkasteluTulos'->'autoliikenne'->>'kaistahaitta'
+                                                                                WHEN '1' THEN '0'::jsonb
+                                                                                WHEN '2' THEN '1'::jsonb
+                                                                                WHEN '3' THEN '2'::jsonb
+                                                                                WHEN '4' THEN '3'::jsonb
+                                                                                WHEN '5' THEN '5'::jsonb
+                                                                                ELSE tyoalue->'tormaystarkasteluTulos'->'autoliikenne'->'kaistahaitta'
+                                                                            END
+                                                                        )
+                                                                    )
+                                                                ELSE
+                                                                    -- Only update kaistahaitta
+                                                                    jsonb_set(
+                                                                        tyoalue,
+                                                                        '{tormaystarkasteluTulos,autoliikenne,kaistahaitta}',
+                                                                        (
+                                                                            CASE tyoalue->'tormaystarkasteluTulos'->'autoliikenne'->>'kaistahaitta'
+                                                                                WHEN '1' THEN '0'::jsonb
+                                                                                WHEN '2' THEN '1'::jsonb
+                                                                                WHEN '3' THEN '2'::jsonb
+                                                                                WHEN '4' THEN '3'::jsonb
+                                                                                WHEN '5' THEN '5'::jsonb
+                                                                                ELSE tyoalue->'tormaystarkasteluTulos'->'autoliikenne'->'kaistahaitta'
+                                                                            END
+                                                                        )
+                                                                    )
+                                                            END
+                                                        ELSE tyoalue
+                                                    END
+                                                )
+                                                FROM jsonb_array_elements(area->'tyoalueet') tyoalue
+                                            )
+                                        ),
+                                        '{kaistahaitta}',
+                                        (
+                                            CASE area->>'kaistahaitta'
+                                                WHEN 'VAHENTAA_KAISTAN_YHDELLA_AJOSUUNNALLA' THEN
+                                                    '"YKSI_KAISTA_VAHENEE"'::jsonb
+                                                WHEN 'VAHENTAA_SAMANAIKAISESTI_KAISTAN_KAHDELLA_AJOSUUNNALLA' THEN
+                                                    '"YKSI_KAISTA_VAHENEE_KAHDELLA_AJOSUUNNALLA"'::jsonb
+                                                WHEN 'VAHENTAA_SAMANAIKAISESTI_USEITA_KAISTOJA_KAHDELLA_AJOSUUNNALLA' THEN
+                                                    '"USEITA_KAISTOJA_VAHENEE_AJOSUUNNILLA"'::jsonb
+                                                WHEN 'VAHENTAA_SAMANAIKAISESTI_USEITA_KAISTOJA_LIITTYMIEN_ERI_SUUNNILLA' THEN
+                                                    '"USEITA_AJOSUUNTIA_POISTUU_KAYTOSTA"'::jsonb
+                                                ELSE area->'kaistahaitta'
+                                            END
+                                        )
+                                    )
+                                ELSE area
+                            END
+                        )
+                        FROM jsonb_array_elements(applicationData->'areas') area
+                    )
+                )
+            ELSE applicationData
+        END as updated_data
+    FROM applications
+)
+UPDATE applications
+SET applicationData = areas_array.updated_data
+FROM areas_array
+WHERE applications.id = areas_array.id;

--- a/services/hanke-service/src/main/resources/db/changelog/changesets/086-change-car-lane-nuisance-enum.sql
+++ b/services/hanke-service/src/main/resources/db/changelog/changesets/086-change-car-lane-nuisance-enum.sql
@@ -3,23 +3,15 @@
 --comment: Change 'hankealue.kaistahaitta' enum values and 'tormaystarkastelutulos.kaistapituushaitta' and 'applications.applicationData.areas[n].tyoalueet[m].tormaystarkastelutulos.kaistapituushaitta' index values
 
 -- update hankealue.kaistahaitta enum values
-ALTER TABLE hankealue
-    ADD COLUMN kaistahaitta_temp VARCHAR;
-
 UPDATE hankealue
-    SET kaistahaitta_temp =
+    SET kaistahaitta =
         CASE
             WHEN kaistahaitta = 'VAHENTAA_KAISTAN_YHDELLA_AJOSUUNNALLA' THEN 'YKSI_KAISTA_VAHENEE'
             WHEN kaistahaitta = 'VAHENTAA_SAMANAIKAISESTI_KAISTAN_KAHDELLA_AJOSUUNNALLA' THEN 'YKSI_KAISTA_VAHENEE_KAHDELLA_AJOSUUNNALLA'
             WHEN kaistahaitta = 'VAHENTAA_SAMANAIKAISESTI_USEITA_KAISTOJA_KAHDELLA_AJOSUUNNALLA' THEN 'USEITA_KAISTOJA_VAHENEE_AJOSUUNNILLA'
             WHEN kaistahaitta = 'VAHENTAA_SAMANAIKAISESTI_USEITA_KAISTOJA_LIITTYMIEN_ERI_SUUNNILLA' THEN 'USEITA_AJOSUUNTIA_POISTUU_KAYTOSTA'
+            ELSE kaistahaitta
         END;
-
-ALTER TABLE hankealue
-    DROP COLUMN kaistahaitta;
-
-ALTER TABLE hankealue
-    RENAME COLUMN kaistahaitta_temp TO kaistahaitta;
 
 -- update tormaystarkastelutulos.kaistapituushaitta
 UPDATE tormaystarkastelutulos
@@ -38,7 +30,7 @@ UPDATE tormaystarkastelutulos
         END;
 
 -- update applications.applicationData.areas
-WITH RECURSIVE areas_array AS (
+WITH areas_array AS (
     SELECT id,
         CASE
             WHEN (applicationData #>> '{areas}') IS NOT NULL AND jsonb_typeof(applicationData->'areas') = 'array' THEN

--- a/services/hanke-service/src/main/resources/db/changelog/changesets/086-change-car-lane-nuisance-enum.sql
+++ b/services/hanke-service/src/main/resources/db/changelog/changesets/086-change-car-lane-nuisance-enum.sql
@@ -13,22 +13,6 @@ UPDATE hankealue
             ELSE kaistahaitta
         END;
 
--- update tormaystarkastelutulos.kaistapituushaitta
-UPDATE tormaystarkastelutulos
-    SET kaistapituushaitta=0
-    WHERE kaistapituushaitta=1;
-
--- update tormaystarkastelutulos.kaistahaitta
-UPDATE tormaystarkastelutulos
-    SET kaistahaitta =
-        CASE kaistahaitta
-            WHEN 1 THEN 0
-            WHEN 2 THEN 1
-            WHEN 3 THEN 2
-            WHEN 4 THEN 3
-            ELSE kaistahaitta
-        END;
-
 -- update applications.applicationData.areas
 WITH areas_array AS (
     SELECT id,
@@ -39,79 +23,23 @@ WITH areas_array AS (
                     '{areas}',
                     (
                         SELECT jsonb_agg(
-                            CASE
-                                WHEN (area #>> '{tyoalueet}') IS NOT NULL AND jsonb_typeof(area->'tyoalueet') = 'array' THEN
-                                    -- Update area level kaistahaitta first
-                                    jsonb_set(
-                                        jsonb_set(
-                                            area,
-                                            '{tyoalueet}',
-                                            (
-                                                SELECT jsonb_agg(
-                                                    CASE
-                                                        WHEN (tyoalue #>> '{tormaystarkasteluTulos}') IS NOT NULL AND
-                                                            (tyoalue #>> '{tormaystarkasteluTulos,autoliikenne}') IS NOT NULL THEN
-                                                            CASE
-                                                                -- First update kaistapituushaitta if it's 1
-                                                                WHEN tyoalue->'tormaystarkasteluTulos'->'autoliikenne'->>'kaistapituushaitta' = '1' THEN
-                                                                    jsonb_set(
-                                                                        jsonb_set(
-                                                                            tyoalue,
-                                                                            '{tormaystarkasteluTulos,autoliikenne,kaistapituushaitta}',
-                                                                            '0'::jsonb
-                                                                        ),
-                                                                        '{tormaystarkasteluTulos,autoliikenne,kaistahaitta}',
-                                                                        (
-                                                                            CASE tyoalue->'tormaystarkasteluTulos'->'autoliikenne'->>'kaistahaitta'
-                                                                                WHEN '1' THEN '0'::jsonb
-                                                                                WHEN '2' THEN '1'::jsonb
-                                                                                WHEN '3' THEN '2'::jsonb
-                                                                                WHEN '4' THEN '3'::jsonb
-                                                                                WHEN '5' THEN '5'::jsonb
-                                                                                ELSE tyoalue->'tormaystarkasteluTulos'->'autoliikenne'->'kaistahaitta'
-                                                                            END
-                                                                        )
-                                                                    )
-                                                                ELSE
-                                                                    -- Only update kaistahaitta
-                                                                    jsonb_set(
-                                                                        tyoalue,
-                                                                        '{tormaystarkasteluTulos,autoliikenne,kaistahaitta}',
-                                                                        (
-                                                                            CASE tyoalue->'tormaystarkasteluTulos'->'autoliikenne'->>'kaistahaitta'
-                                                                                WHEN '1' THEN '0'::jsonb
-                                                                                WHEN '2' THEN '1'::jsonb
-                                                                                WHEN '3' THEN '2'::jsonb
-                                                                                WHEN '4' THEN '3'::jsonb
-                                                                                WHEN '5' THEN '5'::jsonb
-                                                                                ELSE tyoalue->'tormaystarkasteluTulos'->'autoliikenne'->'kaistahaitta'
-                                                                            END
-                                                                        )
-                                                                    )
-                                                            END
-                                                        ELSE tyoalue
-                                                    END
-                                                )
-                                                FROM jsonb_array_elements(area->'tyoalueet') tyoalue
-                                            )
-                                        ),
-                                        '{kaistahaitta}',
-                                        (
-                                            CASE area->>'kaistahaitta'
-                                                WHEN 'VAHENTAA_KAISTAN_YHDELLA_AJOSUUNNALLA' THEN
-                                                    '"YKSI_KAISTA_VAHENEE"'::jsonb
-                                                WHEN 'VAHENTAA_SAMANAIKAISESTI_KAISTAN_KAHDELLA_AJOSUUNNALLA' THEN
-                                                    '"YKSI_KAISTA_VAHENEE_KAHDELLA_AJOSUUNNALLA"'::jsonb
-                                                WHEN 'VAHENTAA_SAMANAIKAISESTI_USEITA_KAISTOJA_KAHDELLA_AJOSUUNNALLA' THEN
-                                                    '"USEITA_KAISTOJA_VAHENEE_AJOSUUNNILLA"'::jsonb
-                                                WHEN 'VAHENTAA_SAMANAIKAISESTI_USEITA_KAISTOJA_LIITTYMIEN_ERI_SUUNNILLA' THEN
-                                                    '"USEITA_AJOSUUNTIA_POISTUU_KAYTOSTA"'::jsonb
-                                                ELSE area->'kaistahaitta'
-                                            END
-                                        )
-                                    )
-                                ELSE area
-                            END
+                            jsonb_set(
+                                area,
+                                '{kaistahaitta}',
+                                (
+                                    CASE area->>'kaistahaitta'
+                                        WHEN 'VAHENTAA_KAISTAN_YHDELLA_AJOSUUNNALLA' THEN
+                                            '"YKSI_KAISTA_VAHENEE"'::jsonb
+                                        WHEN 'VAHENTAA_SAMANAIKAISESTI_KAISTAN_KAHDELLA_AJOSUUNNALLA' THEN
+                                            '"YKSI_KAISTA_VAHENEE_KAHDELLA_AJOSUUNNALLA"'::jsonb
+                                        WHEN 'VAHENTAA_SAMANAIKAISESTI_USEITA_KAISTOJA_KAHDELLA_AJOSUUNNALLA' THEN
+                                            '"USEITA_KAISTOJA_VAHENEE_AJOSUUNNILLA"'::jsonb
+                                        WHEN 'VAHENTAA_SAMANAIKAISESTI_USEITA_KAISTOJA_LIITTYMIEN_ERI_SUUNNILLA' THEN
+                                            '"USEITA_AJOSUUNTIA_POISTUU_KAYTOSTA"'::jsonb
+                                        ELSE area->'kaistahaitta'
+                                    END
+                                )
+                            )
                         )
                         FROM jsonb_array_elements(applicationData->'areas') area
                     )

--- a/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -199,3 +199,5 @@ databaseChangeLog:
       file: db/changelog/changesets/084-remove-datalock-from-hankeyhteystieto.sql
   - include:
       file: db/changelog/changesets/085-create-tables-for-taydennys.sql
+  - include:
+      file: db/changelog/changesets/086-change-car-lane-nuisance-enum.sql

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/domain/HankeTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/domain/HankeTest.kt
@@ -30,8 +30,7 @@ internal class HankeTest {
                 haittaAlkuPvm = b,
                 haittaLoppuPvm = d,
                 kaistaHaitta =
-                    VaikutusAutoliikenteenKaistamaariin
-                        .VAHENTAA_SAMANAIKAISESTI_KAISTAN_KAHDELLA_AJOSUUNNALLA,
+                    VaikutusAutoliikenteenKaistamaariin.YKSI_KAISTA_VAHENEE_KAHDELLA_AJOSUUNNALLA,
                 kaistaPituusHaitta = AutoliikenteenKaistavaikutustenPituus.PITUUS_10_99_METRIA,
                 meluHaitta = Meluhaitta.JATKUVA_MELUHAITTA,
                 polyHaitta = Polyhaitta.JATKUVA_POLYHAITTA,

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/ApplicationFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/ApplicationFactory.kt
@@ -97,7 +97,7 @@ class ApplicationFactory(
             polyhaitta: Polyhaitta = Polyhaitta.TOISTUVA_POLYHAITTA,
             tarinahaitta: Tarinahaitta = Tarinahaitta.SATUNNAINEN_TARINAHAITTA,
             kaistahaitta: VaikutusAutoliikenteenKaistamaariin =
-                VaikutusAutoliikenteenKaistamaariin.VAHENTAA_KAISTAN_YHDELLA_AJOSUUNNALLA,
+                VaikutusAutoliikenteenKaistamaariin.YKSI_KAISTA_VAHENEE,
             kaistahaittojenPituus: AutoliikenteenKaistavaikutustenPituus =
                 AutoliikenteenKaistavaikutustenPituus.PITUUS_ALLE_10_METRIA,
             lisatiedot: String = "Lisätiedot",

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankealueFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankealueFactory.kt
@@ -27,8 +27,8 @@ object HankealueFactory {
             HaittaAjanKestoLuokittelu.YLI_KOLME_KUUKAUTTA.value,
             TormaystarkasteluKatuluokka.TONTTIKATU_TAI_AJOYHTEYS.value,
             Liikennemaaraluokittelu.LIIKENNEMAARA_ALLE_500.value,
-            VaikutusAutoliikenteenKaistamaariin.VAHENTAA_KAISTAN_YHDELLA_AJOSUUNNALLA.value,
-            AutoliikenteenKaistavaikutustenPituus.PITUUS_ALLE_10_METRIA.value
+            VaikutusAutoliikenteenKaistamaariin.YKSI_KAISTA_VAHENEE.value,
+            AutoliikenteenKaistavaikutustenPituus.PITUUS_ALLE_10_METRIA.value,
         )
 
     val TORMAYSTARKASTELU_ZERO_AUTOLIIKENNELUOKITTELU =
@@ -37,7 +37,7 @@ object HankealueFactory {
             0, // if both 'katuluokka' and 'liikennemaara' is 0, the index is 0.0
             0, // if both 'katuluokka' and 'liikennemaara' is 0, the index is 0.0
             1,
-            1
+            1,
         )
 
     fun create(
@@ -47,7 +47,7 @@ object HankealueFactory {
         haittaLoppuPvm: ZonedDateTime? = DateFactory.getEndDatetime(),
         geometriat: Geometriat? = GeometriaFactory.create(),
         kaistaHaitta: VaikutusAutoliikenteenKaistamaariin? =
-            VaikutusAutoliikenteenKaistamaariin.VAHENTAA_KAISTAN_YHDELLA_AJOSUUNNALLA,
+            VaikutusAutoliikenteenKaistamaariin.YKSI_KAISTA_VAHENEE,
         kaistaPituusHaitta: AutoliikenteenKaistavaikutustenPituus? =
             AutoliikenteenKaistavaikutustenPituus.PITUUS_ALLE_10_METRIA,
         meluHaitta: Meluhaitta? = Meluhaitta.SATUNNAINEN_MELUHAITTA,
@@ -98,7 +98,7 @@ object HankealueFactory {
                     "Linja-autoliikenteelle koituvien haittojen hallintasuunnitelma",
                 Haittojenhallintatyyppi.RAITIOLIIKENNE to
                     "Raitioliikenteelle koituvien haittojen hallintasuunnitelma",
-                Haittojenhallintatyyppi.MUUT to "Muiden haittojen hallintasuunnitelma"
+                Haittojenhallintatyyppi.MUUT to "Muiden haittojen hallintasuunnitelma",
             )
         overrides.forEach { (haittojenhallintatyyppi, suunnitelma) ->
             if (suunnitelma == null) {
@@ -135,7 +135,7 @@ object HankealueFactory {
             polyHaitta,
             tarinaHaitta,
             nimi,
-            null
+            null,
         )
     }
 

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluLaskentaServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluLaskentaServiceTest.kt
@@ -131,7 +131,7 @@ internal class TormaystarkasteluLaskentaServiceTest {
         )
         fun `returns matching classification when there is traffic`(
             volume: Int,
-            expectedResult: Int
+            expectedResult: Int,
         ) {
             every { tormaysService.maxLiikennemaara(geometriat, RADIUS_15) } returns volume
 
@@ -247,15 +247,7 @@ internal class TormaystarkasteluLaskentaServiceTest {
         }
 
         @ParameterizedTest
-        @CsvSource(
-            "0,2",
-            "1,3",
-            "10,3",
-            "11,4",
-            "20,4",
-            "21,5",
-            "100,5",
-        )
+        @CsvSource("0,2", "1,3", "10,3", "11,4", "20,4", "21,5", "100,5")
         fun `returns classification based on rush hour buses when there's no trunk line`(
             rushHourBuses: Int,
             expectedResult: Int,
@@ -267,7 +259,8 @@ internal class TormaystarkasteluLaskentaServiceTest {
                         0,
                         rushHourBuses,
                         TormaystarkasteluBussiRunkolinja.EI,
-                    ))
+                    )
+                )
             every { tormaysService.anyIntersectsCriticalBusRoutes(geometriat) } returns false
             every { tormaysService.getIntersectingBusRoutes(geometriat) } returns busLines
 
@@ -281,13 +274,10 @@ internal class TormaystarkasteluLaskentaServiceTest {
         }
 
         @ParameterizedTest
-        @CsvSource(
-            "ON,4",
-            "EI,2",
-        )
+        @CsvSource("ON,4", "EI,2")
         fun `returns classification based on trunk lines when there are zero rush hour buses`(
             runkolinja: TormaystarkasteluBussiRunkolinja,
-            expectedResult: Int
+            expectedResult: Int,
         ) {
             val busLines = setOf(TormaystarkasteluBussireitti("", 0, 0, runkolinja))
             every { tormaysService.anyIntersectsCriticalBusRoutes(geometriat) } returns false
@@ -317,9 +307,9 @@ internal class TormaystarkasteluLaskentaServiceTest {
         assertThat(tulos.autoliikenne.haitanKesto).isEqualTo(1)
         assertThat(tulos.autoliikenne.katuluokka).isEqualTo(4)
         assertThat(tulos.autoliikenne.liikennemaara).isEqualTo(2)
-        assertThat(tulos.autoliikenne.kaistahaitta).isEqualTo(2)
+        assertThat(tulos.autoliikenne.kaistahaitta).isEqualTo(1)
         assertThat(tulos.autoliikenne.kaistapituushaitta).isEqualTo(2)
-        assertThat(tulos.autoliikenne.indeksi).isEqualTo(2.3f)
+        assertThat(tulos.autoliikenne.indeksi).isEqualTo(2.1f)
         assertThat(tulos.linjaautoliikenneindeksi).isEqualTo(5.0f)
         assertThat(tulos.raitioliikenneindeksi).isEqualTo(3.0f)
         assertThat(tulos.pyoraliikenneindeksi).isEqualTo(3.0f)
@@ -379,20 +369,14 @@ internal class TormaystarkasteluLaskentaServiceTest {
                         liikennemaara,
                         kaistahaitta,
                         kaistapituushaitta,
-                    ))
+                    )
+                )
                 .isEqualTo(indeksi)
         }
 
         @Test
         fun `index should be 0 when there is no street class nor traffic`() {
-            assertThat(
-                    TormaystarkasteluLaskentaService.calculateAutoliikenneindeksi(
-                        5,
-                        0,
-                        0,
-                        5,
-                        5,
-                    ))
+            assertThat(TormaystarkasteluLaskentaService.calculateAutoliikenneindeksi(5, 0, 0, 5, 5))
                 .isEqualTo(0.0f)
         }
     }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluLaskentaServiceWithGeometryTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluLaskentaServiceWithGeometryTest.kt
@@ -131,7 +131,7 @@ internal class TormaystarkasteluLaskentaServiceWithGeometryTest {
         )
         fun `returns matching classification when there is traffic`(
             volume: Int,
-            expectedResult: Int
+            expectedResult: Int,
         ) {
             every { tormaysService.maxLiikennemaara(geometry, RADIUS_15) } returns volume
 
@@ -238,15 +238,7 @@ internal class TormaystarkasteluLaskentaServiceWithGeometryTest {
         }
 
         @ParameterizedTest
-        @CsvSource(
-            "0,2",
-            "1,3",
-            "10,3",
-            "11,4",
-            "20,4",
-            "21,5",
-            "100,5",
-        )
+        @CsvSource("0,2", "1,3", "10,3", "11,4", "20,4", "21,5", "100,5")
         fun `returns classification based on rush hour buses when there's no trunk line`(
             rushHourBuses: Int,
             expectedResult: Int,
@@ -258,7 +250,8 @@ internal class TormaystarkasteluLaskentaServiceWithGeometryTest {
                         0,
                         rushHourBuses,
                         TormaystarkasteluBussiRunkolinja.EI,
-                    ))
+                    )
+                )
             every { tormaysService.anyIntersectsCriticalBusRoutes(geometry) } returns false
             every { tormaysService.getIntersectingBusRoutes(geometry) } returns busLines
 
@@ -272,13 +265,10 @@ internal class TormaystarkasteluLaskentaServiceWithGeometryTest {
         }
 
         @ParameterizedTest
-        @CsvSource(
-            "ON,4",
-            "EI,2",
-        )
+        @CsvSource("ON,4", "EI,2")
         fun `returns classification based on trunk lines when there are zero rush hour buses`(
             runkolinja: TormaystarkasteluBussiRunkolinja,
-            expectedResult: Int
+            expectedResult: Int,
         ) {
             val busLines = setOf(TormaystarkasteluBussireitti("", 0, 0, runkolinja))
             every { tormaysService.anyIntersectsCriticalBusRoutes(geometry) } returns false
@@ -303,7 +293,7 @@ internal class TormaystarkasteluLaskentaServiceWithGeometryTest {
             laskentaService.calculateTormaystarkastelu(
                 featureCollection,
                 5,
-                VaikutusAutoliikenteenKaistamaariin.VAHENTAA_KAISTAN_YHDELLA_AJOSUUNNALLA,
+                VaikutusAutoliikenteenKaistamaariin.YKSI_KAISTA_VAHENEE,
                 AutoliikenteenKaistavaikutustenPituus.PITUUS_100_499_METRIA,
             )
 
@@ -313,9 +303,9 @@ internal class TormaystarkasteluLaskentaServiceWithGeometryTest {
         assertThat(tulos.autoliikenne.haitanKesto).isEqualTo(1)
         assertThat(tulos.autoliikenne.katuluokka).isEqualTo(4)
         assertThat(tulos.autoliikenne.liikennemaara).isEqualTo(2)
-        assertThat(tulos.autoliikenne.kaistahaitta).isEqualTo(2)
+        assertThat(tulos.autoliikenne.kaistahaitta).isEqualTo(1)
         assertThat(tulos.autoliikenne.kaistapituushaitta).isEqualTo(4)
-        assertThat(tulos.autoliikenne.indeksi).isEqualTo(2.7f)
+        assertThat(tulos.autoliikenne.indeksi).isEqualTo(2.5f)
         assertThat(tulos.linjaautoliikenneindeksi).isEqualTo(5.0f)
         assertThat(tulos.raitioliikenneindeksi).isEqualTo(3.0f)
         assertThat(tulos.pyoraliikenneindeksi).isEqualTo(3.0f)


### PR DESCRIPTION
# Description

Adjust enum values for kaistahaitta and kaistapituushaitta. Migrate old values into new ones in database. Does not recalculate the whole tormaystarkastelu in database with new values. Calculation happens when hanke or hakemus is updated.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2815

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [x] Other

# Instructions for testing
1. Use branch `HAI-2816/update-car-lane-nuisance-indices` of UI (see https://github.com/City-of-Helsinki/haitaton-ui/pull/963)
2. Check the "Alueet" form page of both hanke and kaivuilmoitus - there should be new values in the dropdowns for kaistahaitta and kaistapituushaitta
3. Saving new values work as well as loading them
4. Törmäystarkastelu calculation works and new 0 values for both types have gray color

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 

# Other relevant info
Please describe here if there is e.g. some requirements for this change or
 other info that the tester/user needs to know.