### PR TITLE
HAI-2759 Fix täydennys data

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceITest.kt
@@ -16,7 +16,6 @@ import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
 import assertk.assertions.isGreaterThan
 import assertk.assertions.isInstanceOf
-import assertk.assertions.isNotEmpty
 import assertk.assertions.isNotNull
 import assertk.assertions.isNull
 import assertk.assertions.isTrue
@@ -312,7 +311,14 @@ class HakemusServiceITest(
             val response = hakemusService.getWithExtras(hakemus.id)
 
             assertThat(response.taydennys).isNotNull().all {
-                prop(TaydennysWithMuutokset::muutokset).isNotEmpty()
+                prop(TaydennysWithMuutokset::hakemusData)
+                    .isInstanceOf(JohtoselvityshakemusData::class)
+                    .all {
+                        prop(JohtoselvityshakemusData::emergencyWork).isTrue()
+                        prop(JohtoselvityshakemusData::postalAddress).hasStreetName("Tie 3")
+                    }
+                prop(TaydennysWithMuutokset::muutokset)
+                    .containsExactlyInAnyOrder("emergencyWork", "postalAddress")
             }
         }
     }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/taydennys/Taydennys.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/taydennys/Taydennys.kt
@@ -13,12 +13,12 @@ data class Taydennys(
 ) : HasId<UUID> {
     fun toResponse() = TaydennysResponse(id, hakemusData.toResponse())
 
-    fun withMuutokset(hakemusData: HakemusData): TaydennysWithMuutokset {
+    fun withMuutokset(otherData: HakemusData): TaydennysWithMuutokset {
         return TaydennysWithMuutokset(
             id = id,
             taydennyspyyntoId = taydennyspyyntoId,
             hakemusData = hakemusData,
-            muutokset = hakemusData.listChanges(this.hakemusData),
+            muutokset = hakemusData.listChanges(otherData),
         )
     }
 }


### PR DESCRIPTION
# Description

When adding the changes from the application to the täydennys, the application data is accidentally copied over the täydennys data. Fix this by using a different name for the application data parameter.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2759

## Type of change

- [X] Bug fix 
- [ ] New feature 
- [ ] Other

# Instructions for testing
Try to edit a täydennys. It will fail without this fix.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 