### PR TITLE
HAI-2761 API for sending täydennys

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/allu/AlluClientITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/allu/AlluClientITests.kt
@@ -277,7 +277,8 @@ class AlluClientITests {
                     .setResponseCode(400)
                     .setHeader(CONTENT_TYPE, APPLICATION_JSON_VALUE)
                     .setBody(
-                        """[{"errorMessage":"Cable report should have one orderer contact","additionalInfo":"customerWithContacts"}]""")
+                        """[{"errorMessage":"Cable report should have one orderer contact","additionalInfo":"customerWithContacts"}]"""
+                    )
             mockWebServer.enqueue(applicationIdResponse)
 
             assertThrows<WebClientResponseException.BadRequest> {
@@ -389,15 +390,10 @@ class AlluClientITests {
         @Test
         fun `calls the right address when the hakemus is a johtoselvityshakemus`() {
             val applicationData = AlluFactory.createCableReportApplicationData()
-            val fields = listOf(InformationRequestFieldKey.AREA, InformationRequestFieldKey.OTHER)
+            val fields = setOf(InformationRequestFieldKey.AREA, InformationRequestFieldKey.OTHER)
             mockWebServer.enqueue(MockResponse().setResponseCode(200))
 
-            service.respondToInformationRequest(
-                alluid,
-                requestId,
-                applicationData,
-                fields,
-            )
+            service.respondToInformationRequest(alluid, requestId, applicationData, fields)
 
             val request = mockWebServer.takeRequest()
             assertThat(request.method).isEqualTo("POST")
@@ -413,21 +409,17 @@ class AlluClientITests {
         fun `calls the right address when the hakemus is a kaivuilmoitus`() {
             val applicationData = AlluFactory.createExcavationNotificationData()
             val fields =
-                listOf(InformationRequestFieldKey.START_TIME, InformationRequestFieldKey.END_TIME)
+                setOf(InformationRequestFieldKey.START_TIME, InformationRequestFieldKey.END_TIME)
             mockWebServer.enqueue(MockResponse().setResponseCode(200))
 
-            service.respondToInformationRequest(
-                alluid,
-                requestId,
-                applicationData,
-                fields,
-            )
+            service.respondToInformationRequest(alluid, requestId, applicationData, fields)
 
             val request = mockWebServer.takeRequest()
             assertThat(request.method).isEqualTo("POST")
             assertThat(request.path)
                 .isEqualTo(
-                    "/v2/excavationannouncements/$alluid/informationrequests/$requestId/response")
+                    "/v2/excavationannouncements/$alluid/informationrequests/$requestId/response"
+                )
             val expectedBody = InformationRequestResponse(applicationData, fields).toJsonString()
             val actualBody = request.body.readUtf8()
             JSONAssert.assertEquals(expectedBody, actualBody, JSONCompareMode.NON_EXTENSIBLE)
@@ -443,7 +435,8 @@ class AlluClientITests {
                 MockResponse()
                     .setResponseCode(200)
                     .setHeader(CONTENT_TYPE, APPLICATION_PDF_VALUE)
-                    .setBody(pdfContent()))
+                    .setBody(pdfContent())
+            )
 
             val response = service.getDecisionPdf(12)
 
@@ -462,7 +455,8 @@ class AlluClientITests {
                 MockResponse()
                     .setResponseCode(200)
                     .setHeader(CONTENT_TYPE, APPLICATION_PDF_VALUE)
-                    .setBody(content))
+                    .setBody(content)
+            )
 
             val response = service.getDecisionPdf(12)
 
@@ -475,7 +469,8 @@ class AlluClientITests {
                 MockResponse()
                     .setResponseCode(404)
                     .setHeader(CONTENT_TYPE, APPLICATION_JSON_VALUE)
-                    .setBody("Not found"))
+                    .setBody("Not found")
+            )
 
             val exception =
                 assertThrows<HakemusDecisionNotFoundException> { service.getDecisionPdf(12) }
@@ -489,7 +484,8 @@ class AlluClientITests {
                 MockResponse()
                     .setResponseCode(500)
                     .setHeader(CONTENT_TYPE, APPLICATION_JSON_VALUE)
-                    .setBody("Other error"))
+                    .setBody("Other error")
+            )
 
             assertThrows<WebClientResponseException> { service.getDecisionPdf(12) }
         }
@@ -500,7 +496,8 @@ class AlluClientITests {
                 MockResponse()
                     .setResponseCode(200)
                     .setHeader(CONTENT_TYPE, IMAGE_PNG)
-                    .setBody(pdfContent()))
+                    .setBody(pdfContent())
+            )
 
             assertThrows<AlluApiException> { service.getDecisionPdf(12) }
         }
@@ -511,7 +508,8 @@ class AlluClientITests {
                 MockResponse()
                     .setResponseCode(200)
                     .setHeader(CONTENT_TYPE, APPLICATION_PDF)
-                    .setBody(""))
+                    .setBody("")
+            )
 
             assertThrows<AlluApiException> { service.getDecisionPdf(12) }
         }
@@ -525,7 +523,8 @@ class AlluClientITests {
                 MockResponse()
                     .setResponseCode(200)
                     .setHeader(CONTENT_TYPE, APPLICATION_PDF_VALUE)
-                    .setBody(pdfContent()))
+                    .setBody(pdfContent())
+            )
 
             val response = service.getOperationalConditionPdf(12)
 
@@ -545,7 +544,8 @@ class AlluClientITests {
                 MockResponse()
                     .setResponseCode(200)
                     .setHeader(CONTENT_TYPE, APPLICATION_PDF_VALUE)
-                    .setBody(content))
+                    .setBody(content)
+            )
 
             val response = service.getOperationalConditionPdf(12)
 
@@ -558,7 +558,8 @@ class AlluClientITests {
                 MockResponse()
                     .setResponseCode(404)
                     .setHeader(CONTENT_TYPE, APPLICATION_JSON_VALUE)
-                    .setBody("Not found"))
+                    .setBody("Not found")
+            )
 
             val exception =
                 assertThrows<HakemusDecisionNotFoundException> {
@@ -574,7 +575,8 @@ class AlluClientITests {
                 MockResponse()
                     .setResponseCode(500)
                     .setHeader(CONTENT_TYPE, APPLICATION_JSON_VALUE)
-                    .setBody("Other error"))
+                    .setBody("Other error")
+            )
 
             assertThrows<WebClientResponseException> { service.getOperationalConditionPdf(12) }
         }
@@ -585,7 +587,8 @@ class AlluClientITests {
                 MockResponse()
                     .setResponseCode(200)
                     .setHeader(CONTENT_TYPE, IMAGE_PNG)
-                    .setBody(pdfContent()))
+                    .setBody(pdfContent())
+            )
 
             assertThrows<AlluApiException> { service.getOperationalConditionPdf(12) }
         }
@@ -596,7 +599,8 @@ class AlluClientITests {
                 MockResponse()
                     .setResponseCode(200)
                     .setHeader(CONTENT_TYPE, APPLICATION_PDF)
-                    .setBody(""))
+                    .setBody("")
+            )
 
             assertThrows<AlluApiException> { service.getOperationalConditionPdf(12) }
         }
@@ -611,7 +615,8 @@ class AlluClientITests {
                 MockResponse()
                     .setResponseCode(200)
                     .setHeader(CONTENT_TYPE, APPLICATION_PDF_VALUE)
-                    .setBody(pdfContent()))
+                    .setBody(pdfContent())
+            )
 
             val response = service.getWorkFinishedPdf(12)
 
@@ -631,7 +636,8 @@ class AlluClientITests {
                 MockResponse()
                     .setResponseCode(200)
                     .setHeader(CONTENT_TYPE, APPLICATION_PDF_VALUE)
-                    .setBody(content))
+                    .setBody(content)
+            )
 
             val response = service.getOperationalConditionPdf(12)
 
@@ -644,7 +650,8 @@ class AlluClientITests {
                 MockResponse()
                     .setResponseCode(404)
                     .setHeader(CONTENT_TYPE, APPLICATION_JSON_VALUE)
-                    .setBody("Not found"))
+                    .setBody("Not found")
+            )
 
             val exception =
                 assertThrows<HakemusDecisionNotFoundException> { service.getWorkFinishedPdf(12) }
@@ -658,7 +665,8 @@ class AlluClientITests {
                 MockResponse()
                     .setResponseCode(500)
                     .setHeader(CONTENT_TYPE, APPLICATION_JSON_VALUE)
-                    .setBody("Other error"))
+                    .setBody("Other error")
+            )
 
             assertThrows<WebClientResponseException> { service.getWorkFinishedPdf(12) }
         }
@@ -669,7 +677,8 @@ class AlluClientITests {
                 MockResponse()
                     .setResponseCode(200)
                     .setHeader(CONTENT_TYPE, IMAGE_PNG)
-                    .setBody(pdfContent()))
+                    .setBody(pdfContent())
+            )
 
             assertThrows<AlluApiException> { service.getWorkFinishedPdf(12) }
         }
@@ -680,7 +689,8 @@ class AlluClientITests {
                 MockResponse()
                     .setResponseCode(200)
                     .setHeader(CONTENT_TYPE, APPLICATION_PDF)
-                    .setBody(""))
+                    .setBody("")
+            )
 
             assertThrows<AlluApiException> { service.getWorkFinishedPdf(12) }
         }
@@ -697,7 +707,8 @@ class AlluClientITests {
                 MockResponse()
                     .setResponseCode(200)
                     .setHeader(CONTENT_TYPE, APPLICATION_JSON_VALUE)
-                    .setBody(histories.toJsonString()))
+                    .setBody(histories.toJsonString())
+            )
 
             val response = service.getApplicationStatusHistories(alluids, eventsAfter)
 
@@ -716,7 +727,8 @@ class AlluClientITests {
                 MockResponse()
                     .setResponseCode(200)
                     .setHeader(CONTENT_TYPE, APPLICATION_JSON_VALUE)
-                    .setBody("[]"))
+                    .setBody("[]")
+            )
 
             val response = service.getApplicationStatusHistories(alluids, eventsAfter)
 
@@ -731,7 +743,8 @@ class AlluClientITests {
                 MockResponse()
                     .setResponseCode(404)
                     .setHeader(CONTENT_TYPE, APPLICATION_JSON_VALUE)
-                    .setBody("Error message"))
+                    .setBody("Error message")
+            )
 
             assertFailure { service.getApplicationStatusHistories(alluids, eventsAfter) }
                 .hasClass(WebClientResponseException.NotFound::class)

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusHistoryServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusHistoryServiceITest.kt
@@ -122,11 +122,14 @@ class HakemusHistoryServiceITest(
                 ApplicationHistoryFactory.create(
                     alluId,
                     ApplicationHistoryFactory.createEvent(
-                        firstEventTime.plusDays(5), ApplicationStatus.PENDING),
+                        firstEventTime.plusDays(5),
+                        ApplicationStatus.PENDING,
+                    ),
                     ApplicationHistoryFactory.createEvent(
-                        firstEventTime.plusDays(10), ApplicationStatus.HANDLING),
-                    ApplicationHistoryFactory.createEvent(
-                        firstEventTime, ApplicationStatus.PENDING),
+                        firstEventTime.plusDays(10),
+                        ApplicationStatus.HANDLING,
+                    ),
+                    ApplicationHistoryFactory.createEvent(firstEventTime, ApplicationStatus.PENDING),
                 )
 
             historyService.handleHakemusUpdates(listOf(history), updateTime)
@@ -191,7 +194,9 @@ class HakemusHistoryServiceITest(
             assertThat(applications.map { it.alluid }).containsExactlyInAnyOrder(alluId, alluId + 2)
             assertThat(applications.map { it.alluStatus })
                 .containsExactlyInAnyOrder(
-                    ApplicationStatus.PENDING_CLIENT, ApplicationStatus.PENDING_CLIENT)
+                    ApplicationStatus.PENDING_CLIENT,
+                    ApplicationStatus.PENDING_CLIENT,
+                )
             assertThat(applications.map { it.applicationIdentifier })
                 .containsExactlyInAnyOrder("JS2300082", "JS2300084")
         }
@@ -211,7 +216,9 @@ class HakemusHistoryServiceITest(
                         alluId,
                         ApplicationHistoryFactory.createEvent(
                             applicationIdentifier = identifier,
-                            newStatus = ApplicationStatus.DECISION)),
+                            newStatus = ApplicationStatus.DECISION,
+                        ),
+                    )
                 )
 
             historyService.handleHakemusUpdates(histories, updateTime)
@@ -221,12 +228,15 @@ class HakemusHistoryServiceITest(
             assertThat(email.allRecipients[0].toString()).isEqualTo(hakija.sahkoposti)
             assertThat(email.subject)
                 .isEqualTo(
-                    "Haitaton: Johtoselvitys $identifier / Ledningsutredning $identifier / Cable report $identifier")
+                    "Haitaton: Johtoselvitys $identifier / Ledningsutredning $identifier / Cable report $identifier"
+                )
         }
 
         @ParameterizedTest
         @EnumSource(
-            ApplicationStatus::class, names = ["DECISION", "OPERATIONAL_CONDITION", "FINISHED"])
+            ApplicationStatus::class,
+            names = ["DECISION", "OPERATIONAL_CONDITION", "FINISHED"],
+        )
         fun `sends email to the contacts when a kaivuilmoitus gets a decision`(
             applicationStatus: ApplicationStatus
         ) {
@@ -246,7 +256,7 @@ class HakemusHistoryServiceITest(
                             applicationIdentifier = identifier,
                             newStatus = applicationStatus,
                         ),
-                    ),
+                    )
                 )
             mockAlluDownload(applicationStatus)
             every { alluClient.getApplicationInformation(alluId) } returns
@@ -259,14 +269,17 @@ class HakemusHistoryServiceITest(
             assertThat(email.allRecipients[0].toString()).isEqualTo(hakija.sahkoposti)
             assertThat(email.subject)
                 .isEqualTo(
-                    "Haitaton: Kaivuilmoitukseen KP2300001 liittyvä päätös on ladattavissa / Kaivuilmoitukseen KP2300001 liittyvä päätös on ladattavissa / Kaivuilmoitukseen KP2300001 liittyvä päätös on ladattavissa")
+                    "Haitaton: Kaivuilmoitukseen KP2300001 liittyvä päätös on ladattavissa / Kaivuilmoitukseen KP2300001 liittyvä päätös on ladattavissa / Kaivuilmoitukseen KP2300001 liittyvä päätös on ladattavissa"
+                )
             verifyAlluDownload(applicationStatus)
             verify { alluClient.getApplicationInformation(alluId) }
         }
 
         @ParameterizedTest
         @EnumSource(
-            ApplicationStatus::class, names = ["DECISION", "OPERATIONAL_CONDITION", "FINISHED"])
+            ApplicationStatus::class,
+            names = ["DECISION", "OPERATIONAL_CONDITION", "FINISHED"],
+        )
         fun `downloads the document when a kaivuilmoitus gets a decision`(
             status: ApplicationStatus
         ) {
@@ -282,7 +295,8 @@ class HakemusHistoryServiceITest(
                         ApplicationHistoryFactory.createEvent(
                             applicationIdentifier = identifier,
                             newStatus = status,
-                        )),
+                        ),
+                    )
                 )
             mockAlluDownload(status)
             every { alluClient.getApplicationInformation(alluId) } returns
@@ -352,7 +366,8 @@ class HakemusHistoryServiceITest(
             assertThat(emails).each {
                 it.prop(MimeMessage::getSubject)
                     .isEqualTo(
-                        "Haitaton: Hakemuksellesi on tullut täydennyspyyntö / Hakemuksellesi on tullut täydennyspyyntö / Hakemuksellesi on tullut täydennyspyyntö")
+                        "Haitaton: Hakemuksellesi on tullut täydennyspyyntö / Hakemuksellesi on tullut täydennyspyyntö / Hakemuksellesi on tullut täydennyspyyntö"
+                    )
             }
             verifySequence { alluClient.getInformationRequest(alluId) }
         }
@@ -383,7 +398,8 @@ class HakemusHistoryServiceITest(
                 prop(TaydennyspyyntoEntity::kentat)
                     .containsOnly(
                         InformationRequestFieldKey.OTHER to
-                            AlluFactory.DEFAULT_INFORMATION_REQUEST_DESCRIPTION)
+                            AlluFactory.DEFAULT_INFORMATION_REQUEST_DESCRIPTION
+                    )
             }
             verifySequence { alluClient.getInformationRequest(alluId) }
         }
@@ -464,7 +480,9 @@ class HakemusHistoryServiceITest(
             assertThat(output).contains("ERROR")
             assertThat(output)
                 .contains(
-                    "A hakemus moved to handling and it had a täydennyspyyntö, but the previous state was not 'HANDLING'. status=DECISION")
+                    "A hakemus moved to handling and it had a täydennyspyyntö, " +
+                        "but the previous state was not 'WAITING_INFORMATION'. status=DECISION"
+                )
         }
 
         private fun mockAlluDownload(status: ApplicationStatus) =

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/taydennys/UpdateTaydennysITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/taydennys/UpdateTaydennysITest.kt
@@ -135,7 +135,7 @@ class UpdateTaydennysITest(
 
         exception.all {
             hasClass(TaydennysNotFoundException::class)
-            messageContains("Id=21404863-edc8-4c28-8d14-35ffc06c04eb")
+            messageContains("id=21404863-edc8-4c28-8d14-35ffc06c04eb")
         }
     }
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeError.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeError.kt
@@ -57,7 +57,8 @@ enum class HankeError(val errorMessage: String) {
     HAI4006("Duplicate hankekayttaja"),
     HAI4007("Verified name not found in Profiili"),
     HAI5001("Decision not found"),
-    HAI6001("Taydennys not found");
+    HAI6001("Taydennys not found"),
+    HAI6002("Taydennys has no changes");
 
     val errorCode: String
         get() = name

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/AlluApplicationData.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/AlluApplicationData.kt
@@ -61,7 +61,7 @@ data class AlluCableReportApplicationData(
 
 data class InformationRequestResponse(
     val applicationData: AlluApplicationData,
-    val updatedFields: List<InformationRequestFieldKey>
+    val updatedFields: Set<InformationRequestFieldKey>,
 )
 
 data class AlluExcavationNotificationData(

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/InformationRequest.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/InformationRequest.kt
@@ -1,12 +1,15 @@
 package fi.hel.haitaton.hanke.allu
 
 data class InformationRequest(
-        val applicationId: Int,
-        val informationRequestId: Int,
-        val fields: List<InformationRequestField>
+    val applicationId: Int,
+    val informationRequestId: Int,
+    val fields: List<InformationRequestField>,
 )
 
-data class InformationRequestField(val requestDescription: String, val fieldKey: InformationRequestFieldKey)
+data class InformationRequestField(
+    val requestDescription: String,
+    val fieldKey: InformationRequestFieldKey,
+)
 
 enum class InformationRequestFieldKey {
     CUSTOMER,
@@ -25,5 +28,29 @@ enum class InformationRequestFieldKey {
     PROPERTY_IDENTIFICATION_NUMBER,
     ATTACHMENT,
     AREA,
-    OTHER
+    OTHER;
+
+    companion object {
+        fun fromHaitatonFieldName(name: String): InformationRequestFieldKey? =
+            when (name) {
+                "name" -> null
+                "postalAddress" -> POSTAL_ADDRESS
+                "constructionWork" -> OTHER
+                "maintenanceWork" -> OTHER
+                "propertyConnectivity" -> OTHER
+                "emergencyWork" -> OTHER
+                "rockExcavation" -> OTHER
+                "workDescription" -> OTHER
+                "startTime" -> START_TIME
+                "endTime" -> END_TIME
+                "customerWithContacts" -> CUSTOMER
+                "contractorWithContacts" -> CONTRACTOR
+                "propertyDeveloperWithContacts" -> PROPERTY_DEVELOPER
+                "representativeWithContacts" -> REPRESENTATIVE
+                "invoicingCustomer" -> INVOICING_CUSTOMER
+                else -> {
+                    if (name.startsWith("areas")) GEOMETRY else null
+                }
+            }
+    }
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/Hakemus.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/Hakemus.kt
@@ -254,7 +254,7 @@ data class KaivuilmoitusData(
         )
 
     override fun listChanges(other: HakemusData): List<String> {
-        val changes = mutableListOf<String>()
+        val changes = super.listChanges(other).toMutableList()
 
         other as KaivuilmoitusData
         checkChange(KaivuilmoitusData::workDescription, other)?.let { changes.add(it) }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/AuditLogEntry.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/AuditLogEntry.kt
@@ -34,12 +34,12 @@ enum class Operation(val isChange: Boolean) {
      * itself (for now), so add a row with this operation when manually setting that restriction
      * flag.
      */
-    UNLOCK(false)
+    UNLOCK(false),
 }
 
 enum class Status {
     SUCCESS,
-    FAILED
+    FAILED,
 }
 
 enum class ObjectType {
@@ -91,5 +91,7 @@ data class AuditLogEntry(
                         failureDescription = failureDescription,
                         actor = AuditLogActor(userId, userRole, ipAddress),
                         target = AuditLogTarget(objectId, objectType, objectBefore, objectAfter),
-                    )))
+                    )
+                )
+        )
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/AuditLogEntry.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/AuditLogEntry.kt
@@ -59,6 +59,7 @@ enum class ObjectType {
     TAYDENNYS,
     TAYDENNYS_CONTACT,
     TAYDENNYS_CUSTOMER,
+    TAYDENNYSPYYNTO,
     YHTEYSTIETO,
 }
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/TaydennyspyyntoLoggingService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/TaydennyspyyntoLoggingService.kt
@@ -1,0 +1,11 @@
+package fi.hel.haitaton.hanke.logging
+
+import fi.hel.haitaton.hanke.taydennys.Taydennyspyynto
+import java.util.UUID
+import org.springframework.stereotype.Service
+
+@Service
+class TaydennyspyyntoLoggingService(auditLogService: AuditLogService) :
+    ChangeLoggingService<UUID, Taydennyspyynto>(auditLogService) {
+    override val objectType: ObjectType = ObjectType.TAYDENNYSPYYNTO
+}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennysAuthorizer.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennysAuthorizer.kt
@@ -18,8 +18,12 @@ class TaydennysAuthorizer(
 ) : Authorizer(permissionService, hankeRepository) {
 
     @Transactional(readOnly = true)
-    fun authorize(id: UUID, permissionCode: String): Boolean =
-        taydennysRepository.findByIdOrNull(id)?.taydennyspyynto?.applicationId?.let {
+    fun authorize(id: UUID, permissionCode: String): Boolean {
+        val taydennys =
+            taydennysRepository.findByIdOrNull(id) ?: throw TaydennysNotFoundException(id)
+
+        return taydennys.taydennyspyynto.applicationId.let {
             hakemusAuthorizer.authorizeHakemusId(it, permissionCode)
-        } ?: false
+        }
+    }
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennysController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennysController.kt
@@ -163,4 +163,12 @@ class TaydennysController(private val taydennysService: TaydennysService) {
         logger.warn(ex) { ex.message }
         return HankeError.HAI2002
     }
+
+    @ExceptionHandler(NoChangesException::class)
+    @ResponseStatus(HttpStatus.CONFLICT)
+    @Hidden
+    fun noChangesException(ex: NoChangesException): HankeError {
+        logger.warn(ex) { ex.message }
+        return HankeError.HAI6002
+    }
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennysController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennysController.kt
@@ -3,6 +3,7 @@ package fi.hel.haitaton.hanke.taydennys
 import fi.hel.haitaton.hanke.HankeError
 import fi.hel.haitaton.hanke.HankeErrorDetail
 import fi.hel.haitaton.hanke.currentUserId
+import fi.hel.haitaton.hanke.hakemus.HakemusResponse
 import fi.hel.haitaton.hanke.hakemus.HakemusUpdateRequest
 import fi.hel.haitaton.hanke.hakemus.InvalidHakemusDataException
 import fi.hel.haitaton.hanke.hakemus.ValidHakemusUpdateRequest
@@ -57,7 +58,8 @@ class TaydennysController(private val taydennysService: TaydennysService) {
                     responseCode = "409",
                     content = [Content(schema = Schema(implementation = HankeError::class))],
                 ),
-            ])
+            ]
+    )
     @PreAuthorize("@hakemusAuthorizer.authorizeHakemusId(#id, 'EDIT_APPLICATIONS')")
     fun create(@PathVariable id: Long): TaydennysResponse =
         taydennysService.create(id, currentUserId()).toResponse()
@@ -97,20 +99,38 @@ class TaydennysController(private val taydennysService: TaydennysService) {
                                             value = "{hankeError: 'HAI2002'}",
                                         ),
                                     ],
-                            )],
+                            )
+                        ],
                 ),
                 ApiResponse(
                     description = "A täydennys was not found with the given id",
                     responseCode = "404",
                     content = [Content(schema = Schema(implementation = HankeError::class))],
                 ),
-            ])
+            ]
+    )
     @PreAuthorize("@taydennysAuthorizer.authorize(#id, 'EDIT_APPLICATIONS')")
     fun update(
         @PathVariable id: UUID,
         @ValidHakemusUpdateRequest @RequestBody request: HakemusUpdateRequest,
     ): TaydennysResponse =
         taydennysService.updateTaydennys(id, request, currentUserId()).toResponse()
+
+    @PostMapping("/taydennykset/{id}/laheta")
+    @Operation(
+        summary = "Send the täydennys, respond to the täydennyspyyntö",
+        description =
+            """
+               Sends the täydennys as a response to the information request it's based on.
+
+               Merges the updated information to the hakemus. The täydennys and täydennyspyyntö will be removed.
+
+               Returns the updated hakemus.                              
+            """,
+    )
+    @PreAuthorize("@taydennysAuthorizer.authorize(#id, 'EDIT_APPLICATIONS')")
+    fun send(@PathVariable id: UUID): HakemusResponse =
+        taydennysService.sendTaydennys(id, currentUserId()).toResponse()
 
     @ExceptionHandler(InvalidHakemusDataException::class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/taydennys/Taydennyspyynto.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/taydennys/Taydennyspyynto.kt
@@ -1,9 +1,13 @@
 package fi.hel.haitaton.hanke.taydennys
 
 import fi.hel.haitaton.hanke.allu.InformationRequestFieldKey
+import fi.hel.haitaton.hanke.domain.HasId
 import java.util.UUID
 
-data class Taydennyspyynto(val id: UUID, val kentat: Map<InformationRequestFieldKey, String>) {
+data class Taydennyspyynto(
+    override val id: UUID,
+    val kentat: Map<InformationRequestFieldKey, String>,
+) : HasId<UUID> {
     fun toResponse(): TaydennyspyyntoResponse =
         TaydennyspyyntoResponse(
             id = id,

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusyhteystietoFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusyhteystietoFactory.kt
@@ -20,9 +20,9 @@ object HakemusyhteystietoFactory {
     private const val DEFAULT_YTUNNUS = "1817548-2"
     private const val DEFAULT_OVT = "003718175482"
 
-    private const val DEFAULT_PERSON_NIMI = "Pertti Perushenkilö"
-    private const val DEFAULT_PERSON_SAHKOPOSTI = "pertti@perus.fi"
-    private const val DEFAULT_PERSON_PUHELINNUMERO = "554466546"
+    const val DEFAULT_PERSON_NIMI = "Pertti Perushenkilö"
+    const val DEFAULT_PERSON_SAHKOPOSTI = "pertti@perus.fi"
+    const val DEFAULT_PERSON_PUHELINNUMERO = "554466546"
 
     fun createEntity(
         tyyppi: CustomerType = CustomerType.COMPANY,
@@ -51,7 +51,7 @@ object HakemusyhteystietoFactory {
         sahkoposti: String = DEFAULT_SAHKOPOSTI,
         puhelinnumero: String = DEFAULT_PUHELINNUMERO,
         registryKey: String? = DEFAULT_YTUNNUS,
-        yhteyshenkilot: List<Hakemusyhteyshenkilo> = listOf()
+        yhteyshenkilot: List<Hakemusyhteyshenkilo> = listOf(),
     ) =
         Hakemusyhteystieto(
             id = id,
@@ -72,7 +72,7 @@ object HakemusyhteystietoFactory {
         sahkoposti: String = DEFAULT_PERSON_SAHKOPOSTI,
         puhelinnumero: String = DEFAULT_PERSON_PUHELINNUMERO,
         registryKey: String? = null,
-        yhteyshenkilot: List<Hakemusyhteyshenkilo> = listOf()
+        yhteyshenkilot: List<Hakemusyhteyshenkilo> = listOf(),
     ) =
         Hakemusyhteystieto(
             id,

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusDataTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusDataTest.kt
@@ -224,6 +224,8 @@ class HakemusDataTest {
 
         private fun johtoselvitysCases(): List<Arguments> =
             listOf(
+                // One shared field to test that the super method gets called.
+                Arguments.of(base.copy(startTime = base.startTime!!.minusDays(1)), "startTime"),
                 Arguments.of(
                     base.copy(postalAddress = ApplicationFactory.createPostalAddress()),
                     "postalAddress",
@@ -262,6 +264,8 @@ class HakemusDataTest {
         private fun kaivuilmoitusCases(): List<Arguments> {
             val base = HakemusFactory.createKaivuilmoitusData()
             return listOf(
+                // One shared field to test that the super method gets called.
+                Arguments.of(base.copy(startTime = base.startTime!!.minusDays(1)), "startTime"),
                 Arguments.of(base.copy(workDescription = "New description."), "workDescription"),
                 Arguments.of(base.copy(constructionWork = true), "constructionWork"),
                 Arguments.of(base.copy(maintenanceWork = true), "maintenanceWork"),

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/test/Asserts.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/test/Asserts.kt
@@ -5,12 +5,17 @@ import assertk.all
 import assertk.assertions.contains
 import assertk.assertions.containsExactlyInAnyOrder
 import assertk.assertions.extracting
+import assertk.assertions.hasClass
 import assertk.assertions.isBetween
 import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
+import assertk.assertions.isInstanceOf
 import assertk.assertions.isNotNull
 import assertk.assertions.isTrue
 import assertk.assertions.prop
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.node.NullNode
+import com.fasterxml.jackson.databind.node.TextNode
 import fi.hel.haitaton.hanke.hakemus.PostalAddress
 import fi.hel.haitaton.hanke.hakemus.StreetAddress
 import fi.hel.haitaton.hanke.validation.ValidationResult
@@ -70,4 +75,12 @@ object Asserts {
     }
 
     fun Assert<ValidationResult>.isSuccess() = this.prop(ValidationResult::isOk).isTrue()
+
+    fun Assert<JsonNode>.hasNullNode(path: String) = hasPath(path).hasClass(NullNode::class)
+
+    fun Assert<JsonNode>.hasTextNode(path: String) =
+        hasPath(path).isInstanceOf(TextNode::class).transform { node: JsonNode -> node.textValue() }
+
+    private fun Assert<JsonNode>.hasPath(path: String) =
+        transform { node: JsonNode -> node.get(path) }.isNotNull()
 }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/test/AuditLogEntryEntityAsserts.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/test/AuditLogEntryEntityAsserts.kt
@@ -7,6 +7,8 @@ import assertk.assertions.isFalse
 import assertk.assertions.isNotNull
 import assertk.assertions.isNull
 import assertk.assertions.prop
+import com.fasterxml.jackson.databind.node.ObjectNode
+import fi.hel.haitaton.hanke.OBJECT_MAPPER
 import fi.hel.haitaton.hanke.logging.AuditLogActor
 import fi.hel.haitaton.hanke.logging.AuditLogEntryEntity
 import fi.hel.haitaton.hanke.logging.AuditLogEvent
@@ -65,6 +67,12 @@ object AuditLogEntryEntityAsserts {
             .isNotNull()
             .transform { it.parseJson<T>() }
             .all { body(this) }
+
+    fun Assert<AuditLogTarget>.hasObjectBeforeJson(body: Assert<ObjectNode>.() -> Unit) =
+        prop(AuditLogTarget::objectBefore)
+            .isNotNull()
+            .transform { OBJECT_MAPPER.readTree(it) as ObjectNode }
+            .all(body)
 
     inline fun <reified T> Assert<AuditLogTarget>.hasObjectAfter(after: T) =
         hasObjectAfter<T> { isEqualTo(after) }


### PR DESCRIPTION
# Description

Add an API endpoint for sending the täydennys to Allu. The täydennys is validated like a hakemus before it's sent to make sure it has all mandatory fields. It also needs at least one change compared to the hakemus and the status of the hakemus needs to be WAITING_INFORMATION.

The täydennys and täydennyspyyntö will be removed after sending.

The data will be merged with the hakemus in the next PR.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2761

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
1. Create a hakemus with a täydennys.
2. Use the Swagger UI (http://localhost:3001/api/swagger-ui/index.html#/taydennys-controller/send) to send it.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 