### PR TITLE
HAI-2871 Correctly updates applications.applicationData.areas

### DIFF
--- a/services/hanke-service/src/main/resources/db/changelog/changesets/086-change-car-lane-nuisance-enum.sql
+++ b/services/hanke-service/src/main/resources/db/changelog/changesets/086-change-car-lane-nuisance-enum.sql
@@ -14,41 +14,40 @@ UPDATE hankealue
         END;
 
 -- update applications.applicationData.areas
-WITH areas_array AS (
+WITH updated_areas AS (
     SELECT id,
         CASE
             WHEN (applicationData #>> '{areas}') IS NOT NULL AND jsonb_typeof(applicationData->'areas') = 'array' THEN
                 jsonb_set(
                     applicationData,
                     '{areas}',
-                    (
-                        SELECT jsonb_agg(
-                            jsonb_set(
-                                area,
-                                '{kaistahaitta}',
-                                (
+                    jsonb_agg(
+                        CASE
+                            WHEN (area #>> '{kaistahaitta}') IS NOT NULL THEN
+                                jsonb_set(
+                                    area,
+                                    '{kaistahaitta}',
                                     CASE area->>'kaistahaitta'
-                                        WHEN 'VAHENTAA_KAISTAN_YHDELLA_AJOSUUNNALLA' THEN
-                                            '"YKSI_KAISTA_VAHENEE"'::jsonb
-                                        WHEN 'VAHENTAA_SAMANAIKAISESTI_KAISTAN_KAHDELLA_AJOSUUNNALLA' THEN
-                                            '"YKSI_KAISTA_VAHENEE_KAHDELLA_AJOSUUNNALLA"'::jsonb
-                                        WHEN 'VAHENTAA_SAMANAIKAISESTI_USEITA_KAISTOJA_KAHDELLA_AJOSUUNNALLA' THEN
-                                            '"USEITA_KAISTOJA_VAHENEE_AJOSUUNNILLA"'::jsonb
-                                        WHEN 'VAHENTAA_SAMANAIKAISESTI_USEITA_KAISTOJA_LIITTYMIEN_ERI_SUUNNILLA' THEN
-                                            '"USEITA_AJOSUUNTIA_POISTUU_KAYTOSTA"'::jsonb
+                                        WHEN 'VAHENTAA_KAISTAN_YHDELLA_AJOSUUNNALLA' THEN '"YKSI_KAISTA_VAHENEE"'::jsonb
+                                        WHEN 'VAHENTAA_SAMANAIKAISESTI_KAISTAN_KAHDELLA_AJOSUUNNALLA' THEN '"YKSI_KAISTA_VAHENEE_KAHDELLA_AJOSUUNNALLA"'::jsonb
+                                        WHEN 'VAHENTAA_SAMANAIKAISESTI_USEITA_KAISTOJA_KAHDELLA_AJOSUUNNALLA' THEN '"USEITA_KAISTOJA_VAHENEE_AJOSUUNNILLA"'::jsonb
+                                        WHEN 'VAHENTAA_SAMANAIKAISESTI_USEITA_KAISTOJA_LIITTYMIEN_ERI_SUUNNILLA' THEN '"USEITA_AJOSUUNTIA_POISTUU_KAYTOSTA"'::jsonb
                                         ELSE area->'kaistahaitta'
                                     END
                                 )
-                            )
-                        )
-                        FROM jsonb_array_elements(applicationData->'areas') area
+                            ELSE area
+                        END
                     )
                 )
             ELSE applicationData
-        END as updated_data
-    FROM applications
+        END AS updated_data
+    FROM applications,
+         jsonb_array_elements(applicationData->'areas') AS area
+    WHERE applicationData IS NOT NULL
+    GROUP BY id, applicationData
 )
+
 UPDATE applications
-SET applicationData = areas_array.updated_data
-FROM areas_array
-WHERE applications.id = areas_array.id;
+SET applicationData = updated_areas.updated_data
+    FROM updated_areas
+WHERE applications.id = updated_areas.id;

--- a/services/hanke-service/src/main/resources/db/changelog/changesets/086-change-car-lane-nuisance-enum.sql
+++ b/services/hanke-service/src/main/resources/db/changelog/changesets/086-change-car-lane-nuisance-enum.sql
@@ -14,40 +14,31 @@ UPDATE hankealue
         END;
 
 -- update applications.applicationData.areas
-WITH updated_areas AS (
-    SELECT id,
-        CASE
-            WHEN (applicationData #>> '{areas}') IS NOT NULL AND jsonb_typeof(applicationData->'areas') = 'array' THEN
-                jsonb_set(
-                    applicationData,
-                    '{areas}',
-                    jsonb_agg(
-                        CASE
-                            WHEN (area #>> '{kaistahaitta}') IS NOT NULL THEN
-                                jsonb_set(
-                                    area,
-                                    '{kaistahaitta}',
-                                    CASE area->>'kaistahaitta'
-                                        WHEN 'VAHENTAA_KAISTAN_YHDELLA_AJOSUUNNALLA' THEN '"YKSI_KAISTA_VAHENEE"'::jsonb
-                                        WHEN 'VAHENTAA_SAMANAIKAISESTI_KAISTAN_KAHDELLA_AJOSUUNNALLA' THEN '"YKSI_KAISTA_VAHENEE_KAHDELLA_AJOSUUNNALLA"'::jsonb
-                                        WHEN 'VAHENTAA_SAMANAIKAISESTI_USEITA_KAISTOJA_KAHDELLA_AJOSUUNNALLA' THEN '"USEITA_KAISTOJA_VAHENEE_AJOSUUNNILLA"'::jsonb
-                                        WHEN 'VAHENTAA_SAMANAIKAISESTI_USEITA_KAISTOJA_LIITTYMIEN_ERI_SUUNNILLA' THEN '"USEITA_AJOSUUNTIA_POISTUU_KAYTOSTA"'::jsonb
-                                        ELSE area->'kaistahaitta'
-                                    END
-                                )
-                            ELSE area
+UPDATE applications
+SET applicationData = jsonb_set(
+    applicationData,
+    '{areas}',
+    (
+        SELECT jsonb_agg(
+            CASE
+                WHEN (area #>> '{kaistahaitta}') IS NOT NULL THEN
+                    jsonb_set(
+                        area,
+                        '{kaistahaitta}',
+                        CASE area->>'kaistahaitta'
+                            WHEN 'VAHENTAA_KAISTAN_YHDELLA_AJOSUUNNALLA' THEN '"YKSI_KAISTA_VAHENEE"'::jsonb
+                            WHEN 'VAHENTAA_SAMANAIKAISESTI_KAISTAN_KAHDELLA_AJOSUUNNALLA' THEN '"YKSI_KAISTA_VAHENEE_KAHDELLA_AJOSUUNNALLA"'::jsonb
+                            WHEN 'VAHENTAA_SAMANAIKAISESTI_USEITA_KAISTOJA_KAHDELLA_AJOSUUNNALLA' THEN '"USEITA_KAISTOJA_VAHENEE_AJOSUUNNILLA"'::jsonb
+                            WHEN 'VAHENTAA_SAMANAIKAISESTI_USEITA_KAISTOJA_LIITTYMIEN_ERI_SUUNNILLA' THEN '"USEITA_AJOSUUNTIA_POISTUU_KAYTOSTA"'::jsonb
+                            ELSE area->'kaistahaitta'
                         END
                     )
-                )
-            ELSE applicationData
-        END AS updated_data
-    FROM applications,
-         jsonb_array_elements(applicationData->'areas') AS area
-    WHERE applicationData IS NOT NULL
-    GROUP BY id, applicationData
+                ELSE area
+            END
+        )
+        FROM jsonb_array_elements(applicationData->'areas') AS area
+    )
 )
-
-UPDATE applications
-SET applicationData = updated_areas.updated_data
-    FROM updated_areas
-WHERE applications.id = updated_areas.id;
+WHERE applicationType = 'EXCAVATION_NOTIFICATION'
+  AND (applicationData #>> '{areas}') IS NOT NULL
+  AND jsonb_typeof(applicationData->'areas') = 'array';


### PR DESCRIPTION
# Description

Correctly updates applications.applicationData.areas without accidently deleting applicationData or applicationData.areas or other applicationData fields

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2871

## Type of change

- [x] Bug fix 
- [ ] New feature 
- [ ] Other

# Instructions for testing

In order to verify that the migration works correctly with "production data" (data before the buggy 086 migration script was run) do the following:
1. Checkout version before the buggy migration script: `git checkout 6a06e84d025ad7dc9e6fe5fac46e52134b81a7ed`
2. Manually run `delete from databasechangelog where id='086-change-car-lane-nuisance-enum';` into database
3. Manually revert old values of the enums in database:
```
UPDATE hankealue
SET kaistahaitta =
        CASE
            WHEN kaistahaitta = 'YKSI_KAISTA_VAHENEE' THEN 'VAHENTAA_KAISTAN_YHDELLA_AJOSUUNNALLA'
            WHEN kaistahaitta = 'YKSI_KAISTA_VAHENEE_KAHDELLA_AJOSUUNNALLA' THEN 'VAHENTAA_SAMANAIKAISESTI_KAISTAN_KAHDELLA_AJOSUUNNALLA'
            WHEN kaistahaitta = 'USEITA_KAISTOJA_VAHENEE_AJOSUUNNILLA' THEN 'VAHENTAA_SAMANAIKAISESTI_USEITA_KAISTOJA_KAHDELLA_AJOSUUNNALLA'
            WHEN kaistahaitta = 'USEITA_AJOSUUNTIA_POISTUU_KAYTOSTA' THEN 'VAHENTAA_SAMANAIKAISESTI_USEITA_KAISTOJA_LIITTYMIEN_ERI_SUUNNILLA'
            ELSE kaistahaitta
            END;

UPDATE applications
SET applicationData = jsonb_set(
        applicationData,
        '{areas}',
        (
            SELECT jsonb_agg(
                           CASE
                               WHEN area ? 'kaistahaitta' THEN
                                   jsonb_set(
                                           area,
                                           '{kaistahaitta}',
                                           CASE area->>'kaistahaitta'
                                               WHEN 'YKSI_KAISTA_VAHENEE' THEN '"VAHENTAA_KAISTAN_YHDELLA_AJOSUUNNALLA"'::jsonb
                                               WHEN 'YKSI_KAISTA_VAHENEE_KAHDELLA_AJOSUUNNALLA' THEN '"VAHENTAA_SAMANAIKAISESTI_KAISTAN_KAHDELLA_AJOSUUNNALLA"'::jsonb
                                               WHEN 'USEITA_KAISTOJA_VAHENEE_AJOSUUNNILLA' THEN '"VAHENTAA_SAMANAIKAISESTI_USEITA_KAISTOJA_KAHDELLA_AJOSUUNNALLA"'::jsonb
                                               WHEN 'USEITA_AJOSUUNTIA_POISTUU_KAYTOSTA' THEN '"VAHENTAA_SAMANAIKAISESTI_USEITA_KAISTOJA_LIITTYMIEN_ERI_SUUNNILLA"'::jsonb
                                               ELSE area->'kaistahaitta'
                                               END
                                   )
                               ELSE area
                               END
                   )
            FROM jsonb_array_elements(applicationData->'areas') AS area
        )
                      )
WHERE applicationType = 'EXCAVATION_NOTIFICATION'
  AND applicationData ? 'areas'
  AND jsonb_typeof(applicationData->'areas') = 'array';
```
5. Start the version
6. Checkout version of the UI that has no these enum changes: `git checkout 868cadd4d7744d6b5f82df742218d4d6716f2490`
7. Create a johtoselvityshakemus and a kaivuilmoitus with complete data
8. Restart the application with this version of the backend and latest dev-version of the frontend (or maybe `HAI-2816/fix-translation-keys` that has some bug fixes related to these enum changes)
9. Both applications should work correctly and contain all the data they previously had. The new enum values should be in place.

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 

# Other relevant info
Please describe here if there is e.g. some requirements for this change or
 other info that the tester/user needs to know.