### PR TITLE
HAI-2776 Send form data PDF to Allu

### DIFF
--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/DisclosureLogService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/DisclosureLogService.kt
@@ -200,10 +200,8 @@ class DisclosureLogService(private val auditLogService: AuditLogService) {
             throw e
         } catch (e: Throwable) {
             // There was an exception outside login, so there was at least an attempt to send
-            // the
-            // application to Allu. Allu might have read it and rejected it, so we should log
-            // this
-            // as a disclosure event.
+            // the application to Allu. Allu might have read it and rejected it, so we should log
+            // this as a disclosure event.
             saveForAllu(
                 applicationId,
                 alluApplicationData,


### PR DESCRIPTION
# Description

When sending the täydennys to Allu, create a PDF of the form data. The PDF should be identical to the one generated for a hakemus, except with a different filename and description.

Also, remove the `withDisclosureLogging` implementation from HakemusService. It's identical to the one in DisclosureLogService.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2776

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
Create and send a täydennys to Allu. Check Allu for the PDF attachment.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 