### PR TITLE
HAI-2888 Read verified name form the token for AD users

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/IntegrationTestConfiguration.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/IntegrationTestConfiguration.kt
@@ -24,6 +24,7 @@ import fi.hel.haitaton.hanke.permissions.HankeKayttajaService
 import fi.hel.haitaton.hanke.permissions.HankekayttajaDeleteService
 import fi.hel.haitaton.hanke.permissions.PermissionService
 import fi.hel.haitaton.hanke.profiili.ProfiiliClient
+import fi.hel.haitaton.hanke.profiili.ProfiiliService
 import fi.hel.haitaton.hanke.security.AccessRules
 import fi.hel.haitaton.hanke.taydennys.TaydennysAuthorizer
 import fi.hel.haitaton.hanke.taydennys.TaydennysService
@@ -52,7 +53,6 @@ import org.springframework.security.web.SecurityFilterChain
 @EnableMethodSecurity(prePostEnabled = true)
 @Import(value = [AopAutoConfiguration::class, DisclosureLoggingAspect::class])
 class IntegrationTestConfiguration {
-
     @Bean fun applicationAttachmentMetadataService(): ApplicationAttachmentMetadataService = mockk()
 
     @Bean fun applicationAttachmentService(): ApplicationAttachmentService = mockk()
@@ -67,11 +67,9 @@ class IntegrationTestConfiguration {
 
     @Bean fun gdprService(): GdprService = mockk(relaxUnitFun = true)
 
-    @Bean fun geometriatDao(jdbcOperations: JdbcOperations): GeometriatDao = mockk()
+    @Bean fun geometriatDao(): GeometriatDao = mockk()
 
-    @Bean
-    fun geometriatService(service: HankeService, geometriatDao: GeometriatDao): GeometriatService =
-        mockk()
+    @Bean fun geometriatService(): GeometriatService = mockk()
 
     @Bean fun hakemusAuthorizer(): HakemusAuthorizer = mockk(relaxUnitFun = true)
 
@@ -107,14 +105,15 @@ class IntegrationTestConfiguration {
 
     @Bean fun profiiliClient(): ProfiiliClient = mockk()
 
+    @Bean fun profiiliService(): ProfiiliService = mockk()
+
     @Bean fun taydennysAuthorizer(): TaydennysAuthorizer = mockk()
 
     @Bean fun taydennysService(): TaydennysService = mockk()
 
     @Bean fun testDataService(): TestDataService = mockk(relaxUnitFun = true)
 
-    @Bean
-    fun tormaysService(jdbcOperations: JdbcOperations): TormaystarkasteluTormaysService = mockk()
+    @Bean fun tormaysService(): TormaystarkasteluTormaysService = mockk()
 
     @Bean fun tormaystarkasteluLaskentaService(): TormaystarkasteluLaskentaService = mockk()
 

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceITest.kt
@@ -220,6 +220,7 @@ class HakemusServiceITest(
                 prop(Hakemus::id).isEqualTo(hakemus.id)
                 prop(Hakemus::applicationData).isInstanceOf(JohtoselvityshakemusData::class).all {
                     prop(JohtoselvityshakemusData::name).isEqualTo(hakemus.applicationData.name)
+                    prop(JohtoselvityshakemusData::areas).isNotNull().single().isNotNull()
                 }
             }
             assertThat(response.paatokset).isEmpty()

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/profiili/ProfiiliClientITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/profiili/ProfiiliClientITest.kt
@@ -18,11 +18,6 @@ import fi.hel.haitaton.hanke.factory.ProfiiliFactory
 import fi.hel.haitaton.hanke.toJsonString
 import io.mockk.checkUnnecessaryStub
 import io.mockk.clearAllMocks
-import io.mockk.confirmVerified
-import io.mockk.every
-import io.mockk.mockk
-import io.mockk.verify
-import io.mockk.verifySequence
 import java.net.URLEncoder
 import okhttp3.HttpUrl
 import okhttp3.mockwebserver.MockResponse
@@ -34,9 +29,6 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
-import org.springframework.security.core.Authentication
-import org.springframework.security.core.context.SecurityContext
-import org.springframework.security.oauth2.jwt.Jwt
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.WebClientResponseException
 
@@ -46,7 +38,6 @@ class ProfiiliClientITest {
     private lateinit var mockGraphQl: MockWebServer
     private lateinit var mockConfigurationApi: MockWebServer
     private lateinit var profiiliClient: ProfiiliClient
-    private val securityContext: SecurityContext = mockk()
 
     @BeforeEach
     fun setUp() {
@@ -72,33 +63,18 @@ class ProfiiliClientITest {
         mockGraphQl.shutdown()
         mockConfigurationApi.shutdown()
         checkUnnecessaryStub()
-        confirmVerified(securityContext)
     }
 
     @Nested
     inner class GetVerifiedName {
         @Test
-        fun `throws exception when accessToken not found from authentication`() {
-            every { securityContext.authentication } returns null
-
-            val failure = assertFailure { profiiliClient.getVerifiedName(securityContext) }
-
-            failure.all {
-                hasClass(VerifiedNameNotFound::class)
-                messageContains("User not authenticated")
-            }
-            assertThat(mockApiTokensApi.requestCount).isEqualTo(0)
-            verify { securityContext.authentication }
-        }
-
-        @Test
         fun `throws exception when OpenID configuration can't be found`() {
-            mockAccessToken()
             mockConfigurationApi.dispatcher = QueueDispatcher()
             mockConfigurationApi.enqueue(
-                MockResponse().setResponseCode(404).setBody("This is the message body from error"))
+                MockResponse().setResponseCode(404).setBody("This is the message body from error")
+            )
 
-            val failure = assertFailure { profiiliClient.getVerifiedName(securityContext) }
+            val failure = assertFailure { profiiliClient.getVerifiedName(ACCESS_TOKEN) }
 
             failure.all {
                 hasClass(ProfiiliConfigurationError::class)
@@ -109,16 +85,14 @@ class ProfiiliClientITest {
                 cause().isNotNull().isInstanceOf(WebClientResponseException::class.java)
             }
             assertThat(mockApiTokensApi.requestCount).isEqualTo(0)
-            verifySequence { securityContext.authentication }
         }
 
         @Test
         fun `throws exception when token endpoint can't be found from OpenID configuration`() {
-            mockAccessToken()
             mockConfigurationApi.dispatcher = QueueDispatcher()
             mockConfigurationApi.enqueueSuccess("{}")
 
-            val failure = assertFailure { profiiliClient.getVerifiedName(securityContext) }
+            val failure = assertFailure { profiiliClient.getVerifiedName(ACCESS_TOKEN) }
 
             failure.all {
                 hasClass(ProfiiliConfigurationError::class)
@@ -127,49 +101,44 @@ class ProfiiliClientITest {
                 hasNoCause()
             }
             assertThat(mockApiTokensApi.requestCount).isEqualTo(0)
-            verifySequence { securityContext.authentication }
         }
 
         @Test
         fun `calls configuration API with the correct url and headers`() {
-            mockAccessToken()
             mockApiToken()
             mockGraphQl()
 
-            profiiliClient.getVerifiedName(securityContext)
+            profiiliClient.getVerifiedName(ACCESS_TOKEN)
 
             val request = mockConfigurationApi.takeRequest()
             assertThat(request.requestUrl)
                 .isNotNull()
                 .prop(HttpUrl::toString)
                 .isEqualTo(
-                    "http://localhost:${mockConfigurationApi.port}/auth/realms/helsinki-tunnistus/.well-known/openid-configuration")
+                    "http://localhost:${mockConfigurationApi.port}/auth/realms/helsinki-tunnistus/.well-known/openid-configuration"
+                )
             assertThat(request.getHeader("Authorization")).isNull()
             assertThat(request.getHeader("Accept")).isEqualTo(MediaType.APPLICATION_JSON_VALUE)
-            verifySequence { securityContext.authentication }
         }
 
         @Test
         fun `throws exception when API tokens not found`() {
-            mockAccessToken()
             mockApiTokensApi.enqueue(MockResponse().setResponseCode(404))
 
-            val failure = assertFailure { profiiliClient.getVerifiedName(securityContext) }
+            val failure = assertFailure { profiiliClient.getVerifiedName(ACCESS_TOKEN) }
 
             failure.all {
                 hasClass(WebClientResponseException.NotFound::class)
                 messageContains("404 Not Found from POST")
             }
             assertThat(mockApiTokensApi.requestCount).isEqualTo(1)
-            verifySequence { securityContext.authentication }
         }
 
         @Test
         fun `throws exception when API tokens is empty`() {
-            mockAccessToken()
             mockApiTokensApi.enqueueSuccess("{}")
 
-            val failure = assertFailure { profiiliClient.getVerifiedName(securityContext) }
+            val failure = assertFailure { profiiliClient.getVerifiedName(ACCESS_TOKEN) }
 
             failure.all {
                 hasClass(VerifiedNameNotFound::class)
@@ -177,15 +146,13 @@ class ProfiiliClientITest {
                 messageContains("Token response did not contain an access token")
             }
             assertThat(mockApiTokensApi.requestCount).isEqualTo(1)
-            verifySequence { securityContext.authentication }
         }
 
         @Test
         fun `throws exception when there's no access token in the token API response`() {
-            mockAccessToken()
             mockApiTokensApi.enqueueSuccess(mapOf("some-other-audience" to "some-other-token"))
 
-            val failure = assertFailure { profiiliClient.getVerifiedName(securityContext) }
+            val failure = assertFailure { profiiliClient.getVerifiedName(ACCESS_TOKEN) }
 
             failure.all {
                 hasClass(VerifiedNameNotFound::class)
@@ -193,16 +160,14 @@ class ProfiiliClientITest {
                 messageContains("Token response did not contain an access token")
             }
             assertThat(mockApiTokensApi.requestCount).isEqualTo(1)
-            verifySequence { securityContext.authentication }
         }
 
         @Test
         fun `calls the API token endpoint with the correct url and headers`() {
-            mockAccessToken()
             mockApiToken()
             mockGraphQl()
 
-            profiiliClient.getVerifiedName(securityContext)
+            profiiliClient.getVerifiedName(ACCESS_TOKEN)
 
             val request = mockApiTokensApi.takeRequest()
             assertThat(request.requestUrl)
@@ -213,16 +178,14 @@ class ProfiiliClientITest {
             assertThat(request.getHeader("Accept")).isEqualTo(MediaType.APPLICATION_JSON_VALUE)
             assertThat(request.getHeader("Content-Type"))
                 .isEqualTo(MediaType.APPLICATION_FORM_URLENCODED_VALUE + ";charset=UTF-8")
-            verifySequence { securityContext.authentication }
         }
 
         @Test
         fun `calls the API token endpoint with the correct body`() {
-            mockAccessToken()
             mockApiToken()
             mockGraphQl()
 
-            profiiliClient.getVerifiedName(securityContext)
+            profiiliClient.getVerifiedName(ACCESS_TOKEN)
 
             val request = mockApiTokensApi.takeRequest()
 
@@ -233,16 +196,14 @@ class ProfiiliClientITest {
             val expectedBody =
                 "audience=$encodedAudience&grant_type=$encodedGrantType&permission=$encodedPermission"
             assertThat(request.body.readUtf8()).isEqualTo(expectedBody)
-            verifySequence { securityContext.authentication }
         }
 
         @Test
         fun `throws exception when GraphQL request fails`() {
-            mockAccessToken()
             mockApiToken()
             mockGraphQl.enqueue(MockResponse().setResponseCode(404))
 
-            val failure = assertFailure { profiiliClient.getVerifiedName(securityContext) }
+            val failure = assertFailure { profiiliClient.getVerifiedName(ACCESS_TOKEN) }
 
             failure.all {
                 hasClass(WebClientResponseException.NotFound::class)
@@ -250,16 +211,14 @@ class ProfiiliClientITest {
             }
             assertThat(mockApiTokensApi.requestCount).isEqualTo(1)
             assertThat(mockGraphQl.requestCount).isEqualTo(1)
-            verifySequence { securityContext.authentication }
         }
 
         @Test
         fun `throws exception when user doesn't have a profile`() {
-            mockAccessToken()
             mockApiToken()
             mockGraphQl.enqueueSuccess(ProfiiliResponse(ProfiiliData(null)))
 
-            val failure = assertFailure { profiiliClient.getVerifiedName(securityContext) }
+            val failure = assertFailure { profiiliClient.getVerifiedName(ACCESS_TOKEN) }
 
             failure.all {
                 hasClass(VerifiedNameNotFound::class)
@@ -267,16 +226,14 @@ class ProfiiliClientITest {
             }
             assertThat(mockApiTokensApi.requestCount).isEqualTo(1)
             assertThat(mockGraphQl.requestCount).isEqualTo(1)
-            verifySequence { securityContext.authentication }
         }
 
         @Test
         fun `returns null when user's profile doesn't have verified information`() {
-            mockAccessToken()
             mockApiToken()
             mockGraphQl.enqueueSuccess(ProfiiliResponse(ProfiiliData(MyProfile(null))))
 
-            val failure = assertFailure { profiiliClient.getVerifiedName(securityContext) }
+            val failure = assertFailure { profiiliClient.getVerifiedName(ACCESS_TOKEN) }
 
             failure.all {
                 hasClass(VerifiedNameNotFound::class)
@@ -284,15 +241,13 @@ class ProfiiliClientITest {
             }
             assertThat(mockApiTokensApi.requestCount).isEqualTo(1)
             assertThat(mockGraphQl.requestCount).isEqualTo(1)
-            verifySequence { securityContext.authentication }
         }
 
         @Test
         fun `returns name when user's profile has verified information`() {
-            mockAccessToken()
             mockApiToken()
             mockGraphQl()
-            val response = profiiliClient.getVerifiedName(securityContext)
+            val response = profiiliClient.getVerifiedName(ACCESS_TOKEN)
 
             assertThat(response).isNotNull().all {
                 prop(Names::firstName).isEqualTo(ProfiiliFactory.DEFAULT_FIRST_NAME)
@@ -301,16 +256,14 @@ class ProfiiliClientITest {
             }
             assertThat(mockApiTokensApi.requestCount).isEqualTo(1)
             assertThat(mockGraphQl.requestCount).isEqualTo(1)
-            verifySequence { securityContext.authentication }
         }
 
         @Test
         fun `calls the GraphQL API with correct url and headers`() {
-            mockAccessToken()
             mockApiToken()
             mockGraphQl()
 
-            profiiliClient.getVerifiedName(securityContext)
+            profiiliClient.getVerifiedName(ACCESS_TOKEN)
 
             val request = mockGraphQl.takeRequest()
             assertThat(request.requestUrl)
@@ -321,16 +274,14 @@ class ProfiiliClientITest {
             assertThat(request.getHeader("Accept")).isEqualTo(MediaType.APPLICATION_JSON_VALUE)
             assertThat(request.getHeader("Content-Type"))
                 .isEqualTo(MediaType.APPLICATION_JSON_VALUE)
-            verifySequence { securityContext.authentication }
         }
 
         @Test
         fun `calls the GraphQL API with the correct body`() {
-            mockAccessToken()
             mockApiToken()
             mockGraphQl()
 
-            profiiliClient.getVerifiedName(securityContext)
+            profiiliClient.getVerifiedName(ACCESS_TOKEN)
 
             val request = mockGraphQl.takeRequest()
             val body = request.body.readUtf8()
@@ -350,9 +301,9 @@ class ProfiiliClientITest {
                            |  }
                            |}
                            |"""
-                            .trimMargin())
+                            .trimMargin()
+                    )
             }
-            verifySequence { securityContext.authentication }
         }
     }
 
@@ -361,7 +312,8 @@ class ProfiiliClientITest {
             MockResponse()
                 .setResponseCode(200)
                 .setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-                .setBody(body))
+                .setBody(body)
+        )
     }
 
     private fun MockWebServer.enqueueSuccess(body: Any) {
@@ -373,20 +325,14 @@ class ProfiiliClientITest {
             MockResponse()
                 .setResponseCode(200)
                 .setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-                .setBody(mapOf("access_token" to API_TOKEN).toJsonString()))
-    }
-
-    private fun mockAccessToken() {
-        val jwtMock = mockk<Jwt>()
-        every { jwtMock.tokenValue } returns ACCESS_TOKEN
-        val authenticationMock: Authentication = mockk()
-        every { authenticationMock.credentials } returns jwtMock
-        every { securityContext.authentication } returns authenticationMock
+                .setBody(mapOf("access_token" to API_TOKEN).toJsonString())
+        )
     }
 
     private fun mockGraphQl() {
         mockGraphQl.enqueueSuccess(
-            ProfiiliResponse(ProfiiliData(MyProfile(ProfiiliFactory.DEFAULT_NAMES))))
+            ProfiiliResponse(ProfiiliData(MyProfile(ProfiiliFactory.DEFAULT_NAMES)))
+        )
     }
 
     companion object {

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/profiili/ProfiiliControllerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/profiili/ProfiiliControllerITest.kt
@@ -34,15 +34,13 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers
 
 private const val BASE_URL = "/profiili"
 
-@WebMvcTest(
-    controllers = [ProfiiliController::class],
-)
+@WebMvcTest(controllers = [ProfiiliController::class])
 @Import(IntegrationTestConfiguration::class)
 @ActiveProfiles("test")
 @WithMockUser(USERNAME)
 class ProfiiliControllerITest(@Autowired override val mockMvc: MockMvc) : ControllerTest {
 
-    @Autowired private lateinit var profiiliClient: ProfiiliClient
+    @Autowired private lateinit var profiiliService: ProfiiliService
     @Autowired private lateinit var disclosureLogService: DisclosureLogService
 
     @BeforeEach
@@ -64,34 +62,34 @@ class ProfiiliControllerITest(@Autowired override val mockMvc: MockMvc) : Contro
         fun `Without user ID returns 401`() {
             get(url).andExpect(MockMvcResultMatchers.status().isUnauthorized)
 
-            verify { profiiliClient wasNot Called }
+            verify { profiiliService wasNot Called }
             verify { disclosureLogService wasNot Called }
         }
 
         @Test
         fun `returns 404 when profiili client throws expected exception`() {
-            every { profiiliClient.getVerifiedName(any()) } throws
+            every { profiiliService.getVerifiedName(any()) } throws
                 VerifiedNameNotFound("Because of reasons.")
 
             get(url).andExpect(MockMvcResultMatchers.status().isNotFound)
 
-            verifyAll { profiiliClient.getVerifiedName(any()) }
+            verifyAll { profiiliService.getVerifiedName(any()) }
             verify { disclosureLogService wasNot Called }
         }
 
         @Test
         fun `returns 500 when Profiili client throws unexpected exception`() {
-            every { profiiliClient.getVerifiedName(any()) } throws SocketTimeoutException()
+            every { profiiliService.getVerifiedName(any()) } throws SocketTimeoutException()
 
             get(url).andExpect(MockMvcResultMatchers.status().isInternalServerError)
 
-            verifyAll { profiiliClient.getVerifiedName(any()) }
+            verifyAll { profiiliService.getVerifiedName(any()) }
             verify { disclosureLogService wasNot Called }
         }
 
         @Test
         fun `returns verified names`() {
-            every { profiiliClient.getVerifiedName(any()) } returns ProfiiliFactory.DEFAULT_NAMES
+            every { profiiliService.getVerifiedName(any()) } returns ProfiiliFactory.DEFAULT_NAMES
             every { disclosureLogService.saveForProfiiliNimi(any(), any()) } just Runs
 
             val names: Names =
@@ -103,7 +101,7 @@ class ProfiiliControllerITest(@Autowired override val mockMvc: MockMvc) : Contro
                 prop(Names::givenName).isEqualTo(ProfiiliFactory.DEFAULT_GIVEN_NAME)
             }
             verifyAll {
-                profiiliClient.getVerifiedName(any())
+                profiiliService.getVerifiedName(any())
                 disclosureLogService.saveForProfiiliNimi(any(), any())
             }
         }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Utils.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Utils.kt
@@ -8,7 +8,6 @@ import java.time.temporal.Temporal
 import mu.KotlinLogging
 import org.springframework.security.core.context.SecurityContext
 import org.springframework.security.core.context.SecurityContextHolder
-import org.springframework.security.oauth2.core.OAuth2AccessToken
 
 private val logger = KotlinLogging.logger {}
 
@@ -35,7 +34,7 @@ private val businessIdMultipliers = listOf(7, 9, 10, 5, 8, 4, 2)
 fun <ID, Source : HasId<ID>, Target : HasId<ID & Any>> mergeDataInto(
     source: List<Source>,
     target: MutableList<Target>,
-    converterFn: (Source, Target?) -> Target
+    converterFn: (Source, Target?) -> Target,
 ) {
     // Existing data is collected for mapping
     val targetMap = target.associateBy { it.id }
@@ -61,15 +60,9 @@ fun LocalDateTime.zonedDateTime(): ZonedDateTime = ZonedDateTime.of(this, TZ_UTC
  */
 fun getCurrentTimeUTCAsLocalTime(): LocalDateTime = getCurrentTimeUTC().toLocalDateTime()
 
-fun currentUserId(): String = SecurityContextHolder.getContext().authentication.name
+fun currentUserId(): String = SecurityContextHolder.getContext().userId()
 
 fun SecurityContext.userId(): String = authentication.name
-
-fun SecurityContext.accessToken(): String? =
-    when (val token = this.authentication.credentials) {
-        is OAuth2AccessToken -> token.tokenValue
-        else -> null
-    }
 
 /**
  * Valid business id (y-tunnus) requirements:

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/profiili/ProfiiliController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/profiili/ProfiiliController.kt
@@ -24,9 +24,7 @@ private val logger = KotlinLogging.logger {}
 @RestController
 @RequestMapping("/profiili")
 @SecurityRequirement(name = "bearerAuth")
-class ProfiiliController(
-    private val profiiliClient: ProfiiliClient,
-) {
+class ProfiiliController(private val profiiliService: ProfiiliService) {
 
     @GetMapping("/verified-name")
     @Operation(summary = "Get verified name from Profiili")
@@ -34,10 +32,11 @@ class ProfiiliController(
     @ApiResponse(
         description = "Verification not found.",
         responseCode = "404",
-        content = [Content(schema = Schema(implementation = HankeError::class))])
+        content = [Content(schema = Schema(implementation = HankeError::class))],
+    )
     fun verifiedName(
-        @Parameter(hidden = true) @CurrentSecurityContext securityContext: SecurityContext,
-    ): Names = profiiliClient.getVerifiedName(securityContext)
+        @Parameter(hidden = true) @CurrentSecurityContext securityContext: SecurityContext
+    ): Names = profiiliService.getVerifiedName(securityContext)
 
     @ExceptionHandler(VerifiedNameNotFound::class)
     @ResponseStatus(HttpStatus.NOT_FOUND)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/profiili/ProfiiliService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/profiili/ProfiiliService.kt
@@ -1,0 +1,48 @@
+package fi.hel.haitaton.hanke.profiili
+
+import org.springframework.security.core.context.SecurityContext
+import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.stereotype.Service
+
+@Service
+class ProfiiliService(private val profiiliClient: ProfiiliClient) {
+
+    fun getVerifiedName(securityContext: SecurityContext): Names {
+        val credentials =
+            securityContext.authentication?.let { it.credentials as Jwt }
+                ?: throw VerifiedNameNotFound("User not authenticated.")
+
+        val amr = credentials.getClaim<List<String>>(AMR_CLAIM)
+        return if (amr.contains(SUOMI_FI_AMR_TAG)) {
+            profiiliClient.getVerifiedName(credentials.tokenValue)
+        } else if (amr.contains(AD_AMR_TAG)) {
+            nameFromToken(credentials)
+        } else {
+            throw AuthenticationMethodNotSupported(amr)
+        }
+    }
+
+    private fun nameFromToken(credentials: Jwt): Names {
+        val given: String =
+            credentials.getClaim(GIVEN_NAME_CLAIM) ?: throw NameClaimNotFound(GIVEN_NAME_CLAIM)
+        val family: String =
+            credentials.getClaim(FAMILY_NAME_CLAIM) ?: throw NameClaimNotFound(FAMILY_NAME_CLAIM)
+        return Names(given, family, given)
+    }
+
+    companion object {
+        const val AMR_CLAIM = "amr"
+        const val GIVEN_NAME_CLAIM = "given_name"
+        const val FAMILY_NAME_CLAIM = "family_name"
+        const val SUOMI_FI_AMR_TAG = "suomi_fi"
+        const val AD_AMR_TAG = "helsinkiad"
+    }
+}
+
+class NameClaimNotFound(claim: String) :
+    RuntimeException(
+        "Claim $claim not found from token even though the token is with Helsinki AD authentication."
+    )
+
+class AuthenticationMethodNotSupported(amr: List<String>?) :
+    RuntimeException("Authentication method not supported: $amr")

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/profiili/ProfiiliServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/profiili/ProfiiliServiceTest.kt
@@ -1,0 +1,184 @@
+package fi.hel.haitaton.hanke.profiili
+
+import assertk.all
+import assertk.assertFailure
+import assertk.assertThat
+import assertk.assertions.hasClass
+import assertk.assertions.hasMessage
+import assertk.assertions.isEqualTo
+import assertk.assertions.messageContains
+import assertk.assertions.prop
+import fi.hel.haitaton.hanke.factory.ProfiiliFactory
+import fi.hel.haitaton.hanke.test.AuthenticationMocks
+import io.mockk.Called
+import io.mockk.checkUnnecessaryStub
+import io.mockk.clearAllMocks
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verifySequence
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.security.core.Authentication
+import org.springframework.security.core.context.SecurityContext
+import org.springframework.security.oauth2.jwt.Jwt
+
+class ProfiiliServiceTest {
+
+    private val securityContext: SecurityContext = mockk()
+    private val profiiliClient: ProfiiliClient = mockk()
+
+    private val profiiliService = ProfiiliService(profiiliClient)
+
+    @BeforeEach
+    fun clearMocks() {
+        clearAllMocks()
+    }
+
+    @AfterEach
+    fun checkMocks() {
+        checkUnnecessaryStub()
+        confirmVerified(securityContext, profiiliClient)
+    }
+
+    @Nested
+    inner class GetVerifiedName {
+        @Test
+        fun `throws exception when no authentication is found`() {
+            every { securityContext.authentication } returns null
+
+            val failure = assertFailure { profiiliService.getVerifiedName(securityContext) }
+
+            failure.all {
+                hasClass(VerifiedNameNotFound::class)
+                hasMessage("Verified name of user could not be obtained. User not authenticated.")
+            }
+            verifySequence { securityContext.authentication }
+        }
+
+        @Test
+        fun `throws exception when authentication has no credentials`() {
+            val authentication: Authentication = mockk()
+            every { securityContext.authentication } returns authentication
+            every { authentication.credentials } returns null
+
+            val failure = assertFailure { profiiliService.getVerifiedName(securityContext) }
+
+            failure.all {
+                hasClass(NullPointerException::class)
+                hasMessage(
+                    "null cannot be cast to non-null type org.springframework.security.oauth2.jwt.Jwt"
+                )
+            }
+            verifySequence { securityContext.authentication }
+        }
+
+        @Test
+        fun `gets name from Profiili when amr claim says the user authenticated with Suomi fi`() {
+            val authentication = AuthenticationMocks.suomiFiAuthentication()
+            every { securityContext.authentication } returns authentication
+            val token = AuthenticationMocks.TOKEN_VALUE
+            every { profiiliClient.getVerifiedName(token) } returns ProfiiliFactory.DEFAULT_NAMES
+
+            val response = profiiliService.getVerifiedName(securityContext)
+
+            assertThat(response).isEqualTo(ProfiiliFactory.DEFAULT_NAMES)
+            verifySequence {
+                securityContext.authentication
+                profiiliClient.getVerifiedName(token)
+            }
+        }
+
+        @Test
+        fun `propagates the exception when ProfiiliClient throws an exception`() {
+            val authentication = AuthenticationMocks.suomiFiAuthentication()
+            every { securityContext.authentication } returns authentication
+            val token = AuthenticationMocks.TOKEN_VALUE
+            val message = "Token response did not contain an access token."
+            every { profiiliClient.getVerifiedName(token) } throws VerifiedNameNotFound(message)
+
+            val failure = assertFailure { profiiliService.getVerifiedName(securityContext) }
+
+            failure.all {
+                hasClass(VerifiedNameNotFound::class)
+                messageContains(message)
+            }
+            verifySequence {
+                securityContext.authentication
+                profiiliClient.getVerifiedName(token)
+            }
+        }
+
+        @Test
+        fun `returns the name from the access token when user is authenticated with Helsinki AD`() {
+            val authentication = AuthenticationMocks.adAuthentication()
+            every { securityContext.authentication } returns authentication
+
+            val response = profiiliService.getVerifiedName(securityContext)
+
+            assertThat(response).all {
+                prop(Names::firstName).isEqualTo(ProfiiliFactory.DEFAULT_GIVEN_NAME)
+                prop(Names::lastName).isEqualTo(ProfiiliFactory.DEFAULT_LAST_NAME)
+                prop(Names::givenName).isEqualTo(ProfiiliFactory.DEFAULT_GIVEN_NAME)
+            }
+            verifySequence {
+                securityContext.authentication
+                profiiliClient wasNot Called
+            }
+        }
+
+        @Test
+        fun `throws an exception when given name not found in token`() {
+            val jwt =
+                Jwt.withTokenValue(AuthenticationMocks.TOKEN_VALUE)
+                    .header("alg", "none")
+                    .claim(ProfiiliService.AMR_CLAIM, listOf("helsinkiad"))
+                    .claim(ProfiiliService.FAMILY_NAME_CLAIM, ProfiiliFactory.DEFAULT_LAST_NAME)
+                    .build()
+            val authentication: Authentication = mockk()
+            every { authentication.credentials } returns jwt
+            every { securityContext.authentication } returns authentication
+
+            val failure = assertFailure { profiiliService.getVerifiedName(securityContext) }
+
+            failure.all {
+                hasClass(NameClaimNotFound::class)
+                hasMessage(
+                    "Claim given_name not found from token even though the token is with Helsinki AD authentication."
+                )
+            }
+            verifySequence {
+                securityContext.authentication
+                profiiliClient wasNot Called
+            }
+        }
+
+        @Test
+        fun `throws an exception when family name not found in token`() {
+            val jwt =
+                Jwt.withTokenValue(AuthenticationMocks.TOKEN_VALUE)
+                    .header("alg", "none")
+                    .claim(ProfiiliService.AMR_CLAIM, listOf("helsinkiad"))
+                    .claim(ProfiiliService.GIVEN_NAME_CLAIM, ProfiiliFactory.DEFAULT_GIVEN_NAME)
+                    .build()
+            val authentication: Authentication = mockk()
+            every { authentication.credentials } returns jwt
+            every { securityContext.authentication } returns authentication
+
+            val failure = assertFailure { profiiliService.getVerifiedName(securityContext) }
+
+            failure.all {
+                hasClass(NameClaimNotFound::class)
+                hasMessage(
+                    "Claim family_name not found from token even though the token is with Helsinki AD authentication."
+                )
+            }
+            verifySequence {
+                securityContext.authentication
+                profiiliClient wasNot Called
+            }
+        }
+    }
+}

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/test/AuthenticationMocks.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/test/AuthenticationMocks.kt
@@ -1,0 +1,61 @@
+package fi.hel.haitaton.hanke.test
+
+import fi.hel.haitaton.hanke.factory.ProfiiliFactory.DEFAULT_GIVEN_NAME
+import fi.hel.haitaton.hanke.factory.ProfiiliFactory.DEFAULT_LAST_NAME
+import fi.hel.haitaton.hanke.profiili.ProfiiliService
+import io.mockk.every
+import io.mockk.mockk
+import org.springframework.security.core.Authentication
+import org.springframework.security.core.context.SecurityContext
+import org.springframework.security.oauth2.jwt.Jwt
+
+object AuthenticationMocks {
+    const val TOKEN_VALUE = "fake value of the JWT"
+
+    fun adLoginMock(userId: String = USERNAME): SecurityContext {
+        val auth: Authentication = adAuthentication(userId)
+        every { auth.name } returns userId
+        val securityContext: SecurityContext = mockk()
+        every { securityContext.authentication } returns auth
+
+        return securityContext
+    }
+
+    fun adAuthentication(userId: String = USERNAME): Authentication {
+        val jwt =
+            Jwt.withTokenValue(TOKEN_VALUE)
+                .header("alg", "none")
+                .subject(userId)
+                .claim(ProfiiliService.AMR_CLAIM, listOf("helsinkiad"))
+                .claim(ProfiiliService.GIVEN_NAME_CLAIM, DEFAULT_GIVEN_NAME)
+                .claim(ProfiiliService.FAMILY_NAME_CLAIM, DEFAULT_LAST_NAME)
+                .build()
+
+        val auth: Authentication = mockk()
+        every { auth.credentials } returns jwt
+        return auth
+    }
+
+    /** When using this, you have to mock ProfiiliClient.getVerifiedName as well. */
+    fun suomiFiLoginMock(userId: String = USERNAME): SecurityContext {
+        val auth: Authentication = suomiFiAuthentication(userId)
+        every { auth.name } returns userId
+        val securityContext: SecurityContext = mockk()
+        every { securityContext.authentication } returns auth
+
+        return securityContext
+    }
+
+    fun suomiFiAuthentication(userId: String = USERNAME): Authentication {
+        val jwt =
+            Jwt.withTokenValue(TOKEN_VALUE)
+                .header("alg", "none")
+                .subject(userId)
+                .claim(ProfiiliService.AMR_CLAIM, listOf("suomi_fi"))
+                .build()
+
+        val auth: Authentication = mockk(relaxed = true)
+        every { auth.credentials } returns jwt
+        return auth
+    }
+}


### PR DESCRIPTION
# Description

Modify the verified name API to handle users who are logged in through Helsinki AD. They don't have a full profile in Helsinki Profiili, so can't call the Profiili API to get a verified name for them. The name we get in the token is reliable, however. It's read from AD, so it's the official the person is known as an employee.

ProfiiliService was created between the controller and the ProfiiliClient to decide how we should get the name of that particular user. We can see from the AMR (Authentication method reference) claim whether the user was authenticated through Suomi.fi or Helsinki AD. The claim is technically an array, but in Profiili there's always a single value. If for some reason the user has both, we default to Suomi.fi method.

Getting a token from the SecurityContext was moved from ProfiiliClient to ProfiiliService since we now have one. I think this is a better separation of concerns. This caused a bunch of changes in tests. Though a lot of the tests in this PR are from ktfmt reformatting closing parentheses and trailing commas.

### Jira Issue: 

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
1. When logging in, select City of Helsinki employee.
2. Login with your Gofore email and password.
3. Your name should show up in the user menu after logging in.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 