### PR TITLE
HAI-2794 Don't send an email if täydennyspyyntö not found in Allu

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/allu/AlluClientITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/allu/AlluClientITests.kt
@@ -372,6 +372,16 @@ class AlluClientITests {
         }
 
         @Test
+        fun `returns null when Allu doesn't have a taydennyspyynto`() {
+            val mockResponse = MockResponse().setResponseCode(200).setBody("")
+            mockWebServer.enqueue(mockResponse)
+
+            val response = service.getInformationRequest(alluid)
+
+            assertThat(response).isNull()
+        }
+
+        @Test
         fun `throws an exception when Allu returns an error`() {
             val mockResponse = MockResponse().setResponseCode(500)
             mockWebServer.enqueue(mockResponse)

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusHistoryServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusHistoryServiceITest.kt
@@ -405,6 +405,28 @@ class HakemusHistoryServiceITest(
         }
 
         @Test
+        fun `doesn't send email or save the taydennyspyynto when the new status is WAITING_INFORMATION but Allu doesn't have the taydennyspyynto`() {
+            hakemusFactory
+                .builder()
+                .withStatus(ApplicationStatus.HANDLING, alluId, identifier)
+                .save()
+            val event =
+                ApplicationHistoryFactory.createEvent(
+                    applicationIdentifier = identifier,
+                    newStatus = ApplicationStatus.WAITING_INFORMATION,
+                )
+            val histories = listOf(ApplicationHistoryFactory.create(alluId, event))
+            every { alluClient.getInformationRequest(alluId) } returns null
+
+            historyService.handleHakemusUpdates(histories, updateTime)
+
+            val emails = greenMail.receivedMessages
+            assertThat(emails).isEmpty()
+            assertThat(taydennyspyyntoRepository.findAll()).isEmpty()
+            verifySequence { alluClient.getInformationRequest(alluId) }
+        }
+
+        @Test
         fun `removes any taydennyspyynto and taydennys when the new status is HANDLING`(
             output: CapturedOutput
         ) {

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennysServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennysServiceITest.kt
@@ -170,6 +170,46 @@ class TaydennysServiceITest(
             }
             verifySequence { alluClient.getInformationRequest(hakemus.alluid!!) }
         }
+
+        @Test
+        fun `returns taydennyspyynto when Allu has one for the application`() {
+            val hakemus = hakemusFactory.builder().withStatus(alluId = alluId).save()
+            val kentat =
+                listOf(
+                    AlluFactory.createInformationRequestField(
+                        InformationRequestFieldKey.GEOMETRY,
+                        "Check the areas",
+                    ),
+                    AlluFactory.createInformationRequestField(
+                        InformationRequestFieldKey.START_TIME,
+                        "Too far in history",
+                    ),
+                )
+            every { alluClient.getInformationRequest(hakemus.alluid!!) } returns
+                AlluFactory.createInformationRequest(applicationAlluId = alluId, fields = kentat)
+
+            val response = taydennysService.saveTaydennyspyyntoFromAllu(hakemus)
+
+            assertThat(response)
+                .isNotNull()
+                .prop(Taydennyspyynto::kentat)
+                .containsOnly(
+                    InformationRequestFieldKey.GEOMETRY to "Check the areas",
+                    InformationRequestFieldKey.START_TIME to "Too far in history",
+                )
+            verifySequence { alluClient.getInformationRequest(hakemus.alluid!!) }
+        }
+
+        @Test
+        fun `returns null when Allu doesn't have the täydennyspyyntö`() {
+            val hakemus = hakemusFactory.builder().withStatus(alluId = alluId).save()
+            every { alluClient.getInformationRequest(hakemus.alluid!!) } returns null
+
+            val response = taydennysService.saveTaydennyspyyntoFromAllu(hakemus)
+
+            assertThat(response).isNull()
+            verifySequence { alluClient.getInformationRequest(hakemus.alluid!!) }
+        }
     }
 
     @Nested

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusHistoryService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusHistoryService.kt
@@ -36,7 +36,7 @@ class HakemusHistoryService(
     @Transactional
     fun handleHakemusUpdates(
         applicationHistories: List<ApplicationHistory>,
-        updateTime: OffsetDateTime
+        updateTime: OffsetDateTime,
     ) {
         applicationHistories.forEach { handleHakemusUpdate(it) }
         val status = alluStatusRepository.getReferenceById(1)
@@ -115,8 +115,9 @@ class HakemusHistoryService(
             }
             ApplicationStatus.WAITING_INFORMATION -> {
                 updateStatus()
-                taydennysService.saveTaydennyspyyntoFromAllu(application)
-                sendInformationRequestEmails(application, event.applicationIdentifier)
+                taydennysService.saveTaydennyspyyntoFromAllu(application)?.also {
+                    sendInformationRequestEmails(application, event.applicationIdentifier)
+                }
             }
             ApplicationStatus.HANDLING -> {
                 logger.info {
@@ -147,10 +148,16 @@ class HakemusHistoryService(
                 when (application.applicationType) {
                     ApplicationType.CABLE_REPORT ->
                         JohtoselvitysCompleteEmail(
-                            it.sahkoposti, application.id, applicationIdentifier)
+                            it.sahkoposti,
+                            application.id,
+                            applicationIdentifier,
+                        )
                     ApplicationType.EXCAVATION_NOTIFICATION ->
                         KaivuilmoitusDecisionEmail(
-                            it.sahkoposti, application.id, applicationIdentifier)
+                            it.sahkoposti,
+                            application.id,
+                            applicationIdentifier,
+                        )
                 }
             applicationEventPublisher.publishEvent(event)
         }
@@ -167,7 +174,8 @@ class HakemusHistoryService(
                         hakemus.hakemusEntityData.name,
                         hakemusTunnus,
                         hakemus.id,
-                    ))
+                    )
+                )
             }
     }
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennysService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennysService.kt
@@ -56,14 +56,15 @@ class TaydennysService(
     fun findTaydennys(hakemusId: Long): Taydennys? =
         taydennysRepository.findByApplicationId(hakemusId)?.toDomain()
 
+    /** Returns the created täydennyspyyntö if one was created, i.e. if it was still in Allu. */
     @Transactional
-    fun saveTaydennyspyyntoFromAllu(hakemus: HakemusIdentifier) {
+    fun saveTaydennyspyyntoFromAllu(hakemus: HakemusIdentifier): Taydennyspyynto? {
         val request: InformationRequest? = alluClient.getInformationRequest(hakemus.alluid!!)
         if (request == null) {
             logger.error {
                 "Couldn't find the information request from Allu. Ignoring the information request. ${hakemus.logString()}"
             }
-            return
+            return null
         }
 
         val entity =
@@ -74,7 +75,7 @@ class TaydennysService(
                     request.fields.associate { it.fieldKey to it.requestDescription }.toMutableMap(),
             )
 
-        taydennyspyyntoRepository.save(entity)
+        return taydennyspyyntoRepository.save(entity).toDomain()
     }
 
     @Transactional

--- a/services/hanke-service/src/main/resources/email/template/taydennyspyynto.text.mustache
+++ b/services/hanke-service/src/main/resources/email/template/taydennyspyynto.text.mustache
@@ -5,11 +5,11 @@ Hakemuksellesi {{hakemusNimi}} ({{hakemusTunnus}}) on tullut täydennyspyyntö. 
 {{{signatures.fi}}}
 
 
-Hakemuksellesi {{hakemusNimi}} ({{hakemusTunnus}}) on tullut täydennyspyyntö. Käy vastaamassa siihen Haitattomassa: {{baseUrl}}/fi/hakemus/{{hakemusId}}.
+Hakemuksellesi {{hakemusNimi}} ({{hakemusTunnus}}) on tullut täydennyspyyntö. Käy vastaamassa siihen Haitattomassa: {{baseUrl}}/sv/ansokan/{{hakemusId}}.
 
 {{{signatures.sv}}}
 
 
-Hakemuksellesi {{hakemusNimi}} ({{hakemusTunnus}}) on tullut täydennyspyyntö. Käy vastaamassa siihen Haitattomassa: {{baseUrl}}/fi/hakemus/{{hakemusId}}.
+Hakemuksellesi {{hakemusNimi}} ({{hakemusTunnus}}) on tullut täydennyspyyntö. Käy vastaamassa siihen Haitattomassa: {{baseUrl}}/en/application/{{hakemusId}}.
 
 {{{signatures.en}}}


### PR DESCRIPTION
# Description

Currently, if the handler in Allu creates a täydennyspyyntö and cancels it before Haitaton can read it during the next history update, we don't save the täydennyspyyntö, but we still send an email that a täydennyspyyntö was created.

Fix this by only sending the email when the täydennyspyyntö has been found and saved.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-725

## Type of change

- [X] Bug fix 
- [ ] New feature 
- [ ] Other

# Instructions for testing
1. Create a johtoselvityshakemus and send it to Allu.
2. In Allu, start to handle the application.
3. Wait for Haitaton to update the application statuses in the background.
4. Create a täydennyspyyntö in Allu and then immediately cancel it.
5. Check [smtp4dev](http://localhost:3003/) that no email was sent about the täydennyspyyntö.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 