### PR TITLE
HAI-1009 Increase header size to accommodate AD tokens

### DIFF
--- a/scripts/nginx/nginx.conf
+++ b/scripts/nginx/nginx.conf
@@ -15,6 +15,7 @@ server {
   }
 
   client_max_body_size 101M;
+  large_client_header_buffers 4 64k;
 
   location /api/ {
     proxy_pass  http://docker-backend/;

--- a/services/hanke-service/src/main/resources/application.yml
+++ b/services/hanke-service/src/main/resources/application.yml
@@ -85,6 +85,9 @@ sentry:
     minimum-event-level: error
 
 server:
+  # Increase the header size to accommodate the Helsinki staff JWT with all of their AD groups.
+  # https://docs.spring.io/spring-boot/appendix/application-properties/index.html#application-properties.server.server.max-http-request-header-size
+  max-http-request-header-size: 64KB
   forward-headers-strategy: FRAMEWORK
 
 spring:


### PR DESCRIPTION
# Description

The Helsinki staff JWTs are fairly long because they belong to a bunch of AD groups. The default allowed header size is 8kB, but the example login token I received was almost 12kB on its own.

From
https://docs.spring.io/spring-boot/appendix/application-properties/index.html#application-properties.server.server.max-http-request-header-size:
> Tomcat applies the limit to the combined size of the request line and
all of the header names and values in the request.

So I'm setting the max value to 64kB, so all GET parameters and other headers fit inside the limit.

Also, increase the local nginx header limit.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1009

## Type of change

- [X] Bug fix 
- [ ] New feature 
- [ ] Other

# Instructions for testing
This can be tested using a query with a completely random 10kB bearer token.

```
curl -i 'http://localhost:3001/api/profiili/verified-name' \
  -H 'Accept: application/json, text/plain, */*' \
  -H 'Accept-Language: en-GB,en-US;q=0.9,en;q=0.8' \
  -H 'Authorization: Bearer dP34N9I4hgHqW0hMFCXOeqYKpzJb5gIvh1yhdy2NwnvjM0HgWTjbDOrwKqt3eUGb2mjeBGJCr01Qlq7LwX2KnP0x0TPXBqbm12HotmWG3F0WJNLQPES3LNfccP9b9zAOu4BGVs8VJMIbgWrklOxhyHbz52IqiTvecYtNArqIaVe0K63kWKszKkxc25018Hr5eOlbq4yMPgQORCbx64Fzt3VTu6rRpYLDKFixSVWOvhh0OtO6WP8sHPgMPiQdCi8QYbiZA9gH9nAahKOnQWP7ttp1jGZmImsoUMRyZPnFpl2muw3278gmtHbkuKyqO58HsLQ6nrsZpRKuD2vs2CbKtDE81Aegm7j6rML1p3kkHQvli66ZA4Fg6Hc3aLzmV6X9zmPCF6l7kg31TcQUPoxwrh1hhPJzy3jIDANQTIQFL2aRwnaLGtiVrLOJFbuN0RUSiUNgmYnKiVvWfmv4s9OZUlpL1xmNK2YdaQZuUnlTPBfwpfkhDekOHg5qMvRyOcpdICEFAGn0Y8MkIwMawZQZF5VuKJP9YgKS9vHt50PMtpqp3sQ4VTUbApJ26Z5cRYgRI99N3WtcuRsRqhVG1sMA1RcCZsmIX8ItCBl0FBXY6xSHostPfxEmuTe1BgB9SlTNc0mcT7UPaLMtEJdAc61l83y5pmlatEWn6LTo0nmcgG7c1AMsiaYXF5UscQ6rZ2MMBoojA7SW8MF4z6GRguKRUAsx2QFAmjfEYk8TWkkYRCbRwy32UJRlucc1A0KLXkOTqqZNejHINf5NVkn1qzWfaKiDZDupy8GDA0bPBUQWf85Sn0WJh7zW6QZBt36faRsrAFeAUzebmjdRCsK7mYfgX4qJ3EZNRlPxzfum8VgtkJaZJn1t7Bske1jxdBo66JlTTidGQH3ktNHn5iHPt1ArgT7Fs4QeS4U2NELJMHWKYlXkqdP6nmRmYyTtCC3vzv8jb5Ses1AjYJhTHDhouKOTUyPlRwS2JnW5K8J02hNcS19wyFdy2AbdUix5UnZ9bAcqIWISaSzrd2GRU3XYi7xEZV8FKnzT3YJwKMk5RUTWv3xw8ljFdPfSk0N4c3qftvSVI6xsof7LLZiHsql3xumVpGKg6urlqJpI209UZIfozxNAtEQxRS8LA8YPrMOQp1Vdta0C0cFTMB4KrWZfhpikxQAc6XPP63Uj4cB95hBUZYMQSFXuJhuKFKDvFOkK2BNxoyXrtOsNoorcmL5uzOxlYCdsZ00MNd4p5tbUhxBvG7T6sSHp1JqdN8Vdezt2jvO5YN6UxWcE89ljXr6vKefalEBxS598HtusdpMp43nhrbMouEWRoAdHhaoPmUVThuedJOkc2UBLaVRsp2nnWgMsFmzdxYWlsBkBx1MtRuPRCEwFyqvkvA7jsjDtZz3g8xmfssHLdAyKJgwyJC2xr2Sc8XE3aEKA2HMQcWeBWX5M0EKXWc1CDh4kxZWFiVB8ArZZWLfFcrLyDjcnRrwXmgIiYJBwdp1qBrQOL5exsMTU6eiPZedLWb9o1A7K9ZwCzm8kyyPWbqfr832rM2dOJaxQlPkWEmaycgPL42IwziHV6pQOQmlnnu83Sd2tDAn12VQQJhGk06VYCZrV2RIjqkuFQnnCnFGvwQMRdxcIKc7gPSk3QG0DWiDfbGwb64ZzWcZjgaiSYsYfilSEtoQ7KgaTFG11vjYAhPnV7A66Fd4Hb3kwYEiguR8nhTrAOTKi6lS41rBvn4Fe3KDoZcy6cDWTjWLTuN2bNoYw1k0f9xMFSHHEcq3qBTslz3Hqtf5hwCp828kCEBjCPPl0bSGM7hjfscvWAJfeMddUwN3BPCsVWGbOxmoeps0SBiTyXtD54mhExxKBIWAwfL5F7zblL4KlONPmwWSOJbPWboWMN1wcAiB6wn4TKUJMuG5nINbkLTHORLTs32OWkPfPa7kdq237J4Gw8zF318tHC1HKfB3FQco0gQUII7QC27OWvi6nFahm6KqzCLmkRr09bjAmACFRyeu1m0MJwa1R2KnkqND7plze2btVlOJXWK3Q7qURgYxrZfDQj5h2tbMXT02NCHBGNXFWpzqGene4msfTCJ3G14XVl12FbY00cxvunWG4UnrgOW1cjhg3BbPuqVwXUsHED1MVklVfmPGpb7NiEPBT44ORHusR243t4TeeS62iHa6iqTcTESF66cj8gZG9wfUY0LSVEnU0mmuvazcgwLLsO6I0makpVijBJrIew8iF60nMfB1fjbfTi3YUczK1PQyQPa8uXUiqc2Wd9xScqqnFvhxYjIaZjGjSdAzYGVSy3J6oumTcJaXfmUWal99rjkuRP1Wz5nKvCdWzMLe2LAy5w3t2MLte6gidzM7MKPAO5oLR77ioja7i7ltjW2K6WNL5FO6tuzHNOFD3kQ8ROnTYJCqefvqYmAJC1J5wzVYuuGkJnaLF9DkDtGwcqpf4lW7xMSRHLW4XOaeg4KzF5205mc63n90Av27xzvJbc8p9JAMcEpYwkW5loGaRzANVdUdB9IDmVtgGT3UgD4KSx2VJdoBsWZHLAZqnlyFXrk5hZNg8vxAxJcDvK4C4Rf4PcbqUEJRTGbZYhgOvzhFTttxr9G43zVS8I8U77cVkwmouJBQbUqKVLrQy50ttbzd3aYUwkIhe6rpzL1YPSedqsm4X1b0DzGPczhSULKMHhzUQWdrzzDRDzsohjNyhi1AwDqHBXTxuwrSFphxckeUJwIYvJDXHpL0w4vR5Oj9TIPYEcJrNxYgdjrJ7Un4vDdhQ6AFgJqtl2b38WLL181TjjrAmOE3qQHy4XW8SJGRoILgpJoa32kneNwcgk3q8i1cHUNkpS3UIsct7J4qXPb8KoXwgoTjqx3pGjoelGGsbdJDvzQy9qjakUzzxDjMUpdoOPR7gHf8mDkgxaLfz2siBXSukEENzeiOkHINoznfOJq2NhD5dyrYYNDICpgNcBcwfUFXpgRWGebQ3afnadfTDrBr92hXOA4sijshHgLn17h5t5uTB7Al3KRJztHYduCcVmC3OL6HTa6TN6MJ5Nt16WA6fyeb0Ri7SQWPpztS9m1Na9DU5D5FnuUeQ6ymrq6OAJrHyoeNST4ngd9IW9pqNUzGTG22lW6w7x4Q22oQsgeL0dZYfuGgJhcJpFhu2CVbArmRrE4Kyw13ZroB80CgIYWKuKfkL8OjGozVH9snj0Y5wTFjzs0VcIWMZs4TYydxrH0SeCWeVne8JQEIWhdu396w8b57hicXC6Oox5XlkeNYwojgfXTmnDY25lbm6dgf3VID4sRc5XlzA8qVEKgYFizMAem6c5zyt5cKvOceVfcELASPHs06sIk7zHcOSMiajFoDPTwJWXh8iMzxaCTuoNpanPJLKLozKkOMXJChRmkBHAu7e5T7qNUmqqfKVcAtABkxF3Zha22GPBN160Siqq3W3m17I3ZCoFH3nQLyGURmhbdDj6iPeLVDNSRpdVAfRiPAWrfg1kANyOpamLWesEQPhfems1OrIxpB91BwepW0C6Z9k03Sxtdc2DUaPevelRQgv4o2knhHQYHmHLFwt8NyWDC26gAGlxEOo2qnPWoelJib1B93nCfaIn5Up2bJ6vAcQ8GLAoKRK9v9geigkomZOpGn7pFW13bEiKXYcLn033NtuVJOGyJQipF9ADv0dG3fkMH8SAAKHfJSlKr8Qn3RoWZsOrD5sC9RgNmjqgeDJWZpMN5Vxvav3dJimPaMukDSGHRndYE9STzrXnridxzuGERdyGaseDd6yDXHRAfAVgYEqdp1kXZIIkTyaz6Iv2kgrb0PsLJnjXoAmIAFKgKsDhoh0PehXmLSR2mtzcAGzIondhYO5VxyDrwKZYahpMYSsirTxzi0ymlCUHy4MeeYlmg1bcFS3XSILOj6oUU2x519KYMA6xWgH6JEB09j4xKWr3bW1MjSUBq72gduqEiHueJiLMNBwshedqnOeA5JwAAxVVRPN7noSMepaNFzLlyF8V39YpxF0gTY2xfwvTA3u9XnfoKfxZNQjxWr4EC7zC7OCIIJqy37U6B9Yw71vAkAIBGV4XrMvUkmJSpdtFGVOGWxVv39R4Al6kX1ZF4dGcqeCVLpzch39JqxHv2bBHYFoiyVIxZUcitOoNUNj2m9jICLeUigb2LSHRIinFC7BWyIUYbTGjZQ8wONAkEagaAlDwO4gOJT316N13cNodKOPfg4UM4ytFFFB0o8uFbj6WzjFednAfPON9BqWf1K6b8ffkVYq0N2r572bBu9pocqqhab7ImHD6h66ixb3DqtL3e3PFrApgifxUOBronO5SLdf16P0dH1BVEbetiQYCLQlOTtAoz4mYepsP1Pa3njizgQuYGG2XSCdTywxYU67IBbmvhgZqjAN9MRIlWXNZuWe4l6Gw8SulT2pFBduRJY6xYSAp9Tl2w41349JJIPqzAMCJaYVoxzFSAaX3ExWj8N8qnyMpY293dXRbT8n1bElIRKS0WrE4MpvQfL9CAEeM56seR0dytio0psGJ17Qi6SS8ppv1TO0xn9n35J0jGNzshu3g3DHhUR2sTlVAZlxgSAlmrR7BwxewlqKW5AwW3mUYjG0T60vpia7cSGabpOl4O2xyEnh213XOcq8qRafZX2R8qaxnqNUlmZL7K18g3u1b7l7RCUK1CMqb6HwILHGaGScCdLPJHXT2dFG5QRhhIc4Ftho2zT3QO0qO3WfdFMElnTOnJSw4TeMPpZTXizjWLATgXesGGUZ8OGrdHGHOcYDe36iLmRg45xkmlZyLJdSIN1F0LjAlQHbBHAxOJU8KbgkpCdwNOKPhbi23Fkv7L7UY5FpR2S6wpe7IZtMT4Zl59tBUGywk8miF9xUHUZZjY0SBDKTUq891O9kAkXcZ4LUXp3QmqDH3IHKZdHTU3Efc6cWt7wQhdzwJpnREXY1y2CkT2PNFu21Bgk5cPZLSybpGJktb3oi0LVerhw4NDIpzDjIIvMKD6ygQFmPhatNcmSh6xinxH3jCZ3U5b4cB1sXxqV1iLCHWNLEuAnUy5X0QjJgn8e1cy6lq5JT1l1xfMXj2DawxkSLOW8Mx3lFIEZViNyE3T7GXhO9CmwKbCJUHJcojttuYnp7SENhk6fxo1zQMRKnbKrLMF0WjnWPF2F5vKT5rFumKqADmVfffZlfsyLt6mQH3X0lwqfpAQRpbzp3N02Uqp1qSfEWUdpRqGk3Ine9j0lLxJKxDDLb7DbXUd3kWgAaRK5jpadqfGvz3wsYoZC6qdqIlwa71TWe83qV3Z1Rl9PnR4sHeoXt5bFclZ2VONbk7LmxZi7wbIYfBZaTmXpG3T8YHRhcwWC8yii3bpwXMEdx5yyOMyLItoWZrQKkBbMONJMiwJtmsq7AAp8qgeghub4AMxrb5Omd9xbDMRrrzOx4hOH4QmAyhk4Rxg3qq4LcR0ZTBzgEOxJFrjkNvlsSLB9vUD88JRkFDVlFab1SiEV4hotHGP1E2ePTW65jtv8lxjQW9lWv3e5toWcE3dcEduNhqM9JMQtk4nj2efMJEJ4HX20WgN5JKTqF0a7FO5tyGyVnly2heruPU793pQhiTG1vIyIAKZX2nLEGlojJEnMvE7dzAXJ9puF2fT8MKcn23hatsW2kmnFg2zvgUHuDJHkS2SOJkTOmKfCocTyFg58wYDIkl6Dq9uBYZQBKB3BvC9KfmgBMnnXXZpg1gy1WrZTMyuUOMKGJU6KEVhA9G9TptTzMRZHHU8YGdLUx6HOB5M80jdW5aGZHjnga0NeWo8FOdUzv0L2xLaFPyNpRCTfiBpEx7IFBjzBTBC6ETDDe04nXmRD4rNjjjA4Vqaiy90suw1S62fgiyBi1oIO7jpu3uDTpDUVaEaFv2RIKlqTZfy2k2D0XPK0bgzo43kNGRXQsinVgOEpMkWhXKDk803aBDezPUX713mhsnnRsvQ8YT5mTXUYaV8U1Ok0bqnllSJgJEPemhZcxy7tZUol5IzH3WboqHgtRwS8VQXK0ZTvnu0zdNPJIBhZwCSxUrbEDMXLVoPf5Q35tzeEWIyFlEINwf0fw1YA8hlt1bcc02HLwAabHFSR59POm2HeHo7Lji29s16mbgKSUqlJuak2xjJSMBFACXSts8P9kPAyKgbxpLP6x6IQVE8e6MzblkubwL3dYCAPwLvXB6HB7r0dR2H7fn3XoBZIDbTUBagSwp2RRRc8G3HRkmEtN57Z2RJI4RPloarXIwz9y43u25lVgvpmN5MGfdy6TcK78RVMAlH1rXWWU079d2LFWcCeHrPMWQk4IL6c13S90rbWgGwrr1FxSgp6JTVlQJAEkQ4ZAednkjq6P4Arw63zAhNG7959aPGi2WuNsqfZKdg4SNKKAgLlwqDxzK5v87mqQmn4pgSzlaXto2E6U5Ujnn6JJTqrMMQYrd1QFVVAg1quiIeKTu3xFM6FbuJ9ZmW47ymHTo3mZ5hUUD8ZOcRvQeOgPrRFFMTrYAm2zpbw1aCI4TBFyr7xELTpzoUITU7byYfhWlRtGFOpRXC9OsKlbzFmguBCLw8hrEmBaa57loTWXupBdWNbUL7zWaAEBPh2mPjEELIpiBU9YzwWypOO6jLCxehZlaUY2at05C7eIdeNUuTsIYR06jJmrJmdi7Ver4sgjX1TlLIswwzBPClZXB1XNnVC2CaSQ7RNYn8F3gxAMN4naDSSJKGbVjPfphhbELY5L0YnXl690TLCltxoYXobE4yWL5mxabGXGRhc7QNtJ3yXpSrlVAhFOoicQH5gC6gtGTDmaQfmSkyhT7SIBv0Qy0ARSl0MmDbaNAOBbAlGbZ8xIRJg30zU2RtrqileEJiBIylr0dWwGqxdMIO1E1xyAf7brsBQd6JxOeUyCA5f4elbAJRf8cCrhRbAJBwxXEcD3lmLKdPU0eJfGO3iGCQW8QUut6h8xoWrBxxUbtLfTO2bUBY60U6zqHFkx1njSW8uEVGvhSJp8vlt9uhxM1wEm3HwgmMShidTHAwLsUkNBn0BNJTZxWphWnC2e87rkCX7QtLxk9HVF3nbqQTtEtez3dNuHgRKL4mroXqdorjBR7jmjB1tF8tOq7FLxY4AD1k4EXdUQfM04UQnBkeqv11PPiyWvyiojWx4atSJChLpVdzs3no9D3dAaGQc3irSup7epHEpLMRXMcIfbNyrYP0xCPyYf6ATi4NiVkK4jBt4M87LOgwMEpho4OC1jDAzUbUrvGRRE7NbAC9Sd7mJuy1bvGldtyPDAkokGIrVHrs1MFkWQD0MEsKpiDgbnBp6qBbLFrWo2xleABgiF3e1aZLXw6Go6ooCIdJ8XaUdbWHRJGmz8yzIk3VU8eZuccH2M5G0DDtbXs40eTlcsV01pxqNaT3WNJGhoR2PetMbC6qiGif3Ptqg6F4LuqectWYxSXSPNYEPXiQ2r2PQkof9i2RVQOB0pvaSlHtjmd0EqiduopOf3FC64piXmJYpZnt5DeNhTkXSL8i34ZawNWGpHOBhhSG7aqLj5eLvENA5fasTM77JPIZYk5vKlng03pur5vmY5wAq1NKBf2HwXjzkNXlyBkjTyfCW2KQ8s3IA77xiWgoO2Z1rfozS9PLep2GvQp7kSSE2Gax7jpa1d3D8hMdWGxo9oR6vwkollJzrbnFIKtItSy94hfHpNItfDXPNygONHcXc80vW7bN39QIflYlWJ7WkocgrWQfvJfdBOmFSWsSLTfUKNmljVxrY56NEbkJyWcIrEg0WcXZLOn78ClXKRXcLbTgMzo2EpabOLncHTIKnZs1jFAp8eGHtrxvSuwdTji2vm59xrHDd6u3KI3YEbs20aNqXA9QZfcogqfpTOm688uBgnfarVP3VqXHvBPDcx2pDuHmtRDxlnTaynYdDUpTQVe8mItGaTBGSiFjnuSLp8IKAxp5vZvjEzw5ovSW4UqDtH76ZlvMMjCgPNzTQjp1F92xNW2ojV9RerviTSpIa1LJbJQsA3hrmRUSoequi6ea9OD3XLG9FQHLvSopL65FYQEdiGrfQ2EsZUjYWDymdBUsz15Pm3QsrSgejXmOg3SzqFhMBvBbjgJjPZofUvGwBQCIx4ydsmK2Q7oxcdRvnSenGRlOfq8BRzThumP8g2w039HhOfBNX2yWA6iL6X5ecJbqnlwDdFfS2Ey1p5hjNLGdC6TNNZQEAJMzd8OtIMANv5wxZWbopS3t7KKtZ5bKS9IBDRHTPnRkOABWLnnHoAFwPJhHHCuZINlHVlWgV4KrkG0NfXvk0qL5KtxoZb2npVNl1YBpwIjkNsn5SpiKXGUV0d810rpbdDjYZyOkdrjrCDnTFwfkHEHp1MogVQ6bvYZCvcrmYZyq2Tznb6vUP2FIrVWAKT0FMvz6GY3TqjVdkYqUth4HARn4bnSJoDPGzHSX9STQfSdf0tVEW1YpMX98A3DuyurlKc9lDJHvUMMkAiiC1Ipzu8bVPEu7Tg7F5OSSttgPeuJOmaczwW38e9QDDzVtVt9DG035v7lTDHI4T8DjeFE3r5R0jwwOJXPnsQVIGNd87U02XxmAsr3ubMhq9t7AeLA1S30sLQzPuA5rmutIPbKfHdOG0amqBZqqRQWyj0Ku2qHoYaIWjRrR7H6jegIQVsY27EULSdUcC667rRwI0GMsvey4HmRocZSSmNoYCXwvzzUjRHyRR64Ihaz53CIU4iDpm3cVoy9kcI0s259XQioIB2tz7upfDLBudUGuYyuK9gKcrzsb0AKb4jUnY3BdbCHlVrGvQ1iGGfVVCIrQgnKcQ6xWCzYMuE6x3qYJfwOh3N9sSAY2gkQxpwmy1hpynWfk2YHoiuLtdJopBgQBFqQJA5ygabMbvrh2wGLnrmzg63UP5iIXH64SEgSi8vpN6kO1gtOWICSM37HVhIrvtwLRTPiGM2VX8JEqHnZvTXI01Xjh9uQPx8QrMG6bXIvNdLBwfQe2neXvJPDe7mQExHJyiInfyKT1c1OpAIViJh86REWjniPgW23nO9C450uNE9lU0w2X3WEJQy8miGvXX7U8K9b5vcxf2UOC8l5tDgTo0UgtAqM5w1VHhsvLYdySDxjNMOv0aLvQS5dGOCyqQHAifAtC33nXkaL9IjLoDgpEyNuOQF23ZyrgmA6XJ2MzaZh8Ko8k2o7v6l4B2st68kkVNRhVPiyFMkNxZHICkOHvqpv5pKHgoLAschCS8cYlg0qoLZccJCpqlXk8QY64TODWzmVSG0DCg3vK7Acn6ndSzhwLVlVjvE1rSyZmiinDs5SKWNq8OfqwvOiVOnCOMGjBo5lSmotneT30xtt3MeSSHO3NMEC2xt35fU4QlGjydj6rCXA3HC6ldQES2XZNZmIIVIQpIQ9bmdMKOKdZDBPxSeRBa6E4NimfEKxXG139He2LyarRALKHDchRkieIjziQaPmkZlfh5Dhd2dUlX44uriSZTdm3YAof36ijMbBeWcPntQviNGhCq8rko0aa1G0XfkuHv4S3BKOWrGUnnpHsQ5Ytew7DZySdcZj5jcqQchFoFIZEpnJrJRGenHMot0IWwRfqsRZzb4oxVzelfJQq5pyF1MVCIE9zfVUMHkmuvfn7OOgchVVBVlMGEPPbTeZHAMtAYcYjKH4Y5neR1Q6FNDrIpYoGfHVS5R4Nqo0lB3PZRMhdlZItuvcBvJTHCTf4OxiCYVBuFgnnJdWB2Q9ICEAIl61V0S4FuDYMqGO5bYOg6MagYIolRETT9VJVpV0iA0sdrIhAYk9uL5hDW11QaLE7QDQcjHdkfSHQOln0sPOx9mK723qT00mq5en0eKs0x6LvhfMYPZOkfVKfSuvLuCNKpEakwpREF41oqHLug3eBDmkKVenxy86BULPpKGuQWa2KlaDiYrxycSQ8fmsMSdgX15oJ34FgGCctfef0lIRj4MFIjecKcU2Du7gi2T9geiJl7gia58bwEsAq7A6UD2iP8ctefdTyc6c9IU7hGOwFQv8qXRkBNYYja7syDbHLbsQBeMoqPejPRygEYK6XdfvttE' \
  -H 'Cache-Control: no-cache' \
  -H 'Connection: keep-alive' \
  -H 'Pragma: no-cache' \
  -H 'Referer: http://localhost:3001/fi' \
  -H 'Sec-Fetch-Dest: empty' \
  -H 'Sec-Fetch-Mode: cors' \
  -H 'Sec-Fetch-Site: same-origin' \
  -H 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36' \
  -H 'sec-ch-ua: "Google Chrome";v="131", "Chromium";v="131", "Not_A Brand";v="24"' \
  -H 'sec-ch-ua-mobile: ?0' \
  -H 'sec-ch-ua-platform: "macOS"'
```

Without this fix, the service returns 400 Bad Request with a very generic response:
```
<!doctype html><html lang="en"><head><title>HTTP Status 400 – Bad Request</title><style type="text/css">body {font-family:Tahoma,Arial,sans-serif;} h1, h2, h3, b {color:white;background-color:#525D76;} h1 {font-size:22px;} h2 {font-size:16px;} h3 {font-size:14px;} p {font-size:12px;} a {color:black;} .line {height:1px;background-color:#525D76;border:none;}</style></head><body><h1>HTTP Status 400 – Bad Request</h1></body></html>
```

With this fix, the header reaches the service, but the token is just random noise, so the service returns 401 Unauthorized. 

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 