### PR TITLE
HAI-780 Delete taydennys API

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennysControllerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennysControllerITest.kt
@@ -39,10 +39,13 @@ import fi.hel.haitaton.hanke.permissions.PermissionCode
 import fi.hel.haitaton.hanke.test.USERNAME
 import fi.hel.haitaton.hanke.toJsonString
 import io.mockk.Called
+import io.mockk.Runs
 import io.mockk.checkUnnecessaryStub
 import io.mockk.clearAllMocks
 import io.mockk.confirmVerified
 import io.mockk.every
+import io.mockk.just
+import io.mockk.verify
 import io.mockk.verifySequence
 import java.time.ZonedDateTime
 import java.util.UUID
@@ -61,6 +64,7 @@ import org.springframework.security.test.context.support.WithAnonymousUser
 import org.springframework.security.test.context.support.WithMockUser
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
 @WebMvcTest(controllers = [TaydennysController::class])
@@ -568,6 +572,56 @@ class TaydennysControllerITest(@Autowired override val mockMvc: MockMvc) : Contr
             verifySequence {
                 taydennysAuthorizer.authorize(id, PermissionCode.EDIT_APPLICATIONS.name)
                 taydennysService.sendTaydennys(id, USERNAME)
+            }
+        }
+    }
+
+    @Nested
+    inner class Delete {
+        private val url = "/taydennykset/$id"
+
+        @Test
+        @WithAnonymousUser
+        fun `returns 401 when user is unknown`() {
+            delete(url).andExpect(status().isUnauthorized).andExpect(hankeError(HankeError.HAI0001))
+
+            verify { taydennysService wasNot Called }
+        }
+
+        @Test
+        fun `returns 404 when no taydennys`() {
+            every {
+                taydennysAuthorizer.authorize(id, PermissionCode.EDIT_APPLICATIONS.name)
+            } throws TaydennysNotFoundException(id)
+
+            delete(url).andExpect(status().isNotFound).andExpect(hankeError(HankeError.HAI6001))
+
+            verify { taydennysAuthorizer.authorize(id, PermissionCode.EDIT_APPLICATIONS.name) }
+        }
+
+        @Test
+        fun `returns 404 when no application`() {
+            every {
+                taydennysAuthorizer.authorize(id, PermissionCode.EDIT_APPLICATIONS.name)
+            } throws HakemusNotFoundException(1L)
+
+            delete(url).andExpect(status().isNotFound).andExpect(hankeError(HankeError.HAI2001))
+
+            verify { taydennysAuthorizer.authorize(id, PermissionCode.EDIT_APPLICATIONS.name) }
+        }
+
+        @Test
+        fun `deletes taydennys`() {
+            every {
+                taydennysAuthorizer.authorize(id, PermissionCode.EDIT_APPLICATIONS.name)
+            } returns true
+            every { taydennysService.delete(id, USERNAME) } just Runs
+
+            delete(url).andExpect(status().isOk).andExpect(content().string(""))
+
+            verifySequence {
+                taydennysAuthorizer.authorize(id, PermissionCode.EDIT_APPLICATIONS.name)
+                taydennysService.delete(id, USERNAME)
             }
         }
     }

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennysControllerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennysControllerITest.kt
@@ -39,12 +39,11 @@ import fi.hel.haitaton.hanke.permissions.PermissionCode
 import fi.hel.haitaton.hanke.test.USERNAME
 import fi.hel.haitaton.hanke.toJsonString
 import io.mockk.Called
-import io.mockk.Runs
 import io.mockk.checkUnnecessaryStub
 import io.mockk.clearAllMocks
 import io.mockk.confirmVerified
 import io.mockk.every
-import io.mockk.just
+import io.mockk.justRun
 import io.mockk.verify
 import io.mockk.verifySequence
 import java.time.ZonedDateTime
@@ -615,7 +614,7 @@ class TaydennysControllerITest(@Autowired override val mockMvc: MockMvc) : Contr
             every {
                 taydennysAuthorizer.authorize(id, PermissionCode.EDIT_APPLICATIONS.name)
             } returns true
-            every { taydennysService.delete(id, USERNAME) } just Runs
+            justRun { taydennysService.delete(id, USERNAME) }
 
             delete(url).andExpect(status().isOk).andExpect(content().string(""))
 

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennysServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennysServiceITest.kt
@@ -707,12 +707,8 @@ class TaydennysServiceITest(
         @Test
         fun `deletes the attachments when deleting a taydennys`() {
             val taydennys = taydennysFactory.saveWithHakemus { it.withMandatoryFields() }
-            attachmentFactory
-                .save(taydennys = taydennys)
-                .withContent(applicationId = taydennys.hakemusId)
-            attachmentFactory
-                .save(taydennys = taydennys)
-                .withContent(applicationId = taydennys.hakemusId)
+            attachmentFactory.save(taydennys = taydennys).withContent()
+            attachmentFactory.save(taydennys = taydennys).withContent()
             assertThat(attachmentRepository.findByTaydennysId(taydennys.id)).hasSize(2)
             assertThat(
                     fileClient.list(
@@ -738,12 +734,8 @@ class TaydennysServiceITest(
         @Test
         fun `deletes all attachment metadata even when deleting attachment content fails`() {
             val taydennys = taydennysFactory.saveWithHakemus { it.withMandatoryFields() }
-            attachmentFactory
-                .save(taydennys = taydennys)
-                .withContent(applicationId = taydennys.hakemusId)
-            attachmentFactory
-                .save(taydennys = taydennys)
-                .withContent(applicationId = taydennys.hakemusId)
+            attachmentFactory.save(taydennys = taydennys).withContent()
+            attachmentFactory.save(taydennys = taydennys).withContent()
             assertThat(attachmentRepository.findByTaydennysId(taydennys.id)).hasSize(2)
             assertThat(
                     fileClient.list(

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennysServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennysServiceITest.kt
@@ -21,7 +21,6 @@ import fi.hel.haitaton.hanke.allu.ApplicationStatus
 import fi.hel.haitaton.hanke.allu.Attachment
 import fi.hel.haitaton.hanke.allu.AttachmentMetadata
 import fi.hel.haitaton.hanke.allu.InformationRequestFieldKey
-import fi.hel.haitaton.hanke.attachment.application.ApplicationAttachmentContentService
 import fi.hel.haitaton.hanke.attachment.azure.Container
 import fi.hel.haitaton.hanke.attachment.common.MockFileClient
 import fi.hel.haitaton.hanke.attachment.common.TaydennysAttachmentRepository
@@ -710,24 +709,12 @@ class TaydennysServiceITest(
             attachmentFactory.save(taydennys = taydennys).withContent()
             attachmentFactory.save(taydennys = taydennys).withContent()
             assertThat(attachmentRepository.findByTaydennysId(taydennys.id)).hasSize(2)
-            assertThat(
-                    fileClient.list(
-                        Container.HAKEMUS_LIITTEET,
-                        ApplicationAttachmentContentService.prefix(taydennys.hakemusId),
-                    )
-                )
-                .hasSize(2)
+            assertThat(fileClient.listBlobs(Container.HAKEMUS_LIITTEET)).hasSize(2)
 
             taydennysService.delete(taydennys.id, USERNAME)
 
             assertThat(taydennysRepository.findAll()).isEmpty()
-            assertThat(
-                    fileClient.list(
-                        Container.HAKEMUS_LIITTEET,
-                        ApplicationAttachmentContentService.prefix(taydennys.hakemusId),
-                    )
-                )
-                .isEmpty()
+            assertThat(fileClient.listBlobs(Container.HAKEMUS_LIITTEET)).isEmpty()
             assertThat(attachmentRepository.findByTaydennysId(taydennys.id)).isEmpty()
         }
 
@@ -737,26 +724,14 @@ class TaydennysServiceITest(
             attachmentFactory.save(taydennys = taydennys).withContent()
             attachmentFactory.save(taydennys = taydennys).withContent()
             assertThat(attachmentRepository.findByTaydennysId(taydennys.id)).hasSize(2)
-            assertThat(
-                    fileClient.list(
-                        Container.HAKEMUS_LIITTEET,
-                        ApplicationAttachmentContentService.prefix(taydennys.hakemusId),
-                    )
-                )
-                .hasSize(2)
+            assertThat(fileClient.listBlobs(Container.HAKEMUS_LIITTEET)).hasSize(2)
             fileClient.connected = false
 
             taydennysService.delete(taydennys.id, USERNAME)
 
             fileClient.connected = true
             assertThat(taydennysRepository.findAll()).isEmpty()
-            assertThat(
-                    fileClient.list(
-                        Container.HAKEMUS_LIITTEET,
-                        ApplicationAttachmentContentService.prefix(taydennys.hakemusId),
-                    )
-                )
-                .hasSize(2)
+            assertThat(fileClient.listBlobs(Container.HAKEMUS_LIITTEET)).hasSize(2)
             assertThat(attachmentRepository.findByTaydennysId(taydennys.id)).isEmpty()
         }
 

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennysServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennysServiceITest.kt
@@ -6,6 +6,7 @@ import assertk.assertThat
 import assertk.assertions.contains
 import assertk.assertions.containsOnly
 import assertk.assertions.hasClass
+import assertk.assertions.hasSize
 import assertk.assertions.isEmpty
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNotNull
@@ -20,11 +21,16 @@ import fi.hel.haitaton.hanke.allu.ApplicationStatus
 import fi.hel.haitaton.hanke.allu.Attachment
 import fi.hel.haitaton.hanke.allu.AttachmentMetadata
 import fi.hel.haitaton.hanke.allu.InformationRequestFieldKey
+import fi.hel.haitaton.hanke.attachment.application.ApplicationAttachmentContentService
+import fi.hel.haitaton.hanke.attachment.azure.Container
+import fi.hel.haitaton.hanke.attachment.common.MockFileClient
+import fi.hel.haitaton.hanke.attachment.common.TaydennysAttachmentRepository
 import fi.hel.haitaton.hanke.factory.AlluFactory
 import fi.hel.haitaton.hanke.factory.ApplicationFactory
 import fi.hel.haitaton.hanke.factory.DateFactory
 import fi.hel.haitaton.hanke.factory.HakemusFactory
 import fi.hel.haitaton.hanke.factory.HakemusyhteystietoFactory
+import fi.hel.haitaton.hanke.factory.TaydennysAttachmentFactory
 import fi.hel.haitaton.hanke.factory.TaydennysFactory
 import fi.hel.haitaton.hanke.factory.TaydennyspyyntoFactory
 import fi.hel.haitaton.hanke.findByType
@@ -39,8 +45,10 @@ import fi.hel.haitaton.hanke.hakemus.JohtoselvityshakemusEntityData
 import fi.hel.haitaton.hanke.hakemus.KaivuilmoitusData
 import fi.hel.haitaton.hanke.logging.ALLU_AUDIT_LOG_USERID
 import fi.hel.haitaton.hanke.logging.AuditLogRepository
+import fi.hel.haitaton.hanke.logging.AuditLogTarget
 import fi.hel.haitaton.hanke.logging.ObjectType
 import fi.hel.haitaton.hanke.logging.Operation
+import fi.hel.haitaton.hanke.permissions.HankekayttajaRepository
 import fi.hel.haitaton.hanke.test.AlluException
 import fi.hel.haitaton.hanke.test.Asserts.hasNullNode
 import fi.hel.haitaton.hanke.test.Asserts.hasTextNode
@@ -55,6 +63,7 @@ import fi.hel.haitaton.hanke.test.AuditLogEntryEntityAsserts.hasTargetType
 import fi.hel.haitaton.hanke.test.AuditLogEntryEntityAsserts.hasUserActor
 import fi.hel.haitaton.hanke.test.AuditLogEntryEntityAsserts.isSuccess
 import fi.hel.haitaton.hanke.test.AuditLogEntryEntityAsserts.withTarget
+import fi.hel.haitaton.hanke.test.TestUtils
 import fi.hel.haitaton.hanke.test.USERNAME
 import io.mockk.checkUnnecessaryStub
 import io.mockk.clearAllMocks
@@ -75,11 +84,17 @@ class TaydennysServiceITest(
     @Autowired private val hakemusService: HakemusService,
     @Autowired private val taydennyspyyntoRepository: TaydennyspyyntoRepository,
     @Autowired private val taydennysRepository: TaydennysRepository,
+    @Autowired private val taydennysyhteystietoRepository: TaydennysyhteystietoRepository,
+    @Autowired private val taydennysyhteyshenkiloRepository: TaydennysyhteyshenkiloRepository,
     @Autowired private val hankeRepository: HankeRepository,
+    @Autowired private val hankekayttajaRepository: HankekayttajaRepository,
+    @Autowired private val attachmentRepository: TaydennysAttachmentRepository,
     @Autowired private val alluClient: AlluClient,
+    @Autowired private val fileClient: MockFileClient,
     @Autowired private val hakemusFactory: HakemusFactory,
     @Autowired private val taydennyspyyntoFactory: TaydennyspyyntoFactory,
     @Autowired private val taydennysFactory: TaydennysFactory,
+    @Autowired private val attachmentFactory: TaydennysAttachmentFactory,
     @Autowired private val auditLogRepository: AuditLogRepository,
 ) : IntegrationTest() {
     private val alluId = 3464
@@ -684,6 +699,129 @@ class TaydennysServiceITest(
                 alluClient.addAttachment(hakemus.alluid!!, any())
                 alluClient.getApplicationInformation(hakemus.alluid!!)
             }
+        }
+    }
+
+    @Nested
+    inner class Delete {
+        @Test
+        fun `deletes the attachments when deleting a taydennys`() {
+            val taydennys = taydennysFactory.saveWithHakemus { it.withMandatoryFields() }
+            attachmentFactory
+                .save(taydennys = taydennys)
+                .withContent(applicationId = taydennys.hakemusId)
+            attachmentFactory
+                .save(taydennys = taydennys)
+                .withContent(applicationId = taydennys.hakemusId)
+            assertThat(attachmentRepository.findByTaydennysId(taydennys.id)).hasSize(2)
+            assertThat(
+                    fileClient.list(
+                        Container.HAKEMUS_LIITTEET,
+                        ApplicationAttachmentContentService.prefix(taydennys.hakemusId),
+                    )
+                )
+                .hasSize(2)
+
+            taydennysService.delete(taydennys.id, USERNAME)
+
+            assertThat(taydennysRepository.findAll()).isEmpty()
+            assertThat(
+                    fileClient.list(
+                        Container.HAKEMUS_LIITTEET,
+                        ApplicationAttachmentContentService.prefix(taydennys.hakemusId),
+                    )
+                )
+                .isEmpty()
+            assertThat(attachmentRepository.findByTaydennysId(taydennys.id)).isEmpty()
+        }
+
+        @Test
+        fun `deletes all attachment metadata even when deleting attachment content fails`() {
+            val taydennys = taydennysFactory.saveWithHakemus { it.withMandatoryFields() }
+            attachmentFactory
+                .save(taydennys = taydennys)
+                .withContent(applicationId = taydennys.hakemusId)
+            attachmentFactory
+                .save(taydennys = taydennys)
+                .withContent(applicationId = taydennys.hakemusId)
+            assertThat(attachmentRepository.findByTaydennysId(taydennys.id)).hasSize(2)
+            assertThat(
+                    fileClient.list(
+                        Container.HAKEMUS_LIITTEET,
+                        ApplicationAttachmentContentService.prefix(taydennys.hakemusId),
+                    )
+                )
+                .hasSize(2)
+            fileClient.connected = false
+
+            taydennysService.delete(taydennys.id, USERNAME)
+
+            fileClient.connected = true
+            assertThat(taydennysRepository.findAll()).isEmpty()
+            assertThat(
+                    fileClient.list(
+                        Container.HAKEMUS_LIITTEET,
+                        ApplicationAttachmentContentService.prefix(taydennys.hakemusId),
+                    )
+                )
+                .hasSize(2)
+            assertThat(attachmentRepository.findByTaydennysId(taydennys.id)).isEmpty()
+        }
+
+        @Test
+        fun `writes audit log for the deleted taydennys`() {
+            TestUtils.addMockedRequestIp()
+            val taydennys = taydennysFactory.saveWithHakemus { it.withMandatoryFields() }
+            auditLogRepository.deleteAll()
+
+            taydennysService.delete(taydennys.id, USERNAME)
+
+            assertThat(auditLogRepository.findAll()).single().isSuccess(Operation.DELETE) {
+                hasUserActor(USERNAME, TestUtils.mockedIp)
+                withTarget {
+                    prop(AuditLogTarget::id).isEqualTo(taydennys.id.toString())
+                    prop(AuditLogTarget::type).isEqualTo(ObjectType.TAYDENNYS)
+                    hasObjectBefore(taydennys)
+                    hasNoObjectAfter()
+                }
+            }
+        }
+
+        @Test
+        fun `deletes yhteystiedot and yhteyshenkilot but no hankekayttaja`() {
+            val taydennys =
+                taydennysFactory
+                    .builder()
+                    .hakija()
+                    .rakennuttaja()
+                    .tyonSuorittaja()
+                    .asianhoitaja()
+                    .saveEntity()
+            assertThat(taydennysRepository.findAll()).hasSize(1)
+            assertThat(taydennysyhteystietoRepository.findAll()).hasSize(4)
+            assertThat(taydennysyhteyshenkiloRepository.findAll()).hasSize(4)
+            assertThat(hankekayttajaRepository.count())
+                .isEqualTo(5) // Hanke founder + one kayttaja for each role
+
+            taydennysService.delete(taydennys.id, USERNAME)
+
+            assertThat(taydennysRepository.findAll()).isEmpty()
+            assertThat(taydennysyhteystietoRepository.findAll()).isEmpty()
+            assertThat(taydennysyhteyshenkiloRepository.findAll()).isEmpty()
+            assertThat(hankekayttajaRepository.count())
+                .isEqualTo(5) // Hanke founder + one kayttaja for each role
+        }
+
+        @Test
+        fun `deletes taydennys but not taydennyspyynto`() {
+            val taydennys = taydennysFactory.builder().saveEntity()
+            assertThat(taydennysRepository.findAll()).hasSize(1)
+            assertThat(taydennyspyyntoRepository.findAll()).hasSize(1)
+
+            taydennysService.delete(taydennys.id, USERNAME)
+
+            assertThat(taydennysRepository.findAll()).isEmpty()
+            assertThat(taydennyspyyntoRepository.findAll()).hasSize(1)
         }
     }
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/common/AttachmentEntity.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/common/AttachmentEntity.kt
@@ -217,6 +217,8 @@ interface TaydennysAttachmentRepository : JpaRepository<TaydennysAttachmentEntit
     fun findByTaydennysId(taydennysId: UUID): List<TaydennysAttachmentEntity>
 
     fun countByTaydennysId(taydennysId: UUID): Int
+
+    fun deleteByTaydennysId(taydennysId: UUID): List<TaydennysAttachmentEntity>
 }
 
 enum class ApplicationAttachmentType {

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/taydennys/TaydennysAttachmentMetadataService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/taydennys/TaydennysAttachmentMetadataService.kt
@@ -72,4 +72,20 @@ class TaydennysAttachmentMetadataService(
         }
         return totalAttachmentCount >= ALLOWED_ATTACHMENT_COUNT
     }
+
+    /**
+     * Delete all attachments for täydennys and return the blob locations of the deleted
+     * attachments.
+     */
+    @Transactional
+    fun deleteAllAttachments(taydennys: TaydennysIdentifier): List<String> {
+        return attachmentRepository
+            .deleteByTaydennysId(taydennys.id)
+            .map(TaydennysAttachmentEntity::blobLocation)
+            .also {
+                logger.info {
+                    "Deleted all attachment metadata for täydennys ${taydennys.logString()}"
+                }
+            }
+    }
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/taydennys/TaydennysAttachmentService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/taydennys/TaydennysAttachmentService.kt
@@ -100,15 +100,14 @@ class TaydennysAttachmentService(
 
     fun deleteAllAttachments(taydennys: TaydennysIdentifier) {
         logger.info { "Deleting all attachments from täydennys. ${taydennys.logString()}" }
+        val paths = metadataService.deleteAllAttachments(taydennys)
         try {
-            metadataService
-                .deleteAllAttachments(taydennys)
-                .forEach(attachmentContentService::delete)
-            logger.info { "Deleted all attachments from täydennys. ${taydennys.logString()}" }
+            paths.forEach(attachmentContentService::delete)
         } catch (e: Exception) {
             logger.error(e) {
-                "Failed to delete all attachment content for täydennys. Continuing with täydennyys deletion regardless of error. ${taydennys.logString()}"
+                "Failed to delete all attachment content for täydennys. Continuing with täydennys deletion regardless of error. ${taydennys.logString()}"
             }
         }
+        logger.info { "Deleted all attachments from täydennys. ${taydennys.logString()}" }
     }
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/taydennys/TaydennysAttachmentService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/taydennys/TaydennysAttachmentService.kt
@@ -97,4 +97,18 @@ class TaydennysAttachmentService(
         }
         return newAttachment
     }
+
+    fun deleteAllAttachments(taydennys: TaydennysIdentifier) {
+        logger.info { "Deleting all attachments from täydennys. ${taydennys.logString()}" }
+        try {
+            metadataService
+                .deleteAllAttachments(taydennys)
+                .forEach(attachmentContentService::delete)
+            logger.info { "Deleted all attachments from täydennys. ${taydennys.logString()}" }
+        } catch (e: Exception) {
+            logger.error(e) {
+                "Failed to delete all attachment content for täydennys. Continuing with täydennyys deletion regardless of error. ${taydennys.logString()}"
+            }
+        }
+    }
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennysController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennysController.kt
@@ -20,11 +20,12 @@ import mu.KotlinLogging
 import org.springframework.http.HttpStatus
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 
@@ -64,7 +65,7 @@ class TaydennysController(private val taydennysService: TaydennysService) {
     fun create(@PathVariable id: Long): TaydennysResponse =
         taydennysService.create(id, currentUserId()).toResponse()
 
-    @RequestMapping("/taydennykset/{id}")
+    @PutMapping("/taydennykset/{id}")
     @Operation(
         summary = "Update a täydennys",
         description =
@@ -131,6 +132,30 @@ class TaydennysController(private val taydennysService: TaydennysService) {
     @PreAuthorize("@taydennysAuthorizer.authorize(#id, 'EDIT_APPLICATIONS')")
     fun send(@PathVariable id: UUID): HakemusResponse =
         taydennysService.sendTaydennys(id, currentUserId()).toResponse()
+
+    @DeleteMapping("/taydennykset/{id}")
+    @Operation(
+        summary = "Delete a täydennys",
+        description =
+            """
+               Deletes a täydennys.
+            """,
+    )
+    @ApiResponses(
+        value =
+            [
+                ApiResponse(description = "Täydennys deleted, no body", responseCode = "200"),
+                ApiResponse(
+                    description = "A täydennys was not found with the given id",
+                    responseCode = "404",
+                    content = [Content(schema = Schema(implementation = HankeError::class))],
+                ),
+            ]
+    )
+    @PreAuthorize("@taydennysAuthorizer.authorize(#id, 'EDIT_APPLICATIONS')")
+    fun delete(@PathVariable id: UUID) {
+        taydennysService.delete(id, currentUserId())
+    }
 
     @ExceptionHandler(InvalidHakemusDataException::class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennysController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennysController.kt
@@ -134,13 +134,7 @@ class TaydennysController(private val taydennysService: TaydennysService) {
         taydennysService.sendTaydennys(id, currentUserId()).toResponse()
 
     @DeleteMapping("/taydennykset/{id}")
-    @Operation(
-        summary = "Delete a täydennys",
-        description =
-            """
-               Deletes a täydennys.
-            """,
-    )
+    @Operation(summary = "Delete a täydennys", description = "Deletes a täydennys.")
     @ApiResponses(
         value =
             [

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennysyhteyshenkiloRepository.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennysyhteyshenkiloRepository.kt
@@ -1,0 +1,8 @@
+package fi.hel.haitaton.hanke.taydennys
+
+import java.util.UUID
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface TaydennysyhteyshenkiloRepository : JpaRepository<TaydennysyhteyshenkiloEntity, UUID>

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennysyhteystietoRepository.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennysyhteystietoRepository.kt
@@ -1,0 +1,8 @@
+package fi.hel.haitaton.hanke.taydennys
+
+import java.util.UUID
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface TaydennysyhteystietoRepository : JpaRepository<TaydennysyhteystietoEntity, UUID>

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/attachment/common/MockFileClient.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/attachment/common/MockFileClient.kt
@@ -44,7 +44,7 @@ class MockFileClient : FileClient {
                 contentType,
                 content.size,
                 "attachment; filename*=UTF-8''${encodeFilename(originalFilename)}",
-                BinaryData.fromBytes(content)
+                BinaryData.fromBytes(content),
             )
     }
 
@@ -53,7 +53,8 @@ class MockFileClient : FileClient {
             ?: throw DownloadNotFoundException(path, container)
 
     override fun delete(container: Container, path: String): Boolean =
-        fileMap[container]!!.remove(path) != null
+        if (connected) fileMap[container]!!.remove(path) != null
+        else throw IllegalStateException("Not connected")
 
     override fun deleteAllByPrefix(container: Container, prefix: String) {
         if (!connected) throw IllegalStateException("Not connected")

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/attachment/common/MockFileClient.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/attachment/common/MockFileClient.kt
@@ -53,8 +53,7 @@ class MockFileClient : FileClient {
             ?: throw DownloadNotFoundException(path, container)
 
     override fun delete(container: Container, path: String): Boolean =
-        if (connected) fileMap[container]!!.remove(path) != null
-        else throw IllegalStateException("Not connected")
+        if (connected) fileMap[container]!!.remove(path) != null else error("Not connected")
 
     override fun deleteAllByPrefix(container: Container, prefix: String) {
         if (!connected) throw IllegalStateException("Not connected")

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/TaydennysBuilder.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/TaydennysBuilder.kt
@@ -1,0 +1,184 @@
+package fi.hel.haitaton.hanke.factory
+
+import fi.hel.haitaton.hanke.hakemus.ApplicationContactType
+import fi.hel.haitaton.hanke.permissions.HankekayttajaEntity
+import fi.hel.haitaton.hanke.permissions.HankekayttajaInput
+import fi.hel.haitaton.hanke.permissions.Kayttooikeustaso
+import fi.hel.haitaton.hanke.taydennys.TaydennysEntity
+import fi.hel.haitaton.hanke.taydennys.TaydennysRepository
+import fi.hel.haitaton.hanke.taydennys.TaydennysyhteyshenkiloEntity
+import fi.hel.haitaton.hanke.taydennys.TaydennysyhteyshenkiloRepository
+import fi.hel.haitaton.hanke.taydennys.TaydennysyhteystietoEntity
+
+data class TaydennysBuilder(
+    private var taydennysEntity: TaydennysEntity,
+    private var hankeId: Int,
+    private val taydennysRepository: TaydennysRepository,
+    private val hankeKayttajaFactory: HankeKayttajaFactory,
+    private val taydennysyhteyshenkiloRepository: TaydennysyhteyshenkiloRepository,
+) {
+    fun saveEntity(): TaydennysEntity {
+        val savedTaydennys = taydennysRepository.save(taydennysEntity)
+        savedTaydennys.yhteystiedot.forEach { (_, yhteystieto) ->
+            yhteystieto.yhteyshenkilot.forEach { yhteyshenkilo ->
+                taydennysyhteyshenkiloRepository.save(yhteyshenkilo)
+            }
+        }
+        return savedTaydennys
+    }
+
+    fun hakija(
+        yhteystieto: TaydennysyhteystietoEntity =
+            TaydennysFactory.createYhteystietoEntity(
+                taydennysEntity,
+                rooli = ApplicationContactType.HAKIJA,
+            ),
+        vararg yhteyshenkilot: HankekayttajaEntity =
+            arrayOf(kayttaja(HankeKayttajaFactory.KAYTTAJA_INPUT_HAKIJA)),
+    ): TaydennysBuilder = yhteystieto(ApplicationContactType.HAKIJA, yhteystieto, *yhteyshenkilot)
+
+    fun hakija(kayttooikeustaso: Kayttooikeustaso, tilaaja: Boolean = true): TaydennysBuilder =
+        yhteystieto(
+            kayttooikeustaso,
+            tilaaja,
+            ApplicationContactType.HAKIJA,
+            HankeKayttajaFactory.KAYTTAJA_INPUT_HAKIJA,
+        )
+
+    fun hakija(
+        first: HankekayttajaEntity,
+        vararg yhteyshenkilot: HankekayttajaEntity,
+    ): TaydennysBuilder = hakija(yhteyshenkilot = arrayOf(first) + yhteyshenkilot)
+
+    fun tyonSuorittaja(
+        yhteystieto: TaydennysyhteystietoEntity =
+            TaydennysFactory.createYhteystietoEntity(
+                taydennysEntity,
+                rooli = ApplicationContactType.TYON_SUORITTAJA,
+            ),
+        vararg yhteyshenkilot: HankekayttajaEntity =
+            arrayOf(kayttaja(HankeKayttajaFactory.KAYTTAJA_INPUT_SUORITTAJA)),
+    ): TaydennysBuilder =
+        yhteystieto(ApplicationContactType.TYON_SUORITTAJA, yhteystieto, *yhteyshenkilot)
+
+    fun tyonSuorittaja(
+        kayttooikeustaso: Kayttooikeustaso,
+        tilaaja: Boolean = false,
+    ): TaydennysBuilder =
+        yhteystieto(
+            kayttooikeustaso,
+            tilaaja,
+            ApplicationContactType.TYON_SUORITTAJA,
+            HankeKayttajaFactory.KAYTTAJA_INPUT_SUORITTAJA,
+        )
+
+    fun tyonSuorittaja(
+        first: HankekayttajaEntity,
+        vararg yhteyshenkilot: HankekayttajaEntity,
+    ): TaydennysBuilder = tyonSuorittaja(yhteyshenkilot = arrayOf(first) + yhteyshenkilot)
+
+    fun rakennuttaja(
+        yhteystieto: TaydennysyhteystietoEntity =
+            TaydennysFactory.createYhteystietoEntity(
+                taydennysEntity,
+                rooli = ApplicationContactType.RAKENNUTTAJA,
+            ),
+        vararg yhteyshenkilot: HankekayttajaEntity =
+            arrayOf(kayttaja(HankeKayttajaFactory.KAYTTAJA_INPUT_RAKENNUTTAJA)),
+    ): TaydennysBuilder =
+        yhteystieto(ApplicationContactType.RAKENNUTTAJA, yhteystieto, *yhteyshenkilot)
+
+    fun rakennuttaja(
+        kayttooikeustaso: Kayttooikeustaso,
+        tilaaja: Boolean = false,
+    ): TaydennysBuilder =
+        yhteystieto(
+            kayttooikeustaso,
+            tilaaja,
+            ApplicationContactType.RAKENNUTTAJA,
+            HankeKayttajaFactory.KAYTTAJA_INPUT_RAKENNUTTAJA,
+        )
+
+    fun rakennuttaja(
+        first: HankekayttajaEntity,
+        vararg yhteyshenkilot: HankekayttajaEntity,
+    ): TaydennysBuilder = rakennuttaja(yhteyshenkilot = arrayOf(first) + yhteyshenkilot)
+
+    fun asianhoitaja(
+        yhteystieto: TaydennysyhteystietoEntity =
+            TaydennysFactory.createYhteystietoEntity(
+                taydennysEntity,
+                rooli = ApplicationContactType.ASIANHOITAJA,
+            ),
+        vararg yhteyshenkilot: HankekayttajaEntity =
+            arrayOf(kayttaja(HankeKayttajaFactory.KAYTTAJA_INPUT_ASIANHOITAJA)),
+    ): TaydennysBuilder =
+        yhteystieto(ApplicationContactType.ASIANHOITAJA, yhteystieto, *yhteyshenkilot)
+
+    fun asianhoitaja(
+        kayttooikeustaso: Kayttooikeustaso,
+        tilaaja: Boolean = false,
+    ): TaydennysBuilder =
+        yhteystieto(
+            kayttooikeustaso,
+            tilaaja,
+            ApplicationContactType.ASIANHOITAJA,
+            HankeKayttajaFactory.KAYTTAJA_INPUT_ASIANHOITAJA,
+        )
+
+    fun asianhoitaja(
+        first: HankekayttajaEntity,
+        vararg yhteyshenkilot: HankekayttajaEntity,
+    ): TaydennysBuilder = asianhoitaja(yhteyshenkilot = arrayOf(first) + yhteyshenkilot)
+
+    private fun yhteystieto(
+        rooli: ApplicationContactType,
+        yhteystietoEntity: TaydennysyhteystietoEntity =
+            TaydennysFactory.createYhteystietoEntity(taydennysEntity),
+        vararg yhteyshenkilot: HankekayttajaEntity,
+    ): TaydennysBuilder {
+        val yhteyshenkiloEntities =
+            yhteyshenkilot.map { createYhteyshenkiloEntity(yhteystietoEntity, it) }
+        yhteystietoEntity.yhteyshenkilot.addAll(yhteyshenkiloEntities)
+        taydennysEntity.yhteystiedot[rooli] = yhteystietoEntity
+
+        return this
+    }
+
+    private fun yhteystieto(
+        kayttooikeustaso: Kayttooikeustaso,
+        tilaaja: Boolean,
+        rooli: ApplicationContactType,
+        kayttajaInput: HankekayttajaInput,
+    ): TaydennysBuilder {
+        val yhteystietoEntity =
+            TaydennysFactory.createYhteystietoEntity(taydennysEntity, rooli = rooli)
+        val kayttaja = kayttaja(kayttajaInput, kayttooikeustaso)
+        val yhteyshenkiloEntity = createYhteyshenkiloEntity(yhteystietoEntity, kayttaja, tilaaja)
+
+        yhteystietoEntity.yhteyshenkilot.add(yhteyshenkiloEntity)
+        taydennysEntity.yhteystiedot[rooli] = yhteystietoEntity
+        return this
+    }
+
+    private fun kayttaja(
+        kayttajaInput: HankekayttajaInput,
+        kayttooikeustaso: Kayttooikeustaso = Kayttooikeustaso.KATSELUOIKEUS,
+    ): HankekayttajaEntity =
+        hankeKayttajaFactory.findOrSaveIdentifiedUser(
+            hankeId,
+            kayttajaInput,
+            kayttooikeustaso = kayttooikeustaso,
+        )
+
+    private fun createYhteyshenkiloEntity(
+        yhteystietoEntity: TaydennysyhteystietoEntity,
+        kayttaja: HankekayttajaEntity,
+        tilaaja: Boolean = false,
+    ) =
+        TaydennysyhteyshenkiloEntity(
+            hankekayttaja = kayttaja,
+            taydennysyhteystieto = yhteystietoEntity,
+            tilaaja = tilaaja,
+        )
+}

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/TaydennysFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/TaydennysFactory.kt
@@ -23,7 +23,7 @@ import fi.hel.haitaton.hanke.taydennys.TaydennysyhteyshenkiloRepository
 import fi.hel.haitaton.hanke.taydennys.TaydennysyhteystietoEntity
 import fi.hel.haitaton.hanke.test.USERNAME
 import fi.hel.haitaton.hanke.toJsonString
-import java.util.*
+import java.util.UUID
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
 

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/TaydennysFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/TaydennysFactory.kt
@@ -19,10 +19,11 @@ import fi.hel.haitaton.hanke.taydennys.TaydennysRepository
 import fi.hel.haitaton.hanke.taydennys.TaydennysWithMuutokset
 import fi.hel.haitaton.hanke.taydennys.TaydennyspyyntoEntity
 import fi.hel.haitaton.hanke.taydennys.TaydennysyhteyshenkiloEntity
+import fi.hel.haitaton.hanke.taydennys.TaydennysyhteyshenkiloRepository
 import fi.hel.haitaton.hanke.taydennys.TaydennysyhteystietoEntity
 import fi.hel.haitaton.hanke.test.USERNAME
 import fi.hel.haitaton.hanke.toJsonString
-import java.util.UUID
+import java.util.*
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
 
@@ -30,8 +31,31 @@ import org.springframework.transaction.annotation.Transactional
 class TaydennysFactory(
     private val taydennysRepository: TaydennysRepository,
     private val taydennyspyyntoFactory: TaydennyspyyntoFactory,
+    private val taydennysyhteyshenkiloRepository: TaydennysyhteyshenkiloRepository,
     private val hakemusFactory: HakemusFactory,
+    private val hankeKayttajaFactory: HankeKayttajaFactory,
 ) {
+    fun builder(userId: String = USERNAME): TaydennysBuilder {
+        val hakemusEntity =
+            hakemusFactory
+                .builder(userId)
+                .withMandatoryFields()
+                .withStatus(ApplicationStatus.WAITING_INFORMATION)
+                .saveEntity()
+        val taydennysEntity =
+            createEntity(taydennyspyynto = taydennyspyyntoFactory.saveEntity(hakemusEntity.id))
+        return builder(taydennysEntity, hakemusEntity.hanke.id)
+    }
+
+    private fun builder(taydennysEntity: TaydennysEntity, hankeId: Int): TaydennysBuilder =
+        TaydennysBuilder(
+            taydennysEntity,
+            hankeId,
+            taydennysRepository,
+            hankeKayttajaFactory,
+            taydennysyhteyshenkiloRepository,
+        )
+
     fun save(
         applicationId: Long? = null,
         hakemusData: HakemusEntityData = ApplicationFactory.createCableReportApplicationData(),


### PR DESCRIPTION
# Description

API for deleting täydennys incl. its attachments and contacts.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-780

## Type of change

- [ ] Bug fix 
- [x] New feature 
- [ ] Other

# Instructions for testing
1. Create täydennys (with some new contacts, attachments cannot yet be added)
2. Delete täydennys: http://localhost:3001/api/swagger-ui/index.html#/taydennys-controller/delete
3. Check database that there is no `taydennys` row or `taydennysyhteystieto` or `taydennysyhteyshenkilo` for the deleted täydennys any more
4. In UI the application is reverted back to where there is "Täydennä" button for it

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 

# Other relevant info
Please describe here if there is e.g. some requirements for this change or
 other info that the tester/user needs to know.