### PR TITLE
HAI-2794 Send email when a täydennyspyyntö is canceled

### DIFF
--- a/email/taydennyspyynto-peruttu.mjml
+++ b/email/taydennyspyynto-peruttu.mjml
@@ -1,0 +1,44 @@
+<mjml>
+    <mj-head>
+        <mj-include path="common/attributes.partial"/>
+    </mj-head>
+    <mj-body>
+        <mj-include path="common/header-content.partial"/>
+        <mj-section>
+            <mj-column>
+                <mj-text mj-class="header-txt">
+                    Hakemustasi koskeva täydennyspyyntö on peruttu / Hakemustasi koskeva täydennyspyyntö on peruttu /
+                    Hakemustasi koskeva täydennyspyyntö on peruttu
+                </mj-text>
+                <mj-text mj-class="basic-txt">
+                    Hakemuksellesi {{hakemusNimi}} ({{hakemustunnus}}) tehty täydennyspyyntö on peruttu käsittelijän
+                    toimesta. Mahdollinen täydennyspyynnön luonnos on poistettu Haitattomasta ja hakemuksesi on muutettu
+                    takaisin käsittelyssä tilaiseksi:
+                    <a href="{{baseUrl}}/fi/hakemus/{{hakemusId}}">{{baseUrl}}/fi/hakemus/{{hakemusId}}</a>
+                </mj-text>
+                <mj-include path="common/signature-fi.partial"/>
+
+                <mj-divider mj-class="language-separator"/>
+
+                <mj-text mj-class="basic-txt">
+                    Hakemuksellesi {{hakemusNimi}} ({{hakemustunnus}}) tehty täydennyspyyntö on peruttu käsittelijän
+                    toimesta. Mahdollinen täydennyspyynnön luonnos on poistettu Haitattomasta ja hakemuksesi on muutettu
+                    takaisin käsittelyssä tilaiseksi:
+                    <a href="{{baseUrl}}/fi/hakemus/{{hakemusId}}">{{baseUrl}}/sv/ansokan/{{hakemusId}}</a>
+                </mj-text>
+                <mj-include path="common/signature-sv.partial"/>
+
+                <mj-divider mj-class="language-separator"/>
+
+                <mj-text mj-class="basic-txt">
+                    Hakemuksellesi {{hakemusNimi}} ({{hakemustunnus}}) tehty täydennyspyyntö on peruttu käsittelijän
+                    toimesta. Mahdollinen täydennyspyynnön luonnos on poistettu Haitattomasta ja hakemuksesi on muutettu
+                    takaisin käsittelyssä tilaiseksi:
+                    <a href="{{baseUrl}}/fi/hakemus/{{hakemusId}}">{{baseUrl}}/en/application/{{hakemusId}}</a>
+                </mj-text>
+                <mj-include path="common/signature-en.partial"/>
+            </mj-column>
+        </mj-section>
+        <mj-include path="common/footer-content.partial"/>
+    </mj-body>
+</mjml>

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/allu/AlluClientITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/allu/AlluClientITests.kt
@@ -24,6 +24,8 @@ import fi.hel.haitaton.hanke.configuration.Configuration.Companion.webClientWith
 import fi.hel.haitaton.hanke.factory.AlluFactory
 import fi.hel.haitaton.hanke.factory.ApplicationAttachmentFactory
 import fi.hel.haitaton.hanke.factory.ApplicationHistoryFactory
+import fi.hel.haitaton.hanke.factory.ApplicationHistoryFactory.asList
+import fi.hel.haitaton.hanke.factory.ApplicationHistoryFactory.withDefaultEvents
 import fi.hel.haitaton.hanke.hakemus.HakemusDecisionNotFoundException
 import fi.hel.haitaton.hanke.parseJson
 import fi.hel.haitaton.hanke.toJsonString
@@ -712,7 +714,8 @@ class AlluClientITests {
         fun `returns application histories`() {
             val alluids = listOf(12, 13)
             val eventsAfter = ZonedDateTime.parse("2022-10-10T15:25:34.981654Z")
-            val histories = listOf(ApplicationHistoryFactory.create(applicationId = 12))
+            val histories =
+                ApplicationHistoryFactory.create(applicationId = 12).withDefaultEvents().asList()
             mockWebServer.enqueue(
                 MockResponse()
                     .setResponseCode(200)

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusHistoryServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusHistoryServiceITest.kt
@@ -30,6 +30,9 @@ import fi.hel.haitaton.hanke.attachment.common.MockFileClient
 import fi.hel.haitaton.hanke.attachment.common.TestFile
 import fi.hel.haitaton.hanke.factory.AlluFactory
 import fi.hel.haitaton.hanke.factory.ApplicationHistoryFactory
+import fi.hel.haitaton.hanke.factory.ApplicationHistoryFactory.asList
+import fi.hel.haitaton.hanke.factory.ApplicationHistoryFactory.withDefaultEvents
+import fi.hel.haitaton.hanke.factory.ApplicationHistoryFactory.withEvent
 import fi.hel.haitaton.hanke.factory.HakemusFactory
 import fi.hel.haitaton.hanke.factory.HankeFactory
 import fi.hel.haitaton.hanke.factory.HankeKayttajaFactory
@@ -119,18 +122,10 @@ class HakemusHistoryServiceITest(
             hakemusFactory.builder(USERNAME).withStatus(alluId = alluId).save()
             val firstEventTime = ZonedDateTime.parse("2022-09-05T14:15:16Z")
             val history =
-                ApplicationHistoryFactory.create(
-                    alluId,
-                    ApplicationHistoryFactory.createEvent(
-                        firstEventTime.plusDays(5),
-                        ApplicationStatus.PENDING,
-                    ),
-                    ApplicationHistoryFactory.createEvent(
-                        firstEventTime.plusDays(10),
-                        ApplicationStatus.HANDLING,
-                    ),
-                    ApplicationHistoryFactory.createEvent(firstEventTime, ApplicationStatus.PENDING),
-                )
+                ApplicationHistoryFactory.create(alluId)
+                    .withEvent(firstEventTime.plusDays(5), ApplicationStatus.PENDING)
+                    .withEvent(firstEventTime.plusDays(10), ApplicationStatus.HANDLING)
+                    .withEvent(firstEventTime, ApplicationStatus.PENDING)
 
             historyService.handleHakemusUpdates(listOf(history), updateTime)
 
@@ -155,13 +150,11 @@ class HakemusHistoryServiceITest(
                 )
                 .save()
             val history =
-                ApplicationHistoryFactory.create(
-                    alluId,
-                    ApplicationHistoryFactory.createEvent(
+                ApplicationHistoryFactory.create(alluId)
+                    .withEvent(
                         applicationIdentifier = "JS2400001-13",
                         newStatus = ApplicationStatus.REPLACED,
-                    ),
-                )
+                    )
 
             historyService.handleHakemusUpdates(listOf(history), updateTime)
 
@@ -181,9 +174,9 @@ class HakemusHistoryServiceITest(
             hakemusFactory.builder(USERNAME, hanke).withStatus(alluId = alluId + 2).save()
             val histories =
                 listOf(
-                    ApplicationHistoryFactory.create(alluId, "JS2300082"),
-                    ApplicationHistoryFactory.create(alluId + 1, "JS2300083"),
-                    ApplicationHistoryFactory.create(alluId + 2, "JS2300084"),
+                    ApplicationHistoryFactory.create(alluId).withDefaultEvents("JS2300082"),
+                    ApplicationHistoryFactory.create(alluId + 1).withDefaultEvents("JS2300083"),
+                    ApplicationHistoryFactory.create(alluId + 2).withDefaultEvents("JS2300084"),
                 )
 
             historyService.handleHakemusUpdates(histories, updateTime)
@@ -211,15 +204,12 @@ class HakemusHistoryServiceITest(
                 .hakija(hakija)
                 .saveEntity()
             val histories =
-                listOf(
-                    ApplicationHistoryFactory.create(
-                        alluId,
-                        ApplicationHistoryFactory.createEvent(
-                            applicationIdentifier = identifier,
-                            newStatus = ApplicationStatus.DECISION,
-                        ),
+                ApplicationHistoryFactory.create(alluId)
+                    .withEvent(
+                        applicationIdentifier = identifier,
+                        newStatus = ApplicationStatus.DECISION,
                     )
-                )
+                    .asList()
 
             historyService.handleHakemusUpdates(histories, updateTime)
 
@@ -249,15 +239,9 @@ class HakemusHistoryServiceITest(
                 .hakija(hakija)
                 .saveEntity()
             val histories =
-                listOf(
-                    ApplicationHistoryFactory.create(
-                        alluId,
-                        ApplicationHistoryFactory.createEvent(
-                            applicationIdentifier = identifier,
-                            newStatus = applicationStatus,
-                        ),
-                    )
-                )
+                ApplicationHistoryFactory.create(alluId)
+                    .withEvent(applicationIdentifier = identifier, newStatus = applicationStatus)
+                    .asList()
             mockAlluDownload(applicationStatus)
             every { alluClient.getApplicationInformation(alluId) } returns
                 AlluFactory.createAlluApplicationResponse(id = alluId, applicationId = identifier)
@@ -289,15 +273,9 @@ class HakemusHistoryServiceITest(
                     .withStatus(ApplicationStatus.HANDLING, alluId, identifier)
                     .save()
             val histories =
-                listOf(
-                    ApplicationHistoryFactory.create(
-                        alluId,
-                        ApplicationHistoryFactory.createEvent(
-                            applicationIdentifier = identifier,
-                            newStatus = status,
-                        ),
-                    )
-                )
+                ApplicationHistoryFactory.create(alluId)
+                    .withEvent(applicationIdentifier = identifier, newStatus = status)
+                    .asList()
             mockAlluDownload(status)
             every { alluClient.getApplicationInformation(alluId) } returns
                 AlluFactory.createAlluApplicationResponse()
@@ -347,12 +325,13 @@ class HakemusHistoryServiceITest(
                 .rakennuttaja(rakennuttaja, suorittaja, asianhoitaja)
                 .asianhoitaja(asianhoitaja, rakennuttaja, suorittaja, hakija)
                 .save()
-            val event =
-                ApplicationHistoryFactory.createEvent(
-                    applicationIdentifier = identifier,
-                    newStatus = ApplicationStatus.WAITING_INFORMATION,
-                )
-            val histories = listOf(ApplicationHistoryFactory.create(alluId, event))
+            val histories =
+                ApplicationHistoryFactory.create(alluId)
+                    .withEvent(
+                        applicationIdentifier = identifier,
+                        newStatus = ApplicationStatus.WAITING_INFORMATION,
+                    )
+                    .asList()
             every { alluClient.getInformationRequest(alluId) } returns
                 AlluFactory.createInformationRequest()
 
@@ -380,12 +359,13 @@ class HakemusHistoryServiceITest(
                     .builder(hanke)
                     .withStatus(ApplicationStatus.HANDLING, alluId, identifier)
                     .save()
-            val event =
-                ApplicationHistoryFactory.createEvent(
-                    applicationIdentifier = identifier,
-                    newStatus = ApplicationStatus.WAITING_INFORMATION,
-                )
-            val histories = listOf(ApplicationHistoryFactory.create(alluId, event))
+            val histories =
+                ApplicationHistoryFactory.create(alluId)
+                    .withEvent(
+                        applicationIdentifier = identifier,
+                        newStatus = ApplicationStatus.WAITING_INFORMATION,
+                    )
+                    .asList()
             every { alluClient.getInformationRequest(alluId) } returns
                 AlluFactory.createInformationRequest(applicationAlluId = alluId)
 
@@ -410,12 +390,13 @@ class HakemusHistoryServiceITest(
                 .builder()
                 .withStatus(ApplicationStatus.HANDLING, alluId, identifier)
                 .save()
-            val event =
-                ApplicationHistoryFactory.createEvent(
-                    applicationIdentifier = identifier,
-                    newStatus = ApplicationStatus.WAITING_INFORMATION,
-                )
-            val histories = listOf(ApplicationHistoryFactory.create(alluId, event))
+            val histories =
+                ApplicationHistoryFactory.create(alluId)
+                    .withEvent(
+                        applicationIdentifier = identifier,
+                        newStatus = ApplicationStatus.WAITING_INFORMATION,
+                    )
+                    .asList()
             every { alluClient.getInformationRequest(alluId) } returns null
 
             historyService.handleHakemusUpdates(histories, updateTime)
@@ -433,15 +414,16 @@ class HakemusHistoryServiceITest(
             val hakemus =
                 hakemusFactory
                     .builder()
-                    .withStatus(ApplicationStatus.WAITING_INFORMATION, 42)
+                    .withStatus(ApplicationStatus.WAITING_INFORMATION, alluId)
                     .save()
             taydennysFactory.save(applicationId = hakemus.id)
-            val event =
-                ApplicationHistoryFactory.createEvent(
-                    applicationIdentifier = identifier,
-                    newStatus = ApplicationStatus.HANDLING,
-                )
-            val histories = listOf(ApplicationHistoryFactory.create(alluId, event))
+            val histories =
+                ApplicationHistoryFactory.create(alluId)
+                    .withEvent(
+                        applicationIdentifier = identifier,
+                        newStatus = ApplicationStatus.HANDLING,
+                    )
+                    .asList()
 
             historyService.handleHakemusUpdates(histories, updateTime)
 
@@ -456,16 +438,55 @@ class HakemusHistoryServiceITest(
         }
 
         @Test
+        fun `sends emails when removing the taydennyspyynto`() {
+            val hakemus =
+                hakemusFactory
+                    .builder()
+                    .withStatus(ApplicationStatus.WAITING_INFORMATION, alluId, identifier)
+                    .hakija(Kayttooikeustaso.KAIKKI_OIKEUDET)
+                    .tyonSuorittaja(Kayttooikeustaso.HAKEMUSASIOINTI)
+                    .rakennuttaja(Kayttooikeustaso.HANKEMUOKKAUS)
+                    .asianhoitaja(Kayttooikeustaso.KATSELUOIKEUS)
+                    .save()
+            taydennysFactory.save(applicationId = hakemus.id)
+            val histories =
+                ApplicationHistoryFactory.create(alluId)
+                    .withEvent(
+                        applicationIdentifier = identifier,
+                        newStatus = ApplicationStatus.HANDLING,
+                    )
+                    .asList()
+
+            historyService.handleHakemusUpdates(histories, updateTime)
+
+            val emails = greenMail.receivedMessages
+            val recipients = emails.map { it.allRecipients.toList() }.flatten()
+            assertThat(recipients)
+                .extracting { it.toString() }
+                .containsExactlyInAnyOrder(
+                    HankeKayttajaFactory.KAYTTAJA_INPUT_HAKIJA.email,
+                    HankeKayttajaFactory.KAYTTAJA_INPUT_SUORITTAJA.email,
+                )
+            assertThat(emails).each {
+                it.prop(MimeMessage::getSubject)
+                    .isEqualTo(
+                        "Haitaton: Hakemustasi koskeva täydennyspyyntö on peruttu / Hakemustasi koskeva täydennyspyyntö on peruttu / Hakemustasi koskeva täydennyspyyntö on peruttu"
+                    )
+            }
+        }
+
+        @Test
         fun `updates the status when the new status is HANDLING and there is no taydennyspyynto`(
             output: CapturedOutput
         ) {
             hakemusFactory.builder().withStatus(ApplicationStatus.WAITING_INFORMATION, 42).save()
-            val event =
-                ApplicationHistoryFactory.createEvent(
-                    applicationIdentifier = identifier,
-                    newStatus = ApplicationStatus.HANDLING,
-                )
-            val histories = listOf(ApplicationHistoryFactory.create(alluId, event))
+            val histories =
+                ApplicationHistoryFactory.create(alluId)
+                    .withEvent(
+                        applicationIdentifier = identifier,
+                        newStatus = ApplicationStatus.HANDLING,
+                    )
+                    .asList()
 
             historyService.handleHakemusUpdates(histories, updateTime)
 
@@ -483,12 +504,13 @@ class HakemusHistoryServiceITest(
         ) {
             val hakemus = hakemusFactory.builder().withStatus(ApplicationStatus.DECISION, 42).save()
             taydennysFactory.save(applicationId = hakemus.id)
-            val event =
-                ApplicationHistoryFactory.createEvent(
-                    applicationIdentifier = identifier,
-                    newStatus = ApplicationStatus.HANDLING,
-                )
-            val histories = listOf(ApplicationHistoryFactory.create(alluId, event))
+            val histories =
+                ApplicationHistoryFactory.create(alluId)
+                    .withEvent(
+                        applicationIdentifier = identifier,
+                        newStatus = ApplicationStatus.HANDLING,
+                    )
+                    .asList()
 
             historyService.handleHakemusUpdates(histories, updateTime)
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/email/EmailEvent.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/email/EmailEvent.kt
@@ -60,3 +60,10 @@ data class InformationRequestEmail(
     val hakemusTunnus: String,
     val hakemusId: Long,
 ) : EmailEvent
+
+data class InformationRequestCanceledEmail(
+    override val to: String,
+    val hakemusNimi: String,
+    val hakemustunnus: String,
+    val hakemusId: Long,
+) : EmailEvent

--- a/services/hanke-service/src/main/resources/email/template/taydennyspyynto-peruttu.html.mustache
+++ b/services/hanke-service/src/main/resources/email/template/taydennyspyynto-peruttu.html.mustache
@@ -1,0 +1,215 @@
+<!doctype html>
+<html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
+
+<head>
+  <title></title>
+  <!--[if !mso]><!-->
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <!--<![endif]-->
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <style type="text/css">#outlook a{padding:0}body{margin:0;padding:0;-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%}table,td{border-collapse:collapse;mso-table-lspace:0;mso-table-rspace:0}img{border:0;height:auto;line-height:100%;outline:0;text-decoration:none;-ms-interpolation-mode:bicubic}p{display:block;margin:13px 0}</style>
+  <!--[if mso]>
+    <noscript>
+    <xml>
+    <o:OfficeDocumentSettings>
+      <o:AllowPNG/>
+      <o:PixelsPerInch>96</o:PixelsPerInch>
+    </o:OfficeDocumentSettings>
+    </xml>
+    </noscript>
+    <![endif]-->
+  <!--[if lte mso 11]>
+    <style type="text/css">
+      .mj-outlook-group-fix { width:100% !important; }
+    </style>
+    <![endif]-->
+  <style type="text/css">@media only screen and (min-width:480px){.mj-column-per-100{width:100%!important;max-width:100%}}</style>
+  <style media="screen and (min-width:480px)">.moz-text-html .mj-column-per-100{width:100%!important;max-width:100%}</style>
+</head>
+
+<body style="word-spacing:normal">
+  <div lang="und" dir="auto">
+    <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    <div style="margin:0 auto;max-width:600px">
+      <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%">
+        <tbody>
+          <tr>
+            <td style="direction:ltr;font-size:0;padding:20px 0;text-align:center">
+              <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
+              <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%">
+                <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top" width="100%">
+                  <tbody>
+                    <div style="display:flex;align-items:center">
+                      <div style="padding-left:24px;padding-top:16px">
+                        <img src="{{baseUrl}}/helsinki.png" alt="Helsingin logo" width="131" height="65">
+                      </div>
+                      <div style="padding-left:16px;padding-top:12px;font-family:Arial;font-size:24px"> Haitaton </div>
+                    </div>
+                  </tbody>
+                </table>
+              </div>
+              <!--[if mso | IE]></td></tr></table><![endif]-->
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    <div style="margin:0 auto;max-width:600px">
+      <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%">
+        <tbody>
+          <tr>
+            <td style="direction:ltr;font-size:0;padding:20px 0;text-align:center">
+              <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
+              <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%">
+                <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top" width="100%">
+                  <tbody>
+                    <tr>
+                      <td align="left" style="font-size:0;padding:16px 24px 16px 24px;word-break:break-word">
+                        <div style="font-family:Arial;font-size:36px;line-height:43px;text-align:left;color:#000">Hakemustasi koskeva täydennyspyyntö on peruttu / Hakemustasi koskeva täydennyspyyntö on peruttu / Hakemustasi koskeva täydennyspyyntö on peruttu</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="left" style="font-size:0;padding:16px 24px 0 24px;word-break:break-word">
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">Hakemuksellesi {{hakemusNimi}} ({{hakemustunnus}}) tehty täydennyspyyntö on peruttu käsittelijän toimesta. Mahdollinen täydennyspyynnön luonnos on poistettu Haitattomasta ja hakemuksesi on muutettu takaisin käsittelyssä tilaiseksi: <a href="{{baseUrl}}/fi/hakemus/{{hakemusId}}">{{baseUrl}}/fi/hakemus/{{hakemusId}}</a></div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="left" style="font-size:0;padding:16px 24px 0 24px;word-break:break-word">
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">Haitaton on Helsingin kaupungin asiointijärjestelmä yleisille alueille sijoittuvien hankkeiden edistämiseen ja haittojen hallintaan.</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="left" style="font-size:0;padding:16px 24px 0 24px;word-break:break-word">
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">Tämä on automaattinen sähköposti – älä vastaa tähän viestiin.</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="left" style="font-size:0;padding:16px 24px 0 24px;word-break:break-word">
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">Ystävällisin terveisin,</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="left" style="font-size:0;padding:16px 24px 16px 24px;word-break:break-word">
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">Helsingin kaupungin kaupunkiympäristön toimiala <br> Haitaton-asiointi <br> haitaton@hel.fi</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="center" style="font-size:0;padding:10px 25px;word-break:break-word">
+                        <p style="border-top:solid 1px #999898;font-size:1px;margin:0 auto;width:100%">
+                        </p>
+                        <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" style="border-top:solid 1px #999898;font-size:1px;margin:0px auto;width:550px;" role="presentation" width="550px" ><tr><td style="height:0;line-height:0;"> &nbsp;
+</td></tr></table><![endif]-->
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="left" style="font-size:0;padding:16px 24px 0 24px;word-break:break-word">
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">Hakemuksellesi {{hakemusNimi}} ({{hakemustunnus}}) tehty täydennyspyyntö on peruttu käsittelijän toimesta. Mahdollinen täydennyspyynnön luonnos on poistettu Haitattomasta ja hakemuksesi on muutettu takaisin käsittelyssä tilaiseksi: <a href="{{baseUrl}}/fi/hakemus/{{hakemusId}}">{{baseUrl}}/sv/ansokan/{{hakemusId}}</a></div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="left" style="font-size:0;padding:16px 24px 0 24px;word-break:break-word">
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">Haitaton är Helsingfors stads hanteringssystem för att främja projekt i allmänna områden och att hantera olägenheter</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="left" style="font-size:0;padding:16px 24px 0 24px;word-break:break-word">
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">Det här är ett automatiskt e-postmeddelande – svara inte på det.</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="left" style="font-size:0;padding:16px 24px 0 24px;word-break:break-word">
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">Med vänlig hälsning,</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="left" style="font-size:0;padding:16px 24px 16px 24px;word-break:break-word">
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">Helsingfors stads stadsmiljösektor <br> Haitaton-ärenden <br> haitaton@hel.fi</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="center" style="font-size:0;padding:10px 25px;word-break:break-word">
+                        <p style="border-top:solid 1px #999898;font-size:1px;margin:0 auto;width:100%">
+                        </p>
+                        <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" style="border-top:solid 1px #999898;font-size:1px;margin:0px auto;width:550px;" role="presentation" width="550px" ><tr><td style="height:0;line-height:0;"> &nbsp;
+</td></tr></table><![endif]-->
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="left" style="font-size:0;padding:16px 24px 0 24px;word-break:break-word">
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">Hakemuksellesi {{hakemusNimi}} ({{hakemustunnus}}) tehty täydennyspyyntö on peruttu käsittelijän toimesta. Mahdollinen täydennyspyynnön luonnos on poistettu Haitattomasta ja hakemuksesi on muutettu takaisin käsittelyssä tilaiseksi: <a href="{{baseUrl}}/fi/hakemus/{{hakemusId}}">{{baseUrl}}/en/application/{{hakemusId}}</a></div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="left" style="font-size:0;padding:16px 24px 0 24px;word-break:break-word">
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">Haitaton is the City of Helsinki’s service system intended for advancing projects taking place in public areas and managing the disturbances caused by them.</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="left" style="font-size:0;padding:16px 24px 0 24px;word-break:break-word">
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">This email was generated automatically – please do not reply to this message.</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="left" style="font-size:0;padding:16px 24px 0 24px;word-break:break-word">
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">Kind regards,</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="left" style="font-size:0;padding:16px 24px 16px 24px;word-break:break-word">
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">City of Helsinki Urban Environment Division <br> Haitaton services <br> haitaton@hel.fi</div>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+              <!--[if mso | IE]></td></tr></table><![endif]-->
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#FFC61E" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    <div style="background:#ffc61e;background-color:#ffc61e;margin:0 auto;max-width:600px">
+      <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#ffc61e;background-color:#ffc61e;width:100%">
+        <tbody>
+          <tr>
+            <td style="direction:ltr;font-size:0;padding:20px 0;text-align:center">
+              <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
+              <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%">
+                <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top" width="100%">
+                  <tbody>
+                    <div style="display:flex;align-items:center">
+                      <div style="padding-left:24px;padding-top:5px;padding-bottom:16px">
+                        <img src="{{baseUrl}}/helsinki.png" alt="Helsingin logo" width="87" height="43">
+                      </div>
+                      <div style="padding-left:16px;padding-top:12px;padding-bottom:26px;font-family:Arial;font-size:16px"> Haitaton </div>
+                    </div>
+                    <tr>
+                      <td align="center" style="font-size:0;padding:0 24px 16px 24px;word-break:break-word">
+                        <p style="border-top:solid 1px #999898;font-size:1px;margin:0 auto;width:100%">
+                        </p>
+                        <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" style="border-top:solid 1px #999898;font-size:1px;margin:0px auto;width:552px;" role="presentation" width="552px" ><tr><td style="height:0;line-height:0;"> &nbsp;
+</td></tr></table><![endif]-->
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="left" style="font-size:0;padding:0 24px 0 24px;word-break:break-word">
+                        <div style="font-family:Arial;font-size:16px;line-height:1;text-align:left;color:#000">© Helsingin kaupunki 2023</div>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+              <!--[if mso | IE]></td></tr></table><![endif]-->
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <!--[if mso | IE]></td></tr></table><![endif]-->
+  </div>
+</body>
+
+</html>

--- a/services/hanke-service/src/main/resources/email/template/taydennyspyynto-peruttu.subject.mustache
+++ b/services/hanke-service/src/main/resources/email/template/taydennyspyynto-peruttu.subject.mustache
@@ -1,0 +1,1 @@
+Haitaton: Hakemustasi koskeva täydennyspyyntö on peruttu / Hakemustasi koskeva täydennyspyyntö on peruttu / Hakemustasi koskeva täydennyspyyntö on peruttu

--- a/services/hanke-service/src/main/resources/email/template/taydennyspyynto-peruttu.text.mustache
+++ b/services/hanke-service/src/main/resources/email/template/taydennyspyynto-peruttu.text.mustache
@@ -1,0 +1,15 @@
+Hakemustasi koskeva täydennyspyyntö on peruttu / Hakemustasi koskeva täydennyspyyntö on peruttu / Hakemustasi koskeva täydennyspyyntö on peruttu
+
+Hakemuksellesi {{hakemusNimi}} ({{hakemustunnus}}) tehty täydennyspyyntö on peruttu käsittelijän toimesta. Mahdollinen täydennyspyynnön luonnos on poistettu Haitattomasta ja hakemuksesi on muutettu takaisin käsittelyssä tilaiseksi: {{baseUrl}}/fi/hakemus/{{hakemusId}}.
+
+{{{signatures.fi}}}
+
+
+Hakemuksellesi {{hakemusNimi}} ({{hakemustunnus}}) tehty täydennyspyyntö on peruttu käsittelijän toimesta. Mahdollinen täydennyspyynnön luonnos on poistettu Haitattomasta ja hakemuksesi on muutettu takaisin käsittelyssä tilaiseksi: {{baseUrl}}/sv/ansokan/{{hakemusId}}.
+
+{{{signatures.sv}}}
+
+
+Hakemuksellesi {{hakemusNimi}} ({{hakemustunnus}}) tehty täydennyspyyntö on peruttu käsittelijän toimesta. Mahdollinen täydennyspyynnön luonnos on poistettu Haitattomasta ja hakemuksesi on muutettu takaisin käsittelyssä tilaiseksi: {{baseUrl}}/en/application/{{hakemusId}}.
+
+{{{signatures.en}}}

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/ApplicationHistoryFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/ApplicationHistoryFactory.kt
@@ -13,32 +13,6 @@ object ApplicationHistoryFactory {
     val DEFAULT_STATUS: ApplicationStatus = ApplicationStatus.PENDING
     val DEFAULT_TARGET_STATUS: ApplicationStatus? = null
 
-    /**
-     * Create a history for an application with two events at different times. Supervision events
-     * are not included.
-     */
-    fun create(
-        applicationId: Int = DEFAULT_APPLICATION_ID,
-        applicationIdentifier: String = DEFAULT_APPLICATION_IDENTIFIER,
-    ): ApplicationHistory =
-        ApplicationHistory(
-            applicationId,
-            events =
-                listOf(
-                    createEvent(
-                        eventTime = ZonedDateTime.parse("2022-10-12T15:25:34.981654Z"),
-                        newStatus = ApplicationStatus.PENDING,
-                        applicationIdentifier = applicationIdentifier,
-                    ),
-                    createEvent(
-                        eventTime = ZonedDateTime.parse("2023-01-09T14:37:09.135Z"),
-                        newStatus = ApplicationStatus.PENDING_CLIENT,
-                        applicationIdentifier = applicationIdentifier,
-                    ),
-                ),
-            supervisionEvents = listOf()
-        )
-
     fun create(
         applicationId: Int = DEFAULT_APPLICATION_ID,
         vararg events: ApplicationStatusEvent,
@@ -56,6 +30,35 @@ object ApplicationHistoryFactory {
             eventTime = eventTime,
             newStatus = newStatus,
             applicationIdentifier = applicationIdentifier,
-            targetStatus = targetStatus
+            targetStatus = targetStatus,
         )
+
+    /** Add a status event for an application. */
+    fun ApplicationHistory.withEvent(
+        eventTime: ZonedDateTime = DEFAULT_EVENT_TIME,
+        newStatus: ApplicationStatus = DEFAULT_STATUS,
+        applicationIdentifier: String = DEFAULT_APPLICATION_IDENTIFIER,
+        targetStatus: ApplicationStatus? = DEFAULT_TARGET_STATUS,
+    ) =
+        this.copy(
+            events = events + createEvent(eventTime, newStatus, applicationIdentifier, targetStatus)
+        )
+
+    /** Add two events at different times. Supervision events are not included. */
+    fun ApplicationHistory.withDefaultEvents(
+        applicationIdentifier: String = DEFAULT_APPLICATION_IDENTIFIER
+    ) =
+        withEvent(
+                eventTime = ZonedDateTime.parse("2022-10-12T15:25:34.981654Z"),
+                newStatus = ApplicationStatus.PENDING,
+                applicationIdentifier = applicationIdentifier,
+            )
+            .withEvent(
+                eventTime = ZonedDateTime.parse("2023-01-09T14:37:09.135Z"),
+                newStatus = ApplicationStatus.PENDING_CLIENT,
+                applicationIdentifier = applicationIdentifier,
+            )
+
+    /** Return a singleton list with this history. */
+    fun ApplicationHistory.asList(): List<ApplicationHistory> = listOf(this)
 }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/AlluUpdateServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/AlluUpdateServiceTest.kt
@@ -4,6 +4,8 @@ import assertk.assertThat
 import fi.hel.haitaton.hanke.allu.AlluClient
 import fi.hel.haitaton.hanke.configuration.LockService
 import fi.hel.haitaton.hanke.factory.ApplicationHistoryFactory
+import fi.hel.haitaton.hanke.factory.ApplicationHistoryFactory.asList
+import fi.hel.haitaton.hanke.factory.ApplicationHistoryFactory.withDefaultEvents
 import fi.hel.haitaton.hanke.test.Asserts.isRecent
 import io.mockk.Called
 import io.mockk.checkUnnecessaryStub
@@ -88,7 +90,10 @@ class AlluUpdateServiceTest {
         fun `calls application service with the returned histories`() {
             mockLocking(true)
             val alluids = listOf(23, 24)
-            val histories = listOf(ApplicationHistoryFactory.create(applicationId = 24))
+            val histories =
+                ApplicationHistoryFactory.create(applicationId = 24, *emptyArray())
+                    .withDefaultEvents()
+                    .asList()
             every { historyService.getAllAlluIds() } returns alluids
             every { historyService.getLastUpdateTime() } returns lastUpdated
             every { alluClient.getApplicationStatusHistories(alluids, eventsAfter) } returns


### PR DESCRIPTION
# Description

Send emails when a täydennyspyyntö is cancelled. The emails are sent to the hakemus contacts with edit permissions for the hakemus.

Also, refactor the factory methods for ApplicationHistory for easier use.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-725

## Type of change

- [X] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
1. Create a täydennyspyyntö in Allu for a hakemus.
2. Wait a minute for Haitaton to get the status update.
3. Cancel the täydennyspyyntö in Allu.
4. Check [Smtp4dev](http://localhost:3003/) for the email.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 