### PR TITLE
HAI-1302 Delete täydennyspyyntö and päätös when unlinking applications

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/testdata/TestDataServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/testdata/TestDataServiceITest.kt
@@ -3,27 +3,45 @@ package fi.hel.haitaton.hanke.testdata
 import assertk.assertThat
 import assertk.assertions.each
 import assertk.assertions.hasSize
+import assertk.assertions.isEmpty
 import assertk.assertions.isNull
 import assertk.assertions.prop
+import ch.qos.logback.access.tomcat.LogbackValve.DEFAULT_FILENAME
 import fi.hel.haitaton.hanke.IntegrationTest
 import fi.hel.haitaton.hanke.allu.ApplicationStatus
-import fi.hel.haitaton.hanke.factory.ApplicationFactory
+import fi.hel.haitaton.hanke.attachment.PDF_BYTES
+import fi.hel.haitaton.hanke.attachment.azure.Container
+import fi.hel.haitaton.hanke.attachment.common.MockFileClient
+import fi.hel.haitaton.hanke.factory.HakemusFactory
 import fi.hel.haitaton.hanke.factory.HankeFactory
-import fi.hel.haitaton.hanke.factory.PaperDecisionReceiverFactory
+import fi.hel.haitaton.hanke.factory.PaatosFactory
+import fi.hel.haitaton.hanke.factory.TaydennysAttachmentFactory
+import fi.hel.haitaton.hanke.factory.TaydennysFactory
 import fi.hel.haitaton.hanke.hakemus.HakemusEntity
 import fi.hel.haitaton.hanke.hakemus.HakemusEntityData
 import fi.hel.haitaton.hanke.hakemus.HakemusRepository
+import fi.hel.haitaton.hanke.paatos.PaatosRepository
+import fi.hel.haitaton.hanke.taydennys.TaydennysRepository
+import fi.hel.haitaton.hanke.taydennys.TaydennyspyyntoRepository
 import fi.hel.haitaton.hanke.test.USERNAME
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.MediaType
 
 class TestDataServiceITest : IntegrationTest() {
 
     @Autowired private lateinit var testDataService: TestDataService
     @Autowired private lateinit var hakemusRepository: HakemusRepository
-    @Autowired private lateinit var applicationFactory: ApplicationFactory
+    @Autowired private lateinit var paatosRepository: PaatosRepository
+    @Autowired private lateinit var taydennysRepository: TaydennysRepository
+    @Autowired private lateinit var taydennyspyyntoRepository: TaydennyspyyntoRepository
+    @Autowired private lateinit var hakemusFactory: HakemusFactory
     @Autowired private lateinit var hankeFactory: HankeFactory
+    @Autowired private lateinit var paatosFactory: PaatosFactory
+    @Autowired private lateinit var taydennysFactory: TaydennysFactory
+    @Autowired private lateinit var taydennysAttachmentFactory: TaydennysAttachmentFactory
+    @Autowired private lateinit var fileClient: MockFileClient
 
     @Nested
     inner class UnlinkApplicationsFromAllu {
@@ -34,29 +52,15 @@ class TestDataServiceITest : IntegrationTest() {
 
         @Test
         fun `With applications resets their allu fields`() {
-            val applicationData = ApplicationFactory.createCableReportApplicationData()
             for (i in 1..4) {
                 val hanke = hankeFactory.builder(USERNAME).saveEntity()
-                applicationFactory.saveApplicationEntity(
-                    USERNAME,
-                    hanke = hanke,
-                    alluStatus = ApplicationStatus.entries[i + 4],
-                    alluId = i,
-                    applicationIdentifier = "JS00$i",
-                    hakemusEntityData =
-                        applicationData.copy(
-                            paperDecisionReceiver = PaperDecisionReceiverFactory.default
-                        ),
-                )
+                hakemusFactory
+                    .builder(hanke)
+                    .withStatus(status = ApplicationStatus.entries[i + 4], alluId = i)
+                    .withPaperReceiver()
+                    .save()
 
-                applicationFactory.saveApplicationEntity(
-                    USERNAME,
-                    hanke,
-                    alluStatus = null,
-                    alluId = null,
-                    applicationIdentifier = null,
-                    hakemusEntityData = applicationData,
-                )
+                hakemusFactory.builder(hanke).save()
             }
 
             testDataService.unlinkApplicationsFromAllu()
@@ -72,6 +76,53 @@ class TestDataServiceITest : IntegrationTest() {
                     .prop(HakemusEntityData::paperDecisionReceiver)
                     .isNull()
             }
+        }
+
+        @Test
+        fun `deletes taydennyspyynnot and taydennykset`() {
+            taydennysFactory.saveWithHakemus()
+
+            testDataService.unlinkApplicationsFromAllu()
+
+            assertThat(taydennysRepository.findAll()).isEmpty()
+            assertThat(taydennyspyyntoRepository.findAll()).isEmpty()
+        }
+
+        @Test
+        fun `deletes taydennys attachments from Blob storage`() {
+            val taydennys = taydennysFactory.saveWithHakemus()
+            taydennysAttachmentFactory.save(taydennys = taydennys).withContent().value
+
+            testDataService.unlinkApplicationsFromAllu()
+
+            assertThat(fileClient.listBlobs(Container.HAKEMUS_LIITTEET)).isEmpty()
+        }
+
+        @Test
+        fun `deletes paatokset`() {
+            val hakemus = hakemusFactory.builder().withMandatoryFields().withStatus().save()
+            paatosFactory.save(hakemus)
+
+            testDataService.unlinkApplicationsFromAllu()
+
+            assertThat(paatosRepository.findAll()).isEmpty()
+        }
+
+        @Test
+        fun `deletes paatos attachments from Blob storage`() {
+            val hakemus = hakemusFactory.builder().withMandatoryFields().withStatus().save()
+            val paatos = paatosFactory.save(hakemus)
+            fileClient.upload(
+                Container.PAATOKSET,
+                paatos.blobLocation,
+                DEFAULT_FILENAME,
+                MediaType.APPLICATION_PDF,
+                PDF_BYTES,
+            )
+
+            testDataService.unlinkApplicationsFromAllu()
+
+            assertThat(fileClient.listBlobs(Container.PAATOKSET)).isEmpty()
         }
     }
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/testdata/TestDataService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/testdata/TestDataService.kt
@@ -1,6 +1,13 @@
 package fi.hel.haitaton.hanke.testdata
 
+import fi.hel.haitaton.hanke.attachment.application.ApplicationAttachmentContentService
+import fi.hel.haitaton.hanke.attachment.azure.Container
+import fi.hel.haitaton.hanke.attachment.common.FileClient
+import fi.hel.haitaton.hanke.attachment.common.TaydennysAttachmentRepository
 import fi.hel.haitaton.hanke.hakemus.HakemusRepository
+import fi.hel.haitaton.hanke.paatos.PaatosEntity
+import fi.hel.haitaton.hanke.paatos.PaatosRepository
+import fi.hel.haitaton.hanke.taydennys.TaydennyspyyntoRepository
 import mu.KotlinLogging
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.stereotype.Service
@@ -10,7 +17,14 @@ private val logger = KotlinLogging.logger {}
 
 @Service
 @ConditionalOnProperty(name = ["haitaton.testdata.enabled"], havingValue = "true")
-class TestDataService(private val hakemusRepository: HakemusRepository) {
+class TestDataService(
+    private val hakemusRepository: HakemusRepository,
+    private val taydennyspyyntoRepository: TaydennyspyyntoRepository,
+    private val taydennysAttachmentRepository: TaydennysAttachmentRepository,
+    private val paatosRepository: PaatosRepository,
+    private val attachmentContentService: ApplicationAttachmentContentService,
+    private val fileClient: FileClient,
+) {
     @Transactional
     fun unlinkApplicationsFromAllu() {
         logger.warn { "Unlinking all applications from Allu." }
@@ -21,5 +35,19 @@ class TestDataService(private val hakemusRepository: HakemusRepository) {
             it.applicationIdentifier = null
             it.hakemusEntityData = it.hakemusEntityData.copy(paperDecisionReceiver = null)
         }
+        logger.warn { "Removing all täydennyspyynnöt and täydennykset from Haitaton." }
+        taydennysAttachmentRepository.findAll().forEach {
+            attachmentContentService.delete(it.blobLocation)
+        }
+        taydennyspyyntoRepository.deleteAll()
+
+        logger.warn { "Removing all päätökset and täydennykset." }
+        paatosRepository.findAll().forEach { deletePaatosWithAttachments(it) }
+    }
+
+    private fun deletePaatosWithAttachments(paatosEntity: PaatosEntity) {
+        logger.warn { "Deleting paatos id=${paatosEntity.id} hakemusId=${paatosEntity.hakemusId}" }
+        fileClient.delete(Container.PAATOKSET, paatosEntity.blobLocation)
+        paatosRepository.delete(paatosEntity)
     }
 }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusBuilder.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusBuilder.kt
@@ -21,6 +21,7 @@ import fi.hel.haitaton.hanke.hakemus.JohtoselvitysHakemusalue
 import fi.hel.haitaton.hanke.hakemus.JohtoselvityshakemusEntityData
 import fi.hel.haitaton.hanke.hakemus.KaivuilmoitusAlue
 import fi.hel.haitaton.hanke.hakemus.KaivuilmoitusEntityData
+import fi.hel.haitaton.hanke.hakemus.PaperDecisionReceiver
 import fi.hel.haitaton.hanke.permissions.HankeKayttajaService
 import fi.hel.haitaton.hanke.permissions.HankekayttajaEntity
 import fi.hel.haitaton.hanke.permissions.HankekayttajaInput
@@ -161,6 +162,12 @@ data class HakemusBuilder(
         updateApplicationData(
             { throw InvalidParameterException("Not available for cable reports.") },
             { copy(invoicingCustomer = invoicingCustomer) },
+        )
+
+    fun withPaperReceiver(receiver: PaperDecisionReceiver = PaperDecisionReceiverFactory.default) =
+        updateApplicationData(
+            { copy(paperDecisionReceiver = receiver) },
+            { copy(paperDecisionReceiver = receiver) },
         )
 
     private fun updateApplicationData(

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/TaydennysAttachmentBuilder.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/TaydennysAttachmentBuilder.kt
@@ -1,10 +1,24 @@
 package fi.hel.haitaton.hanke.factory
 
+import fi.hel.haitaton.hanke.attachment.FILE_NAME_PDF
+import fi.hel.haitaton.hanke.attachment.PDF_BYTES
 import fi.hel.haitaton.hanke.attachment.common.TaydennysAttachmentEntity
 import fi.hel.haitaton.hanke.attachment.common.TaydennysAttachmentRepository
+import org.springframework.http.MediaType
 
 data class TaydennysAttachmentBuilder(
     val value: TaydennysAttachmentEntity,
     val attachmentRepository: TaydennysAttachmentRepository,
     val attachmentFactory: TaydennysAttachmentFactory,
-)
+) {
+    fun withContent(
+        filename: String = FILE_NAME_PDF,
+        mediaType: MediaType = MediaType.APPLICATION_PDF,
+        bytes: ByteArray = PDF_BYTES,
+    ): TaydennysAttachmentBuilder {
+        value.size = bytes.size.toLong()
+        attachmentRepository.save(value)
+        attachmentFactory.saveContent(value.blobLocation, filename, mediaType, bytes)
+        return this
+    }
+}


### PR DESCRIPTION
# Description

When unlinking hakemukset from Allu, they return to the draft state. It doesn't make any sense to have täydennyspyyntö or päätös for a hakemus that's a draft. So we can delete the related objects.

For täydennyspyyntö, it's also important because Allu reuses their ID after a reset so they might cause conflicts.

Also, delete the täydennys attachments and päätökset from Blob Storage.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1302

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [X] Other

# Instructions for testing
1. With a local database after a full day of testing, write down some of the attachments the täydennykset and decisions the current applications have.
2. Call the [unlinking tool](http://localhost:3001/api/swagger-ui/index.html#/test-data-controller/unlinkApplicationsFromAllu).
3. Check that the täydennykset, täydennyspyynnöt and päätökset are all gone.
4. Check with Azure Storage Explorer that the files you wrote down earlier have been removed.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 