### PR TITLE
HAI-751 Get täydennys attachments API

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/taydennys/TaydennysAttachmentControllerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/taydennys/TaydennysAttachmentControllerITest.kt
@@ -4,20 +4,26 @@ import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNotNull
 import fi.hel.haitaton.hanke.ControllerTest
+import fi.hel.haitaton.hanke.HankeError
 import fi.hel.haitaton.hanke.HankeError.HAI0001
 import fi.hel.haitaton.hanke.IntegrationTestConfiguration
 import fi.hel.haitaton.hanke.andReturnBody
 import fi.hel.haitaton.hanke.attachment.APPLICATION_ID
+import fi.hel.haitaton.hanke.attachment.DUMMY_DATA
 import fi.hel.haitaton.hanke.attachment.FILE_NAME_PDF
 import fi.hel.haitaton.hanke.attachment.andExpectError
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType.MUU
+import fi.hel.haitaton.hanke.attachment.common.AttachmentContent
 import fi.hel.haitaton.hanke.attachment.common.TaydennysAttachmentMetadataDto
+import fi.hel.haitaton.hanke.attachment.common.ValtakirjaForbiddenException
 import fi.hel.haitaton.hanke.attachment.testFile
 import fi.hel.haitaton.hanke.factory.TaydennysAttachmentFactory
 import fi.hel.haitaton.hanke.factory.TaydennysFactory.Companion.DEFAULT_ID
 import fi.hel.haitaton.hanke.hakemus.HakemusNotFoundException
+import fi.hel.haitaton.hanke.hankeError
 import fi.hel.haitaton.hanke.permissions.PermissionCode.EDIT_APPLICATIONS
+import fi.hel.haitaton.hanke.permissions.PermissionCode.VIEW
 import fi.hel.haitaton.hanke.taydennys.TaydennysAuthorizer
 import fi.hel.haitaton.hanke.test.USERNAME
 import io.mockk.checkUnnecessaryStub
@@ -25,6 +31,7 @@ import io.mockk.clearAllMocks
 import io.mockk.confirmVerified
 import io.mockk.every
 import io.mockk.verifyOrder
+import io.mockk.verifySequence
 import java.util.UUID
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
@@ -33,6 +40,11 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.context.annotation.Import
+import org.springframework.http.HttpHeaders.CONTENT_DISPOSITION
+import org.springframework.http.MediaType
+import org.springframework.http.MediaType.APPLICATION_JSON
+import org.springframework.http.MediaType.APPLICATION_PDF
+import org.springframework.http.MediaType.APPLICATION_PDF_VALUE
 import org.springframework.mock.web.MockMultipartFile
 import org.springframework.security.test.context.support.WithAnonymousUser
 import org.springframework.security.test.context.support.WithMockUser
@@ -41,6 +53,8 @@ import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.ResultActions
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.header
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
 @WebMvcTest(TaydennysAttachmentController::class)
@@ -61,6 +75,61 @@ class TaydennysAttachmentControllerITest(@Autowired override val mockMvc: MockMv
     fun checkMocks() {
         checkUnnecessaryStub()
         confirmVerified(attachmentService, authorizer)
+    }
+
+    @Nested
+    inner class GetAttachmentContent {
+        @Test
+        fun `when valid request should return attachment file`() {
+            val attachmentId = UUID.fromString("afc778b1-eb7c-4bad-951c-de70e173a757")
+            every { authorizer.authorizeAttachment(DEFAULT_ID, attachmentId, VIEW.name) } returns
+                true
+            every { attachmentService.getContent(attachmentId) } returns
+                AttachmentContent(FILE_NAME_PDF, APPLICATION_PDF_VALUE, DUMMY_DATA)
+
+            getAttachmentContent(attachmentId = attachmentId)
+                .andExpect(status().isOk)
+                .andExpect(
+                    header().string(CONTENT_DISPOSITION, "attachment; filename=$FILE_NAME_PDF")
+                )
+                .andExpect(content().bytes(DUMMY_DATA))
+
+            verifySequence {
+                authorizer.authorizeAttachment(DEFAULT_ID, attachmentId, VIEW.name)
+                attachmentService.getContent(attachmentId)
+            }
+        }
+
+        @Test
+        @WithAnonymousUser
+        fun `unauthorized should return error`() {
+            getAttachmentContent(resultType = APPLICATION_JSON).andExpectError(HAI0001)
+        }
+
+        @Test
+        fun `returns 403 when asking for valtakirja`() {
+            val attachmentId = UUID.fromString("afc778b1-eb7c-4bad-951c-de70e173a757")
+            every { authorizer.authorizeAttachment(DEFAULT_ID, attachmentId, VIEW.name) } returns
+                true
+            every { attachmentService.getContent(attachmentId) } throws
+                ValtakirjaForbiddenException(attachmentId)
+
+            get("/taydennykset/$DEFAULT_ID/liitteet/$attachmentId/content")
+                .andExpect(status().isForbidden)
+                .andExpect(hankeError(HankeError.HAI3004))
+
+            verifySequence {
+                authorizer.authorizeAttachment(DEFAULT_ID, attachmentId, VIEW.name)
+                attachmentService.getContent(attachmentId)
+            }
+        }
+
+        private fun getAttachmentContent(
+            taydennysId: UUID = DEFAULT_ID,
+            attachmentId: UUID = UUID.fromString("df37fe12-fb36-4f61-8b07-2fb4ae8233f8"),
+            resultType: MediaType = APPLICATION_PDF,
+        ): ResultActions =
+            get("/taydennykset/$taydennysId/liitteet/$attachmentId/content", resultType)
     }
 
     @Nested

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennysAuthorizerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennysAuthorizerITest.kt
@@ -1,0 +1,116 @@
+package fi.hel.haitaton.hanke.taydennys
+
+import assertk.all
+import assertk.assertFailure
+import assertk.assertThat
+import assertk.assertions.hasClass
+import assertk.assertions.isTrue
+import assertk.assertions.messageContains
+import fi.hel.haitaton.hanke.IntegrationTest
+import fi.hel.haitaton.hanke.attachment.common.AttachmentNotFoundException
+import fi.hel.haitaton.hanke.factory.HakemusFactory
+import fi.hel.haitaton.hanke.factory.HankeFactory
+import fi.hel.haitaton.hanke.factory.TaydennysAttachmentFactory
+import fi.hel.haitaton.hanke.factory.TaydennysFactory
+import fi.hel.haitaton.hanke.hakemus.HakemusNotFoundException
+import fi.hel.haitaton.hanke.permissions.Kayttooikeustaso
+import fi.hel.haitaton.hanke.permissions.PermissionCode.EDIT
+import fi.hel.haitaton.hanke.permissions.PermissionCode.VIEW
+import fi.hel.haitaton.hanke.permissions.PermissionService
+import fi.hel.haitaton.hanke.test.USERNAME
+import java.util.UUID
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+
+class TaydennysAuthorizerITest(
+    @Autowired private val authorizer: TaydennysAuthorizer,
+    @Autowired private val taydennysFactory: TaydennysFactory,
+    @Autowired private val hakemusFactory: HakemusFactory,
+    @Autowired private val hankeFactory: HankeFactory,
+    @Autowired private val permissionService: PermissionService,
+    @Autowired private val attachmentFactory: TaydennysAttachmentFactory,
+) : IntegrationTest() {
+
+    @Nested
+    inner class AuthorizeAttachment {
+        private val taydennysId: UUID = UUID.fromString("1f163338-93ed-409c-8230-ab7041565c70")
+        private val attachmentId = UUID.fromString("2f163338-93ed-409c-8230-ab7041565c70")
+
+        @Test
+        fun `throws exception if taydennys is not found`() {
+            assertFailure { authorizer.authorizeAttachment(taydennysId, attachmentId, VIEW.name) }
+                .all {
+                    hasClass(TaydennysNotFoundException::class)
+                    messageContains(taydennysId.toString())
+                }
+        }
+
+        @Test
+        fun `throws exception if user doesn't have the required permission for the hanke`() {
+            val hanke = hankeFactory.saveMinimal()
+            permissionService.create(hanke.id, USERNAME, Kayttooikeustaso.KATSELUOIKEUS)
+            val hakemus = hakemusFactory.builder(hanke).saveEntity()
+            val taydennys = taydennysFactory.builder(hakemus.id, hanke.id).saveEntity()
+
+            assertFailure { authorizer.authorizeAttachment(taydennys.id, attachmentId, EDIT.name) }
+                .all {
+                    hasClass(HakemusNotFoundException::class)
+                    messageContains(hakemus.id.toString())
+                }
+        }
+
+        @Test
+        fun `throws exception if the attachment is not found`() {
+            val taydennys = taydennysFactory.builder().saveEntity()
+
+            assertFailure { authorizer.authorizeAttachment(taydennys.id, attachmentId, VIEW.name) }
+                .all {
+                    hasClass(AttachmentNotFoundException::class)
+                    messageContains(attachmentId.toString())
+                }
+        }
+
+        @Test
+        fun `throws exception if the attachment belongs to another taydennys`() {
+            val taydennys = taydennysFactory.builder().saveEntity()
+            val taydennys2 = taydennysFactory.builder(id = taydennysId, alluId = 2).saveEntity()
+            val attachment =
+                attachmentFactory.save(taydennys = taydennys2.toDomain()).withContent().value
+
+            assertFailure {
+                    authorizer.authorizeAttachment(taydennys.id, attachment.id!!, VIEW.name)
+                }
+                .all {
+                    hasClass(AttachmentNotFoundException::class)
+                    messageContains(attachment.id.toString())
+                }
+        }
+
+        @Test
+        fun `returns true if the attachment is found, it belongs to the taydennys and the user has the correct permission`() {
+            val attachment = attachmentFactory.save().withContent().value
+
+            assertThat(
+                    authorizer.authorizeAttachment(
+                        attachment.taydennysId,
+                        attachment.id!!,
+                        VIEW.name,
+                    )
+                )
+                .isTrue()
+        }
+
+        @Test
+        fun `throws error if enum value not found`() {
+            val taydennys = taydennysFactory.builder().saveEntity()
+            assertFailure { authorizer.authorizeAttachment(taydennys.id, attachmentId, "Not real") }
+                .all {
+                    hasClass(IllegalArgumentException::class)
+                    messageContains(
+                        "No enum constant fi.hel.haitaton.hanke.permissions.PermissionCode.Not real"
+                    )
+                }
+        }
+    }
+}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentContentService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentContentService.kt
@@ -14,14 +14,12 @@ import org.springframework.stereotype.Service
 private val logger = KotlinLogging.logger {}
 
 @Service
-class ApplicationAttachmentContentService(
-    val fileClient: FileClient,
-) {
+class ApplicationAttachmentContentService(val fileClient: FileClient) {
     fun upload(
         filename: String,
         contentType: MediaType,
         content: ByteArray,
-        applicationId: Long
+        applicationId: Long,
     ): String {
         val blobPath = generateBlobPath(applicationId)
         fileClient.upload(Container.HAKEMUS_LIITTEET, blobPath, filename, contentType, content)
@@ -44,13 +42,13 @@ class ApplicationAttachmentContentService(
     }
 
     fun find(attachment: ApplicationAttachmentMetadata): ByteArray =
+        find(attachment.blobLocation, attachment.id)
+
+    fun find(blobPath: String, id: UUID): ByteArray =
         try {
-            fileClient
-                .download(Container.HAKEMUS_LIITTEET, attachment.blobLocation)
-                .content
-                .toBytes()
-        } catch (e: DownloadNotFoundException) {
-            throw AttachmentNotFoundException(attachment.id)
+            fileClient.download(Container.HAKEMUS_LIITTEET, blobPath).content.toBytes()
+        } catch (_: DownloadNotFoundException) {
+            throw AttachmentNotFoundException(id)
         }
 
     companion object {

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/taydennys/TaydennysAttachmentController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/taydennys/TaydennysAttachmentController.kt
@@ -2,7 +2,10 @@ package fi.hel.haitaton.hanke.attachment.taydennys
 
 import fi.hel.haitaton.hanke.HankeError
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType
+import fi.hel.haitaton.hanke.attachment.common.HeadersBuilder.buildHeaders
 import fi.hel.haitaton.hanke.attachment.common.TaydennysAttachmentMetadataDto
+import fi.hel.haitaton.hanke.attachment.common.ValtakirjaForbiddenException
+import io.swagger.v3.oas.annotations.Hidden
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
@@ -11,12 +14,17 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import java.util.UUID
 import mu.KotlinLogging
+import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.multipart.MultipartFile
 
@@ -26,6 +34,32 @@ private val logger = KotlinLogging.logger {}
 @RequestMapping("/taydennykset/{taydennysId}/liitteet")
 @SecurityRequirement(name = "bearerAuth")
 class TaydennysAttachmentController(private val attachmentService: TaydennysAttachmentService) {
+
+    @GetMapping("/{attachmentId}/content")
+    @Operation(summary = "Download attachment file")
+    @ApiResponses(
+        value =
+            [
+                ApiResponse(description = "Attachment file", responseCode = "200"),
+                ApiResponse(
+                    description = "Attachment not found",
+                    responseCode = "404",
+                    content = [Content(schema = Schema(implementation = HankeError::class))],
+                ),
+            ]
+    )
+    @PreAuthorize("@taydennysAuthorizer.authorizeAttachment(#taydennysId, #attachmentId, 'VIEW')")
+    fun getApplicationAttachmentContent(
+        @PathVariable taydennysId: UUID,
+        @PathVariable attachmentId: UUID,
+    ): ResponseEntity<ByteArray> {
+        val content = attachmentService.getContent(attachmentId)
+
+        return ResponseEntity.ok()
+            .headers(buildHeaders(content.fileName, content.contentType))
+            .body(content.bytes)
+    }
+
     @PostMapping(consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
     @Operation(summary = "Upload attachment for täydennys", description = "Upload attachment.")
     @ApiResponses(
@@ -51,5 +85,13 @@ class TaydennysAttachmentController(private val attachmentService: TaydennysAtta
         @RequestParam("liite") attachment: MultipartFile,
     ): TaydennysAttachmentMetadataDto {
         return attachmentService.addAttachment(taydennysId, tyyppi, attachment)
+    }
+
+    @ExceptionHandler(ValtakirjaForbiddenException::class)
+    @ResponseStatus(HttpStatus.FORBIDDEN)
+    @Hidden
+    fun valtakirjaForbiddenException(ex: ValtakirjaForbiddenException): HankeError {
+        logger.warn(ex) { ex.message }
+        return HankeError.HAI3004
     }
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/taydennys/TaydennysAttachmentController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/taydennys/TaydennysAttachmentController.kt
@@ -5,6 +5,7 @@ import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType
 import fi.hel.haitaton.hanke.attachment.common.HeadersBuilder.buildHeaders
 import fi.hel.haitaton.hanke.attachment.common.TaydennysAttachmentMetadataDto
 import fi.hel.haitaton.hanke.attachment.common.ValtakirjaForbiddenException
+import fi.hel.haitaton.hanke.taydennys.TaydennysNotFoundException
 import io.swagger.v3.oas.annotations.Hidden
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
@@ -93,5 +94,13 @@ class TaydennysAttachmentController(private val attachmentService: TaydennysAtta
     fun valtakirjaForbiddenException(ex: ValtakirjaForbiddenException): HankeError {
         logger.warn(ex) { ex.message }
         return HankeError.HAI3004
+    }
+
+    @ExceptionHandler(TaydennysNotFoundException::class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    @Hidden
+    fun taydennysNotFoundException(ex: TaydennysNotFoundException): HankeError {
+        logger.warn(ex) { ex.message }
+        return HankeError.HAI6001
     }
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/taydennys/TaydennysAttachmentMetadataService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/taydennys/TaydennysAttachmentMetadataService.kt
@@ -30,10 +30,7 @@ class TaydennysAttachmentMetadataService(
 
     @Transactional(readOnly = true)
     fun findAttachment(attachmentId: UUID): TaydennysAttachmentMetadata =
-        findAttachmentEntity(attachmentId).toDomain()
-
-    private fun findAttachmentEntity(attachmentId: UUID): TaydennysAttachmentEntity =
-        attachmentRepository.findByIdOrNull(attachmentId)
+        attachmentRepository.findByIdOrNull(attachmentId)?.toDomain()
             ?: throw AttachmentNotFoundException(attachmentId)
 
     @Transactional

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/taydennys/TaydennysAttachmentMetadataService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/taydennys/TaydennysAttachmentMetadataService.kt
@@ -4,6 +4,7 @@ import fi.hel.haitaton.hanke.ALLOWED_ATTACHMENT_COUNT
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentRepository
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType
 import fi.hel.haitaton.hanke.attachment.common.AttachmentLimitReachedException
+import fi.hel.haitaton.hanke.attachment.common.AttachmentNotFoundException
 import fi.hel.haitaton.hanke.attachment.common.TaydennysAttachmentEntity
 import fi.hel.haitaton.hanke.attachment.common.TaydennysAttachmentMetadata
 import fi.hel.haitaton.hanke.attachment.common.TaydennysAttachmentRepository
@@ -12,6 +13,7 @@ import fi.hel.haitaton.hanke.taydennys.TaydennysIdentifier
 import java.time.OffsetDateTime
 import java.util.UUID
 import mu.KotlinLogging
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -25,6 +27,14 @@ class TaydennysAttachmentMetadataService(
     @Transactional(readOnly = true)
     fun getMetadataList(taydennysId: UUID): List<TaydennysAttachmentMetadata> =
         attachmentRepository.findByTaydennysId(taydennysId).map { it.toDomain() }
+
+    @Transactional(readOnly = true)
+    fun findAttachment(attachmentId: UUID): TaydennysAttachmentMetadata =
+        findAttachmentEntity(attachmentId).toDomain()
+
+    private fun findAttachmentEntity(attachmentId: UUID): TaydennysAttachmentEntity =
+        attachmentRepository.findByIdOrNull(attachmentId)
+            ?: throw AttachmentNotFoundException(attachmentId)
 
     @Transactional
     fun create(

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/taydennys/TaydennysAttachmentService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/taydennys/TaydennysAttachmentService.kt
@@ -2,12 +2,14 @@ package fi.hel.haitaton.hanke.attachment.taydennys
 
 import fi.hel.haitaton.hanke.attachment.application.ApplicationAttachmentContentService
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType
+import fi.hel.haitaton.hanke.attachment.common.AttachmentContent
 import fi.hel.haitaton.hanke.attachment.common.AttachmentInvalidException
 import fi.hel.haitaton.hanke.attachment.common.AttachmentValidator
 import fi.hel.haitaton.hanke.attachment.common.FileScanClient
 import fi.hel.haitaton.hanke.attachment.common.FileScanInput
 import fi.hel.haitaton.hanke.attachment.common.TaydennysAttachmentMetadata
 import fi.hel.haitaton.hanke.attachment.common.TaydennysAttachmentMetadataDto
+import fi.hel.haitaton.hanke.attachment.common.ValtakirjaForbiddenException
 import fi.hel.haitaton.hanke.attachment.common.hasInfected
 import fi.hel.haitaton.hanke.taydennys.TaydennysIdentifier
 import fi.hel.haitaton.hanke.taydennys.TaydennysNotFoundException
@@ -28,6 +30,18 @@ class TaydennysAttachmentService(
     private val attachmentContentService: ApplicationAttachmentContentService,
     private val scanClient: FileScanClient,
 ) {
+    fun getContent(attachmentId: UUID): AttachmentContent {
+        val attachment = metadataService.findAttachment(attachmentId)
+
+        if (attachment.attachmentType == ApplicationAttachmentType.VALTAKIRJA) {
+            throw ValtakirjaForbiddenException(attachmentId)
+        }
+
+        val content = attachmentContentService.find(attachment.blobLocation, attachment.id)
+
+        return AttachmentContent(attachment.fileName, attachment.contentType, content)
+    }
+
     fun addAttachment(
         taydennysId: UUID,
         attachmentType: ApplicationAttachmentType,

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennysAuthorizer.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennysAuthorizer.kt
@@ -1,6 +1,8 @@
 package fi.hel.haitaton.hanke.taydennys
 
 import fi.hel.haitaton.hanke.HankeRepository
+import fi.hel.haitaton.hanke.attachment.common.AttachmentNotFoundException
+import fi.hel.haitaton.hanke.attachment.common.TaydennysAttachmentRepository
 import fi.hel.haitaton.hanke.hakemus.HakemusAuthorizer
 import fi.hel.haitaton.hanke.permissions.Authorizer
 import fi.hel.haitaton.hanke.permissions.PermissionService
@@ -15,6 +17,7 @@ class TaydennysAuthorizer(
     hankeRepository: HankeRepository,
     private val taydennysRepository: TaydennysRepository,
     private val hakemusAuthorizer: HakemusAuthorizer,
+    private val attachmentRepository: TaydennysAttachmentRepository,
 ) : Authorizer(permissionService, hankeRepository) {
 
     @Transactional(readOnly = true)
@@ -26,4 +29,18 @@ class TaydennysAuthorizer(
             hakemusAuthorizer.authorizeHakemusId(it, permissionCode)
         }
     }
+
+    @Transactional(readOnly = true)
+    fun authorizeAttachment(
+        taydennysId: UUID,
+        attachmentId: UUID,
+        permissionCode: String,
+    ): Boolean {
+        authorize(taydennysId, permissionCode)
+        return findTaydennysIdForAttachment(attachmentId) == taydennysId ||
+            throw AttachmentNotFoundException(attachmentId)
+    }
+
+    private fun findTaydennysIdForAttachment(attachmentId: UUID): UUID? =
+        attachmentRepository.findByIdOrNull(attachmentId)?.taydennysId
 }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/TaydennysAttachmentFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/TaydennysAttachmentFactory.kt
@@ -35,7 +35,7 @@ class TaydennysAttachmentFactory(
         createdByUser: String = USERNAME,
         createdAt: OffsetDateTime = CREATED_AT,
         attachmentType: ApplicationAttachmentType = MUU,
-        taydennys: Taydennys = taydennysFactory.save(1L),
+        taydennys: Taydennys = taydennysFactory.builder().saveEntity().toDomain(),
     ): TaydennysAttachmentBuilder {
         val entity =
             attachmentRepository.save(

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/TaydennysFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/TaydennysFactory.kt
@@ -3,6 +3,7 @@ package fi.hel.haitaton.hanke.factory
 import fi.hel.haitaton.hanke.HankeEntity
 import fi.hel.haitaton.hanke.allu.ApplicationStatus
 import fi.hel.haitaton.hanke.allu.CustomerType
+import fi.hel.haitaton.hanke.factory.TaydennyspyyntoFactory.Companion.DEFAULT_ALLU_ID
 import fi.hel.haitaton.hanke.hakemus.ApplicationContactType
 import fi.hel.haitaton.hanke.hakemus.ApplicationType
 import fi.hel.haitaton.hanke.hakemus.HakemusData
@@ -35,16 +36,29 @@ class TaydennysFactory(
     private val hakemusFactory: HakemusFactory,
     private val hankeKayttajaFactory: HankeKayttajaFactory,
 ) {
-    fun builder(userId: String = USERNAME): TaydennysBuilder {
-        val hakemusEntity =
+    fun builder(
+        userId: String = USERNAME,
+        id: UUID = DEFAULT_ID,
+        alluId: Int = DEFAULT_ALLU_ID,
+    ): TaydennysBuilder {
+        val hakemusEntity: HakemusEntity =
             hakemusFactory
                 .builder(userId)
                 .withMandatoryFields()
-                .withStatus(ApplicationStatus.WAITING_INFORMATION)
+                .withStatus(ApplicationStatus.WAITING_INFORMATION, alluId)
                 .saveEntity()
         val taydennysEntity =
-            createEntity(taydennyspyynto = taydennyspyyntoFactory.saveEntity(hakemusEntity.id))
+            createEntity(
+                id = id,
+                taydennyspyynto = taydennyspyyntoFactory.saveEntity(hakemusEntity.id, alluId),
+            )
         return builder(taydennysEntity, hakemusEntity.hanke.id)
+    }
+
+    fun builder(hakemusId: Long, hankeId: Int): TaydennysBuilder {
+        val taydennysEntity =
+            createEntity(taydennyspyynto = taydennyspyyntoFactory.saveEntity(hakemusId))
+        return builder(taydennysEntity, hankeId)
     }
 
     private fun builder(taydennysEntity: TaydennysEntity, hankeId: Int): TaydennysBuilder =


### PR DESCRIPTION
# Description

API for getting täydennys attachments.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-751

## Type of change

- [ ] Bug fix 
- [x] New feature 
- [ ] Other

# Instructions for testing
1. Add some attachments for a täydennys: http://localhost:3001/api/swagger-ui/index.html#/taydennys-attachment-controller/postAttachment
2. Get attachment by calling the API: http://localhost:3001/api/swagger-ui/index.html#/taydennys-attachment-controller/getApplicationAttachmentContent

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 

# Other relevant info
Please describe here if there is e.g. some requirements for this change or
 other info that the tester/user needs to know.