### PR TITLE
HAI-1331 Remove attachments when täydennyspyyntö is canceled

### DIFF
--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/AuditLogService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/AuditLogService.kt
@@ -74,6 +74,18 @@ class AuditLogService(private val auditLogRepository: AuditLogRepository) {
                 objectAfter = null,
             )
 
+        fun <ID, T : HasId<ID>> deleteEntryForAllu(type: ObjectType, deletedObject: T) =
+            AuditLogEntry(
+                operation = Operation.DELETE,
+                status = Status.SUCCESS,
+                userId = ALLU_AUDIT_LOG_USERID,
+                userRole = UserRole.SERVICE,
+                objectId = deletedObject.id!!.toString(),
+                objectType = type,
+                objectBefore = deletedObject.toChangeLogJsonString(),
+                objectAfter = null,
+            )
+
         fun <ID, T : HasId<ID>> createEntry(userId: String, type: ObjectType, createdObject: T) =
             AuditLogEntry(
                 operation = Operation.CREATE,
@@ -95,7 +107,7 @@ class AuditLogService(private val auditLogRepository: AuditLogRepository) {
             userId: String,
             type: ObjectType,
             objectBefore: T,
-            objectAfter: T
+            objectAfter: T,
         ): AuditLogEntry? {
             val jsonBefore = objectBefore.toChangeLogJsonString()
             val jsonAfter = objectAfter.toChangeLogJsonString()

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/ChangeLoggingService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/ChangeLoggingService.kt
@@ -25,4 +25,9 @@ abstract class ChangeLoggingService<ID, T : HasId<ID>>(
     open fun logDelete(before: T, userId: String) {
         auditLogService.create(AuditLogService.deleteEntry(userId, objectType, before))
     }
+
+    @Transactional(propagation = Propagation.MANDATORY)
+    open fun logDeleteFromAllu(before: T) {
+        auditLogService.create(AuditLogService.deleteEntryForAllu(objectType, before))
+    }
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennysService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennysService.kt
@@ -119,6 +119,13 @@ class TaydennysService(
         return taydennys
     }
 
+    /**
+     * Delete the täydennyspyyntö related to the given application if the application has one. The
+     * related objects (täydennys and it's attachments, customers and contacts) are removed as well.
+     *
+     * The deletions are logged to have been done by Allu, since this is called from the Allu event
+     * handler.
+     */
     @Transactional
     fun removeTaydennyspyyntoIfItExists(application: HakemusEntity) {
         logger.info {

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennysService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennysService.kt
@@ -125,8 +125,17 @@ class TaydennysService(
             "A hakemus has has entered handling. Checking if there's a täydennyspyyntö for the hakemus. ${application.logString()}"
         }
 
-        taydennyspyyntoRepository.findByApplicationId(application.id)?.let {
+        taydennysRepository.findByApplicationId(application.id)?.also {
+            logger.info { "A täydennys was found. Removing it." }
+            attachmentService.deleteAllAttachments(it)
+            taydennysLoggingService.logDeleteFromAllu(it.toDomain())
+            taydennysRepository.delete(it)
+            taydennysRepository.flush()
+        }
+
+        taydennyspyyntoRepository.findByApplicationId(application.id)?.also {
             logger.info { "A täydennyspyyntö was found. Removing it." }
+            taydennyspyyntoLoggingService.logDeleteFromAllu(it.toDomain())
             taydennyspyyntoRepository.delete(it)
             taydennyspyyntoRepository.flush()
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/taydennys/Taydennyspyynto.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/taydennys/Taydennyspyynto.kt
@@ -6,6 +6,7 @@ import java.util.UUID
 
 data class Taydennyspyynto(
     override val id: UUID,
+    val hakemusId: Long,
     val kentat: Map<InformationRequestFieldKey, String>,
 ) : HasId<UUID> {
     fun toResponse(): TaydennyspyyntoResponse =

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennyspyyntoEntity.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennyspyyntoEntity.kt
@@ -30,5 +30,5 @@ class TaydennyspyyntoEntity(
     @MapKeyEnumerated(EnumType.STRING)
     val kentat: MutableMap<InformationRequestFieldKey, String> = mutableMapOf(),
 ) {
-    fun toDomain(): Taydennyspyynto = Taydennyspyynto(id, kentat.toMap())
+    fun toDomain(): Taydennyspyynto = Taydennyspyynto(id, applicationId, kentat.toMap())
 }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/TaydennyspyyntoFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/TaydennyspyyntoFactory.kt
@@ -44,8 +44,9 @@ class TaydennyspyyntoFactory(private val taydennyspyyntoRepository: Taydennyspyy
 
         fun create(
             id: UUID = DEFAULT_ID,
+            hakemusId: Long = ApplicationFactory.DEFAULT_APPLICATION_ID,
             kentat: Map<InformationRequestFieldKey, String> = DEFAULT_KENTAT,
-        ): Taydennyspyynto = Taydennyspyynto(id = id, kentat = kentat)
+        ): Taydennyspyynto = Taydennyspyynto(id = id, hakemusId = hakemusId, kentat = kentat)
 
         fun TaydennyspyyntoEntity.addKentta(key: InformationRequestFieldKey, message: String) =
             kentat.put(key, message)


### PR DESCRIPTION
# Description

When a täydennyspyyntö is cancelled in Allu, remove any täydennys attachment contents from Blob storage.

Also, add missing audit logging for the removal of the täydennys and täydennyspyyntö when they are deleted after the täydennyspyyntö is cancelled in Allu.  Allu is marked as the actor. Even though technically the data is deleted by Haitaton itself, Allu initiates the process by cancelling the täydennyspyyntö.

Add hakemus ID to the täydennyspyyntö domain class so that it's logged as well.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1331

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
1. Create a täydennys and add attachments to it.
2. Cancel the täydennyspyyntö in Allu.
3. Check that Haitaton removed the attachments with Azure Storage Explorer.
4. Check that the audit log table in the database has entries for the deletion.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 