### PR TITLE
HAI-752 API for deleting täydennys attachments

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/taydennys/TaydennysAttachmentControllerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/taydennys/TaydennysAttachmentControllerITest.kt
@@ -4,8 +4,12 @@ import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNotNull
 import fi.hel.haitaton.hanke.ControllerTest
-import fi.hel.haitaton.hanke.HankeError
 import fi.hel.haitaton.hanke.HankeError.HAI0001
+import fi.hel.haitaton.hanke.HankeError.HAI1001
+import fi.hel.haitaton.hanke.HankeError.HAI2001
+import fi.hel.haitaton.hanke.HankeError.HAI3002
+import fi.hel.haitaton.hanke.HankeError.HAI3004
+import fi.hel.haitaton.hanke.HankeError.HAI6001
 import fi.hel.haitaton.hanke.HankeNotFoundException
 import fi.hel.haitaton.hanke.IntegrationTestConfiguration
 import fi.hel.haitaton.hanke.andReturnBody
@@ -67,6 +71,8 @@ class TaydennysAttachmentControllerITest(@Autowired override val mockMvc: MockMv
     @Autowired private lateinit var attachmentService: TaydennysAttachmentService
     @Autowired private lateinit var authorizer: TaydennysAuthorizer
 
+    private val attachmentId: UUID = UUID.fromString("df37fe12-fb36-4f61-8b07-2fb4ae8233f8")
+
     @BeforeEach
     fun clearMocks() {
         clearAllMocks()
@@ -81,11 +87,10 @@ class TaydennysAttachmentControllerITest(@Autowired override val mockMvc: MockMv
     @Nested
     inner class GetAttachmentContent {
 
-        private val attachmentId: UUID = UUID.fromString("df37fe12-fb36-4f61-8b07-2fb4ae8233f8")
         private val url = "/taydennykset/$DEFAULT_ID/liitteet/$attachmentId/content"
 
         @Test
-        fun `returns attachment file when request is valid`() {
+        fun `returns 200 and attachment file when request is valid`() {
             every { authorizer.authorizeAttachment(DEFAULT_ID, attachmentId, VIEW.name) } returns
                 true
             every { attachmentService.getContent(attachmentId) } returns
@@ -106,7 +111,7 @@ class TaydennysAttachmentControllerITest(@Autowired override val mockMvc: MockMv
 
         @Test
         @WithAnonymousUser
-        fun `returns 401 and error when request is unauthorized`() {
+        fun `returns 401 and error when user is unauthorized`() {
             get(url).andExpectError(HAI0001)
         }
 
@@ -115,7 +120,7 @@ class TaydennysAttachmentControllerITest(@Autowired override val mockMvc: MockMv
             every { authorizer.authorizeAttachment(DEFAULT_ID, attachmentId, VIEW.name) } throws
                 HakemusNotFoundException(APPLICATION_ID)
 
-            get(url).andExpect(status().isNotFound).andExpect(hankeError(HankeError.HAI2001))
+            get(url).andExpect(status().isNotFound).andExpect(hankeError(HAI2001))
 
             verifySequence { authorizer.authorizeAttachment(DEFAULT_ID, attachmentId, VIEW.name) }
         }
@@ -127,7 +132,7 @@ class TaydennysAttachmentControllerITest(@Autowired override val mockMvc: MockMv
             every { attachmentService.getContent(attachmentId) } throws
                 ValtakirjaForbiddenException(attachmentId)
 
-            get(url).andExpect(status().isForbidden).andExpect(hankeError(HankeError.HAI3004))
+            get(url).andExpect(status().isForbidden).andExpect(hankeError(HAI3004))
 
             verifySequence {
                 authorizer.authorizeAttachment(DEFAULT_ID, attachmentId, VIEW.name)
@@ -136,21 +141,21 @@ class TaydennysAttachmentControllerITest(@Autowired override val mockMvc: MockMv
         }
 
         @Test
-        fun `returns 404 and error when asking for non-existing attachment`() {
+        fun `returns 404 and error when attachment not found`() {
             every { authorizer.authorizeAttachment(DEFAULT_ID, attachmentId, VIEW.name) } throws
                 AttachmentNotFoundException(attachmentId)
 
-            get(url).andExpect(status().isNotFound).andExpect(hankeError(HankeError.HAI3002))
+            get(url).andExpect(status().isNotFound).andExpect(hankeError(HAI3002))
 
             verifySequence { authorizer.authorizeAttachment(DEFAULT_ID, attachmentId, VIEW.name) }
         }
 
         @Test
-        fun `returns 404 and error when asking for non-existing taydennys`() {
+        fun `returns 404 and error when taydennys not found`() {
             every { authorizer.authorizeAttachment(DEFAULT_ID, attachmentId, VIEW.name) } throws
                 TaydennysNotFoundException(DEFAULT_ID)
 
-            get(url).andExpect(status().isNotFound).andExpect(hankeError(HankeError.HAI6001))
+            get(url).andExpect(status().isNotFound).andExpect(hankeError(HAI6001))
 
             verifySequence { authorizer.authorizeAttachment(DEFAULT_ID, attachmentId, VIEW.name) }
         }
@@ -188,9 +193,7 @@ class TaydennysAttachmentControllerITest(@Autowired override val mockMvc: MockMv
             every { authorizer.authorize(DEFAULT_ID, EDIT_APPLICATIONS.name) } throws
                 HankeNotFoundException("HAI24-1")
 
-            postAttachment()
-                .andExpect(status().isNotFound)
-                .andExpect(hankeError(HankeError.HAI1001))
+            postAttachment().andExpect(status().isNotFound).andExpect(hankeError(HAI1001))
 
             verifyOrder { authorizer.authorize(DEFAULT_ID, EDIT_APPLICATIONS.name) }
         }
@@ -200,9 +203,7 @@ class TaydennysAttachmentControllerITest(@Autowired override val mockMvc: MockMv
             every { authorizer.authorize(DEFAULT_ID, EDIT_APPLICATIONS.name) } throws
                 HakemusNotFoundException(APPLICATION_ID)
 
-            postAttachment()
-                .andExpect(status().isNotFound)
-                .andExpect(hankeError(HankeError.HAI2001))
+            postAttachment().andExpect(status().isNotFound).andExpect(hankeError(HAI2001))
 
             verifyOrder { authorizer.authorize(DEFAULT_ID, EDIT_APPLICATIONS.name) }
         }
@@ -229,15 +230,17 @@ class TaydennysAttachmentControllerITest(@Autowired override val mockMvc: MockMv
 
     @Nested
     inner class DeleteAttachment {
+
+        private val url = "/taydennykset/$DEFAULT_ID/liitteet/$attachmentId"
+
         @Test
-        fun `when valid request should succeed`() {
-            val attachmentId = UUID.fromString("5c97dcf2-686f-4cd6-9b9d-4124aff23a07")
+        fun `returns 200 and empty body when deletion succeeds`() {
             every {
                 authorizer.authorizeAttachment(DEFAULT_ID, attachmentId, EDIT_APPLICATIONS.name)
             } returns true
             justRun { attachmentService.deleteAttachment(attachmentId) }
 
-            deleteAttachment(attachmentId = attachmentId).andExpect(status().isOk)
+            delete(url).andExpect(status().isOk).andExpect(content().string(""))
 
             verifySequence {
                 authorizer.authorizeAttachment(DEFAULT_ID, attachmentId, EDIT_APPLICATIONS.name)
@@ -247,32 +250,47 @@ class TaydennysAttachmentControllerITest(@Autowired override val mockMvc: MockMv
 
         @Test
         @WithAnonymousUser
-        fun `unauthorized should return error`() {
-            deleteAttachment().andExpectError(HAI0001)
+        fun `returns 401 and error when user is unauthorized`() {
+            delete(url).andExpectError(HAI0001)
         }
 
         @Test
-        fun `when attachment not found should return error`() {
-            val attachmentId = UUID.fromString("5c97dcf2-686f-4cd6-9b9d-4124aff23a07")
+        fun `returns 404 and error when user has no rights for application`() {
             every {
                 authorizer.authorizeAttachment(DEFAULT_ID, attachmentId, EDIT_APPLICATIONS.name)
-            } returns true
-            every { attachmentService.deleteAttachment(attachmentId) } throws
-                AttachmentNotFoundException(attachmentId)
+            } throws HakemusNotFoundException(APPLICATION_ID)
 
-            deleteAttachment(attachmentId = attachmentId)
-                .andExpect(status().isNotFound)
-                .andExpect(hankeError(HankeError.HAI3002))
+            delete(url).andExpect(status().isNotFound).andExpect(hankeError(HAI2001))
 
             verifySequence {
                 authorizer.authorizeAttachment(DEFAULT_ID, attachmentId, EDIT_APPLICATIONS.name)
-                attachmentService.deleteAttachment(attachmentId)
             }
         }
 
-        private fun deleteAttachment(
-            taydennysId: UUID = DEFAULT_ID,
-            attachmentId: UUID = UUID.fromString("5f79cc05-6a5e-4bb9-b457-f7df0e5e5471"),
-        ): ResultActions = delete("/taydennykset/$taydennysId/liitteet/$attachmentId")
+        @Test
+        fun `returns 404 and error when attachment not found`() {
+            every {
+                authorizer.authorizeAttachment(DEFAULT_ID, attachmentId, EDIT_APPLICATIONS.name)
+            } throws AttachmentNotFoundException(attachmentId)
+
+            delete(url).andExpect(status().isNotFound).andExpect(hankeError(HAI3002))
+
+            verifySequence {
+                authorizer.authorizeAttachment(DEFAULT_ID, attachmentId, EDIT_APPLICATIONS.name)
+            }
+        }
+
+        @Test
+        fun `returns 404 and error when taydennys not found`() {
+            every {
+                authorizer.authorizeAttachment(DEFAULT_ID, attachmentId, EDIT_APPLICATIONS.name)
+            } throws TaydennysNotFoundException(DEFAULT_ID)
+
+            delete(url).andExpect(status().isNotFound).andExpect(hankeError(HAI6001))
+
+            verifySequence {
+                authorizer.authorizeAttachment(DEFAULT_ID, attachmentId, EDIT_APPLICATIONS.name)
+            }
+        }
     }
 }

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/taydennys/TaydennysAttachmentServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/taydennys/TaydennysAttachmentServiceITest.kt
@@ -22,8 +22,6 @@ import fi.hel.haitaton.hanke.attachment.PDF_BYTES
 import fi.hel.haitaton.hanke.attachment.azure.Container.HAKEMUS_LIITTEET
 import fi.hel.haitaton.hanke.attachment.body
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType
-import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType.MUU
-import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType.VALTAKIRJA
 import fi.hel.haitaton.hanke.attachment.common.AttachmentInvalidException
 import fi.hel.haitaton.hanke.attachment.common.AttachmentLimitReachedException
 import fi.hel.haitaton.hanke.attachment.common.AttachmentNotFoundException
@@ -104,7 +102,11 @@ class TaydennysAttachmentServiceITest(
 
         @Test
         fun `Throws exception when trying to get valtakirja content`() {
-            val attachment = attachmentFactory.save(attachmentType = VALTAKIRJA).withContent().value
+            val attachment =
+                attachmentFactory
+                    .save(attachmentType = ApplicationAttachmentType.VALTAKIRJA)
+                    .withContent()
+                    .value
 
             val failure = assertFailure { attachmentService.getContent(attachment.id!!) }
 
@@ -172,7 +174,7 @@ class TaydennysAttachmentServiceITest(
             val result =
                 attachmentService.addAttachment(
                     taydennysId = taydennys.id,
-                    attachmentType = MUU,
+                    attachmentType = ApplicationAttachmentType.MUU,
                     attachment = testFile(fileName = "exa*mple.pdf"),
                 )
 
@@ -194,7 +196,7 @@ class TaydennysAttachmentServiceITest(
             val failure = assertFailure {
                 attachmentService.addAttachment(
                     taydennysId = taydennys.id,
-                    attachmentType = VALTAKIRJA,
+                    attachmentType = ApplicationAttachmentType.VALTAKIRJA,
                     attachment = testFile(),
                 )
             }
@@ -214,7 +216,7 @@ class TaydennysAttachmentServiceITest(
             val failure = assertFailure {
                 attachmentService.addAttachment(
                     taydennysId = taydennys.id,
-                    attachmentType = VALTAKIRJA,
+                    attachmentType = ApplicationAttachmentType.VALTAKIRJA,
                     attachment = testFile(data = byteArrayOf()),
                 )
             }
@@ -232,7 +234,7 @@ class TaydennysAttachmentServiceITest(
             val failure = assertFailure {
                 attachmentService.addAttachment(
                     taydennysId = taydennys.id,
-                    attachmentType = VALTAKIRJA,
+                    attachmentType = ApplicationAttachmentType.VALTAKIRJA,
                     attachment = testFile(contentType = null),
                 )
             }
@@ -248,7 +250,7 @@ class TaydennysAttachmentServiceITest(
             val failure = assertFailure {
                 attachmentService.addAttachment(
                     taydennysId = UUID.randomUUID(),
-                    attachmentType = MUU,
+                    attachmentType = ApplicationAttachmentType.MUU,
                     attachment = testFile(),
                 )
             }
@@ -265,7 +267,7 @@ class TaydennysAttachmentServiceITest(
             val failure = assertFailure {
                 attachmentService.addAttachment(
                     taydennysId = taydennys.id,
-                    attachmentType = VALTAKIRJA,
+                    attachmentType = ApplicationAttachmentType.VALTAKIRJA,
                     attachment = testFile(fileName = invalidFilename),
                 )
             }
@@ -285,7 +287,7 @@ class TaydennysAttachmentServiceITest(
             val failure = assertFailure {
                 attachmentService.addAttachment(
                     taydennysId = taydennys.id,
-                    attachmentType = VALTAKIRJA,
+                    attachmentType = ApplicationAttachmentType.VALTAKIRJA,
                     attachment = testFile(fileName = invalidFilename),
                 )
             }
@@ -294,7 +296,7 @@ class TaydennysAttachmentServiceITest(
                 hasClass(AttachmentInvalidException::class)
                 messageContains("File extension is not valid for attachment type")
                 messageContains("filename=$invalidFilename")
-                messageContains("attachmentType=${VALTAKIRJA}")
+                messageContains("attachmentType=${ApplicationAttachmentType.VALTAKIRJA}")
             }
             assertThat(attachmentRepository.findAll()).isEmpty()
         }
@@ -307,7 +309,7 @@ class TaydennysAttachmentServiceITest(
             val failure = assertFailure {
                 attachmentService.addAttachment(
                     taydennysId = taydennys.id,
-                    attachmentType = VALTAKIRJA,
+                    attachmentType = ApplicationAttachmentType.VALTAKIRJA,
                     attachment = testFile(),
                 )
             }

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/taydennys/TaydennysAttachmentServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/taydennys/TaydennysAttachmentServiceITest.kt
@@ -3,8 +3,10 @@ package fi.hel.haitaton.hanke.attachment.taydennys
 import assertk.all
 import assertk.assertFailure
 import assertk.assertThat
+import assertk.assertions.containsExactly
 import assertk.assertions.hasClass
 import assertk.assertions.hasMessage
+import assertk.assertions.hasSize
 import assertk.assertions.isEmpty
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNotNull
@@ -17,9 +19,10 @@ import fi.hel.haitaton.hanke.IntegrationTest
 import fi.hel.haitaton.hanke.attachment.DEFAULT_SIZE
 import fi.hel.haitaton.hanke.attachment.FILE_NAME_PDF
 import fi.hel.haitaton.hanke.attachment.PDF_BYTES
-import fi.hel.haitaton.hanke.attachment.azure.Container
+import fi.hel.haitaton.hanke.attachment.azure.Container.HAKEMUS_LIITTEET
 import fi.hel.haitaton.hanke.attachment.body
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType
+import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType.MUU
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType.VALTAKIRJA
 import fi.hel.haitaton.hanke.attachment.common.AttachmentInvalidException
 import fi.hel.haitaton.hanke.attachment.common.AttachmentLimitReachedException
@@ -49,7 +52,6 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.http.MediaType
 import org.springframework.http.MediaType.APPLICATION_PDF_VALUE
 
 class TaydennysAttachmentServiceITest(
@@ -133,7 +135,7 @@ class TaydennysAttachmentServiceITest(
             assertThat(result.id).isNotNull()
             assertThat(result.createdByUserId).isEqualTo(USERNAME)
             assertThat(result.fileName).isEqualTo(FILE_NAME_PDF)
-            assertThat(result.contentType).isEqualTo(MediaType.APPLICATION_PDF_VALUE)
+            assertThat(result.contentType).isEqualTo(APPLICATION_PDF_VALUE)
             assertThat(result.size).isEqualTo(DEFAULT_SIZE)
             assertThat(result.createdAt).isRecent()
             assertThat(result.taydennysId).isEqualTo(taydennys.id)
@@ -144,8 +146,7 @@ class TaydennysAttachmentServiceITest(
                 prop(TaydennysAttachmentEntity::id).isEqualTo(result.id)
                 prop(TaydennysAttachmentEntity::createdByUserId).isEqualTo(USERNAME)
                 prop(TaydennysAttachmentEntity::fileName).isEqualTo(FILE_NAME_PDF)
-                prop(TaydennysAttachmentEntity::contentType)
-                    .isEqualTo(MediaType.APPLICATION_PDF_VALUE)
+                prop(TaydennysAttachmentEntity::contentType).isEqualTo(APPLICATION_PDF_VALUE)
                 prop(TaydennysAttachmentEntity::size).isEqualTo(DEFAULT_SIZE)
                 prop(TaydennysAttachmentEntity::createdAt).isRecent()
                 prop(TaydennysAttachmentEntity::taydennysId).isEqualTo(taydennys.id)
@@ -155,8 +156,7 @@ class TaydennysAttachmentServiceITest(
                     .startsWith("${taydennys.hakemusId}/")
             }
 
-            val content =
-                fileClient.download(Container.HAKEMUS_LIITTEET, attachments.first().blobLocation)
+            val content = fileClient.download(HAKEMUS_LIITTEET, attachments.first().blobLocation)
             assertThat(content)
                 .isNotNull()
                 .prop(DownloadResponse::content)
@@ -172,7 +172,7 @@ class TaydennysAttachmentServiceITest(
             val result =
                 attachmentService.addAttachment(
                     taydennysId = taydennys.id,
-                    attachmentType = ApplicationAttachmentType.MUU,
+                    attachmentType = MUU,
                     attachment = testFile(fileName = "exa*mple.pdf"),
                 )
 
@@ -194,7 +194,7 @@ class TaydennysAttachmentServiceITest(
             val failure = assertFailure {
                 attachmentService.addAttachment(
                     taydennysId = taydennys.id,
-                    attachmentType = ApplicationAttachmentType.VALTAKIRJA,
+                    attachmentType = VALTAKIRJA,
                     attachment = testFile(),
                 )
             }
@@ -214,7 +214,7 @@ class TaydennysAttachmentServiceITest(
             val failure = assertFailure {
                 attachmentService.addAttachment(
                     taydennysId = taydennys.id,
-                    attachmentType = ApplicationAttachmentType.VALTAKIRJA,
+                    attachmentType = VALTAKIRJA,
                     attachment = testFile(data = byteArrayOf()),
                 )
             }
@@ -232,7 +232,7 @@ class TaydennysAttachmentServiceITest(
             val failure = assertFailure {
                 attachmentService.addAttachment(
                     taydennysId = taydennys.id,
-                    attachmentType = ApplicationAttachmentType.VALTAKIRJA,
+                    attachmentType = VALTAKIRJA,
                     attachment = testFile(contentType = null),
                 )
             }
@@ -248,7 +248,7 @@ class TaydennysAttachmentServiceITest(
             val failure = assertFailure {
                 attachmentService.addAttachment(
                     taydennysId = UUID.randomUUID(),
-                    attachmentType = ApplicationAttachmentType.MUU,
+                    attachmentType = MUU,
                     attachment = testFile(),
                 )
             }
@@ -265,7 +265,7 @@ class TaydennysAttachmentServiceITest(
             val failure = assertFailure {
                 attachmentService.addAttachment(
                     taydennysId = taydennys.id,
-                    attachmentType = ApplicationAttachmentType.VALTAKIRJA,
+                    attachmentType = VALTAKIRJA,
                     attachment = testFile(fileName = invalidFilename),
                 )
             }
@@ -285,7 +285,7 @@ class TaydennysAttachmentServiceITest(
             val failure = assertFailure {
                 attachmentService.addAttachment(
                     taydennysId = taydennys.id,
-                    attachmentType = ApplicationAttachmentType.VALTAKIRJA,
+                    attachmentType = VALTAKIRJA,
                     attachment = testFile(fileName = invalidFilename),
                 )
             }
@@ -294,7 +294,7 @@ class TaydennysAttachmentServiceITest(
                 hasClass(AttachmentInvalidException::class)
                 messageContains("File extension is not valid for attachment type")
                 messageContains("filename=$invalidFilename")
-                messageContains("attachmentType=${ApplicationAttachmentType.VALTAKIRJA}")
+                messageContains("attachmentType=${VALTAKIRJA}")
             }
             assertThat(attachmentRepository.findAll()).isEmpty()
         }
@@ -307,7 +307,7 @@ class TaydennysAttachmentServiceITest(
             val failure = assertFailure {
                 attachmentService.addAttachment(
                     taydennysId = taydennys.id,
-                    attachmentType = ApplicationAttachmentType.VALTAKIRJA,
+                    attachmentType = VALTAKIRJA,
                     attachment = testFile(),
                 )
             }
@@ -319,6 +319,34 @@ class TaydennysAttachmentServiceITest(
                 )
             }
             assertThat(attachmentRepository.findAll()).isEmpty()
+        }
+    }
+
+    @Nested
+    inner class DeleteAttachment {
+        @Test
+        fun `Throws exception when attachment not found`() {
+            val attachmentId = UUID.fromString("ab7993b7-a775-4eac-b5b7-8546332944fe")
+
+            val failure = assertFailure { attachmentService.deleteAttachment(attachmentId) }
+
+            failure.all {
+                hasClass(AttachmentNotFoundException::class)
+                messageContains(attachmentId.toString())
+            }
+        }
+
+        @Test
+        fun `Deletes attachment and content when attachment exists`() {
+            val attachment = attachmentFactory.save().withContent().value
+            assertThat(attachmentRepository.findAll()).hasSize(1)
+            assertThat(fileClient.listBlobs(HAKEMUS_LIITTEET).map { it.path })
+                .containsExactly(attachment.blobLocation)
+
+            attachmentService.deleteAttachment(attachment.id!!)
+
+            assertThat(attachmentRepository.findAll()).isEmpty()
+            assertThat(fileClient.listBlobs(HAKEMUS_LIITTEET)).isEmpty()
         }
     }
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/taydennys/TaydennysAttachmentController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/taydennys/TaydennysAttachmentController.kt
@@ -19,6 +19,7 @@ import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -86,6 +87,30 @@ class TaydennysAttachmentController(private val attachmentService: TaydennysAtta
         @RequestParam("liite") attachment: MultipartFile,
     ): TaydennysAttachmentMetadataDto {
         return attachmentService.addAttachment(taydennysId, tyyppi, attachment)
+    }
+
+    @DeleteMapping("/{attachmentId}")
+    @Operation(
+        summary = "Delete attachment from täydennys",
+        description = "Deletes attachment from täydennys.",
+    )
+    @ApiResponses(
+        value =
+            [
+                ApiResponse(description = "Delete attachment", responseCode = "200"),
+                ApiResponse(
+                    description = "Attachment not found",
+                    responseCode = "404",
+                    content = [Content(schema = Schema(implementation = HankeError::class))],
+                ),
+            ]
+    )
+    @PreAuthorize(
+        "@taydennysAuthorizer.authorizeAttachment(#taydennysId, #attachmentId, 'EDIT_APPLICATIONS')"
+    )
+    fun deleteAttachment(@PathVariable taydennysId: UUID, @PathVariable attachmentId: UUID) {
+        logger.info { "Deleting attachment $attachmentId from täydennys $taydennysId." }
+        attachmentService.deleteAttachment(attachmentId)
     }
 
     @ExceptionHandler(ValtakirjaForbiddenException::class)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/taydennys/TaydennysAttachmentMetadataService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/taydennys/TaydennysAttachmentMetadataService.kt
@@ -80,6 +80,12 @@ class TaydennysAttachmentMetadataService(
         return totalAttachmentCount >= ALLOWED_ATTACHMENT_COUNT
     }
 
+    @Transactional
+    fun deleteAttachmentById(attachmentId: UUID) {
+        attachmentRepository.deleteById(attachmentId)
+        logger.info { "Deleted attachment metadata $attachmentId" }
+    }
+
     /**
      * Delete all attachments for täydennys and return the blob locations of the deleted
      * attachments.

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/taydennys/TaydennysAttachmentService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/taydennys/TaydennysAttachmentService.kt
@@ -112,6 +112,15 @@ class TaydennysAttachmentService(
         return newAttachment
     }
 
+    fun deleteAttachment(attachmentId: UUID) {
+        val attachment = metadataService.findAttachment(attachmentId)
+        logger.info { "Deleting attachment metadata ${attachment.id}" }
+        metadataService.deleteAttachmentById(attachment.id)
+        logger.info { "Deleting attachment content at ${attachment.blobLocation}" }
+        attachmentContentService.delete(attachment.blobLocation)
+        logger.info { "Deleted attachment $attachmentId from täydennys ${attachment.taydennysId}" }
+    }
+
     fun deleteAllAttachments(taydennys: TaydennysIdentifier) {
         logger.info { "Deleting all attachments from täydennys. ${taydennys.logString()}" }
         val paths = metadataService.deleteAllAttachments(taydennys)


### PR DESCRIPTION
# Description

API for deleting täydennys attachments.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-752

## Type of change

- [ ] Bug fix 
- [x] New feature 
- [ ] Other

# Instructions for testing
1. Add some attachment(s) to a täydennys: http://localhost:3001/api/swagger-ui/index.html#/taydennys-attachment-controller/postAttachment
2. Delete attachment(s) from täydennys: http://localhost:3001/api/swagger-ui/index.html#/taydennys-attachment-controller/deleteAttachment
3. Check blob storage and database that the attachment content and metadata is deleted

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 

# Other relevant info
Please describe here if there is e.g. some requirements for this change or
 other info that the tester/user needs to know.