### PR TITLE
HAI-3326 Use builder pattern for saving test täydennys

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/taydennys/TaydennysAttachmentServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/taydennys/TaydennysAttachmentServiceITest.kt
@@ -125,7 +125,7 @@ class TaydennysAttachmentServiceITest(
             typeInput: ApplicationAttachmentType
         ) {
             mockClamAv.enqueue(response(body(results = successResult())))
-            val taydennys = taydennysFactory.saveWithHakemus()
+            val taydennys = taydennysFactory.builder().save()
 
             val result =
                 attachmentService.addAttachment(
@@ -169,7 +169,7 @@ class TaydennysAttachmentServiceITest(
         @Test
         fun `Sanitizes filenames with special characters`() {
             mockClamAv.enqueue(response(body(results = successResult())))
-            val taydennys = taydennysFactory.saveWithHakemus()
+            val taydennys = taydennysFactory.builder().save()
 
             val result =
                 attachmentService.addAttachment(
@@ -185,7 +185,7 @@ class TaydennysAttachmentServiceITest(
 
         @Test
         fun `Throws exception when allowed attachment amount is reached`() {
-            val taydennys = taydennysFactory.saveWithHakemus()
+            val taydennys = taydennysFactory.builder().save()
             val attachments =
                 (1..ALLOWED_ATTACHMENT_COUNT).map {
                     TaydennysAttachmentFactory.Companion.createEntity(taydennysId = taydennys.id)
@@ -211,7 +211,7 @@ class TaydennysAttachmentServiceITest(
 
         @Test
         fun `Throws exception without content`() {
-            val taydennys = taydennysFactory.saveWithHakemus()
+            val taydennys = taydennysFactory.builder().save()
 
             val failure = assertFailure {
                 attachmentService.addAttachment(
@@ -229,7 +229,7 @@ class TaydennysAttachmentServiceITest(
 
         @Test
         fun `Throws exception without content type`() {
-            val taydennys = taydennysFactory.saveWithHakemus()
+            val taydennys = taydennysFactory.builder().save()
 
             val failure = assertFailure {
                 attachmentService.addAttachment(
@@ -261,7 +261,7 @@ class TaydennysAttachmentServiceITest(
 
         @Test
         fun `Throws exception when file type is not supported`() {
-            val taydennys = taydennysFactory.saveWithHakemus()
+            val taydennys = taydennysFactory.builder().save()
             val invalidFilename = "hello.html"
 
             val failure = assertFailure {
@@ -281,7 +281,7 @@ class TaydennysAttachmentServiceITest(
 
         @Test
         fun `Throws exception when file type is not supported for attachment type`() {
-            val taydennys = taydennysFactory.saveWithHakemus()
+            val taydennys = taydennysFactory.builder().save()
             val invalidFilename = "hello.jpeg"
 
             val failure = assertFailure {
@@ -304,7 +304,7 @@ class TaydennysAttachmentServiceITest(
         @Test
         fun `Throws exception when virus scan fails`() {
             mockClamAv.enqueue(response(body(results = failResult())))
-            val taydennys = taydennysFactory.saveWithHakemus()
+            val taydennys = taydennysFactory.builder().save()
 
             val failure = assertFailure {
                 attachmentService.addAttachment(

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceITest.kt
@@ -279,7 +279,7 @@ class HakemusServiceITest(
                     .withMandatoryFields()
                     .withStatus(ApplicationStatus.WAITING_INFORMATION)
                     .saveEntity()
-            val taydennys = taydennysFactory.saveForHakemus(hakemus)
+            val taydennys = taydennysFactory.builder(hakemus).save()
 
             val response = hakemusService.getWithExtras(hakemus.id)
 
@@ -301,13 +301,11 @@ class HakemusServiceITest(
                     .withMandatoryFields()
                     .withStatus(ApplicationStatus.WAITING_INFORMATION)
                     .saveEntity()
-            taydennysFactory.saveForHakemus(hakemus) {
-                this as JohtoselvityshakemusEntityData
-                copy(
-                    emergencyWork = true,
-                    postalAddress = postalAddress?.copy(streetAddress = StreetAddress("Tie 3")),
-                )
-            }
+            taydennysFactory
+                .builder(hakemus)
+                .withEmergencyWork(true)
+                .withStreetAddress("Tie 3")
+                .saveEntity()
 
             val response = hakemusService.getWithExtras(hakemus.id)
 

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennysAuthorizerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennysAuthorizerITest.kt
@@ -74,7 +74,7 @@ class TaydennysAuthorizerITest(
         @Test
         fun `throws exception if the attachment belongs to another taydennys`() {
             val taydennys = taydennysFactory.builder().saveEntity()
-            val taydennys2 = taydennysFactory.builder(id = taydennysId, alluId = 2).saveEntity()
+            val taydennys2 = taydennysFactory.builder(alluId = 2).saveEntity()
             val attachment =
                 attachmentFactory.save(taydennys = taydennys2.toDomain()).withContent().value
 

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/testdata/TestDataServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/testdata/TestDataServiceITest.kt
@@ -80,7 +80,7 @@ class TestDataServiceITest : IntegrationTest() {
 
         @Test
         fun `deletes taydennyspyynnot and taydennykset`() {
-            taydennysFactory.saveWithHakemus()
+            taydennysFactory.builder().save()
 
             testDataService.unlinkApplicationsFromAllu()
 
@@ -90,7 +90,7 @@ class TestDataServiceITest : IntegrationTest() {
 
         @Test
         fun `deletes taydennys attachments from Blob storage`() {
-            val taydennys = taydennysFactory.saveWithHakemus()
+            val taydennys = taydennysFactory.builder().save()
             taydennysAttachmentFactory.save(taydennys = taydennys).withContent().value
 
             testDataService.unlinkApplicationsFromAllu()

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusBuilder.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusBuilder.kt
@@ -175,14 +175,12 @@ data class HakemusBuilder(
         onExcavationNotification: KaivuilmoitusEntityData.() -> KaivuilmoitusEntityData,
     ) = apply {
         hakemusEntity.hakemusEntityData =
-            when (hakemusEntity.applicationType) {
-                ApplicationType.CABLE_REPORT -> {
-                    (hakemusEntity.hakemusEntityData as JohtoselvityshakemusEntityData)
-                        .onCableReport()
+            when (val data = hakemusEntity.hakemusEntityData) {
+                is JohtoselvityshakemusEntityData -> {
+                    data.onCableReport()
                 }
-                ApplicationType.EXCAVATION_NOTIFICATION -> {
-                    (hakemusEntity.hakemusEntityData as KaivuilmoitusEntityData)
-                        .onExcavationNotification()
+                is KaivuilmoitusEntityData -> {
+                    data.onExcavationNotification()
                 }
             }
     }


### PR DESCRIPTION
# Description

There are now several methods of creating a täydennys for test purposes. There's some overlap between them, so using fewer methods is better.

Replace the TaydennysFactory save methods with the builder pattern since it's the most versatile.

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [X] Other