### PR TITLE
HAI-876 Add haittojenhallintasuunnitelma to KaivuilmoitusAlue

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/UpdateHakemusITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/UpdateHakemusITest.kt
@@ -32,6 +32,7 @@ import fi.hel.haitaton.hanke.email.textBody
 import fi.hel.haitaton.hanke.factory.ApplicationFactory
 import fi.hel.haitaton.hanke.factory.ApplicationFactory.Companion.createExcavationNotificationArea
 import fi.hel.haitaton.hanke.factory.ApplicationFactory.Companion.createTyoalue
+import fi.hel.haitaton.hanke.factory.ApplicationFactory.Companion.withHaittojenhallintasuunnitelma
 import fi.hel.haitaton.hanke.factory.GeometriaFactory
 import fi.hel.haitaton.hanke.factory.HakemusFactory
 import fi.hel.haitaton.hanke.factory.HakemusUpdateRequestFactory
@@ -49,6 +50,7 @@ import fi.hel.haitaton.hanke.factory.HakemusUpdateRequestFactory.withWorkDescrip
 import fi.hel.haitaton.hanke.factory.HakemusyhteystietoFactory
 import fi.hel.haitaton.hanke.factory.HankeFactory
 import fi.hel.haitaton.hanke.factory.HankeKayttajaFactory
+import fi.hel.haitaton.hanke.factory.HankealueFactory
 import fi.hel.haitaton.hanke.findByType
 import fi.hel.haitaton.hanke.firstReceivedMessage
 import fi.hel.haitaton.hanke.hakemus.ApplicationContactType.TYON_SUORITTAJA
@@ -890,6 +892,40 @@ class UpdateHakemusITest(
                 .prop(Tyoalue::tormaystarkasteluTulos)
                 .isNotNull()
                 .isEqualTo(expectedTormaystarkasteluTulos)
+        }
+
+        @Test
+        fun `updates the haittojenhallintasuunnitelma`() {
+            val hanke = hankeFactory.builder(USERNAME).withHankealue().save()
+            val hankeEntity = hankeRepository.findAll().single()
+            val hakemus =
+                hakemusFactory
+                    .builder(USERNAME, hankeEntity, ApplicationType.EXCAVATION_NOTIFICATION)
+                    .save()
+            val area =
+                createExcavationNotificationArea(hankealueId = hanke.alueet.single().id!!)
+                    .withHaittojenhallintasuunnitelma()
+            val request =
+                hakemus
+                    .toUpdateRequest()
+                    .withDates(ZonedDateTime.now(), ZonedDateTime.now().plusDays(1))
+                    .withArea(area)
+
+            val updatedHakemus = hakemusService.updateHakemus(hakemus.id, request, USERNAME)
+
+            assertThat(updatedHakemus.applicationData.areas)
+                .isNotNull()
+                .single()
+                .isInstanceOf(KaivuilmoitusAlue::class)
+                .prop(KaivuilmoitusAlue::haittojenhallintasuunnitelma)
+                .isEqualTo(HankealueFactory.DEFAULT_HHS)
+            val persistedHakemus = hakemusRepository.findAll().single()
+            assertThat(persistedHakemus.hakemusEntityData.areas)
+                .isNotNull()
+                .single()
+                .isInstanceOf(KaivuilmoitusAlue::class)
+                .prop(KaivuilmoitusAlue::haittojenhallintasuunnitelma)
+                .isEqualTo(HankealueFactory.DEFAULT_HHS)
         }
     }
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/Hakemusalue.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/Hakemusalue.kt
@@ -1,5 +1,6 @@
 package fi.hel.haitaton.hanke.hakemus
 
+import fi.hel.haitaton.hanke.domain.Haittojenhallintasuunnitelma
 import fi.hel.haitaton.hanke.domain.TyomaaTyyppi
 import fi.hel.haitaton.hanke.tormaystarkastelu.AutoliikenteenKaistavaikutustenPituus
 import fi.hel.haitaton.hanke.tormaystarkastelu.Meluhaitta
@@ -32,6 +33,7 @@ data class KaivuilmoitusAlue(
     val kaistahaitta: VaikutusAutoliikenteenKaistamaariin,
     val kaistahaittojenPituus: AutoliikenteenKaistavaikutustenPituus,
     val lisatiedot: String?,
+    val haittojenhallintasuunnitelma: Haittojenhallintasuunnitelma,
 ) : Hakemusalue {
     override fun geometries(): List<Polygon> = tyoalueet.map { it.geometry }
 

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/ApplicationFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/ApplicationFactory.kt
@@ -3,7 +3,11 @@ package fi.hel.haitaton.hanke.factory
 import fi.hel.haitaton.hanke.HankeEntity
 import fi.hel.haitaton.hanke.allu.ApplicationStatus
 import fi.hel.haitaton.hanke.allu.CustomerType
+import fi.hel.haitaton.hanke.domain.Haittojenhallintasuunnitelma
+import fi.hel.haitaton.hanke.domain.Haittojenhallintatyyppi
 import fi.hel.haitaton.hanke.domain.TyomaaTyyppi
+import fi.hel.haitaton.hanke.factory.HankealueFactory.DEFAULT_HHS_PYORALIIKENNE
+import fi.hel.haitaton.hanke.factory.HankealueFactory.createHaittojenhallintasuunnitelma
 import fi.hel.haitaton.hanke.hakemus.ApplicationType
 import fi.hel.haitaton.hanke.hakemus.HakemusEntity
 import fi.hel.haitaton.hanke.hakemus.HakemusEntityData
@@ -101,6 +105,8 @@ class ApplicationFactory(
             kaistahaittojenPituus: AutoliikenteenKaistavaikutustenPituus =
                 AutoliikenteenKaistavaikutustenPituus.PITUUS_ALLE_10_METRIA,
             lisatiedot: String = "Lisätiedot",
+            haittojenhallintasuunnitelma: Haittojenhallintasuunnitelma =
+                mapOf(Haittojenhallintatyyppi.PYORALIIKENNE to DEFAULT_HHS_PYORALIIKENNE),
         ): KaivuilmoitusAlue =
             KaivuilmoitusAlue(
                 name,
@@ -114,6 +120,7 @@ class ApplicationFactory(
                 kaistahaitta,
                 kaistahaittojenPituus,
                 lisatiedot,
+                haittojenhallintasuunnitelma,
             )
 
         fun createTyoalue(
@@ -121,6 +128,11 @@ class ApplicationFactory(
             area: Double = 100.0,
             tormaystarkasteluTulos: TormaystarkasteluTulos? = null,
         ) = Tyoalue(geometry, area, tormaystarkasteluTulos)
+
+        fun KaivuilmoitusAlue.withHaittojenhallintasuunnitelma(
+            haittojenhallintasuunnitelma: Haittojenhallintasuunnitelma =
+                createHaittojenhallintasuunnitelma()
+        ): KaivuilmoitusAlue = copy(haittojenhallintasuunnitelma = haittojenhallintasuunnitelma)
 
         fun createBlankApplicationData(applicationType: ApplicationType): HakemusEntityData =
             when (applicationType) {

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankealueFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankealueFactory.kt
@@ -40,6 +40,24 @@ object HankealueFactory {
             1,
         )
 
+    val DEFAULT_HHS_YLEINEN = "Yleisten haittojen hallintasuunnitelma"
+    val DEFAULT_HHS_PYORALIIKENNE = "Pyöräliikenteelle koituvien haittojen hallintasuunnitelma"
+    val DEFAULT_HHS_AUTOLIIKENNE = "Autoliikenteelle koituvien haittojen hallintasuunnitelma"
+    val DEFAULT_HHS_LINJAAUTOLIIKENNE =
+        "Linja-autoliikenteelle koituvien haittojen hallintasuunnitelma"
+    val DEFAULT_HHS_RAITIOLIIKENNE = "Raitioliikenteelle koituvien haittojen hallintasuunnitelma"
+    val DEFAULT_HHS_MUUT = "Muiden haittojen hallintasuunnitelma"
+
+    val DEFAULT_HHS: Haittojenhallintasuunnitelma =
+        mapOf(
+            Haittojenhallintatyyppi.YLEINEN to DEFAULT_HHS_YLEINEN,
+            Haittojenhallintatyyppi.PYORALIIKENNE to DEFAULT_HHS_PYORALIIKENNE,
+            Haittojenhallintatyyppi.AUTOLIIKENNE to DEFAULT_HHS_AUTOLIIKENNE,
+            Haittojenhallintatyyppi.LINJAAUTOLIIKENNE to DEFAULT_HHS_LINJAAUTOLIIKENNE,
+            Haittojenhallintatyyppi.RAITIOLIIKENNE to DEFAULT_HHS_RAITIOLIIKENNE,
+            Haittojenhallintatyyppi.MUUT to DEFAULT_HHS_MUUT,
+        )
+
     fun create(
         id: Int? = 1,
         hankeId: Int? = 2,
@@ -87,19 +105,7 @@ object HankealueFactory {
     fun createHaittojenhallintasuunnitelma(
         vararg overrides: Pair<Haittojenhallintatyyppi, String?>
     ): Haittojenhallintasuunnitelma {
-        val haittojenhallintasuunnitelma =
-            mutableMapOf(
-                Haittojenhallintatyyppi.YLEINEN to "Yleisten haittojen hallintasuunnitelma",
-                Haittojenhallintatyyppi.PYORALIIKENNE to
-                    "Pyöräliikenteelle koituvien haittojen hallintasuunnitelma",
-                Haittojenhallintatyyppi.AUTOLIIKENNE to
-                    "Autoliikenteelle koituvien haittojen hallintasuunnitelma",
-                Haittojenhallintatyyppi.LINJAAUTOLIIKENNE to
-                    "Linja-autoliikenteelle koituvien haittojen hallintasuunnitelma",
-                Haittojenhallintatyyppi.RAITIOLIIKENNE to
-                    "Raitioliikenteelle koituvien haittojen hallintasuunnitelma",
-                Haittojenhallintatyyppi.MUUT to "Muiden haittojen hallintasuunnitelma",
-            )
+        val haittojenhallintasuunnitelma = DEFAULT_HHS.toMutableMap()
         overrides.forEach { (haittojenhallintatyyppi, suunnitelma) ->
             if (suunnitelma == null) {
                 haittojenhallintasuunnitelma.remove(haittojenhallintatyyppi)

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/pdf/KaivuilmoitusPdfEncoderTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/pdf/KaivuilmoitusPdfEncoderTest.kt
@@ -86,7 +86,8 @@ class KaivuilmoitusPdfEncoderTest {
                                 sahkoposti = "tapio@tilaaja.test",
                                 puhelin = "09876543",
                                 tilaaja = true,
-                            ))
+                            ),
+                )
 
             val pdfData = KaivuilmoitusPdfEncoder.createPdf(applicationData, 1f, listOf(), listOf())
 
@@ -98,7 +99,8 @@ class KaivuilmoitusPdfEncoderTest {
                 contains("Olemassaolevan rakenteen kunnossapitotyöstä")
                 hasPhrase(
                     "Kaivutyö on aloitettu ennen kaivuilmoituksen tekemistä " +
-                        "merkittävien vahinkojen välttämiseksi")
+                        "merkittävien vahinkojen välttämiseksi"
+                )
                 contains("JS2400001, JS2400002")
                 hasPhrase("Louhitaanko työn yhteydessä, esimerkiksi maaperää? Ei")
                 contains("Sopimus1, Sopimus2")
@@ -145,7 +147,8 @@ class KaivuilmoitusPdfEncoderTest {
                 HakemusFactory.createKaivuilmoitusData(
                     startTime = ZonedDateTime.parse("2022-11-17T22:00:00.000Z"),
                     endTime = ZonedDateTime.parse("2022-11-28T21:59:59.999Z"),
-                    areas = listOf())
+                    areas = listOf(),
+                )
             val area =
                 EnrichedKaivuilmoitusalue(
                     223.41411f,
@@ -167,7 +170,9 @@ class KaivuilmoitusPdfEncoderTest {
                         kaistahaittojenPituus =
                             AutoliikenteenKaistavaikutustenPituus.EI_VAIKUTA_KAISTAJARJESTELYIHIN,
                         lisatiedot = "Lisätiedot hakemusalueesta.",
-                    ))
+                        haittojenhallintasuunnitelma = mapOf(),
+                    ),
+                )
 
             val pdfData =
                 KaivuilmoitusPdfEncoder.createPdf(hakemusData, 614f, listOf(), listOf(area))
@@ -199,7 +204,8 @@ class KaivuilmoitusPdfEncoderTest {
                     representativeWithContacts =
                         HakemusyhteystietoFactory.createPerson().withYhteyshenkilo(),
                     propertyDeveloperWithContacts =
-                        HakemusyhteystietoFactory.create().withYhteyshenkilo())
+                        HakemusyhteystietoFactory.create().withYhteyshenkilo(),
+                )
 
             val pdfData = KaivuilmoitusPdfEncoder.createPdf(hakemusData, 1f, listOf(), listOf())
 
@@ -285,7 +291,8 @@ class KaivuilmoitusPdfEncoderTest {
         fun `created PDF contains paper decision receiver when present on the application`() {
             val hakemusData =
                 HakemusFactory.createKaivuilmoitusData(
-                    paperDecisionReceiver = PaperDecisionReceiverFactory.default)
+                    paperDecisionReceiver = PaperDecisionReceiverFactory.default
+                )
 
             val pdfData = KaivuilmoitusPdfEncoder.createPdf(hakemusData, 614f, listOf(), listOf())
 
@@ -320,10 +327,12 @@ class KaivuilmoitusPdfEncoderTest {
                     ApplicationAttachmentFactory.create(fileName = "third.gt"),
                     ApplicationAttachmentFactory.create(
                         fileName = "valtakirja.pdf",
-                        attachmentType = ApplicationAttachmentType.VALTAKIRJA),
+                        attachmentType = ApplicationAttachmentType.VALTAKIRJA,
+                    ),
                     ApplicationAttachmentFactory.create(
                         fileName = "liikenne.pdf",
-                        attachmentType = ApplicationAttachmentType.LIIKENNEJARJESTELY),
+                        attachmentType = ApplicationAttachmentType.LIIKENNEJARJESTELY,
+                    ),
                 )
 
             val pdfData =


### PR DESCRIPTION
# Description

This allows the user to save a haittojenhallintasuunnitelma to each hankealue in the hakemus.

Validation for making sure the haittojenhallintasuunnitelma is completely filled will be added later.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-876

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
With [Swagger UI](http://localhost:3001/api/swagger-ui/index.html#/hakemus-controller/update).

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 