### PR TITLE
HAI-876 Fix haittojenhallintasuunnitelma for existing kaivuilmoitus

### DIFF
--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/Hakemusalue.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/Hakemusalue.kt
@@ -1,5 +1,7 @@
 package fi.hel.haitaton.hanke.hakemus
 
+import com.fasterxml.jackson.annotation.JsonSetter
+import com.fasterxml.jackson.annotation.Nulls
 import fi.hel.haitaton.hanke.domain.Haittojenhallintasuunnitelma
 import fi.hel.haitaton.hanke.domain.TyomaaTyyppi
 import fi.hel.haitaton.hanke.tormaystarkastelu.AutoliikenteenKaistavaikutustenPituus
@@ -33,7 +35,8 @@ data class KaivuilmoitusAlue(
     val kaistahaitta: VaikutusAutoliikenteenKaistamaariin,
     val kaistahaittojenPituus: AutoliikenteenKaistavaikutustenPituus,
     val lisatiedot: String?,
-    val haittojenhallintasuunnitelma: Haittojenhallintasuunnitelma,
+    @JsonSetter(nulls = Nulls.AS_EMPTY)
+    val haittojenhallintasuunnitelma: Haittojenhallintasuunnitelma = mapOf(),
 ) : Hakemusalue {
     override fun geometries(): List<Polygon> = tyoalueet.map { it.geometry }
 


### PR DESCRIPTION
# Description

Give the haittojenhallintasuunnitelma a default value of an empty map, so that missing values in JSON are deserialized to the empty map.

Also, add the `@JsonSetter(nulls = Nulls.AS_EMPTY)` annotation, so that explicit nulls are also deserialized to an empty map.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-876

## Type of change

- [X] Bug fix 
- [ ] New feature 
- [ ] Other

# Instructions for testing
Open an old kaivuilmoitus.