### PR TITLE
HAI-3326 Add täydennys liitteet to hakemus API

### DIFF
--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
@@ -14,6 +14,7 @@ import fi.hel.haitaton.hanke.allu.CustomerType
 import fi.hel.haitaton.hanke.attachment.application.ApplicationAttachmentService
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentMetadata
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType
+import fi.hel.haitaton.hanke.attachment.taydennys.TaydennysAttachmentMetadataService
 import fi.hel.haitaton.hanke.daysBetween
 import fi.hel.haitaton.hanke.domain.Hankevaihe
 import fi.hel.haitaton.hanke.email.ApplicationNotificationEmail
@@ -71,6 +72,7 @@ class HakemusService(
     private val disclosureLogService: DisclosureLogService,
     private val hankeKayttajaService: HankeKayttajaService,
     private val attachmentService: ApplicationAttachmentService,
+    private val taydennysAttachmentService: TaydennysAttachmentMetadataService,
     private val alluClient: AlluClient,
     private val paatosService: PaatosService,
     private val applicationEventPublisher: ApplicationEventPublisher,
@@ -86,10 +88,10 @@ class HakemusService(
         val paatokset = paatosService.findByHakemusId(hakemusId)
         val taydennyspyynto = taydennyspyyntoRepository.findByApplicationId(hakemusId)?.toDomain()
         val taydennys =
-            taydennysRepository
-                .findByApplicationId(hakemusId)
-                ?.toDomain()
-                ?.withMuutokset(hakemus.applicationData)
+            taydennysRepository.findByApplicationId(hakemusId)?.let {
+                val liitteet = taydennysAttachmentService.getMetadataList(it.id)
+                it.toDomain().withExtras(hakemus.applicationData, liitteet)
+            }
 
         return HakemusWithExtras(hakemus, paatokset, taydennyspyynto, taydennys)
     }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusWithExtras.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusWithExtras.kt
@@ -3,8 +3,8 @@ package fi.hel.haitaton.hanke.hakemus
 import com.fasterxml.jackson.annotation.JsonUnwrapped
 import fi.hel.haitaton.hanke.paatos.Paatos
 import fi.hel.haitaton.hanke.paatos.PaatosResponse
-import fi.hel.haitaton.hanke.taydennys.TaydennysWithMuutokset
-import fi.hel.haitaton.hanke.taydennys.TaydennysWithMuutoksetResponse
+import fi.hel.haitaton.hanke.taydennys.TaydennysWithExtras
+import fi.hel.haitaton.hanke.taydennys.TaydennysWithExtrasResponse
 import fi.hel.haitaton.hanke.taydennys.Taydennyspyynto
 import fi.hel.haitaton.hanke.taydennys.TaydennyspyyntoResponse
 
@@ -12,7 +12,7 @@ data class HakemusWithExtras(
     val hakemus: Hakemus,
     val paatokset: List<Paatos>,
     val taydennyspyynto: Taydennyspyynto?,
-    val taydennys: TaydennysWithMuutokset?,
+    val taydennys: TaydennysWithExtras?,
 ) {
     fun toResponse(): HakemusWithExtrasResponse =
         HakemusWithExtrasResponse(
@@ -27,5 +27,5 @@ data class HakemusWithExtrasResponse(
     @JsonUnwrapped val hakemus: HakemusResponse,
     val paatokset: Map<String, List<PaatosResponse>>,
     val taydennyspyynto: TaydennyspyyntoResponse?,
-    val taydennys: TaydennysWithMuutoksetResponse?,
+    val taydennys: TaydennysWithExtrasResponse?,
 )

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/taydennys/Taydennys.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/taydennys/Taydennys.kt
@@ -1,6 +1,8 @@
 package fi.hel.haitaton.hanke.taydennys
 
 import com.fasterxml.jackson.annotation.JsonUnwrapped
+import fi.hel.haitaton.hanke.attachment.common.TaydennysAttachmentMetadata
+import fi.hel.haitaton.hanke.attachment.common.TaydennysAttachmentMetadataDto
 import fi.hel.haitaton.hanke.domain.HasId
 import fi.hel.haitaton.hanke.hakemus.HakemusData
 import fi.hel.haitaton.hanke.hakemus.HakemusDataResponse
@@ -14,32 +16,42 @@ data class Taydennys(
 ) : HasId<UUID> {
     fun toResponse() = TaydennysResponse(id, hakemusData.toResponse())
 
-    fun withMuutokset(otherData: HakemusData): TaydennysWithMuutokset {
-        return TaydennysWithMuutokset(
+    fun withExtras(
+        otherData: HakemusData,
+        liitteet: List<TaydennysAttachmentMetadata>,
+    ): TaydennysWithExtras {
+        return TaydennysWithExtras(
             id = id,
             taydennyspyyntoId = taydennyspyyntoId,
             hakemusData = hakemusData,
             muutokset = hakemusData.listChanges(otherData),
+            liitteet = liitteet,
         )
     }
 }
 
 data class TaydennysResponse(override val id: UUID, val applicationData: HakemusDataResponse) :
     HasId<UUID> {
-    fun withMuutokset(muutokset: List<String>): TaydennysWithMuutoksetResponse =
-        TaydennysWithMuutoksetResponse(this, muutokset)
+    fun withExtras(
+        muutokset: List<String>,
+        liitteet: List<TaydennysAttachmentMetadata>,
+    ): TaydennysWithExtrasResponse =
+        TaydennysWithExtrasResponse(this, muutokset, liitteet.map { it.toDto() })
 }
 
-data class TaydennysWithMuutokset(
+data class TaydennysWithExtras(
     override val id: UUID,
     val taydennyspyyntoId: UUID,
     val hakemusData: HakemusData,
     val muutokset: List<String>,
+    val liitteet: List<TaydennysAttachmentMetadata>,
 ) : HasId<UUID> {
-    fun toResponse() = TaydennysResponse(id, hakemusData.toResponse()).withMuutokset(muutokset)
+    fun toResponse() =
+        TaydennysResponse(id, hakemusData.toResponse()).withExtras(muutokset, liitteet)
 }
 
-data class TaydennysWithMuutoksetResponse(
+data class TaydennysWithExtrasResponse(
     @JsonUnwrapped val taydennys: TaydennysResponse,
     val muutokset: List<String>,
+    val liitteet: List<TaydennysAttachmentMetadataDto>,
 )

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusFactory.kt
@@ -26,7 +26,7 @@ import fi.hel.haitaton.hanke.hakemus.PaperDecisionReceiver
 import fi.hel.haitaton.hanke.hakemus.PostalAddress
 import fi.hel.haitaton.hanke.paatos.Paatos
 import fi.hel.haitaton.hanke.permissions.HankeKayttajaService
-import fi.hel.haitaton.hanke.taydennys.TaydennysWithMuutokset
+import fi.hel.haitaton.hanke.taydennys.TaydennysWithExtras
 import fi.hel.haitaton.hanke.taydennys.Taydennyspyynto
 import fi.hel.haitaton.hanke.test.USERNAME
 import fi.hel.haitaton.hanke.valmistumisilmoitus.Valmistumisilmoitus
@@ -243,7 +243,7 @@ class HakemusFactory(
         fun Hakemus.withExtras(
             paatokset: List<Paatos> = listOf(),
             taydennyspyynto: Taydennyspyynto? = null,
-            taydennys: TaydennysWithMuutokset? = null,
+            taydennys: TaydennysWithExtras? = null,
         ) = HakemusWithExtras(this, paatokset, taydennyspyynto, taydennys)
 
         fun hakemusDataForRegistryKeyTest(tyyppi: CustomerType): KaivuilmoitusData {

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/TaydennysFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/TaydennysFactory.kt
@@ -2,6 +2,7 @@ package fi.hel.haitaton.hanke.factory
 
 import fi.hel.haitaton.hanke.allu.ApplicationStatus
 import fi.hel.haitaton.hanke.allu.CustomerType
+import fi.hel.haitaton.hanke.attachment.common.TaydennysAttachmentMetadata
 import fi.hel.haitaton.hanke.hakemus.ApplicationContactType
 import fi.hel.haitaton.hanke.hakemus.ApplicationType
 import fi.hel.haitaton.hanke.hakemus.HakemusData
@@ -15,7 +16,7 @@ import fi.hel.haitaton.hanke.taydennys.Taydennys
 import fi.hel.haitaton.hanke.taydennys.TaydennysEntity
 import fi.hel.haitaton.hanke.taydennys.TaydennysRepository
 import fi.hel.haitaton.hanke.taydennys.TaydennysService
-import fi.hel.haitaton.hanke.taydennys.TaydennysWithMuutokset
+import fi.hel.haitaton.hanke.taydennys.TaydennysWithExtras
 import fi.hel.haitaton.hanke.taydennys.TaydennyspyyntoEntity
 import fi.hel.haitaton.hanke.taydennys.TaydennysyhteyshenkiloEntity
 import fi.hel.haitaton.hanke.taydennys.TaydennysyhteyshenkiloRepository
@@ -135,8 +136,10 @@ class TaydennysFactory(
         fun Taydennys.toUpdateRequest(): HakemusUpdateRequest =
             this.toResponse().applicationData.toJsonString().parseJson()
 
-        fun Taydennys.withMuutokset(muutokset: List<String>) =
-            TaydennysWithMuutokset(id, taydennyspyyntoId, hakemusData, muutokset)
+        fun Taydennys.withExtras(
+            muutokset: List<String> = listOf(),
+            liitteet: List<TaydennysAttachmentMetadata> = listOf(),
+        ) = TaydennysWithExtras(id, taydennyspyyntoId, hakemusData, muutokset, liitteet)
 
         fun createYhteystietoEntity(
             taydennys: TaydennysEntity,

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceTest.kt
@@ -22,6 +22,7 @@ import fi.hel.haitaton.hanke.allu.Contact
 import fi.hel.haitaton.hanke.allu.Customer
 import fi.hel.haitaton.hanke.allu.CustomerWithContacts
 import fi.hel.haitaton.hanke.attachment.application.ApplicationAttachmentService
+import fi.hel.haitaton.hanke.attachment.taydennys.TaydennysAttachmentMetadataService
 import fi.hel.haitaton.hanke.factory.AlluFactory
 import fi.hel.haitaton.hanke.factory.ApplicationFactory
 import fi.hel.haitaton.hanke.factory.HakemusFactory
@@ -79,6 +80,7 @@ class HakemusServiceTest {
     private val disclosureLogService: DisclosureLogService = mockk(relaxUnitFun = true)
     private val hankeKayttajaService: HankeKayttajaService = mockk(relaxUnitFun = true)
     private val attachmentService: ApplicationAttachmentService = mockk()
+    private val taydennysAttachmentService: TaydennysAttachmentMetadataService = mockk()
     private val alluClient: AlluClient = mockk()
     private val paatosService: PaatosService = mockk()
     private val publisher: ApplicationEventPublisher = mockk()
@@ -97,6 +99,7 @@ class HakemusServiceTest {
             disclosureLogService,
             hankeKayttajaService,
             attachmentService,
+            taydennysAttachmentService,
             alluClient,
             paatosService,
             publisher,
@@ -121,6 +124,7 @@ class HakemusServiceTest {
             disclosureLogService,
             hankeKayttajaService,
             attachmentService,
+            taydennysAttachmentService,
             alluClient,
             paatosService,
             publisher,


### PR DESCRIPTION
# Description

Replay of #895 since it didn't go to dev.

When getting a single hakemus, add liitteet to the täydennys object of the hakemus. Return the information for any existing attachments.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-3326

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
1. Create a täydennys for a johtoselvityshakemus.
2. The hakemus API should return an empty list for `liitteet`.
3. Add some attachments to the täydennys.
4. Check that the API returns the metadata of the added attachments in the `liitteet` field.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 