### PR TITLE
HAI-876 Add validation for haittojenhallintasuunnitelma in kaivuilmoitus

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeControllerITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeControllerITests.kt
@@ -7,6 +7,7 @@ import fi.hel.haitaton.hanke.domain.HankeStatus
 import fi.hel.haitaton.hanke.domain.SavedHankealue
 import fi.hel.haitaton.hanke.domain.TyomaaTyyppi
 import fi.hel.haitaton.hanke.factory.DateFactory
+import fi.hel.haitaton.hanke.factory.HaittaFactory
 import fi.hel.haitaton.hanke.factory.HankeFactory
 import fi.hel.haitaton.hanke.factory.HankeFactory.Companion.withHankealue
 import fi.hel.haitaton.hanke.factory.HankeFactory.Companion.withMuuYhteystieto
@@ -15,8 +16,6 @@ import fi.hel.haitaton.hanke.factory.HankeFactory.Companion.withRakennuttaja
 import fi.hel.haitaton.hanke.factory.HankeFactory.Companion.withTormaystarkasteluTulos
 import fi.hel.haitaton.hanke.factory.HankeFactory.Companion.withToteuttaja
 import fi.hel.haitaton.hanke.factory.HankeYhteyshenkiloFactory
-import fi.hel.haitaton.hanke.factory.HankealueFactory.TORMAYSTARKASTELU_DEFAULT_AUTOLIIKENNELUOKITTELU
-import fi.hel.haitaton.hanke.factory.HankealueFactory.createHaittojenhallintasuunnitelma
 import fi.hel.haitaton.hanke.geometria.Geometriat
 import fi.hel.haitaton.hanke.logging.DisclosureLogService
 import fi.hel.haitaton.hanke.permissions.PermissionCode
@@ -132,7 +131,7 @@ class HankeControllerITests(@Autowired override val mockMvc: MockMvc) : Controll
 
         @Test
         fun `Returns tormaystarkastelutulos with the hanke if it has been calculated`() {
-            val autoliikenne = TORMAYSTARKASTELU_DEFAULT_AUTOLIIKENNELUOKITTELU
+            val autoliikenne = HaittaFactory.TORMAYSTARKASTELU_DEFAULT_AUTOLIIKENNELUOKITTELU
             val pyoraliikenneindeksi = 2.1f
             val linjaautoliikenneindeksi = 1.4f
             val raitioliikenneindeksi = 3f
@@ -553,7 +552,8 @@ class HankeControllerITests(@Autowired override val mockMvc: MockMvc) : Controll
                     polyHaitta = Polyhaitta.TOISTUVA_POLYHAITTA,
                     tarinaHaitta = Tarinahaitta.JATKUVA_TARINAHAITTA,
                     tormaystarkasteluTulos = null,
-                    haittojenhallintasuunnitelma = createHaittojenhallintasuunnitelma(),
+                    haittojenhallintasuunnitelma =
+                        HaittaFactory.createHaittojenhallintasuunnitelma(),
                 )
             hankeToBeUpdated.alueet.add(alue)
             // Prepare the expected result/return

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
@@ -35,6 +35,7 @@ import fi.hel.haitaton.hanke.domain.Yhteyshenkilo
 import fi.hel.haitaton.hanke.domain.YhteystietoTyyppi
 import fi.hel.haitaton.hanke.factory.AlluFactory
 import fi.hel.haitaton.hanke.factory.ApplicationFactory
+import fi.hel.haitaton.hanke.factory.HaittaFactory
 import fi.hel.haitaton.hanke.factory.HakemusFactory
 import fi.hel.haitaton.hanke.factory.HankeAttachmentFactory
 import fi.hel.haitaton.hanke.factory.HankeBuilder.Companion.toModifyRequest
@@ -42,7 +43,6 @@ import fi.hel.haitaton.hanke.factory.HankeFactory
 import fi.hel.haitaton.hanke.factory.HankeFactory.Companion.DEFAULT_HANKE_PERUSTAJA
 import fi.hel.haitaton.hanke.factory.HankeKayttajaFactory
 import fi.hel.haitaton.hanke.factory.HankeYhteystietoFactory
-import fi.hel.haitaton.hanke.factory.HankealueFactory.createHaittojenhallintasuunnitelma
 import fi.hel.haitaton.hanke.factory.ProfiiliFactory.DEFAULT_GIVEN_NAME
 import fi.hel.haitaton.hanke.factory.ProfiiliFactory.DEFAULT_LAST_NAME
 import fi.hel.haitaton.hanke.factory.TEPPO_TESTI
@@ -602,7 +602,8 @@ class HankeServiceITests(
                 hankeFactory
                     .builder(USERNAME)
                     .withHankealue(
-                        haittojenhallintasuunnitelma = createHaittojenhallintasuunnitelma()
+                        haittojenhallintasuunnitelma =
+                            HaittaFactory.createHaittojenhallintasuunnitelma()
                     )
                     .save()
             auditLogRepository.deleteAll()

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/UpdateHankeITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/UpdateHankeITests.kt
@@ -32,6 +32,7 @@ import fi.hel.haitaton.hanke.domain.SavedHankealue
 import fi.hel.haitaton.hanke.domain.TyomaaTyyppi
 import fi.hel.haitaton.hanke.factory.DateFactory
 import fi.hel.haitaton.hanke.factory.GeometriaFactory
+import fi.hel.haitaton.hanke.factory.HaittaFactory
 import fi.hel.haitaton.hanke.factory.HankeBuilder.Companion.toModifyRequest
 import fi.hel.haitaton.hanke.factory.HankeFactory
 import fi.hel.haitaton.hanke.factory.HankeFactory.Companion.withHankealue
@@ -42,7 +43,6 @@ import fi.hel.haitaton.hanke.factory.HankeKayttajaFactory
 import fi.hel.haitaton.hanke.factory.HankeYhteyshenkiloFactory
 import fi.hel.haitaton.hanke.factory.HankeYhteystietoFactory
 import fi.hel.haitaton.hanke.factory.HankealueFactory
-import fi.hel.haitaton.hanke.factory.HankealueFactory.createHaittojenhallintasuunnitelma
 import fi.hel.haitaton.hanke.geometria.Geometriat
 import fi.hel.haitaton.hanke.logging.AuditLogRepository
 import fi.hel.haitaton.hanke.logging.AuditLogTarget
@@ -626,7 +626,7 @@ class UpdateHankeITests(
         assertThat(hankealue.haittojenhallintasuunnitelma!![Haittojenhallintatyyppi.YLEINEN])
             .isEqualTo("Yleisten haittojen hallintasuunnitelma")
         hankealue.haittojenhallintasuunnitelma =
-            createHaittojenhallintasuunnitelma(
+            HaittaFactory.createHaittojenhallintasuunnitelma(
                 Haittojenhallintatyyppi.YLEINEN to "Uusi yleisten haittojen hallintasuunnitelma"
             )
         val request = createdHanke.toModifyRequest()
@@ -646,7 +646,9 @@ class UpdateHankeITests(
         val hankealue = createdHanke.alueet[0]
         assertThat(hankealue.haittojenhallintasuunnitelma!!.size).isEqualTo(6)
         hankealue.haittojenhallintasuunnitelma =
-            createHaittojenhallintasuunnitelma(Haittojenhallintatyyppi.YLEINEN to null)
+            HaittaFactory.createHaittojenhallintasuunnitelma(
+                Haittojenhallintatyyppi.YLEINEN to null
+            )
         val request = createdHanke.toModifyRequest()
 
         val updateHankeResult = hankeService.updateHanke(createdHanke.hankeTunnus, request)
@@ -664,7 +666,9 @@ class UpdateHankeITests(
                 .builder(USERNAME)
                 .withHankealue(
                     haittojenhallintasuunnitelma =
-                        createHaittojenhallintasuunnitelma(Haittojenhallintatyyppi.YLEINEN to null)
+                        HaittaFactory.createHaittojenhallintasuunnitelma(
+                            Haittojenhallintatyyppi.YLEINEN to null
+                        )
                 )
                 .save()
         val hankealue = createdHanke.alueet[0]
@@ -672,7 +676,7 @@ class UpdateHankeITests(
         assertThat(hankealue.haittojenhallintasuunnitelma!![Haittojenhallintatyyppi.YLEINEN])
             .isNull()
         hankealue.haittojenhallintasuunnitelma =
-            createHaittojenhallintasuunnitelma(
+            HaittaFactory.createHaittojenhallintasuunnitelma(
                 Haittojenhallintatyyppi.YLEINEN to "Uusi yleisten haittojen hallintasuunnitelma"
             )
         val request = createdHanke.toModifyRequest()
@@ -896,7 +900,8 @@ class UpdateHankeITests(
         auditLogRepository.deleteAll()
         assertEquals(0, auditLogRepository.count())
         TestUtils.addMockedRequestIp()
-        hanke.alueet[0].haittojenhallintasuunnitelma = createHaittojenhallintasuunnitelma()
+        hanke.alueet[0].haittojenhallintasuunnitelma =
+            HaittaFactory.createHaittojenhallintasuunnitelma()
         val request = hanke.toModifyRequest()
 
         val updatedHanke = hankeService.updateHanke(hanke.hankeTunnus, request)

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusControllerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusControllerITest.kt
@@ -24,6 +24,7 @@ import fi.hel.haitaton.hanke.andReturnBody
 import fi.hel.haitaton.hanke.andReturnContent
 import fi.hel.haitaton.hanke.domain.CreateHankeRequest
 import fi.hel.haitaton.hanke.factory.CreateHakemusRequestFactory
+import fi.hel.haitaton.hanke.factory.HaittaFactory
 import fi.hel.haitaton.hanke.factory.HakemusFactory
 import fi.hel.haitaton.hanke.factory.HakemusFactory.Companion.withExtras
 import fi.hel.haitaton.hanke.factory.HakemusUpdateRequestFactory
@@ -31,7 +32,6 @@ import fi.hel.haitaton.hanke.factory.HakemusUpdateRequestFactory.withRegistryKey
 import fi.hel.haitaton.hanke.factory.HakemusUpdateRequestFactory.withTimes
 import fi.hel.haitaton.hanke.factory.HakemusUpdateRequestFactory.withWorkDescription
 import fi.hel.haitaton.hanke.factory.HankeFactory
-import fi.hel.haitaton.hanke.factory.HankealueFactory
 import fi.hel.haitaton.hanke.factory.PaatosFactory
 import fi.hel.haitaton.hanke.factory.PaperDecisionReceiverFactory
 import fi.hel.haitaton.hanke.factory.TaydennysAttachmentFactory
@@ -483,7 +483,7 @@ class HakemusControllerITest(@Autowired override val mockMvc: MockMvc) : Control
                 .andExpect(jsonPath(haittojenhallintaPath).isMap())
                 .andExpect(
                     jsonPath("$haittojenhallintaPath.PYORALIIKENNE")
-                        .value(HankealueFactory.DEFAULT_HHS_PYORALIIKENNE)
+                        .value(HaittaFactory.DEFAULT_HHS_PYORALIIKENNE)
                 )
 
             verifySequence {

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/UpdateHakemusITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/UpdateHakemusITest.kt
@@ -34,6 +34,7 @@ import fi.hel.haitaton.hanke.factory.ApplicationFactory.Companion.createExcavati
 import fi.hel.haitaton.hanke.factory.ApplicationFactory.Companion.createTyoalue
 import fi.hel.haitaton.hanke.factory.ApplicationFactory.Companion.withHaittojenhallintasuunnitelma
 import fi.hel.haitaton.hanke.factory.GeometriaFactory
+import fi.hel.haitaton.hanke.factory.HaittaFactory
 import fi.hel.haitaton.hanke.factory.HakemusFactory
 import fi.hel.haitaton.hanke.factory.HakemusUpdateRequestFactory
 import fi.hel.haitaton.hanke.factory.HakemusUpdateRequestFactory.toUpdateRequest
@@ -50,7 +51,6 @@ import fi.hel.haitaton.hanke.factory.HakemusUpdateRequestFactory.withWorkDescrip
 import fi.hel.haitaton.hanke.factory.HakemusyhteystietoFactory
 import fi.hel.haitaton.hanke.factory.HankeFactory
 import fi.hel.haitaton.hanke.factory.HankeKayttajaFactory
-import fi.hel.haitaton.hanke.factory.HankealueFactory
 import fi.hel.haitaton.hanke.findByType
 import fi.hel.haitaton.hanke.firstReceivedMessage
 import fi.hel.haitaton.hanke.hakemus.ApplicationContactType.TYON_SUORITTAJA
@@ -918,14 +918,14 @@ class UpdateHakemusITest(
                 .single()
                 .isInstanceOf(KaivuilmoitusAlue::class)
                 .prop(KaivuilmoitusAlue::haittojenhallintasuunnitelma)
-                .isEqualTo(HankealueFactory.DEFAULT_HHS)
+                .isEqualTo(HaittaFactory.DEFAULT_HHS)
             val persistedHakemus = hakemusRepository.findAll().single()
             assertThat(persistedHakemus.hakemusEntityData.areas)
                 .isNotNull()
                 .single()
                 .isInstanceOf(KaivuilmoitusAlue::class)
                 .prop(KaivuilmoitusAlue::haittojenhallintasuunnitelma)
-                .isEqualTo(HankealueFactory.DEFAULT_HHS)
+                .isEqualTo(HaittaFactory.DEFAULT_HHS)
         }
     }
 }

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluControllerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluControllerITest.kt
@@ -8,7 +8,7 @@ import fi.hel.haitaton.hanke.IntegrationTestConfiguration
 import fi.hel.haitaton.hanke.andReturnBody
 import fi.hel.haitaton.hanke.factory.DateFactory
 import fi.hel.haitaton.hanke.factory.GeometriaFactory
-import fi.hel.haitaton.hanke.factory.HankealueFactory.TORMAYSTARKASTELU_DEFAULT_AUTOLIIKENNELUOKITTELU
+import fi.hel.haitaton.hanke.factory.HaittaFactory
 import fi.hel.haitaton.hanke.hankeError
 import fi.hel.haitaton.hanke.test.USERNAME
 import io.mockk.Called
@@ -201,7 +201,7 @@ class TormaystarkasteluControllerITest(
 
         private fun createTulos() =
             TormaystarkasteluTulos(
-                TORMAYSTARKASTELU_DEFAULT_AUTOLIIKENNELUOKITTELU,
+                HaittaFactory.TORMAYSTARKASTELU_DEFAULT_AUTOLIIKENNELUOKITTELU,
                 2.4f,
                 7.1f,
                 5.0f,

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/Hakemusalue.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/Hakemusalue.kt
@@ -42,6 +42,24 @@ data class KaivuilmoitusAlue(
 
     fun withoutTormaystarkastelut() =
         copy(tyoalueet = tyoalueet.map { it.copy(tormaystarkasteluTulos = null) })
+
+    /**
+     * Returns a new [TormaystarkasteluTulos] that contains the combination of the highest indexes
+     * from all the työalue in this area. Autoliikenne contains the autoliikenneluokittelu with the
+     * highest index.
+     */
+    fun worstCasesInTormaystarkastelut(): TormaystarkasteluTulos? {
+        val tulokset = tyoalueet.mapNotNull { it.tormaystarkasteluTulos }.ifEmpty { null }
+
+        return tulokset?.let {
+            TormaystarkasteluTulos(
+                autoliikenne = tulokset.map { it.autoliikenne }.maxBy { it.indeksi },
+                pyoraliikenneindeksi = tulokset.maxOf { it.pyoraliikenneindeksi },
+                linjaautoliikenneindeksi = tulokset.maxOf { it.linjaautoliikenneindeksi },
+                raitioliikenneindeksi = tulokset.maxOf { it.raitioliikenneindeksi },
+            )
+        }
+    }
 }
 
 data class Tyoalue(

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/KaivuilmoitusValidation.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/KaivuilmoitusValidation.kt
@@ -3,9 +3,12 @@ package fi.hel.haitaton.hanke.hakemus
 import fi.hel.haitaton.hanke.allu.CustomerType
 import fi.hel.haitaton.hanke.isValidBusinessId
 import fi.hel.haitaton.hanke.isValidOVT
+import fi.hel.haitaton.hanke.validation.HankePublicValidator.validateHaittojenhallintasuunnitelmaCommonFields
+import fi.hel.haitaton.hanke.validation.HankePublicValidator.validateHaittojenhallintasuunnitelmaLiikennemuodot
 import fi.hel.haitaton.hanke.validation.HenkilotunnusValidator.isValidHenkilotunnus
 import fi.hel.haitaton.hanke.validation.ValidationResult
 import fi.hel.haitaton.hanke.validation.ValidationResult.Companion.allIn
+import fi.hel.haitaton.hanke.validation.ValidationResult.Companion.whenNotNull
 import fi.hel.haitaton.hanke.validation.Validators.isBeforeOrEqual
 import fi.hel.haitaton.hanke.validation.Validators.notBlank
 import fi.hel.haitaton.hanke.validation.Validators.notEmpty
@@ -65,6 +68,12 @@ private fun KaivuilmoitusAlue.validate(path: String): ValidationResult =
     validate { notEmpty(tyoalueet, "$path.tyoalueet") }
         .and { notBlank(katuosoite, "$path.katuosoite") }
         .and { notEmpty(tyonTarkoitukset, "$path.tyonTarkoitukset") }
+        .andNotNull(haittojenhallintasuunnitelma, "$path.haittojenhallintasuunnitelma") { hhs, p ->
+            whenNotNull(this.worstCasesInTormaystarkastelut()) { tt ->
+                    validateHaittojenhallintasuunnitelmaLiikennemuodot(hhs, tt, p)
+                }
+                .and { validateHaittojenhallintasuunnitelmaCommonFields(hhs, p) }
+        }
 
 private fun KaivuilmoitusData.validateWorkInvolves(): ValidationResult =
     validate { validateTrue(constructionWork, "constructionWork") }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/HankeMapperTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/HankeMapperTest.kt
@@ -13,6 +13,7 @@ import fi.hel.haitaton.hanke.domain.YhteystietoTyyppi.YRITYS
 import fi.hel.haitaton.hanke.factory.ApplicationFactory.Companion.TEPPO_EMAIL
 import fi.hel.haitaton.hanke.factory.DateFactory
 import fi.hel.haitaton.hanke.factory.GeometriaFactory
+import fi.hel.haitaton.hanke.factory.HaittaFactory
 import fi.hel.haitaton.hanke.factory.HankeFactory
 import fi.hel.haitaton.hanke.factory.HankeYhteyshenkiloFactory.withYhteyshenkilo
 import fi.hel.haitaton.hanke.factory.HankeYhteystietoFactory
@@ -90,8 +91,7 @@ class HankeMapperTest {
                 haittaLoppuPvm = DateFactory.getEndDatetime().toLocalDate().atStartOfDay(TZ_UTC),
                 geometriat =
                     GeometriaFactory.create().apply { resetFeatureProperties(hankeTunnus) },
-                haittojenhallintasuunnitelma =
-                    HankealueFactory.createHaittojenhallintasuunnitelma(),
+                haittojenhallintasuunnitelma = HaittaFactory.createHaittojenhallintasuunnitelma(),
             )
         )
 }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/ApplicationFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/ApplicationFactory.kt
@@ -4,10 +4,7 @@ import fi.hel.haitaton.hanke.HankeEntity
 import fi.hel.haitaton.hanke.allu.ApplicationStatus
 import fi.hel.haitaton.hanke.allu.CustomerType
 import fi.hel.haitaton.hanke.domain.Haittojenhallintasuunnitelma
-import fi.hel.haitaton.hanke.domain.Haittojenhallintatyyppi
 import fi.hel.haitaton.hanke.domain.TyomaaTyyppi
-import fi.hel.haitaton.hanke.factory.HankealueFactory.DEFAULT_HHS_PYORALIIKENNE
-import fi.hel.haitaton.hanke.factory.HankealueFactory.createHaittojenhallintasuunnitelma
 import fi.hel.haitaton.hanke.hakemus.ApplicationType
 import fi.hel.haitaton.hanke.hakemus.HakemusEntity
 import fi.hel.haitaton.hanke.hakemus.HakemusEntityData
@@ -105,8 +102,7 @@ class ApplicationFactory(
             kaistahaittojenPituus: AutoliikenteenKaistavaikutustenPituus =
                 AutoliikenteenKaistavaikutustenPituus.PITUUS_ALLE_10_METRIA,
             lisatiedot: String = "Lisätiedot",
-            haittojenhallintasuunnitelma: Haittojenhallintasuunnitelma =
-                mapOf(Haittojenhallintatyyppi.PYORALIIKENNE to DEFAULT_HHS_PYORALIIKENNE),
+            haittojenhallintasuunnitelma: Haittojenhallintasuunnitelma = HaittaFactory.DEFAULT_HHS,
         ): KaivuilmoitusAlue =
             KaivuilmoitusAlue(
                 name,
@@ -131,7 +127,7 @@ class ApplicationFactory(
 
         fun KaivuilmoitusAlue.withHaittojenhallintasuunnitelma(
             haittojenhallintasuunnitelma: Haittojenhallintasuunnitelma =
-                createHaittojenhallintasuunnitelma()
+                HaittaFactory.createHaittojenhallintasuunnitelma()
         ): KaivuilmoitusAlue = copy(haittojenhallintasuunnitelma = haittojenhallintasuunnitelma)
 
         fun createBlankApplicationData(applicationType: ApplicationType): HakemusEntityData =

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HaittaFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HaittaFactory.kt
@@ -1,0 +1,86 @@
+package fi.hel.haitaton.hanke.factory
+
+import fi.hel.haitaton.hanke.domain.Haittojenhallintasuunnitelma
+import fi.hel.haitaton.hanke.domain.Haittojenhallintatyyppi
+import fi.hel.haitaton.hanke.tormaystarkastelu.Autoliikenneluokittelu
+import fi.hel.haitaton.hanke.tormaystarkastelu.AutoliikenteenKaistavaikutustenPituus
+import fi.hel.haitaton.hanke.tormaystarkastelu.HaittaAjanKestoLuokittelu
+import fi.hel.haitaton.hanke.tormaystarkastelu.Liikennemaaraluokittelu
+import fi.hel.haitaton.hanke.tormaystarkastelu.TormaystarkasteluKatuluokka
+import fi.hel.haitaton.hanke.tormaystarkastelu.TormaystarkasteluTulos
+import fi.hel.haitaton.hanke.tormaystarkastelu.VaikutusAutoliikenteenKaistamaariin
+
+object HaittaFactory {
+
+    val TORMAYSTARKASTELU_DEFAULT_AUTOLIIKENNELUOKITTELU =
+        Autoliikenneluokittelu(
+            HaittaAjanKestoLuokittelu.YLI_KOLME_KUUKAUTTA.value,
+            TormaystarkasteluKatuluokka.TONTTIKATU_TAI_AJOYHTEYS.value,
+            Liikennemaaraluokittelu.LIIKENNEMAARA_ALLE_500.value,
+            VaikutusAutoliikenteenKaistamaariin.YKSI_KAISTA_VAHENEE.value,
+            AutoliikenteenKaistavaikutustenPituus.PITUUS_ALLE_10_METRIA.value,
+        )
+
+    val TORMAYSTARKASTELU_ZERO_AUTOLIIKENNELUOKITTELU =
+        Autoliikenneluokittelu(
+            1,
+            0, // if both 'katuluokka' and 'liikennemaara' is 0, the index is 0.0
+            0, // if both 'katuluokka' and 'liikennemaara' is 0, the index is 0.0
+            1,
+            1,
+        )
+
+    val DEFAULT_HHS_YLEINEN = "Yleisten haittojen hallintasuunnitelma"
+    val DEFAULT_HHS_PYORALIIKENNE = "Pyöräliikenteelle koituvien haittojen hallintasuunnitelma"
+    val DEFAULT_HHS_AUTOLIIKENNE = "Autoliikenteelle koituvien haittojen hallintasuunnitelma"
+    val DEFAULT_HHS_LINJAAUTOLIIKENNE =
+        "Linja-autoliikenteelle koituvien haittojen hallintasuunnitelma"
+    val DEFAULT_HHS_RAITIOLIIKENNE = "Raitioliikenteelle koituvien haittojen hallintasuunnitelma"
+    val DEFAULT_HHS_MUUT = "Muiden haittojen hallintasuunnitelma"
+
+    val DEFAULT_HHS: Haittojenhallintasuunnitelma =
+        mapOf(
+            Haittojenhallintatyyppi.YLEINEN to DEFAULT_HHS_YLEINEN,
+            Haittojenhallintatyyppi.PYORALIIKENNE to DEFAULT_HHS_PYORALIIKENNE,
+            Haittojenhallintatyyppi.AUTOLIIKENNE to DEFAULT_HHS_AUTOLIIKENNE,
+            Haittojenhallintatyyppi.LINJAAUTOLIIKENNE to DEFAULT_HHS_LINJAAUTOLIIKENNE,
+            Haittojenhallintatyyppi.RAITIOLIIKENNE to DEFAULT_HHS_RAITIOLIIKENNE,
+            Haittojenhallintatyyppi.MUUT to DEFAULT_HHS_MUUT,
+        )
+
+    /**
+     * Creates a haittojenhallintasuunnitelma with values in all fields.
+     *
+     * Values can be overridden with parameters like
+     * `createHaittojenhallintasuunnitelma(Haittojenhallintatyyppi.YLEINEN to "Overridden value")`.
+     *
+     * Values can be removed from the haittojenhallintasuunnitelma by overriding them with null:
+     * `createHaittojenhallintasuunnitelma(Haittojenhallintatyyppi.YLEINEN to null)`.
+     */
+    fun createHaittojenhallintasuunnitelma(
+        vararg overrides: Pair<Haittojenhallintatyyppi, String?>
+    ): Haittojenhallintasuunnitelma {
+        val haittojenhallintasuunnitelma = DEFAULT_HHS.toMutableMap()
+        overrides.forEach { (haittojenhallintatyyppi, suunnitelma) ->
+            if (suunnitelma == null) {
+                haittojenhallintasuunnitelma.remove(haittojenhallintatyyppi)
+            } else {
+                haittojenhallintasuunnitelma[haittojenhallintatyyppi] = suunnitelma
+            }
+        }
+        return haittojenhallintasuunnitelma
+    }
+
+    fun tormaystarkasteluTulos(
+        autoliikenne: Autoliikenneluokittelu = TORMAYSTARKASTELU_DEFAULT_AUTOLIIKENNELUOKITTELU,
+        pyoraliikenneindeksi: Float = 2.5f,
+        linjaautoliikenneindeksi: Float = 3.75f,
+        raitioliikenneindeksi: Float = 3.75f,
+    ) =
+        TormaystarkasteluTulos(
+            autoliikenne,
+            pyoraliikenneindeksi,
+            linjaautoliikenneindeksi,
+            raitioliikenneindeksi,
+        )
+}

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HaittaFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HaittaFactory.kt
@@ -30,13 +30,15 @@ object HaittaFactory {
             1,
         )
 
-    val DEFAULT_HHS_YLEINEN = "Yleisten haittojen hallintasuunnitelma"
-    val DEFAULT_HHS_PYORALIIKENNE = "Pyöräliikenteelle koituvien haittojen hallintasuunnitelma"
-    val DEFAULT_HHS_AUTOLIIKENNE = "Autoliikenteelle koituvien haittojen hallintasuunnitelma"
-    val DEFAULT_HHS_LINJAAUTOLIIKENNE =
+    const val DEFAULT_HHS_YLEINEN = "Yleisten haittojen hallintasuunnitelma"
+    const val DEFAULT_HHS_PYORALIIKENNE =
+        "Pyöräliikenteelle koituvien haittojen hallintasuunnitelma"
+    const val DEFAULT_HHS_AUTOLIIKENNE = "Autoliikenteelle koituvien haittojen hallintasuunnitelma"
+    const val DEFAULT_HHS_LINJAAUTOLIIKENNE =
         "Linja-autoliikenteelle koituvien haittojen hallintasuunnitelma"
-    val DEFAULT_HHS_RAITIOLIIKENNE = "Raitioliikenteelle koituvien haittojen hallintasuunnitelma"
-    val DEFAULT_HHS_MUUT = "Muiden haittojen hallintasuunnitelma"
+    const val DEFAULT_HHS_RAITIOLIIKENNE =
+        "Raitioliikenteelle koituvien haittojen hallintasuunnitelma"
+    const val DEFAULT_HHS_MUUT = "Muiden haittojen hallintasuunnitelma"
 
     val DEFAULT_HHS: Haittojenhallintasuunnitelma =
         mapOf(

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeFactory.kt
@@ -20,8 +20,6 @@ import fi.hel.haitaton.hanke.domain.HankeYhteystieto
 import fi.hel.haitaton.hanke.domain.Hankevaihe
 import fi.hel.haitaton.hanke.domain.TyomaaTyyppi
 import fi.hel.haitaton.hanke.domain.Yhteyshenkilo
-import fi.hel.haitaton.hanke.factory.HankealueFactory.TORMAYSTARKASTELU_DEFAULT_AUTOLIIKENNELUOKITTELU
-import fi.hel.haitaton.hanke.factory.HankealueFactory.createHaittojenhallintasuunnitelma
 import fi.hel.haitaton.hanke.factory.HankealueFactory.createHankeAlueEntity
 import fi.hel.haitaton.hanke.factory.ProfiiliFactory.DEFAULT_NAMES
 import fi.hel.haitaton.hanke.profiili.ProfiiliClient
@@ -83,11 +81,7 @@ class HankeFactory(
 
     fun builder(userId: String = USERNAME): HankeBuilder {
         val hanke =
-            create(
-                nimi = defaultNimi,
-                kuvaus = defaultKuvaus,
-                vaihe = Hankevaihe.OHJELMOINTI,
-            )
+            create(nimi = defaultNimi, kuvaus = defaultKuvaus, vaihe = Hankevaihe.OHJELMOINTI)
         return HankeBuilder(
             hanke,
             DEFAULT_HANKE_PERUSTAJA,
@@ -108,7 +102,7 @@ class HankeFactory(
             hanke.createdByUserId!!,
             hankeKayttajaFactory,
             hankeYhteystietoRepository,
-            hankeYhteyshenkiloRepository
+            hankeYhteyshenkiloRepository,
         )
 
     fun addYhteystiedotTo(hanke: HankeEntity, f: HankeYhteystietoBuilder.() -> Unit) {
@@ -188,7 +182,7 @@ class HankeFactory(
                             HankeYhteystietoFactory.createEntity(1, OMISTAJA, this),
                             HankeYhteystietoFactory.createEntity(2, TOTEUTTAJA, this),
                             HankeYhteystietoFactory.createEntity(3, RAKENNUTTAJA, this),
-                            HankeYhteystietoFactory.createEntity(4, MUU, this)
+                            HankeYhteystietoFactory.createEntity(4, MUU, this),
                         )
                     alueet =
                         mutableListOf(createHankeAlueEntity(mockId = mockId, hankeEntity = this))
@@ -196,14 +190,14 @@ class HankeFactory(
                         mutableListOf(
                             HankeAttachmentFactory.createEntity(
                                 hanke = this,
-                                createdByUser = defaultUser
+                                createdByUser = defaultUser,
                             )
                         )
                 }
 
         fun createRequest(
             nimi: String = defaultNimi,
-            perustaja: HankePerustaja = DEFAULT_HANKE_PERUSTAJA
+            perustaja: HankePerustaja = DEFAULT_HANKE_PERUSTAJA,
         ): CreateHankeRequest = CreateHankeRequest(nimi, perustaja)
 
         /**
@@ -219,7 +213,7 @@ class HankeFactory(
             haittaAlkuPvm: ZonedDateTime? = DateFactory.getStartDatetime(),
             haittaLoppuPvm: ZonedDateTime? = DateFactory.getEndDatetime(),
             haittojenhallintasuunnitelma: Haittojenhallintasuunnitelma? =
-                createHaittojenhallintasuunnitelma(),
+                HaittaFactory.createHaittojenhallintasuunnitelma(),
         ): Hanke {
             this.tyomaaKatuosoite = "Testikatu 1"
             this.tyomaaTyyppi.add(TyomaaTyyppi.VESI)
@@ -238,7 +232,8 @@ class HankeFactory(
         }
 
         fun Hanke.withTormaystarkasteluTulos(
-            autoliikenne: Autoliikenneluokittelu = TORMAYSTARKASTELU_DEFAULT_AUTOLIIKENNELUOKITTELU,
+            autoliikenne: Autoliikenneluokittelu =
+                HaittaFactory.TORMAYSTARKASTELU_DEFAULT_AUTOLIIKENNELUOKITTELU,
             pyoraliikenneindeksi: Float = 1f,
             linjaautoliikenneindeksi: Float = 1f,
             raitioliikenneindeksi: Float = 1f,
@@ -305,7 +300,7 @@ class HankeFactory(
         fun Hanke.withRakennuttaja(
             i: Int,
             id: Int? = i,
-            vararg yhteyshenkilo: Yhteyshenkilo
+            vararg yhteyshenkilo: Yhteyshenkilo,
         ): Hanke {
             rakennuttajat.add(
                 HankeYhteystietoFactory.createDifferentiated(i, id, yhteyshenkilo.toList())
@@ -323,7 +318,7 @@ class HankeFactory(
         fun Hanke.withMuuYhteystieto(
             i: Int,
             id: Int? = i,
-            vararg yhteyshenkilo: Yhteyshenkilo
+            vararg yhteyshenkilo: Yhteyshenkilo,
         ): Hanke {
             muut.add(HankeYhteystietoFactory.createDifferentiated(i, id, yhteyshenkilo.toList()))
             return this

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankealueFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankealueFactory.kt
@@ -4,59 +4,18 @@ import fi.hel.haitaton.hanke.HANKEALUE_DEFAULT_NAME
 import fi.hel.haitaton.hanke.HankeEntity
 import fi.hel.haitaton.hanke.HankealueEntity
 import fi.hel.haitaton.hanke.domain.Haittojenhallintasuunnitelma
-import fi.hel.haitaton.hanke.domain.Haittojenhallintatyyppi
 import fi.hel.haitaton.hanke.domain.SavedHankealue
 import fi.hel.haitaton.hanke.geometria.Geometriat
-import fi.hel.haitaton.hanke.tormaystarkastelu.Autoliikenneluokittelu
 import fi.hel.haitaton.hanke.tormaystarkastelu.AutoliikenteenKaistavaikutustenPituus
-import fi.hel.haitaton.hanke.tormaystarkastelu.HaittaAjanKestoLuokittelu
-import fi.hel.haitaton.hanke.tormaystarkastelu.Liikennemaaraluokittelu
 import fi.hel.haitaton.hanke.tormaystarkastelu.Meluhaitta
 import fi.hel.haitaton.hanke.tormaystarkastelu.Polyhaitta
 import fi.hel.haitaton.hanke.tormaystarkastelu.Tarinahaitta
-import fi.hel.haitaton.hanke.tormaystarkastelu.TormaystarkasteluKatuluokka
 import fi.hel.haitaton.hanke.tormaystarkastelu.TormaystarkasteluTulos
 import fi.hel.haitaton.hanke.tormaystarkastelu.TormaystarkasteluTulosEntity
 import fi.hel.haitaton.hanke.tormaystarkastelu.VaikutusAutoliikenteenKaistamaariin
 import java.time.ZonedDateTime
 
 object HankealueFactory {
-
-    val TORMAYSTARKASTELU_DEFAULT_AUTOLIIKENNELUOKITTELU =
-        Autoliikenneluokittelu(
-            HaittaAjanKestoLuokittelu.YLI_KOLME_KUUKAUTTA.value,
-            TormaystarkasteluKatuluokka.TONTTIKATU_TAI_AJOYHTEYS.value,
-            Liikennemaaraluokittelu.LIIKENNEMAARA_ALLE_500.value,
-            VaikutusAutoliikenteenKaistamaariin.YKSI_KAISTA_VAHENEE.value,
-            AutoliikenteenKaistavaikutustenPituus.PITUUS_ALLE_10_METRIA.value,
-        )
-
-    val TORMAYSTARKASTELU_ZERO_AUTOLIIKENNELUOKITTELU =
-        Autoliikenneluokittelu(
-            1,
-            0, // if both 'katuluokka' and 'liikennemaara' is 0, the index is 0.0
-            0, // if both 'katuluokka' and 'liikennemaara' is 0, the index is 0.0
-            1,
-            1,
-        )
-
-    val DEFAULT_HHS_YLEINEN = "Yleisten haittojen hallintasuunnitelma"
-    val DEFAULT_HHS_PYORALIIKENNE = "Pyöräliikenteelle koituvien haittojen hallintasuunnitelma"
-    val DEFAULT_HHS_AUTOLIIKENNE = "Autoliikenteelle koituvien haittojen hallintasuunnitelma"
-    val DEFAULT_HHS_LINJAAUTOLIIKENNE =
-        "Linja-autoliikenteelle koituvien haittojen hallintasuunnitelma"
-    val DEFAULT_HHS_RAITIOLIIKENNE = "Raitioliikenteelle koituvien haittojen hallintasuunnitelma"
-    val DEFAULT_HHS_MUUT = "Muiden haittojen hallintasuunnitelma"
-
-    val DEFAULT_HHS: Haittojenhallintasuunnitelma =
-        mapOf(
-            Haittojenhallintatyyppi.YLEINEN to DEFAULT_HHS_YLEINEN,
-            Haittojenhallintatyyppi.PYORALIIKENNE to DEFAULT_HHS_PYORALIIKENNE,
-            Haittojenhallintatyyppi.AUTOLIIKENNE to DEFAULT_HHS_AUTOLIIKENNE,
-            Haittojenhallintatyyppi.LINJAAUTOLIIKENNE to DEFAULT_HHS_LINJAAUTOLIIKENNE,
-            Haittojenhallintatyyppi.RAITIOLIIKENNE to DEFAULT_HHS_RAITIOLIIKENNE,
-            Haittojenhallintatyyppi.MUUT to DEFAULT_HHS_MUUT,
-        )
 
     fun create(
         id: Int? = 1,
@@ -72,9 +31,9 @@ object HankealueFactory {
         polyHaitta: Polyhaitta? = Polyhaitta.TOISTUVA_POLYHAITTA,
         tarinaHaitta: Tarinahaitta? = Tarinahaitta.JATKUVA_TARINAHAITTA,
         nimi: String = "$HANKEALUE_DEFAULT_NAME 1",
-        tormaystarkasteluTulos: TormaystarkasteluTulos? = tormaystarkasteluTulos(),
+        tormaystarkasteluTulos: TormaystarkasteluTulos? = HaittaFactory.tormaystarkasteluTulos(),
         haittojenhallintasuunnitelma: Haittojenhallintasuunnitelma? =
-            createHaittojenhallintasuunnitelma(),
+            HaittaFactory.createHaittojenhallintasuunnitelma(),
     ): SavedHankealue {
         return SavedHankealue(
             id,
@@ -91,29 +50,6 @@ object HankealueFactory {
             tormaystarkasteluTulos,
             haittojenhallintasuunnitelma,
         )
-    }
-
-    /**
-     * Creates a haittojenhallintasuunnitelma with values in all fields.
-     *
-     * Values can be overridden with parameters like
-     * `createHaittojenhallintasuunnitelma(Haittojenhallintatyyppi.YLEINEN to "Overridden value")`.
-     *
-     * Values can be removed from the haittojenhallintasuunnitelma by overriding them with null:
-     * `createHaittojenhallintasuunnitelma(Haittojenhallintatyyppi.YLEINEN to null)`.
-     */
-    fun createHaittojenhallintasuunnitelma(
-        vararg overrides: Pair<Haittojenhallintatyyppi, String?>
-    ): Haittojenhallintasuunnitelma {
-        val haittojenhallintasuunnitelma = DEFAULT_HHS.toMutableMap()
-        overrides.forEach { (haittojenhallintatyyppi, suunnitelma) ->
-            if (suunnitelma == null) {
-                haittojenhallintasuunnitelma.remove(haittojenhallintatyyppi)
-            } else {
-                haittojenhallintasuunnitelma[haittojenhallintatyyppi] = suunnitelma
-            }
-        }
-        return haittojenhallintasuunnitelma
     }
 
     fun createMinimal(
@@ -167,30 +103,23 @@ object HankealueFactory {
             }
     }
 
-    private fun tormaystarkasteluTulos() =
-        TormaystarkasteluTulos(
-            autoliikenne = TORMAYSTARKASTELU_DEFAULT_AUTOLIIKENNELUOKITTELU,
-            pyoraliikenneindeksi = 2.5f,
-            linjaautoliikenneindeksi = 3.75f,
-            raitioliikenneindeksi = 3.75f,
-        )
-
     private fun tormaystarkasteluTulosEntity(
         id: Int = 1,
         hankealueEntity: HankealueEntity,
     ): TormaystarkasteluTulosEntity =
-        TormaystarkasteluTulosEntity(
-            id = id,
-            autoliikenne = TORMAYSTARKASTELU_DEFAULT_AUTOLIIKENNELUOKITTELU.indeksi,
-            haitanKesto = TORMAYSTARKASTELU_DEFAULT_AUTOLIIKENNELUOKITTELU.haitanKesto,
-            katuluokka = TORMAYSTARKASTELU_DEFAULT_AUTOLIIKENNELUOKITTELU.katuluokka,
-            autoliikennemaara = TORMAYSTARKASTELU_DEFAULT_AUTOLIIKENNELUOKITTELU.liikennemaara,
-            kaistahaitta = TORMAYSTARKASTELU_DEFAULT_AUTOLIIKENNELUOKITTELU.kaistahaitta,
-            kaistapituushaitta =
-                TORMAYSTARKASTELU_DEFAULT_AUTOLIIKENNELUOKITTELU.kaistapituushaitta,
-            pyoraliikenne = 2.5f,
-            linjaautoliikenne = 3.75f,
-            raitioliikenne = 3.75f,
-            hankealue = hankealueEntity,
-        )
+        with(HaittaFactory.TORMAYSTARKASTELU_DEFAULT_AUTOLIIKENNELUOKITTELU) {
+            TormaystarkasteluTulosEntity(
+                id = id,
+                autoliikenne = indeksi,
+                haitanKesto = haitanKesto,
+                katuluokka = katuluokka,
+                autoliikennemaara = liikennemaara,
+                kaistahaitta = kaistahaitta,
+                kaistapituushaitta = kaistapituushaitta,
+                pyoraliikenne = 2.5f,
+                linjaautoliikenne = 3.75f,
+                raitioliikenne = 3.75f,
+                hankealue = hankealueEntity,
+            )
+        }
 }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusUpdateRequestTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusUpdateRequestTest.kt
@@ -7,10 +7,10 @@ import fi.hel.haitaton.hanke.allu.CustomerType
 import fi.hel.haitaton.hanke.factory.ApplicationFactory
 import fi.hel.haitaton.hanke.factory.ApplicationFactory.Companion.createExcavationNotificationArea
 import fi.hel.haitaton.hanke.factory.ApplicationFactory.Companion.createTyoalue
+import fi.hel.haitaton.hanke.factory.HaittaFactory
 import fi.hel.haitaton.hanke.factory.HakemusUpdateRequestFactory
 import fi.hel.haitaton.hanke.factory.HakemusyhteyshenkiloFactory
 import fi.hel.haitaton.hanke.factory.HakemusyhteystietoFactory
-import fi.hel.haitaton.hanke.factory.HankealueFactory.TORMAYSTARKASTELU_DEFAULT_AUTOLIIKENNELUOKITTELU
 import fi.hel.haitaton.hanke.tormaystarkastelu.TormaystarkasteluTulos
 import java.time.ZonedDateTime
 import java.util.UUID
@@ -99,7 +99,8 @@ class HakemusUpdateRequestTest {
             val original = blankOriginal
             val request =
                 createJohtoselvityshakemusUpdateRequestWithCustomerWithContacts(
-                    "cd1d4d2f-526b-4ee5-a1fa-97b14d25a11f")
+                    "cd1d4d2f-526b-4ee5-a1fa-97b14d25a11f"
+                )
 
             assertThat(request.hasChanges(original)).isTrue()
         }
@@ -108,7 +109,8 @@ class HakemusUpdateRequestTest {
         fun `returns true when new customer contact is added`() {
             val original =
                 createHakemusDataWithYhteystiedot(
-                    Pair("cd1d4d2f-526b-4ee5-a1fa-97b14d25a11f", true))
+                    Pair("cd1d4d2f-526b-4ee5-a1fa-97b14d25a11f", true)
+                )
             val request =
                 createJohtoselvityshakemusUpdateRequestWithCustomerWithContacts(
                     "cd1d4d2f-526b-4ee5-a1fa-97b14d25a11f",
@@ -198,7 +200,7 @@ class HakemusUpdateRequestTest {
     private fun createHakemusDataWithTormaystarkastelu(): HakemusData {
         val tormaystarkasteluTulos =
             TormaystarkasteluTulos(
-                TORMAYSTARKASTELU_DEFAULT_AUTOLIIKENNELUOKITTELU,
+                HaittaFactory.TORMAYSTARKASTELU_DEFAULT_AUTOLIIKENNELUOKITTELU,
                 3.0f,
                 5.0f,
                 5.0f,

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/KaivuilmoitusSendValidationTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/KaivuilmoitusSendValidationTest.kt
@@ -390,11 +390,11 @@ class KaivuilmoitusSendValidationTest {
                     autoliikenne = HaittaFactory.TORMAYSTARKASTELU_DEFAULT_AUTOLIIKENNELUOKITTELU
                 )
             val tyoalue1 =
-                ApplicationFactory.createTyoalue(tormaystarkasteluTulos = withPositiveAutoliikenne)
-            val tyoalue2 =
                 ApplicationFactory.createTyoalue(tormaystarkasteluTulos = withZeroAutoliikenne)
-            val tyoalue3 =
+            val tyoalue2 =
                 ApplicationFactory.createTyoalue(tormaystarkasteluTulos = withPositiveAutoliikenne)
+            val tyoalue3 =
+                ApplicationFactory.createTyoalue(tormaystarkasteluTulos = withZeroAutoliikenne)
             val area =
                 ApplicationFactory.createExcavationNotificationArea(
                     tyoalueet = listOf(tyoalue1, tyoalue2, tyoalue3),

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/validation/HankePublicValidatorTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/validation/HankePublicValidatorTest.kt
@@ -6,13 +6,13 @@ import assertk.assertions.isGreaterThanOrEqualTo
 import fi.hel.haitaton.hanke.domain.Haittojenhallintatyyppi
 import fi.hel.haitaton.hanke.domain.Hanke
 import fi.hel.haitaton.hanke.domain.YhteystietoTyyppi.YKSITYISHENKILO
+import fi.hel.haitaton.hanke.factory.HaittaFactory
+import fi.hel.haitaton.hanke.factory.HaittaFactory.TORMAYSTARKASTELU_DEFAULT_AUTOLIIKENNELUOKITTELU
+import fi.hel.haitaton.hanke.factory.HaittaFactory.TORMAYSTARKASTELU_ZERO_AUTOLIIKENNELUOKITTELU
 import fi.hel.haitaton.hanke.factory.HankeFactory
 import fi.hel.haitaton.hanke.factory.HankeFactory.Companion.withHankealue
 import fi.hel.haitaton.hanke.factory.HankeFactory.Companion.withTormaystarkasteluTulos
 import fi.hel.haitaton.hanke.factory.HankeFactory.Companion.withYhteystiedot
-import fi.hel.haitaton.hanke.factory.HankealueFactory
-import fi.hel.haitaton.hanke.factory.HankealueFactory.TORMAYSTARKASTELU_DEFAULT_AUTOLIIKENNELUOKITTELU
-import fi.hel.haitaton.hanke.factory.HankealueFactory.TORMAYSTARKASTELU_ZERO_AUTOLIIKENNELUOKITTELU
 import fi.hel.haitaton.hanke.factory.modify
 import fi.hel.haitaton.hanke.test.Asserts.failedWith
 import fi.hel.haitaton.hanke.test.Asserts.isSuccess
@@ -52,7 +52,10 @@ class HankePublicValidatorTest {
                     completeHanke().apply { tyomaaKatuosoite = null },
                 ),
                 Arguments.of(
-                    "tyomaaKatuosoite", "empty", completeHanke().apply { tyomaaKatuosoite = "" }),
+                    "tyomaaKatuosoite",
+                    "empty",
+                    completeHanke().apply { tyomaaKatuosoite = "" },
+                ),
                 Arguments.of(
                     "tyomaaKatuosoite",
                     "blank",
@@ -120,7 +123,10 @@ class HankePublicValidatorTest {
                     },
                 ),
                 Arguments.of(
-                    "alueet[0].nimi", "empty", completeHanke().apply { alueet[0].nimi = "" }),
+                    "alueet[0].nimi",
+                    "empty",
+                    completeHanke().apply { alueet[0].nimi = "" },
+                ),
                 Arguments.of(
                     "alueet[0].haittojenhallintasuunnitelma",
                     "missing",
@@ -133,9 +139,11 @@ class HankePublicValidatorTest {
                         alueet[0] =
                             alueet[0].copy(
                                 haittojenhallintasuunnitelma =
-                                    HankealueFactory.createHaittojenhallintasuunnitelma(
-                                        Haittojenhallintatyyppi.YLEINEN to null),
-                                tormaystarkasteluTulos = null)
+                                    HaittaFactory.createHaittojenhallintasuunnitelma(
+                                        Haittojenhallintatyyppi.YLEINEN to null
+                                    ),
+                                tormaystarkasteluTulos = null,
+                            )
                     },
                 ),
                 Arguments.of(
@@ -143,8 +151,9 @@ class HankePublicValidatorTest {
                     "empty",
                     completeHanke().apply {
                         alueet[0].haittojenhallintasuunnitelma =
-                            HankealueFactory.createHaittojenhallintasuunnitelma(
-                                Haittojenhallintatyyppi.AUTOLIIKENNE to "")
+                            HaittaFactory.createHaittojenhallintasuunnitelma(
+                                Haittojenhallintatyyppi.AUTOLIIKENNE to ""
+                            )
                     },
                 ),
                 Arguments.of(
@@ -152,14 +161,21 @@ class HankePublicValidatorTest {
                     "blank",
                     completeHanke().apply {
                         alueet[0].haittojenhallintasuunnitelma =
-                            HankealueFactory.createHaittojenhallintasuunnitelma(
-                                Haittojenhallintatyyppi.MUUT to BLANK)
+                            HaittaFactory.createHaittojenhallintasuunnitelma(
+                                Haittojenhallintatyyppi.MUUT to BLANK
+                            )
                     },
                 ),
                 Arguments.of(
-                    "omistajat", "empty", completeHanke().apply { omistajat = mutableListOf() }),
+                    "omistajat",
+                    "empty",
+                    completeHanke().apply { omistajat = mutableListOf() },
+                ),
                 Arguments.of(
-                    "omistajat[0].nimi", "empty", completeHanke().apply { omistajat[0].nimi = "" }),
+                    "omistajat[0].nimi",
+                    "empty",
+                    completeHanke().apply { omistajat[0].nimi = "" },
+                ),
                 Arguments.of(
                     "omistajat[0].nimi",
                     "blank",
@@ -229,7 +245,8 @@ class HankePublicValidatorTest {
     fun `when rakennuttajat missing should return ok`() {
         val result =
             validateHankeHasMandatoryFields(
-                completeHanke().apply { rakennuttajat = mutableListOf() })
+                completeHanke().apply { rakennuttajat = mutableListOf() }
+            )
 
         assertThat(result).isSuccess()
     }
@@ -304,10 +321,12 @@ class HankePublicValidatorTest {
         hanke.alueet[0] =
             hanke.alueet[0].copy(
                 haittojenhallintasuunnitelma =
-                    HankealueFactory.createHaittojenhallintasuunnitelma(
-                        Haittojenhallintatyyppi.PYORALIIKENNE to null),
+                    HaittaFactory.createHaittojenhallintasuunnitelma(
+                        Haittojenhallintatyyppi.PYORALIIKENNE to null
+                    ),
                 tormaystarkasteluTulos =
-                    hanke.alueet[0].tormaystarkasteluTulos!!.copy(pyoraliikenneindeksi = 0f))
+                    hanke.alueet[0].tormaystarkasteluTulos!!.copy(pyoraliikenneindeksi = 0f),
+            )
 
         val result = validateHankeHasMandatoryFields(hanke)
 
@@ -320,9 +339,11 @@ class HankePublicValidatorTest {
         hanke.alueet[0] =
             hanke.alueet[0].copy(
                 haittojenhallintasuunnitelma =
-                    HankealueFactory.createHaittojenhallintasuunnitelma(
-                        Haittojenhallintatyyppi.AUTOLIIKENNE to ""),
-                tormaystarkasteluTulos = null)
+                    HaittaFactory.createHaittojenhallintasuunnitelma(
+                        Haittojenhallintatyyppi.AUTOLIIKENNE to ""
+                    ),
+                tormaystarkasteluTulos = null,
+            )
 
         val result = validateHankeHasMandatoryFields(hanke)
 
@@ -342,7 +363,8 @@ class HankePublicValidatorTest {
                     alueet[0].geometriat!!.featureCollection!!.features = null
                     alueet[0].nimi = ""
                     kuvaus = null
-                })
+                }
+            )
 
         assertThat(result)
             .failedWith(
@@ -359,7 +381,7 @@ class HankePublicValidatorTest {
     fun `when hanke missing a mandatory field should return not ok and failed path`(
         path: String,
         case: String,
-        hanke: Hanke
+        hanke: Hanke,
     ) {
         case.touch()
 
@@ -377,11 +399,12 @@ class HankePublicValidatorTest {
                 autoliikenne = TORMAYSTARKASTELU_DEFAULT_AUTOLIIKENNELUOKITTELU,
                 pyoraliikenneindeksi = 3f,
                 linjaautoliikenneindeksi = 3f,
-                raitioliikenneindeksi = 3f)
+                raitioliikenneindeksi = 3f,
+            )
 
         @Test
         fun `returns success when suunnitelma present and matching tormaystarkastelutulos is positive`() {
-            val haittojenhallintasuunnitelma = HankealueFactory.createHaittojenhallintasuunnitelma()
+            val haittojenhallintasuunnitelma = HaittaFactory.createHaittojenhallintasuunnitelma()
 
             val result =
                 HankePublicValidator.validateHaittojenhallintasuunnitelmaLiikennemuodot(
@@ -403,7 +426,7 @@ class HankePublicValidatorTest {
             tyyppi: Haittojenhallintatyyppi
         ) {
             val haittojenhallintasuunnitelma =
-                HankealueFactory.createHaittojenhallintasuunnitelma(tyyppi to null)
+                HaittaFactory.createHaittojenhallintasuunnitelma(tyyppi to null)
 
             val result =
                 HankePublicValidator.validateHaittojenhallintasuunnitelmaLiikennemuodot(
@@ -425,7 +448,7 @@ class HankePublicValidatorTest {
             tyyppi: Haittojenhallintatyyppi
         ) {
             val haittojenhallintasuunnitelma =
-                HankealueFactory.createHaittojenhallintasuunnitelma(tyyppi to "")
+                HaittaFactory.createHaittojenhallintasuunnitelma(tyyppi to "")
 
             val result =
                 HankePublicValidator.validateHaittojenhallintasuunnitelmaLiikennemuodot(
@@ -447,7 +470,7 @@ class HankePublicValidatorTest {
             tyyppi: Haittojenhallintatyyppi
         ) {
             val haittojenhallintasuunnitelma =
-                HankealueFactory.createHaittojenhallintasuunnitelma(tyyppi to BLANK)
+                HaittaFactory.createHaittojenhallintasuunnitelma(tyyppi to BLANK)
 
             val result =
                 HankePublicValidator.validateHaittojenhallintasuunnitelmaLiikennemuodot(
@@ -465,7 +488,7 @@ class HankePublicValidatorTest {
             tyyppi: Haittojenhallintatyyppi,
             tormaystarkasteluTulos: TormaystarkasteluTulos,
         ) {
-            val haittojenhallintasuunnitelma = HankealueFactory.createHaittojenhallintasuunnitelma()
+            val haittojenhallintasuunnitelma = HaittaFactory.createHaittojenhallintasuunnitelma()
 
             val result =
                 HankePublicValidator.validateHaittojenhallintasuunnitelmaLiikennemuodot(
@@ -482,16 +505,21 @@ class HankePublicValidatorTest {
                 Arguments.of(
                     Haittojenhallintatyyppi.AUTOLIIKENNE,
                     tormaystarkasteluTulos.copy(
-                        autoliikenne = TORMAYSTARKASTELU_ZERO_AUTOLIIKENNELUOKITTELU)),
+                        autoliikenne = TORMAYSTARKASTELU_ZERO_AUTOLIIKENNELUOKITTELU
+                    ),
+                ),
                 Arguments.of(
                     Haittojenhallintatyyppi.LINJAAUTOLIIKENNE,
-                    tormaystarkasteluTulos.copy(linjaautoliikenneindeksi = 0f)),
+                    tormaystarkasteluTulos.copy(linjaautoliikenneindeksi = 0f),
+                ),
                 Arguments.of(
                     Haittojenhallintatyyppi.RAITIOLIIKENNE,
-                    tormaystarkasteluTulos.copy(raitioliikenneindeksi = 0f)),
+                    tormaystarkasteluTulos.copy(raitioliikenneindeksi = 0f),
+                ),
                 Arguments.of(
                     Haittojenhallintatyyppi.PYORALIIKENNE,
-                    tormaystarkasteluTulos.copy(pyoraliikenneindeksi = 0f)),
+                    tormaystarkasteluTulos.copy(pyoraliikenneindeksi = 0f),
+                ),
             )
     }
 
@@ -503,8 +531,9 @@ class HankePublicValidatorTest {
         @NullSource
         fun `fails when muut is null or blank`(suunnitelma: String?) {
             val haittojenhallintasuunnitelma =
-                HankealueFactory.createHaittojenhallintasuunnitelma(
-                    Haittojenhallintatyyppi.MUUT to suunnitelma)
+                HaittaFactory.createHaittojenhallintasuunnitelma(
+                    Haittojenhallintatyyppi.MUUT to suunnitelma
+                )
 
             val result =
                 HankePublicValidator.validateHaittojenhallintasuunnitelmaCommonFields(
@@ -520,8 +549,9 @@ class HankePublicValidatorTest {
         @NullSource
         fun `fails when yleinen is null or blank`(suunnitelma: String?) {
             val haittojenhallintasuunnitelma =
-                HankealueFactory.createHaittojenhallintasuunnitelma(
-                    Haittojenhallintatyyppi.YLEINEN to suunnitelma)
+                HaittaFactory.createHaittojenhallintasuunnitelma(
+                    Haittojenhallintatyyppi.YLEINEN to suunnitelma
+                )
 
             val result =
                 HankePublicValidator.validateHaittojenhallintasuunnitelmaCommonFields(


### PR DESCRIPTION
# Description

Add validation that checks that the haittojenhallintasuunnitelma is filled in when sending the hakemus to Allu. It uses the same validation function as validation of the haittojenhallintasuunnitelma in a hanke.

Also, move haittojenhallintasuunnitelma and tormaystarkastelutulos stuff from `HankealueFactory` to a new `HaittaFactory`. These classes are also used in Kaivuilmoitus, so having the factories on "neutral ground" makes sense.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-876

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
I didn't test this manually. It would require adding a haittojenhallintasuunnitelma through Swagger UI. The haittojenhallintasuunnitelma should have a missing value for one of the traffic methods where the area of the application has an index. And then sending the application to Allu.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 