### PR TITLE
HAI-1008 AD group checks for authentication

### DIFF
--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/configuration/Configuration.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/configuration/Configuration.kt
@@ -6,6 +6,7 @@ import fi.hel.haitaton.hanke.attachment.azure.Containers
 import fi.hel.haitaton.hanke.email.EmailProperties
 import fi.hel.haitaton.hanke.gdpr.GdprProperties
 import fi.hel.haitaton.hanke.profiili.ProfiiliProperties
+import fi.hel.haitaton.hanke.security.AdFilterProperties
 import io.netty.handler.ssl.SslContextBuilder
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory
 import kotlinx.coroutines.CoroutineDispatcher
@@ -27,6 +28,7 @@ import reactor.netty.http.client.HttpClient
     AlluProperties::class,
     ProfiiliProperties::class,
     EmailProperties::class,
+    AdFilterProperties::class,
     Containers::class,
 )
 class Configuration {

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/profiili/ProfiiliService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/profiili/ProfiiliService.kt
@@ -1,5 +1,7 @@
 package fi.hel.haitaton.hanke.profiili
 
+import fi.hel.haitaton.hanke.security.AmrValues
+import fi.hel.haitaton.hanke.security.JwtClaims
 import org.springframework.security.core.context.SecurityContext
 import org.springframework.security.oauth2.jwt.Jwt
 import org.springframework.stereotype.Service
@@ -12,10 +14,10 @@ class ProfiiliService(private val profiiliClient: ProfiiliClient) {
             securityContext.authentication?.let { it.credentials as Jwt }
                 ?: throw VerifiedNameNotFound("User not authenticated.")
 
-        val amr = credentials.getClaim<List<String>>(AMR_CLAIM)
-        return if (amr.contains(SUOMI_FI_AMR_TAG)) {
+        val amr = credentials.getClaim<List<String>>(JwtClaims.AMR)
+        return if (amr.contains(AmrValues.SUOMI_FI)) {
             profiiliClient.getVerifiedName(credentials.tokenValue)
-        } else if (amr.contains(AD_AMR_TAG)) {
+        } else if (amr.contains(AmrValues.AD)) {
             nameFromToken(credentials)
         } else {
             throw AuthenticationMethodNotSupported(amr)
@@ -24,18 +26,12 @@ class ProfiiliService(private val profiiliClient: ProfiiliClient) {
 
     private fun nameFromToken(credentials: Jwt): Names {
         val given: String =
-            credentials.getClaim(GIVEN_NAME_CLAIM) ?: throw NameClaimNotFound(GIVEN_NAME_CLAIM)
+            credentials.getClaim(JwtClaims.GIVEN_NAME)
+                ?: throw NameClaimNotFound(JwtClaims.GIVEN_NAME)
         val family: String =
-            credentials.getClaim(FAMILY_NAME_CLAIM) ?: throw NameClaimNotFound(FAMILY_NAME_CLAIM)
+            credentials.getClaim(JwtClaims.FAMILY_NAME)
+                ?: throw NameClaimNotFound(JwtClaims.FAMILY_NAME)
         return Names(given, family, given)
-    }
-
-    companion object {
-        const val AMR_CLAIM = "amr"
-        const val GIVEN_NAME_CLAIM = "given_name"
-        const val FAMILY_NAME_CLAIM = "family_name"
-        const val SUOMI_FI_AMR_TAG = "suomi_fi"
-        const val AD_AMR_TAG = "helsinkiad"
     }
 }
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/security/AdFilterProperties.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/security/AdFilterProperties.kt
@@ -1,0 +1,7 @@
+package fi.hel.haitaton.hanke.security
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.convert.Delimiter
+
+@ConfigurationProperties(prefix = "haitaton.ad.filter")
+data class AdFilterProperties(val use: Boolean, @Delimiter(";") val allowedGroups: Set<String>)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/security/JwtClaims.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/security/JwtClaims.kt
@@ -1,0 +1,15 @@
+package fi.hel.haitaton.hanke.security
+
+/** Names of the claims we read from the JWT. */
+object JwtClaims {
+    const val AD_GROUPS = "ad_groups"
+    const val AMR = "amr"
+    const val GIVEN_NAME = "given_name"
+    const val FAMILY_NAME = "family_name"
+}
+
+/** Values that the amr claim in the authentication JWT can have. */
+object AmrValues {
+    const val SUOMI_FI = "suomi_fi"
+    const val AD = "helsinkiad"
+}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/security/OAuth2ResourceServerSecurityConfiguration.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/security/OAuth2ResourceServerSecurityConfiguration.kt
@@ -1,6 +1,7 @@
 package fi.hel.haitaton.hanke.security
 
 import fi.hel.haitaton.hanke.gdpr.GdprProperties
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -8,7 +9,9 @@ import org.springframework.core.annotation.Order
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator
+import org.springframework.security.oauth2.core.OAuth2Error
 import org.springframework.security.oauth2.core.OAuth2TokenValidator
+import org.springframework.security.oauth2.core.OAuth2TokenValidatorResult
 import org.springframework.security.oauth2.jwt.Jwt
 import org.springframework.security.oauth2.jwt.JwtClaimNames
 import org.springframework.security.oauth2.jwt.JwtClaimValidator
@@ -20,13 +23,46 @@ import org.springframework.security.web.SecurityFilterChain
 
 @Configuration
 @EnableMethodSecurity(prePostEnabled = true)
-class OAuth2ResourceServerSecurityConfiguration(private val gdprProperties: GdprProperties) {
+class OAuth2ResourceServerSecurityConfiguration(
+    private val gdprProperties: GdprProperties,
+    private val adFilterProperties: AdFilterProperties,
+    @Value("\${spring.security.oauth2.resourceserver.jwt.issuer-uri}")
+    private val issuerUri: String,
+    @Value("\${spring.security.oauth2.resourceserver.jwt.audiences}") private val audience: String,
+) {
 
     @Bean
     fun filterChain(http: HttpSecurity): SecurityFilterChain {
         AccessRules.configureHttpAccessRules(http)
         http.oauth2ResourceServer { it.jwt {} }
         return http.build()
+    }
+
+    fun adGroupValidator(): OAuth2TokenValidator<Jwt> = AdGroupValidator(adFilterProperties)
+
+    fun audienceValidator(): OAuth2TokenValidator<Jwt?> =
+        JwtClaimValidator<List<String>>(JwtClaimNames.AUD) { aud -> aud.contains(audience) }
+
+    /**
+     * Custom decoder that verifies the AD groups and audience of the token on top of the default
+     * behaviour.
+     *
+     * Adopted from:
+     * https://docs.spring.io/spring-security/reference/servlet/oauth2/resource-server/jwt.html#oauth2resourceserver-jwt-validation-custom
+     */
+    @Bean
+    fun jwtDecoder(): JwtDecoder {
+        val jwtDecoder = JwtDecoders.fromIssuerLocation(issuerUri) as NimbusJwtDecoder
+
+        val adGroupValidator = adGroupValidator()
+        val audienceValidator = audienceValidator()
+        val defaultValidator = JwtValidators.createDefaultWithIssuer(issuerUri)
+        val combinedValidator =
+            DelegatingOAuth2TokenValidator(defaultValidator, audienceValidator, adGroupValidator)
+
+        jwtDecoder.setJwtValidator(combinedValidator)
+
+        return jwtDecoder
     }
 
     /**
@@ -67,7 +103,7 @@ class OAuth2ResourceServerSecurityConfiguration(private val gdprProperties: Gdpr
         return http.build()
     }
 
-    fun audienceValidator(): OAuth2TokenValidator<Jwt?> =
+    fun gdprAudienceValidator(): OAuth2TokenValidator<Jwt?> =
         JwtClaimValidator<List<String>>(JwtClaimNames.AUD) { aud ->
             aud.contains(gdprProperties.audience)
         }
@@ -77,7 +113,7 @@ class OAuth2ResourceServerSecurityConfiguration(private val gdprProperties: Gdpr
         val jwtDecoder: NimbusJwtDecoder =
             JwtDecoders.fromIssuerLocation(gdprProperties.issuer) as NimbusJwtDecoder
 
-        val audienceValidator = audienceValidator()
+        val audienceValidator = gdprAudienceValidator()
         val withIssuer: OAuth2TokenValidator<Jwt> =
             JwtValidators.createDefaultWithIssuer(gdprProperties.issuer)
         val withAudience: OAuth2TokenValidator<Jwt> =
@@ -86,5 +122,36 @@ class OAuth2ResourceServerSecurityConfiguration(private val gdprProperties: Gdpr
         jwtDecoder.setJwtValidator(withAudience)
 
         return jwtDecoder
+    }
+
+    class AdGroupValidator(private val adFilterProperties: AdFilterProperties) :
+        OAuth2TokenValidator<Jwt> {
+        override fun validate(jwt: Jwt): OAuth2TokenValidatorResult =
+            if (jwt.getClaimAsStringList(JwtClaims.AMR).contains(AmrValues.SUOMI_FI)) {
+                OAuth2TokenValidatorResult.success()
+            } else if (jwt.getClaimAsStringList(JwtClaims.AMR).contains(AmrValues.AD)) {
+                validateAdGroups(jwt)
+            } else {
+                val error =
+                    OAuth2Error(
+                        "invalid_token",
+                        "The AMR claim has no recognized authentication methods",
+                        null,
+                    )
+                OAuth2TokenValidatorResult.failure(error)
+            }
+
+        private fun validateAdGroups(jwt: Jwt): OAuth2TokenValidatorResult {
+            val groups = jwt.getClaimAsStringList("ad_groups").toSet()
+
+            return if (!adFilterProperties.use) {
+                OAuth2TokenValidatorResult.success()
+            } else if (adFilterProperties.allowedGroups.any { groups.contains(it) }) {
+                OAuth2TokenValidatorResult.success()
+            } else {
+                val error = OAuth2Error("invalid_token", "No allowed AD groups", null)
+                OAuth2TokenValidatorResult.failure(error)
+            }
+        }
     }
 }

--- a/services/hanke-service/src/main/resources/application.yml
+++ b/services/hanke-service/src/main/resources/application.yml
@@ -1,4 +1,9 @@
 haitaton:
+  ad:
+    filter:
+      use: ${HAITATON_USE_AD_FILTER:false}
+      # List of allowed groups, seperated by ;
+      allowed-groups: ${HAITATON_ALLOWED_AD_GROUPS:}
   allu:
     baseUrl: ${ALLU_BASEURL:/}
     concurrentUploads: ${ALLU_CONCURRENT_UPLOADS:1}

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/profiili/ProfiiliServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/profiili/ProfiiliServiceTest.kt
@@ -9,6 +9,8 @@ import assertk.assertions.isEqualTo
 import assertk.assertions.messageContains
 import assertk.assertions.prop
 import fi.hel.haitaton.hanke.factory.ProfiiliFactory
+import fi.hel.haitaton.hanke.security.AmrValues
+import fi.hel.haitaton.hanke.security.JwtClaims
 import fi.hel.haitaton.hanke.test.AuthenticationMocks
 import io.mockk.Called
 import io.mockk.checkUnnecessaryStub
@@ -134,8 +136,8 @@ class ProfiiliServiceTest {
             val jwt =
                 Jwt.withTokenValue(AuthenticationMocks.TOKEN_VALUE)
                     .header("alg", "none")
-                    .claim(ProfiiliService.AMR_CLAIM, listOf("helsinkiad"))
-                    .claim(ProfiiliService.FAMILY_NAME_CLAIM, ProfiiliFactory.DEFAULT_LAST_NAME)
+                    .claim(JwtClaims.AMR, listOf(AmrValues.AD))
+                    .claim(JwtClaims.FAMILY_NAME, ProfiiliFactory.DEFAULT_LAST_NAME)
                     .build()
             val authentication: Authentication = mockk()
             every { authentication.credentials } returns jwt
@@ -160,8 +162,8 @@ class ProfiiliServiceTest {
             val jwt =
                 Jwt.withTokenValue(AuthenticationMocks.TOKEN_VALUE)
                     .header("alg", "none")
-                    .claim(ProfiiliService.AMR_CLAIM, listOf("helsinkiad"))
-                    .claim(ProfiiliService.GIVEN_NAME_CLAIM, ProfiiliFactory.DEFAULT_GIVEN_NAME)
+                    .claim(JwtClaims.AMR, listOf(AmrValues.AD))
+                    .claim(JwtClaims.GIVEN_NAME, ProfiiliFactory.DEFAULT_GIVEN_NAME)
                     .build()
             val authentication: Authentication = mockk()
             every { authentication.credentials } returns jwt

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/security/AdGroupValidatorTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/security/AdGroupValidatorTest.kt
@@ -1,0 +1,123 @@
+package fi.hel.haitaton.hanke.security
+
+import assertk.Assert
+import assertk.assertThat
+import assertk.assertions.isEmpty
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNull
+import assertk.assertions.prop
+import assertk.assertions.single
+import fi.hel.haitaton.hanke.test.AuthenticationMocks
+import fi.hel.haitaton.hanke.test.AuthenticationMocks.TOKEN_VALUE
+import fi.hel.haitaton.hanke.test.USERNAME
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import org.springframework.security.oauth2.core.OAuth2Error
+import org.springframework.security.oauth2.core.OAuth2TokenValidatorResult
+import org.springframework.security.oauth2.jwt.Jwt
+
+class AdGroupValidatorTest {
+
+    @ParameterizedTest
+    @ValueSource(booleans = [true, false])
+    fun `fails when user is not authenticated with either Suomi fi or AD`(useAdFilter: Boolean) {
+        val validator = validator(useAdFilter)
+        val jwt =
+            Jwt.withTokenValue(TOKEN_VALUE)
+                .header("alg", "none")
+                .subject(USERNAME)
+                .claim(JwtClaims.AMR, listOf("third_method"))
+                .build()
+
+        val result = validator.validate(jwt)
+
+        assertThat(result).hasError("The AMR claim has no recognized authentication methods")
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = [true, false])
+    fun `succeeds when user authenticated with Suomi fi`(useAdFilter: Boolean) {
+        val validator = validator(useAdFilter)
+        val jwt = AuthenticationMocks.suomiFiJwt()
+
+        val result = validator.validate(jwt)
+
+        assertThat(result).isSuccess()
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = [true, false])
+    fun `succeeds when user has an allowed AD group`(useAdFilter: Boolean) {
+        val validator = validator(useAdFilter)
+        val jwt = AuthenticationMocks.adJwt(adGroups = AuthenticationMocks.DEFAULT_AD_GROUPS)
+
+        val result = validator.validate(jwt)
+
+        assertThat(result).isSuccess()
+    }
+
+    @Nested
+    inner class WithFilterEnabled {
+        @Test
+        fun `fails when the user has no allowed AD group`() {
+            val validator = validator(true)
+            val jwt = AuthenticationMocks.adJwt(adGroups = setOf("Something", "else"))
+
+            val result = validator.validate(jwt)
+
+            assertThat(result).hasError("No allowed AD groups")
+        }
+    }
+
+    @Nested
+    inner class WithAdFilterDisabled {
+
+        @Test
+        fun `succeeds when the user has no allowed AD group`() {
+            val validator = validator(false)
+            val jwt = AuthenticationMocks.adJwt(adGroups = setOf("Something", "else"))
+
+            val result = validator.validate(jwt)
+
+            assertThat(result).isSuccess()
+        }
+
+        @Test
+        fun `succeeds when there are no allowed AD groups configured`() {
+            val validator = validator(false, allowedGroups = setOf())
+            val jwt = AuthenticationMocks.adJwt(adGroups = setOf("Something", "else"))
+
+            val result = validator.validate(jwt)
+
+            assertThat(result).isSuccess()
+        }
+    }
+
+    private fun validator(
+        useAdFilter: Boolean,
+        allowedGroups: Set<String> = AuthenticationMocks.DEFAULT_AD_GROUPS,
+    ): OAuth2ResourceServerSecurityConfiguration.AdGroupValidator {
+        val adFilterProperties = AdFilterProperties(useAdFilter, allowedGroups)
+        return OAuth2ResourceServerSecurityConfiguration.AdGroupValidator(adFilterProperties)
+    }
+
+    private fun Assert<OAuth2TokenValidatorResult>.isSuccess() {
+        prop(OAuth2TokenValidatorResult::getErrors).isEmpty()
+        prop(OAuth2TokenValidatorResult::hasErrors).isEqualTo(false)
+    }
+
+    private fun Assert<OAuth2TokenValidatorResult>.hasError(f: Assert<OAuth2Error>.() -> Unit) {
+        prop(OAuth2TokenValidatorResult::getErrors).single().f()
+        prop(OAuth2TokenValidatorResult::hasErrors).isEqualTo(true)
+    }
+
+    private fun Assert<OAuth2TokenValidatorResult>.hasError(description: String) {
+        hasError {
+            prop(OAuth2Error::getUri).isNull()
+            prop(OAuth2Error::getErrorCode).isEqualTo("invalid_token")
+            prop(OAuth2Error::getDescription).isEqualTo(description)
+        }
+    }
+}

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/test/AuthenticationMocks.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/test/AuthenticationMocks.kt
@@ -2,7 +2,8 @@ package fi.hel.haitaton.hanke.test
 
 import fi.hel.haitaton.hanke.factory.ProfiiliFactory.DEFAULT_GIVEN_NAME
 import fi.hel.haitaton.hanke.factory.ProfiiliFactory.DEFAULT_LAST_NAME
-import fi.hel.haitaton.hanke.profiili.ProfiiliService
+import fi.hel.haitaton.hanke.security.AmrValues
+import fi.hel.haitaton.hanke.security.JwtClaims
 import io.mockk.every
 import io.mockk.mockk
 import org.springframework.security.core.Authentication
@@ -11,6 +12,9 @@ import org.springframework.security.oauth2.jwt.Jwt
 
 object AuthenticationMocks {
     const val TOKEN_VALUE = "fake value of the JWT"
+    const val ALLOWED_AD_GROUP_1 = "first_allowed"
+    const val ALLOWED_AD_GROUP_2 = "second_allowed"
+    val DEFAULT_AD_GROUPS = setOf(ALLOWED_AD_GROUP_1, ALLOWED_AD_GROUP_2)
 
     fun adLoginMock(userId: String = USERNAME): SecurityContext {
         val auth: Authentication = adAuthentication(userId)
@@ -22,19 +26,22 @@ object AuthenticationMocks {
     }
 
     fun adAuthentication(userId: String = USERNAME): Authentication {
-        val jwt =
-            Jwt.withTokenValue(TOKEN_VALUE)
-                .header("alg", "none")
-                .subject(userId)
-                .claim(ProfiiliService.AMR_CLAIM, listOf("helsinkiad"))
-                .claim(ProfiiliService.GIVEN_NAME_CLAIM, DEFAULT_GIVEN_NAME)
-                .claim(ProfiiliService.FAMILY_NAME_CLAIM, DEFAULT_LAST_NAME)
-                .build()
+        val jwt = adJwt(userId)
 
         val auth: Authentication = mockk()
         every { auth.credentials } returns jwt
         return auth
     }
+
+    fun adJwt(userId: String = USERNAME, adGroups: Collection<String> = DEFAULT_AD_GROUPS): Jwt =
+        Jwt.withTokenValue(TOKEN_VALUE)
+            .header("alg", "none")
+            .subject(userId)
+            .claim(JwtClaims.AMR, listOf(AmrValues.AD))
+            .claim(JwtClaims.GIVEN_NAME, DEFAULT_GIVEN_NAME)
+            .claim(JwtClaims.FAMILY_NAME, DEFAULT_LAST_NAME)
+            .claim(JwtClaims.AD_GROUPS, adGroups)
+            .build()
 
     /** When using this, you have to mock ProfiiliClient.getVerifiedName as well. */
     fun suomiFiLoginMock(userId: String = USERNAME): SecurityContext {
@@ -47,15 +54,16 @@ object AuthenticationMocks {
     }
 
     fun suomiFiAuthentication(userId: String = USERNAME): Authentication {
-        val jwt =
-            Jwt.withTokenValue(TOKEN_VALUE)
-                .header("alg", "none")
-                .subject(userId)
-                .claim(ProfiiliService.AMR_CLAIM, listOf("suomi_fi"))
-                .build()
-
+        val jwt = suomiFiJwt(userId)
         val auth: Authentication = mockk(relaxed = true)
         every { auth.credentials } returns jwt
         return auth
     }
+
+    fun suomiFiJwt(userId: String = USERNAME): Jwt =
+        Jwt.withTokenValue(TOKEN_VALUE)
+            .header("alg", "none")
+            .subject(userId)
+            .claim(JwtClaims.AMR, listOf(AmrValues.SUOMI_FI))
+            .build()
 }


### PR DESCRIPTION
# Description

When a user has authenticated with the Helsinki AD, check that they are in at least one of the groups allowed to access Haitaton. This is done mainly to stop consultants and other non-employees who happen to have access to the Helsinki AD from using Haitaton with that AD login. They should use Suomi.fi instead.

The AD groups are configurable and there's an option to disable the group checks. The disabling is needed, because developers are consultants who don't have the correct AD groups. We can disable the group checks from e.g. the dev environment so we can still test the AD login process.

The constants describing JWT claims and their values were moved from under ProfiiliService to shared objects.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1008

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
1. Login to Haitaton with Helsinki AD.
2. If your name shows up at the user icon in the top right corner, backend requests are authenticated.
3. Change `haitaton.ad.filter.use` to true in `application.yml`. Restart the backend.
4. Refreshing Haitaton, your name shouldn't show up anymore since the verified-name endpoint should return 401.
5. Get an AD group from your own bearer token, I like to use https://github.com/mike-engel/jwt-cli for decoding the JWT.
6. Add the AD group to `haitaton.ad.filter.allowed-groups`. Restart the backend.
7. Refreshing Haitaton again, the backend should respond to your queries again, so the name should show up once more.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 