### PR TITLE
HAI-3327 Set cableReportDone=true for kaivuilmoitus with accompanying johtoselvityshakemus

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceITest.kt
@@ -1260,7 +1260,8 @@ class HakemusServiceITest(
                     expectedKaivuilmoitusDataAfterSend =
                         hakemusData
                             .copy(
-                                cableReports = listOf(DEFAULT_CABLE_REPORT_APPLICATION_IDENTIFIER)
+                                cableReports = listOf(DEFAULT_CABLE_REPORT_APPLICATION_IDENTIFIER),
+                                cableReportDone = true,
                             )
                             .setOrdererForRepresentative(currentUser.id)
                     expectedCableReportAlluRequest =

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
@@ -246,7 +246,8 @@ class HakemusService(
             hakemus.hakemusEntityData =
                 hakemusEntityData.copy(
                     cableReports =
-                        cableReports.plus(sentJohtoselvityshakemus.applicationIdentifier!!)
+                        cableReports.plus(sentJohtoselvityshakemus.applicationIdentifier!!),
+                    cableReportDone = true,
                 )
         }
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
@@ -246,8 +246,7 @@ class HakemusService(
             hakemus.hakemusEntityData =
                 hakemusEntityData.copy(
                     cableReports =
-                        cableReports.plus(sentJohtoselvityshakemus.applicationIdentifier!!),
-                    cableReportDone = true,
+                        cableReports.plus(sentJohtoselvityshakemus.applicationIdentifier!!)
                 )
         }
 
@@ -256,6 +255,8 @@ class HakemusService(
 
         logger.info { "Hakemus sent, fetching identifier and status. ${hakemus.logString()}" }
         updateStatusFromAllu(hakemus)
+
+        updateCableReportDoneFlag(hakemus)
 
         logger.info("Sent hakemus. ${hakemus.logString()}, alluStatus = ${hakemus.alluStatus}")
         // Save only if sendApplicationToAllu didn't throw an exception
@@ -316,6 +317,16 @@ class HakemusService(
         )
         hakemusLoggingService.logCreate(savedJohtoselvityshakemus.toHakemus(), currentUserId)
         return savedJohtoselvityshakemus
+    }
+
+    private fun updateCableReportDoneFlag(hakemus: HakemusEntity) {
+        val hakemusData = hakemus.hakemusEntityData
+        if (hakemusData is KaivuilmoitusEntityData && !hakemusData.cableReportDone) {
+            hakemus.hakemusEntityData = hakemusData.copy(cableReportDone = true)
+            logger.info(
+                "Set cablereportDone as 'true' after send for accompanying johtoselvityshakemus in kaivuilmoitus. ${hakemus.logString()}"
+            )
+        }
     }
 
     /**


### PR DESCRIPTION
# Description

When sending kaivuilmoitus, set `cableReportDone=true` for kaivuilmoitus with accompanying johtoselvityshakemus.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-3327

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [x] Other

# Instructions for testing
1. Create and fill kaivuilmoitus with "Hae uusi johtoselvitys" selected
2. Send kaivuilmoitus
3. Check that in response (or in database) `cableReportDone` is `true`

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 

# Other relevant info
Please describe here if there is e.g. some requirements for this change or
 other info that the tester/user needs to know.