### PR TITLE
HAI-3321 Complete return values of kaivuilmoitus taydennys

### DIFF
--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Utils.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Utils.kt
@@ -5,6 +5,7 @@ import java.time.LocalDateTime
 import java.time.ZonedDateTime
 import java.time.temporal.ChronoUnit
 import java.time.temporal.Temporal
+import kotlin.reflect.KProperty1
 import mu.KotlinLogging
 import org.springframework.security.core.context.SecurityContext
 import org.springframework.security.core.context.SecurityContextHolder
@@ -141,3 +142,9 @@ fun daysBetween(haittaAlkuPvm: Temporal?, haittaLoppuPvm: Temporal?): Int? =
 /** Helper function to calculate the duration between two dates, inclusive. */
 fun daysBetween(haittaAlkuPvm: Temporal, haittaLoppuPvm: Temporal): Int =
     ChronoUnit.DAYS.between(haittaAlkuPvm, haittaLoppuPvm).toInt() + 1
+
+/** Check whether a property has changed between two objects. */
+fun <T : Any> T.checkChange(property: KProperty1<T, Any?>, second: T): String? =
+    if (property.get(this) != property.get(second)) {
+        property.name
+    } else null

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/Hakemus.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/Hakemus.kt
@@ -86,12 +86,11 @@ private fun checkChangesInAreas(
     secondAreas: List<Hakemusalue>,
 ): List<String> {
     val changedElementsInFirst =
-        firstAreas
-            .withIndex()
-            .filter { (i, area) -> area != secondAreas.getOrNull(i) }
-            .map { it.index }
-    val elementsInSecondButNotFirst = secondAreas.indices.drop(firstAreas.size)
-    return (changedElementsInFirst + elementsInSecondButNotFirst).map { "areas[$it]" }
+        firstAreas.withIndex().mapNotNull { (i, area) ->
+            area.listChanges(i, secondAreas.getOrNull(i))
+        }
+    val elementsInSecondButNotFirst = secondAreas.indices.drop(firstAreas.size).map { "areas[$it]" }
+    return (changedElementsInFirst.flatten() + elementsInSecondButNotFirst)
 }
 
 sealed interface HakemusData {
@@ -266,11 +265,15 @@ data class KaivuilmoitusData(
         checkChange(KaivuilmoitusData::cableReports, other)?.let { changes.add(it) }
         checkChange(KaivuilmoitusData::placementContracts, other)?.let { changes.add(it) }
         checkChange(KaivuilmoitusData::requiredCompetence, other)?.let { changes.add(it) }
-        checkChange(KaivuilmoitusData::contractorWithContacts, other)?.let { changes.add(it) }
-        checkChange(KaivuilmoitusData::propertyDeveloperWithContacts, other)?.let {
+        checkChangeInYhteystieto(KaivuilmoitusData::contractorWithContacts, other)?.let {
             changes.add(it)
         }
-        checkChange(KaivuilmoitusData::representativeWithContacts, other)?.let { changes.add(it) }
+        checkChangeInYhteystieto(KaivuilmoitusData::propertyDeveloperWithContacts, other)?.let {
+            changes.add(it)
+        }
+        checkChangeInYhteystieto(KaivuilmoitusData::representativeWithContacts, other)?.let {
+            changes.add(it)
+        }
         checkChange(KaivuilmoitusData::invoicingCustomer, other)?.let { changes.add(it) }
         checkChange(KaivuilmoitusData::additionalInfo, other)?.let { changes.add(it) }
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/Hakemus.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/Hakemus.kt
@@ -1,6 +1,7 @@
 package fi.hel.haitaton.hanke.hakemus
 
 import fi.hel.haitaton.hanke.allu.ApplicationStatus
+import fi.hel.haitaton.hanke.checkChange
 import fi.hel.haitaton.hanke.domain.HasId
 import fi.hel.haitaton.hanke.valmistumisilmoitus.Valmistumisilmoitus
 import fi.hel.haitaton.hanke.valmistumisilmoitus.ValmistumisilmoitusType
@@ -57,11 +58,6 @@ data class Hakemus(
         )
 }
 
-private fun <D : HakemusData> D.checkChange(property: KProperty1<D, Any?>, second: D): String? =
-    if (property.get(this) != property.get(second)) {
-        property.name
-    } else null
-
 private fun <D : HakemusData> D.checkChangeInYhteystieto(
     property: KProperty1<D, Hakemusyhteystieto?>,
     second: D,
@@ -86,11 +82,11 @@ private fun checkChangesInAreas(
     secondAreas: List<Hakemusalue>,
 ): List<String> {
     val changedElementsInFirst =
-        firstAreas.withIndex().mapNotNull { (i, area) ->
-            area.listChanges(i, secondAreas.getOrNull(i))
+        firstAreas.withIndex().flatMap { (i, area) ->
+            area.listChanges("areas[$i]", secondAreas.getOrNull(i))
         }
     val elementsInSecondButNotFirst = secondAreas.indices.drop(firstAreas.size).map { "areas[$it]" }
-    return (changedElementsInFirst.flatten() + elementsInSecondButNotFirst)
+    return (changedElementsInFirst + elementsInSecondButNotFirst)
 }
 
 sealed interface HakemusData {

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/Hakemusalue.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/Hakemusalue.kt
@@ -3,6 +3,7 @@ package fi.hel.haitaton.hanke.hakemus
 import com.fasterxml.jackson.annotation.JsonSetter
 import com.fasterxml.jackson.annotation.Nulls
 import fi.hel.haitaton.hanke.domain.Haittojenhallintasuunnitelma
+import fi.hel.haitaton.hanke.domain.Haittojenhallintatyyppi
 import fi.hel.haitaton.hanke.domain.TyomaaTyyppi
 import fi.hel.haitaton.hanke.tormaystarkastelu.AutoliikenteenKaistavaikutustenPituus
 import fi.hel.haitaton.hanke.tormaystarkastelu.Meluhaitta
@@ -10,12 +11,16 @@ import fi.hel.haitaton.hanke.tormaystarkastelu.Polyhaitta
 import fi.hel.haitaton.hanke.tormaystarkastelu.Tarinahaitta
 import fi.hel.haitaton.hanke.tormaystarkastelu.TormaystarkasteluTulos
 import fi.hel.haitaton.hanke.tormaystarkastelu.VaikutusAutoliikenteenKaistamaariin
+import kotlin.reflect.KProperty1
 import org.geojson.Polygon
 
 sealed interface Hakemusalue {
     val name: String
 
     fun geometries(): List<Polygon>
+
+    fun listChanges(index: Int, other: Hakemusalue?): List<String>? =
+        if (this != other) listOf("areas[$index]") else null
 }
 
 data class JohtoselvitysHakemusalue(override val name: String, val geometry: Polygon) :
@@ -60,13 +65,51 @@ data class KaivuilmoitusAlue(
             )
         }
     }
+
+    override fun listChanges(index: Int, other: Hakemusalue?): List<String>? {
+        if (other == null) return listOf("areas[$index]")
+        other as KaivuilmoitusAlue
+        val changes = mutableListOf<String>()
+        changes.addAll(checkChangesInTyoalueet(index, tyoalueet, other.tyoalueet))
+        checkChange(index, KaivuilmoitusAlue::name, other)?.let { changes.add(it) }
+        checkChange(index, KaivuilmoitusAlue::katuosoite, other)?.let { changes.add(it) }
+        checkChange(index, KaivuilmoitusAlue::tyonTarkoitukset, other)?.let { changes.add(it) }
+        checkChange(index, KaivuilmoitusAlue::meluhaitta, other)?.let { changes.add(it) }
+        checkChange(index, KaivuilmoitusAlue::polyhaitta, other)?.let { changes.add(it) }
+        checkChange(index, KaivuilmoitusAlue::tarinahaitta, other)?.let { changes.add(it) }
+        checkChange(index, KaivuilmoitusAlue::kaistahaitta, other)?.let { changes.add(it) }
+        checkChange(index, KaivuilmoitusAlue::kaistahaittojenPituus, other)?.let { changes.add(it) }
+        checkChange(index, KaivuilmoitusAlue::lisatiedot, other)?.let { changes.add(it) }
+        // haittojenhallintasuunnitelma changes do not affect the area itself, therefore we add the
+        // root area here if there are changes in other fields.
+        if (changes.isNotEmpty()) {
+            changes.add(0, "areas[$index]")
+        }
+        changes.addAll(
+            checkChangesInHaittojenhallintasuunnitelma(
+                index,
+                haittojenhallintasuunnitelma,
+                other.haittojenhallintasuunnitelma,
+            )
+        )
+        return if (changes.isNotEmpty()) changes else null
+    }
 }
 
 data class Tyoalue(
     val geometry: Polygon,
     val area: Double,
     val tormaystarkasteluTulos: TormaystarkasteluTulos?,
-)
+) {
+    fun listChanges(alueIndex: Int, tyoalueIndex: Int, other: Tyoalue?): List<String>? {
+        if (other == null) return listOf("areas[$alueIndex].tyoalueet[$tyoalueIndex]")
+        val changes = mutableListOf<String>()
+        checkChange(alueIndex, tyoalueIndex, Tyoalue::geometry, other)?.let { changes.add(it) }
+        return if (changes.isNotEmpty())
+            listOf("areas[$alueIndex].tyoalueet[$tyoalueIndex]") + changes
+        else null
+    }
+}
 
 fun List<KaivuilmoitusAlue>?.combinedAddress(): PostalAddress? =
     this?.map { it.katuosoite }
@@ -74,3 +117,47 @@ fun List<KaivuilmoitusAlue>?.combinedAddress(): PostalAddress? =
         ?.joinToString(", ")
         ?.let { StreetAddress(it) }
         ?.let { PostalAddress(it, "", "") }
+
+private fun KaivuilmoitusAlue.checkChange(
+    index: Int,
+    property: KProperty1<KaivuilmoitusAlue, Any?>,
+    second: KaivuilmoitusAlue,
+): String? =
+    if (property.get(this) != property.get(second)) {
+        "areas[$index].${property.name}"
+    } else null
+
+private fun Tyoalue.checkChange(
+    alueIndex: Int,
+    tyoalueIndex: Int,
+    property: KProperty1<Tyoalue, Any?>,
+    second: Tyoalue,
+): String? =
+    if (property.get(this) != property.get(second)) {
+        "areas[$alueIndex].tyoalueet[$tyoalueIndex].${property.name}"
+    } else null
+
+private fun checkChangesInTyoalueet(
+    index: Int,
+    firstAreas: List<Tyoalue>,
+    secondAreas: List<Tyoalue>,
+): List<String> {
+    val changedElementsInFirst =
+        firstAreas.withIndex().mapNotNull { (i, tyoalue) ->
+            tyoalue.listChanges(index, i, secondAreas.getOrNull(i))
+        }
+    val elementsInSecondButNotFirst =
+        secondAreas.indices.drop(firstAreas.size).map { "areas[$index].tyoalueet[$it]" }
+    return (changedElementsInFirst.flatten() + elementsInSecondButNotFirst)
+}
+
+private fun checkChangesInHaittojenhallintasuunnitelma(
+    index: Int,
+    first: Haittojenhallintasuunnitelma,
+    second: Haittojenhallintasuunnitelma,
+): List<String> =
+    Haittojenhallintatyyppi.entries.mapNotNull { tyyppi ->
+        if (first[tyyppi] != second[tyyppi]) {
+            "areas[$index].haittojenhallintasuunnitelma[${tyyppi.name}]"
+        } else null
+    }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/Hakemusalue.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/Hakemusalue.kt
@@ -122,11 +122,9 @@ private fun checkChangesInTyoalueet(
             val otherTyoalue = secondAreas.getOrNull(i)
             if (otherTyoalue == null) {
                 listOf("$workAreaPath[$i]")
-            } else {
-                if (tyoalue.checkChange(Tyoalue::geometry, otherTyoalue) != null) {
-                    listOf("$workAreaPath[$i]", "$workAreaPath[$i].geometry")
-                } else emptyList()
-            }
+            } else if (tyoalue.geometry != otherTyoalue.geometry) {
+                listOf("$workAreaPath[$i]", "$workAreaPath[$i].geometry")
+            } else emptyList()
         }
     val elementsInSecondButNotFirst =
         secondAreas.indices.drop(firstAreas.size).map { "$workAreaPath[$it]" }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusDataTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusDataTest.kt
@@ -7,11 +7,19 @@ import assertk.assertions.containsExactly
 import assertk.assertions.hasClass
 import assertk.assertions.isEmpty
 import assertk.assertions.messageContains
+import fi.hel.haitaton.hanke.domain.TyomaaTyyppi
 import fi.hel.haitaton.hanke.factory.ApplicationFactory
+import fi.hel.haitaton.hanke.factory.GeometriaFactory
+import fi.hel.haitaton.hanke.factory.HaittaFactory.DEFAULT_HHS
 import fi.hel.haitaton.hanke.factory.HakemusFactory
 import fi.hel.haitaton.hanke.factory.HakemusyhteyshenkiloFactory
 import fi.hel.haitaton.hanke.factory.HakemusyhteystietoFactory
 import fi.hel.haitaton.hanke.factory.PaperDecisionReceiverFactory
+import fi.hel.haitaton.hanke.tormaystarkastelu.AutoliikenteenKaistavaikutustenPituus
+import fi.hel.haitaton.hanke.tormaystarkastelu.Meluhaitta
+import fi.hel.haitaton.hanke.tormaystarkastelu.Polyhaitta
+import fi.hel.haitaton.hanke.tormaystarkastelu.Tarinahaitta
+import fi.hel.haitaton.hanke.tormaystarkastelu.VaikutusAutoliikenteenKaistamaariin
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
@@ -24,293 +32,639 @@ import org.junit.jupiter.params.provider.NullSource
 class HakemusDataTest {
 
     @Nested
-    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
     inner class ListChanges {
-        val base: JohtoselvityshakemusData = HakemusFactory.createJohtoselvityshakemusData()
 
-        @Test
-        fun `throws exception when classes don't match`() {
-            val updated = HakemusFactory.createKaivuilmoitusData()
-
-            val failure = assertFailure { base.listChanges(updated) }
-
-            failure.all {
-                hasClass(IncompatibleHakemusDataException::class)
-                messageContains("Incompatible hakemus data when retrieving changes")
-                messageContains("firstClass=JohtoselvityshakemusData")
-                messageContains("secondClass=KaivuilmoitusData")
-            }
-        }
-
-        @Test
-        fun `returns empty when there are no changes`() {
-            val updated = HakemusFactory.createJohtoselvityshakemusData()
-
-            val result = base.listChanges(updated)
-
-            assertThat(result).isEmpty()
-        }
-
-        @Test
-        fun `returns all changes when there are several`() {
-            val updated = base.copy(name = "Other name", startTime = base.startTime!!.plusDays(3))
-
-            val result = base.listChanges(updated)
-
-            assertThat(result).containsExactly("name", "startTime")
-        }
-
-        private fun commonFieldCases(): List<Arguments> =
-            listOf(
-                Arguments.of(
-                    base.copy(applicationType = ApplicationType.EXCAVATION_NOTIFICATION),
-                    "applicationType",
-                ),
-                Arguments.of(base.copy(startTime = base.startTime!!.minusDays(2)), "startTime"),
-                Arguments.of(base.copy(endTime = base.endTime!!.plusDays(2)), "endTime"),
-                Arguments.of(
-                    base.copy(paperDecisionReceiver = PaperDecisionReceiverFactory.default),
-                    "paperDecisionReceiver",
-                ),
-                Arguments.of(
-                    base.copy(customerWithContacts = HakemusyhteystietoFactory.create()),
-                    "customerWithContacts",
-                ),
-            )
-
-        @ParameterizedTest(name = "{displayName} {1}")
-        @MethodSource("commonFieldCases")
-        fun `returns changes when common fields have changes`(updated: HakemusData, name: String) {
-            val changes = base.listChanges(updated)
-
-            assertThat(changes).containsExactly(name)
-        }
-
+        @TestInstance(TestInstance.Lifecycle.PER_CLASS)
         @Nested
-        inner class YhteystietoChanges {
-            private val yhteyshenkilo1 = HakemusyhteyshenkiloFactory.create()
-            private val yhteyshenkilo2 =
-                HakemusyhteyshenkiloFactory.create(
-                    etunimi = "Joku",
-                    sukunimi = "Toinen",
-                    sahkoposti = "joku.toinen@email",
-                )
-            private val base: JohtoselvityshakemusData =
-                this@ListChanges.base.copy(
-                    customerWithContacts =
-                        HakemusyhteystietoFactory.create(
-                            yhteyshenkilot = listOf(yhteyshenkilo1, yhteyshenkilo2)
-                        )
-                )
+        inner class Johtoselvitys {
 
-            private val withOneHenkilo =
-                base.copy(
-                    customerWithContacts =
-                        base.customerWithContacts!!.copy(yhteyshenkilot = listOf(yhteyshenkilo1))
-                )
+            val base: JohtoselvityshakemusData = HakemusFactory.createJohtoselvityshakemusData()
 
             @Test
-            fun `returns a change when yhteyshenkilo removed from yhteystieto`() {
-                val result = base.listChanges(withOneHenkilo)
+            fun `throws exception when classes don't match`() {
+                val updated = HakemusFactory.createKaivuilmoitusData()
 
-                assertThat(result).containsExactly("customerWithContacts")
+                val failure = assertFailure { base.listChanges(updated) }
+
+                failure.all {
+                    hasClass(IncompatibleHakemusDataException::class)
+                    messageContains("Incompatible hakemus data when retrieving changes")
+                    messageContains("firstClass=JohtoselvityshakemusData")
+                    messageContains("secondClass=KaivuilmoitusData")
+                }
             }
 
             @Test
-            fun `returns a change when yhteyshenkilo added to yhteystieto`() {
-                val result = withOneHenkilo.listChanges(base)
-
-                assertThat(result).containsExactly("customerWithContacts")
-            }
-
-            @Test
-            fun `returns a change when yhteyshenkilo changed in yhteystieto`() {
-                val updatedYhteyshenkilo = yhteyshenkilo1.copy(etunimi = "Muutettu")
-                val updated =
-                    base.copy(
-                        customerWithContacts =
-                            base.customerWithContacts!!.copy(
-                                yhteyshenkilot = listOf(yhteyshenkilo1, updatedYhteyshenkilo)
-                            )
-                    )
+            fun `returns empty when there are no changes`() {
+                val updated = HakemusFactory.createJohtoselvityshakemusData()
 
                 val result = base.listChanges(updated)
 
-                assertThat(result).containsExactly("customerWithContacts")
+                assertThat(result).isEmpty()
             }
-        }
 
-        @Nested
-        inner class AreaChanges {
-            private val dataWithTwoAreas =
-                base.copy(
-                    areas =
-                        listOf(
-                            ApplicationFactory.createCableReportApplicationArea(name = "first"),
-                            ApplicationFactory.createCableReportApplicationArea(name = "second"),
-                        )
+            @Test
+            fun `returns all changes when there are several`() {
+                val updated =
+                    base.copy(name = "Other name", startTime = base.startTime!!.plusDays(3))
+
+                val result = base.listChanges(updated)
+
+                assertThat(result).containsExactly("name", "startTime")
+            }
+
+            private fun commonFieldCases(): List<Arguments> =
+                listOf(
+                    Arguments.of(
+                        base.copy(applicationType = ApplicationType.EXCAVATION_NOTIFICATION),
+                        "applicationType",
+                    ),
+                    Arguments.of(base.copy(startTime = base.startTime!!.minusDays(2)), "startTime"),
+                    Arguments.of(base.copy(endTime = base.endTime!!.plusDays(2)), "endTime"),
+                    Arguments.of(
+                        base.copy(paperDecisionReceiver = PaperDecisionReceiverFactory.default),
+                        "paperDecisionReceiver",
+                    ),
+                    Arguments.of(
+                        base.copy(customerWithContacts = HakemusyhteystietoFactory.create()),
+                        "customerWithContacts",
+                    ),
                 )
 
-            @ParameterizedTest
-            @EmptySource
-            @NullSource
-            fun `returns a change when areas were empty but new ones are added`(
-                areas: List<JohtoselvitysHakemusalue>?
+            @ParameterizedTest(name = "{displayName} {1}")
+            @MethodSource("commonFieldCases")
+            fun `returns changes when common fields have changes`(
+                updated: HakemusData,
+                name: String,
             ) {
-                val base = base.copy(areas = areas)
+                val changes = base.listChanges(updated)
 
-                val result = base.listChanges(dataWithTwoAreas)
-
-                assertThat(result).containsExactly("areas[0]", "areas[1]")
+                assertThat(changes).containsExactly(name)
             }
 
-            @ParameterizedTest
-            @EmptySource
-            @NullSource
-            fun `returns a change when there were areas but now they are empty`(
-                areas: List<JohtoselvitysHakemusalue>?
-            ) {
-                val updated = base.copy(areas = areas)
+            @Nested
+            inner class YhteystietoChanges {
+                private val yhteyshenkilo1 = HakemusyhteyshenkiloFactory.create()
+                private val yhteyshenkilo2 =
+                    HakemusyhteyshenkiloFactory.create(
+                        etunimi = "Joku",
+                        sukunimi = "Toinen",
+                        sahkoposti = "joku.toinen@email",
+                    )
+                private val base: JohtoselvityshakemusData =
+                    this@Johtoselvitys.base.copy(
+                        customerWithContacts =
+                            HakemusyhteystietoFactory.create(
+                                yhteyshenkilot = listOf(yhteyshenkilo1, yhteyshenkilo2)
+                            )
+                    )
 
-                val result = dataWithTwoAreas.listChanges(updated)
+                private val withOneHenkilo =
+                    base.copy(
+                        customerWithContacts =
+                            base.customerWithContacts!!.copy(
+                                yhteyshenkilot = listOf(yhteyshenkilo1)
+                            )
+                    )
 
-                assertThat(result).containsExactly("areas[0]", "areas[1]")
+                @Test
+                fun `returns a change when yhteyshenkilo removed from yhteystieto`() {
+                    val result = base.listChanges(withOneHenkilo)
+
+                    assertThat(result).containsExactly("customerWithContacts")
+                }
+
+                @Test
+                fun `returns a change when yhteyshenkilo added to yhteystieto`() {
+                    val result = withOneHenkilo.listChanges(base)
+
+                    assertThat(result).containsExactly("customerWithContacts")
+                }
+
+                @Test
+                fun `returns a change when yhteyshenkilo changed in yhteystieto`() {
+                    val updatedYhteyshenkilo = yhteyshenkilo1.copy(etunimi = "Muutettu")
+                    val updated =
+                        base.copy(
+                            customerWithContacts =
+                                base.customerWithContacts!!.copy(
+                                    yhteyshenkilot = listOf(yhteyshenkilo1, updatedYhteyshenkilo)
+                                )
+                        )
+
+                    val result = base.listChanges(updated)
+
+                    assertThat(result).containsExactly("customerWithContacts")
+                }
             }
 
-            @Test
-            fun `returns several changes when an area is removed from the middle`() {
-                val base =
+            @Nested
+            inner class AreaChanges {
+                private val dataWithTwoAreas =
                     base.copy(
                         areas =
                             listOf(
                                 ApplicationFactory.createCableReportApplicationArea(name = "first"),
-                                ApplicationFactory.createCableReportApplicationArea(
-                                    name = "removed1"
-                                ),
-                                ApplicationFactory.createCableReportApplicationArea(
-                                    name = "removed2"
-                                ),
                                 ApplicationFactory.createCableReportApplicationArea(name = "second"),
                             )
                     )
 
-                val result = base.listChanges(dataWithTwoAreas)
+                @ParameterizedTest
+                @EmptySource
+                @NullSource
+                fun `returns a change when areas were empty but new ones are added`(
+                    areas: List<JohtoselvitysHakemusalue>?
+                ) {
+                    val base = base.copy(areas = areas)
 
-                assertThat(result).containsExactly("areas[1]", "areas[2]", "areas[3]")
+                    val result = base.listChanges(dataWithTwoAreas)
+
+                    assertThat(result).containsExactly("areas[0]", "areas[1]")
+                }
+
+                @ParameterizedTest
+                @EmptySource
+                @NullSource
+                fun `returns a change when there were areas but now they are empty`(
+                    areas: List<JohtoselvitysHakemusalue>?
+                ) {
+                    val updated = base.copy(areas = areas)
+
+                    val result = dataWithTwoAreas.listChanges(updated)
+
+                    assertThat(result).containsExactly("areas[0]", "areas[1]")
+                }
+
+                @Test
+                fun `returns several changes when an area is removed from the middle`() {
+                    val base =
+                        base.copy(
+                            areas =
+                                listOf(
+                                    ApplicationFactory.createCableReportApplicationArea(
+                                        name = "first"
+                                    ),
+                                    ApplicationFactory.createCableReportApplicationArea(
+                                        name = "removed1"
+                                    ),
+                                    ApplicationFactory.createCableReportApplicationArea(
+                                        name = "removed2"
+                                    ),
+                                    ApplicationFactory.createCableReportApplicationArea(
+                                        name = "second"
+                                    ),
+                                )
+                        )
+
+                    val result = base.listChanges(dataWithTwoAreas)
+
+                    assertThat(result).containsExactly("areas[1]", "areas[2]", "areas[3]")
+                }
+
+                @Test
+                fun `returns several changes when an area is added to the middle`() {
+                    val updated =
+                        base.copy(
+                            areas =
+                                listOf(
+                                    ApplicationFactory.createCableReportApplicationArea(
+                                        name = "first"
+                                    ),
+                                    ApplicationFactory.createCableReportApplicationArea(
+                                        name = "added1"
+                                    ),
+                                    ApplicationFactory.createCableReportApplicationArea(
+                                        name = "added2"
+                                    ),
+                                    ApplicationFactory.createCableReportApplicationArea(
+                                        name = "second"
+                                    ),
+                                )
+                        )
+
+                    val result = dataWithTwoAreas.listChanges(updated)
+
+                    assertThat(result).containsExactly("areas[1]", "areas[2]", "areas[3]")
+                }
             }
 
-            @Test
-            fun `returns several changes when an area is added to the middle`() {
-                val updated =
-                    base.copy(
-                        areas =
-                            listOf(
-                                ApplicationFactory.createCableReportApplicationArea(name = "first"),
-                                ApplicationFactory.createCableReportApplicationArea(
-                                    name = "added1"
-                                ),
-                                ApplicationFactory.createCableReportApplicationArea(
-                                    name = "added2"
-                                ),
-                                ApplicationFactory.createCableReportApplicationArea(name = "second"),
-                            )
-                    )
-
-                val result = dataWithTwoAreas.listChanges(updated)
-
-                assertThat(result).containsExactly("areas[1]", "areas[2]", "areas[3]")
-            }
-        }
-
-        private fun johtoselvitysCases(): List<Arguments> =
-            listOf(
-                // One shared field to test that the super method gets called.
-                Arguments.of(base.copy(startTime = base.startTime!!.minusDays(1)), "startTime"),
-                Arguments.of(
-                    base.copy(postalAddress = ApplicationFactory.createPostalAddress()),
-                    "postalAddress",
-                ),
-                Arguments.of(base.copy(constructionWork = true), "constructionWork"),
-                Arguments.of(base.copy(maintenanceWork = true), "maintenanceWork"),
-                Arguments.of(base.copy(propertyConnectivity = true), "propertyConnectivity"),
-                Arguments.of(base.copy(emergencyWork = true), "emergencyWork"),
-                Arguments.of(base.copy(rockExcavation = true), "rockExcavation"),
-                Arguments.of(base.copy(workDescription = "New description"), "workDescription"),
-                Arguments.of(
-                    base.copy(contractorWithContacts = HakemusyhteystietoFactory.create()),
-                    "contractorWithContacts",
-                ),
-                Arguments.of(
-                    base.copy(propertyDeveloperWithContacts = HakemusyhteystietoFactory.create()),
-                    "propertyDeveloperWithContacts",
-                ),
-                Arguments.of(
-                    base.copy(representativeWithContacts = HakemusyhteystietoFactory.create()),
-                    "representativeWithContacts",
-                ),
-            )
-
-        @ParameterizedTest(name = "{displayName} {1}")
-        @MethodSource("johtoselvitysCases")
-        fun `returns changes when johtoselvityshakemus fields have changes`(
-            updated: JohtoselvityshakemusData,
-            name: String,
-        ) {
-            val changes = base.listChanges(updated)
-
-            assertThat(changes).containsExactly(name)
-        }
-
-        private fun kaivuilmoitusCases(): List<Arguments> {
-            val base = HakemusFactory.createKaivuilmoitusData()
-            return listOf(
-                // One shared field to test that the super method gets called.
-                Arguments.of(base.copy(startTime = base.startTime!!.minusDays(1)), "startTime"),
-                Arguments.of(base.copy(workDescription = "New description."), "workDescription"),
-                Arguments.of(base.copy(constructionWork = true), "constructionWork"),
-                Arguments.of(base.copy(maintenanceWork = true), "maintenanceWork"),
-                Arguments.of(base.copy(emergencyWork = true), "emergencyWork"),
-                Arguments.of(base.copy(cableReportDone = !base.cableReportDone), "cableReportDone"),
-                Arguments.of(base.copy(rockExcavation = true), "rockExcavation"),
-                Arguments.of(base.copy(cableReports = listOf("JS2400001")), "cableReports"),
-                Arguments.of(
-                    base.copy(placementContracts = listOf("tunnus")),
-                    "placementContracts",
-                ),
-                Arguments.of(base.copy(requiredCompetence = true), "requiredCompetence"),
-                Arguments.of(
-                    base.copy(contractorWithContacts = HakemusyhteystietoFactory.create()),
-                    "contractorWithContacts",
-                ),
-                Arguments.of(
-                    base.copy(propertyDeveloperWithContacts = HakemusyhteystietoFactory.create()),
-                    "propertyDeveloperWithContacts",
-                ),
-                Arguments.of(
-                    base.copy(representativeWithContacts = HakemusyhteystietoFactory.create()),
-                    "representativeWithContacts",
-                ),
-                Arguments.of(
-                    base.copy(
-                        invoicingCustomer = HakemusyhteystietoFactory.createLaskutusyhteystieto()
+            private fun johtoselvitysCases(): List<Arguments> =
+                listOf(
+                    // One shared field to test that the super method gets called.
+                    Arguments.of(base.copy(startTime = base.startTime!!.minusDays(1)), "startTime"),
+                    Arguments.of(
+                        base.copy(postalAddress = ApplicationFactory.createPostalAddress()),
+                        "postalAddress",
                     ),
-                    "invoicingCustomer",
-                ),
-                Arguments.of(base.copy(additionalInfo = "Uutta lisätietoa"), "additionalInfo"),
-            )
+                    Arguments.of(base.copy(constructionWork = true), "constructionWork"),
+                    Arguments.of(base.copy(maintenanceWork = true), "maintenanceWork"),
+                    Arguments.of(base.copy(propertyConnectivity = true), "propertyConnectivity"),
+                    Arguments.of(base.copy(emergencyWork = true), "emergencyWork"),
+                    Arguments.of(base.copy(rockExcavation = true), "rockExcavation"),
+                    Arguments.of(base.copy(workDescription = "New description"), "workDescription"),
+                    Arguments.of(
+                        base.copy(contractorWithContacts = HakemusyhteystietoFactory.create()),
+                        "contractorWithContacts",
+                    ),
+                    Arguments.of(
+                        base.copy(
+                            propertyDeveloperWithContacts = HakemusyhteystietoFactory.create()
+                        ),
+                        "propertyDeveloperWithContacts",
+                    ),
+                    Arguments.of(
+                        base.copy(representativeWithContacts = HakemusyhteystietoFactory.create()),
+                        "representativeWithContacts",
+                    ),
+                    Arguments.of(
+                        base.copy(
+                            areas =
+                                listOf(
+                                    ApplicationFactory.createCableReportApplicationArea(
+                                        geometry = GeometriaFactory.polygon()
+                                    )
+                                )
+                        ),
+                        "areas[0]",
+                    ),
+                )
+
+            @ParameterizedTest(name = "{displayName} {1}")
+            @MethodSource("johtoselvitysCases")
+            fun `returns changes when johtoselvityshakemus fields have changes`(
+                updated: JohtoselvityshakemusData,
+                name: String,
+            ) {
+                val changes = base.listChanges(updated)
+
+                assertThat(changes).containsExactly(name)
+            }
         }
 
-        @ParameterizedTest(name = "{displayName} {1}")
-        @MethodSource("kaivuilmoitusCases")
-        fun `returns changes when kaivuilmoitus fields have changes`(
-            updated: KaivuilmoitusData,
-            name: String,
-        ) {
-            val base = HakemusFactory.createKaivuilmoitusData()
+        @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+        @Nested
+        inner class Kaivuilmoitus {
 
-            val changes = base.listChanges(updated)
+            val base: KaivuilmoitusData = HakemusFactory.createKaivuilmoitusData()
 
-            assertThat(changes).containsExactly(name)
+            @Test
+            fun `throws exception when classes don't match`() {
+                val updated = HakemusFactory.createJohtoselvityshakemusData()
+
+                val failure = assertFailure { base.listChanges(updated) }
+
+                failure.all {
+                    hasClass(IncompatibleHakemusDataException::class)
+                    messageContains("Incompatible hakemus data when retrieving changes")
+                    messageContains("firstClass=KaivuilmoitusData")
+                    messageContains("secondClass=JohtoselvityshakemusData")
+                }
+            }
+
+            @Test
+            fun `returns empty when there are no changes`() {
+                val updated = HakemusFactory.createKaivuilmoitusData()
+
+                val result = base.listChanges(updated)
+
+                assertThat(result).isEmpty()
+            }
+
+            @Test
+            fun `returns all changes when there are several`() {
+                val updated =
+                    base.copy(name = "Other name", startTime = base.startTime!!.plusDays(3))
+
+                val result = base.listChanges(updated)
+
+                assertThat(result).containsExactly("name", "startTime")
+            }
+
+            private fun commonFieldCases(): List<Arguments> =
+                listOf(
+                    Arguments.of(
+                        base.copy(applicationType = ApplicationType.CABLE_REPORT),
+                        "applicationType",
+                    ),
+                    Arguments.of(base.copy(startTime = base.startTime!!.minusDays(2)), "startTime"),
+                    Arguments.of(base.copy(endTime = base.endTime!!.plusDays(2)), "endTime"),
+                    Arguments.of(
+                        base.copy(paperDecisionReceiver = PaperDecisionReceiverFactory.default),
+                        "paperDecisionReceiver",
+                    ),
+                    Arguments.of(
+                        base.copy(customerWithContacts = HakemusyhteystietoFactory.create()),
+                        "customerWithContacts",
+                    ),
+                )
+
+            @ParameterizedTest(name = "{displayName} {1}")
+            @MethodSource("commonFieldCases")
+            fun `returns changes when common fields have changes`(
+                updated: HakemusData,
+                name: String,
+            ) {
+                val changes = base.listChanges(updated)
+
+                assertThat(changes).containsExactly(name)
+            }
+
+            @Nested
+            inner class YhteystietoChanges {
+                private val yhteyshenkilo1 = HakemusyhteyshenkiloFactory.create()
+                private val yhteyshenkilo2 =
+                    HakemusyhteyshenkiloFactory.create(
+                        etunimi = "Joku",
+                        sukunimi = "Toinen",
+                        sahkoposti = "joku.toinen@email",
+                    )
+                private val base: KaivuilmoitusData =
+                    this@Kaivuilmoitus.base.copy(
+                        customerWithContacts =
+                            HakemusyhteystietoFactory.create(
+                                yhteyshenkilot = listOf(yhteyshenkilo1, yhteyshenkilo2)
+                            )
+                    )
+
+                private val withOneHenkilo =
+                    base.copy(
+                        customerWithContacts =
+                            base.customerWithContacts!!.copy(
+                                yhteyshenkilot = listOf(yhteyshenkilo1)
+                            )
+                    )
+
+                @Test
+                fun `returns a change when yhteyshenkilo removed from yhteystieto`() {
+                    val result = base.listChanges(withOneHenkilo)
+
+                    assertThat(result).containsExactly("customerWithContacts")
+                }
+
+                @Test
+                fun `returns a change when yhteyshenkilo added to yhteystieto`() {
+                    val result = withOneHenkilo.listChanges(base)
+
+                    assertThat(result).containsExactly("customerWithContacts")
+                }
+
+                @Test
+                fun `returns a change when yhteyshenkilo changed in yhteystieto`() {
+                    val updatedYhteyshenkilo = yhteyshenkilo1.copy(etunimi = "Muutettu")
+                    val updated =
+                        base.copy(
+                            customerWithContacts =
+                                base.customerWithContacts!!.copy(
+                                    yhteyshenkilot = listOf(yhteyshenkilo1, updatedYhteyshenkilo)
+                                )
+                        )
+
+                    val result = base.listChanges(updated)
+
+                    assertThat(result).containsExactly("customerWithContacts")
+                }
+            }
+
+            @Nested
+            inner class AreaChanges {
+                private val dataWithTwoAreas =
+                    base.copy(
+                        areas =
+                            listOf(
+                                ApplicationFactory.createExcavationNotificationArea(
+                                    katuosoite = "first"
+                                ),
+                                ApplicationFactory.createExcavationNotificationArea(
+                                    katuosoite = "second"
+                                ),
+                            )
+                    )
+
+                @ParameterizedTest
+                @EmptySource
+                @NullSource
+                fun `returns a change when areas were empty but new ones are added`(
+                    areas: List<KaivuilmoitusAlue>?
+                ) {
+                    val base = base.copy(areas = areas)
+
+                    val result = base.listChanges(dataWithTwoAreas)
+
+                    assertThat(result).containsExactly("areas[0]", "areas[1]")
+                }
+
+                @ParameterizedTest
+                @EmptySource
+                @NullSource
+                fun `returns a change when there were areas but now they are empty`(
+                    areas: List<KaivuilmoitusAlue>?
+                ) {
+                    val updated = base.copy(areas = areas)
+
+                    val result = dataWithTwoAreas.listChanges(updated)
+
+                    assertThat(result).containsExactly("areas[0]", "areas[1]")
+                }
+
+                @Test
+                fun `returns several changes when an area is removed from the middle`() {
+                    val base =
+                        base.copy(
+                            areas =
+                                listOf(
+                                    ApplicationFactory.createExcavationNotificationArea(
+                                        katuosoite = "first"
+                                    ),
+                                    ApplicationFactory.createExcavationNotificationArea(
+                                        katuosoite = "removed1"
+                                    ),
+                                    ApplicationFactory.createExcavationNotificationArea(
+                                        katuosoite = "removed2"
+                                    ),
+                                    ApplicationFactory.createExcavationNotificationArea(
+                                        katuosoite = "second"
+                                    ),
+                                )
+                        )
+
+                    val result = base.listChanges(dataWithTwoAreas)
+
+                    assertThat(result)
+                        .containsExactly("areas[1]", "areas[1].katuosoite", "areas[2]", "areas[3]")
+                }
+
+                @Test
+                fun `returns several changes when an area is added to the middle`() {
+                    val updated =
+                        base.copy(
+                            areas =
+                                listOf(
+                                    ApplicationFactory.createExcavationNotificationArea(
+                                        katuosoite = "first"
+                                    ),
+                                    ApplicationFactory.createExcavationNotificationArea(
+                                        katuosoite = "added1"
+                                    ),
+                                    ApplicationFactory.createExcavationNotificationArea(
+                                        katuosoite = "added2"
+                                    ),
+                                    ApplicationFactory.createExcavationNotificationArea(
+                                        katuosoite = "second"
+                                    ),
+                                )
+                        )
+
+                    val result = dataWithTwoAreas.listChanges(updated)
+
+                    assertThat(result)
+                        .containsExactly("areas[1]", "areas[1].katuosoite", "areas[2]", "areas[3]")
+                }
+
+                @Test
+                fun `returns all changes in area`() {
+                    val updated =
+                        base.copy(
+                            areas =
+                                listOf(
+                                    ApplicationFactory.createExcavationNotificationArea(
+                                        tyoalueet =
+                                            listOf(
+                                                ApplicationFactory.createTyoalue()
+                                                    .copy(geometry = GeometriaFactory.polygon())
+                                            ),
+                                        katuosoite = "Uusi katuosoite",
+                                        tyonTarkoitukset = setOf(TyomaaTyyppi.VIEMARI),
+                                        meluhaitta = Meluhaitta.SATUNNAINEN_MELUHAITTA,
+                                        polyhaitta = Polyhaitta.JATKUVA_POLYHAITTA,
+                                        tarinahaitta = Tarinahaitta.TOISTUVA_TARINAHAITTA,
+                                        kaistahaitta =
+                                            VaikutusAutoliikenteenKaistamaariin
+                                                .YKSI_KAISTA_VAHENEE_KAHDELLA_AJOSUUNNALLA,
+                                        kaistahaittojenPituus =
+                                            AutoliikenteenKaistavaikutustenPituus
+                                                .PITUUS_100_499_METRIA,
+                                        lisatiedot = "Täydennetyt lisätiedot",
+                                        haittojenhallintasuunnitelma =
+                                            DEFAULT_HHS.toMutableMap().mapValues {
+                                                it.value + " täydennetty"
+                                            },
+                                    )
+                                )
+                        )
+
+                    val result = base.listChanges(updated)
+
+                    assertThat(result)
+                        .containsExactly(
+                            "areas[0]",
+                            "areas[0].tyoalueet[0]",
+                            "areas[0].tyoalueet[0].geometry",
+                            "areas[0].katuosoite",
+                            "areas[0].tyonTarkoitukset",
+                            "areas[0].meluhaitta",
+                            "areas[0].polyhaitta",
+                            "areas[0].tarinahaitta",
+                            "areas[0].kaistahaitta",
+                            "areas[0].kaistahaittojenPituus",
+                            "areas[0].lisatiedot",
+                            "areas[0].haittojenhallintasuunnitelma[YLEINEN]",
+                            "areas[0].haittojenhallintasuunnitelma[PYORALIIKENNE]",
+                            "areas[0].haittojenhallintasuunnitelma[AUTOLIIKENNE]",
+                            "areas[0].haittojenhallintasuunnitelma[RAITIOLIIKENNE]",
+                            "areas[0].haittojenhallintasuunnitelma[LINJAAUTOLIIKENNE]",
+                            "areas[0].haittojenhallintasuunnitelma[MUUT]",
+                        )
+                }
+
+                @Test
+                fun `returns changes in haittojenhallintasuunnitelma`() {
+                    val updated =
+                        base.copy(
+                            areas =
+                                listOf(
+                                    ApplicationFactory.createExcavationNotificationArea(
+                                        haittojenhallintasuunnitelma =
+                                            DEFAULT_HHS.toMutableMap().mapValues {
+                                                it.value + " täydennetty"
+                                            }
+                                    )
+                                )
+                        )
+
+                    val result = base.listChanges(updated)
+
+                    assertThat(result)
+                        .containsExactly(
+                            "areas[0].haittojenhallintasuunnitelma[YLEINEN]",
+                            "areas[0].haittojenhallintasuunnitelma[PYORALIIKENNE]",
+                            "areas[0].haittojenhallintasuunnitelma[AUTOLIIKENNE]",
+                            "areas[0].haittojenhallintasuunnitelma[RAITIOLIIKENNE]",
+                            "areas[0].haittojenhallintasuunnitelma[LINJAAUTOLIIKENNE]",
+                            "areas[0].haittojenhallintasuunnitelma[MUUT]",
+                        )
+                }
+            }
+
+            private fun kaivuilmoitusCases(): List<Arguments> {
+                val base = HakemusFactory.createKaivuilmoitusData()
+                return listOf(
+                    // One shared field to test that the super method gets called.
+                    Arguments.of(base.copy(startTime = base.startTime!!.minusDays(1)), "startTime"),
+                    Arguments.of(
+                        base.copy(workDescription = "New description."),
+                        "workDescription",
+                    ),
+                    Arguments.of(base.copy(constructionWork = true), "constructionWork"),
+                    Arguments.of(base.copy(maintenanceWork = true), "maintenanceWork"),
+                    Arguments.of(base.copy(emergencyWork = true), "emergencyWork"),
+                    Arguments.of(
+                        base.copy(cableReportDone = !base.cableReportDone),
+                        "cableReportDone",
+                    ),
+                    Arguments.of(base.copy(rockExcavation = true), "rockExcavation"),
+                    Arguments.of(base.copy(cableReports = listOf("JS2400001")), "cableReports"),
+                    Arguments.of(
+                        base.copy(placementContracts = listOf("tunnus")),
+                        "placementContracts",
+                    ),
+                    Arguments.of(base.copy(requiredCompetence = true), "requiredCompetence"),
+                    Arguments.of(
+                        base.copy(contractorWithContacts = HakemusyhteystietoFactory.create()),
+                        "contractorWithContacts",
+                    ),
+                    Arguments.of(
+                        base.copy(
+                            propertyDeveloperWithContacts = HakemusyhteystietoFactory.create()
+                        ),
+                        "propertyDeveloperWithContacts",
+                    ),
+                    Arguments.of(
+                        base.copy(representativeWithContacts = HakemusyhteystietoFactory.create()),
+                        "representativeWithContacts",
+                    ),
+                    Arguments.of(
+                        base.copy(
+                            invoicingCustomer =
+                                HakemusyhteystietoFactory.createLaskutusyhteystieto()
+                        ),
+                        "invoicingCustomer",
+                    ),
+                    Arguments.of(base.copy(additionalInfo = "Uutta lisätietoa"), "additionalInfo"),
+                )
+            }
+
+            @ParameterizedTest(name = "{displayName} {1}")
+            @MethodSource("kaivuilmoitusCases")
+            fun `returns changes when kaivuilmoitus fields have changes`(
+                updated: KaivuilmoitusData,
+                name: String,
+            ) {
+                val base = HakemusFactory.createKaivuilmoitusData()
+
+                val changes = base.listChanges(updated)
+
+                assertThat(changes).containsExactly(name)
+            }
         }
     }
 }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusalueTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusalueTest.kt
@@ -1,0 +1,262 @@
+package fi.hel.haitaton.hanke.hakemus
+
+import assertk.assertThat
+import assertk.assertions.containsExactly
+import assertk.assertions.isEmpty
+import fi.hel.haitaton.hanke.domain.TyomaaTyyppi
+import fi.hel.haitaton.hanke.factory.ApplicationFactory
+import fi.hel.haitaton.hanke.factory.GeometriaFactory
+import fi.hel.haitaton.hanke.factory.HaittaFactory.DEFAULT_HHS
+import fi.hel.haitaton.hanke.tormaystarkastelu.AutoliikenteenKaistavaikutustenPituus
+import fi.hel.haitaton.hanke.tormaystarkastelu.Meluhaitta
+import fi.hel.haitaton.hanke.tormaystarkastelu.Polyhaitta
+import fi.hel.haitaton.hanke.tormaystarkastelu.Tarinahaitta
+import fi.hel.haitaton.hanke.tormaystarkastelu.VaikutusAutoliikenteenKaistamaariin
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+class HakemusalueTest {
+
+    @Nested
+    inner class ListChanges {
+
+        val path = "areas[0]"
+
+        @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+        @Nested
+        inner class Johtoselvitys {
+
+            val base = ApplicationFactory.createCableReportApplicationArea()
+
+            @Test
+            fun `returns no changes when areas are identical`() {
+                val updated = base.copy()
+
+                val result = base.listChanges(path, updated)
+
+                assertThat(result).isEmpty()
+            }
+
+            @Test
+            fun `returns a change when other area is null`() {
+                val result = base.listChanges(path, null)
+
+                assertThat(result).containsExactly(path)
+            }
+
+            @Test
+            fun `returns a change when name differs`() {
+                val updated = base.copy(name = "Uusi nimi")
+
+                val result = base.listChanges(path, updated)
+
+                assertThat(result).containsExactly(path)
+            }
+
+            @Test
+            fun `returns a change when geometry differs`() {
+                val updated = base.copy(geometry = GeometriaFactory.thirdPolygon())
+
+                val result = base.listChanges(path, updated)
+
+                assertThat(result).containsExactly(path)
+            }
+        }
+
+        @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+        @Nested
+        inner class Kaivuilmoitus {
+
+            val base = ApplicationFactory.createExcavationNotificationArea()
+
+            @Test
+            fun `returns no changes when areas are identical`() {
+                val updated = base.copy()
+
+                val result = base.listChanges(path, updated)
+
+                assertThat(result).isEmpty()
+            }
+
+            @Test
+            fun `returns a change when other area is null`() {
+                val result = base.listChanges(path, null)
+
+                assertThat(result).containsExactly(path)
+            }
+
+            @Test
+            fun `returns all changes in area`() {
+                val updated =
+                    ApplicationFactory.createExcavationNotificationArea(
+                        name = "Uusi nimi",
+                        katuosoite = "Uusi katuosoite",
+                        tyonTarkoitukset = setOf(TyomaaTyyppi.VIEMARI),
+                        meluhaitta = Meluhaitta.SATUNNAINEN_MELUHAITTA,
+                        polyhaitta = Polyhaitta.JATKUVA_POLYHAITTA,
+                        tarinahaitta = Tarinahaitta.TOISTUVA_TARINAHAITTA,
+                        kaistahaitta =
+                            VaikutusAutoliikenteenKaistamaariin
+                                .YKSI_KAISTA_VAHENEE_KAHDELLA_AJOSUUNNALLA,
+                        kaistahaittojenPituus =
+                            AutoliikenteenKaistavaikutustenPituus.PITUUS_100_499_METRIA,
+                        lisatiedot = "Täydennetyt lisätiedot",
+                        haittojenhallintasuunnitelma =
+                            DEFAULT_HHS.toMutableMap().mapValues { it.value + " täydennetty" },
+                    )
+
+                val result = base.listChanges(path, updated)
+
+                assertThat(result)
+                    .containsExactly(
+                        path,
+                        "$path.name",
+                        "$path.katuosoite",
+                        "$path.tyonTarkoitukset",
+                        "$path.meluhaitta",
+                        "$path.polyhaitta",
+                        "$path.tarinahaitta",
+                        "$path.kaistahaitta",
+                        "$path.kaistahaittojenPituus",
+                        "$path.lisatiedot",
+                        "$path.haittojenhallintasuunnitelma[YLEINEN]",
+                        "$path.haittojenhallintasuunnitelma[PYORALIIKENNE]",
+                        "$path.haittojenhallintasuunnitelma[AUTOLIIKENNE]",
+                        "$path.haittojenhallintasuunnitelma[RAITIOLIIKENNE]",
+                        "$path.haittojenhallintasuunnitelma[LINJAAUTOLIIKENNE]",
+                        "$path.haittojenhallintasuunnitelma[MUUT]",
+                    )
+            }
+
+            @Test
+            fun `returns changes in haittojenhallintasuunnitelma`() {
+                val updated =
+                    ApplicationFactory.createExcavationNotificationArea(
+                        haittojenhallintasuunnitelma =
+                            DEFAULT_HHS.toMutableMap().mapValues { it.value + " täydennetty" }
+                    )
+
+                val result = base.listChanges(path, updated)
+
+                assertThat(result)
+                    .containsExactly(
+                        "$path.haittojenhallintasuunnitelma[YLEINEN]",
+                        "$path.haittojenhallintasuunnitelma[PYORALIIKENNE]",
+                        "$path.haittojenhallintasuunnitelma[AUTOLIIKENNE]",
+                        "$path.haittojenhallintasuunnitelma[RAITIOLIIKENNE]",
+                        "$path.haittojenhallintasuunnitelma[LINJAAUTOLIIKENNE]",
+                        "$path.haittojenhallintasuunnitelma[MUUT]",
+                    )
+            }
+
+            @Nested
+            inner class WorkAreaChanges {
+
+                private val areaWithoutWorkAreas = base.copy(tyoalueet = emptyList())
+
+                private val areaWithTwoWorkAreas =
+                    base.copy(
+                        tyoalueet =
+                            listOf(
+                                ApplicationFactory.createTyoalue(
+                                    geometry = GeometriaFactory.polygon()
+                                ),
+                                ApplicationFactory.createTyoalue(
+                                    geometry = GeometriaFactory.secondPolygon()
+                                ),
+                            )
+                    )
+
+                @Test
+                fun `returns a change when work areas were empty but new ones are added`() {
+                    val result = areaWithoutWorkAreas.listChanges(path, areaWithTwoWorkAreas)
+
+                    assertThat(result)
+                        .containsExactly(path, "$path.tyoalueet[0]", "$path.tyoalueet[1]")
+                }
+
+                @Test
+                fun `returns a change when there were work areas but now they are empty`() {
+                    val result = areaWithTwoWorkAreas.listChanges(path, areaWithoutWorkAreas)
+
+                    assertThat(result)
+                        .containsExactly(path, "$path.tyoalueet[0]", "$path.tyoalueet[1]")
+                }
+
+                @Test
+                fun `returns several changes when a work area is removed from the middle`() {
+                    val tyoalueet =
+                        listOf(
+                            ApplicationFactory.createTyoalue(geometry = GeometriaFactory.polygon()),
+                            ApplicationFactory.createTyoalue(
+                                geometry = GeometriaFactory.thirdPolygon()
+                            ),
+                            ApplicationFactory.createTyoalue(
+                                geometry = GeometriaFactory.thirdPolygon()
+                            ),
+                            ApplicationFactory.createTyoalue(
+                                geometry = GeometriaFactory.secondPolygon()
+                            ),
+                        )
+                    val base = base.copy(tyoalueet = tyoalueet)
+
+                    val result = base.listChanges(path, areaWithTwoWorkAreas)
+
+                    assertThat(result)
+                        .containsExactly(
+                            path,
+                            "$path.tyoalueet[1]",
+                            "$path.tyoalueet[1].geometry",
+                            "$path.tyoalueet[2]",
+                            "$path.tyoalueet[3]",
+                        )
+                }
+
+                @Test
+                fun `returns several changes when a work area is added to the middle`() {
+                    val tyoalueet =
+                        listOf(
+                            ApplicationFactory.createTyoalue(geometry = GeometriaFactory.polygon()),
+                            ApplicationFactory.createTyoalue(
+                                geometry = GeometriaFactory.thirdPolygon()
+                            ),
+                            ApplicationFactory.createTyoalue(
+                                geometry = GeometriaFactory.thirdPolygon()
+                            ),
+                            ApplicationFactory.createTyoalue(
+                                geometry = GeometriaFactory.secondPolygon()
+                            ),
+                        )
+                    val updated = base.copy(tyoalueet = tyoalueet)
+
+                    val result = areaWithTwoWorkAreas.listChanges(path, updated)
+
+                    assertThat(result)
+                        .containsExactly(
+                            path,
+                            "$path.tyoalueet[1]",
+                            "$path.tyoalueet[1].geometry",
+                            "$path.tyoalueet[2]",
+                            "$path.tyoalueet[3]",
+                        )
+                }
+
+                @Test
+                fun `returns a change in tyoalue geometry`() {
+                    val tyoalueet =
+                        listOf(
+                            ApplicationFactory.createTyoalue()
+                                .copy(geometry = GeometriaFactory.polygon())
+                        )
+                    val updated = base.copy(tyoalueet = tyoalueet)
+
+                    val result = base.listChanges(path, updated)
+
+                    assertThat(result)
+                        .containsExactly(path, "$path.tyoalueet[0]", "$path.tyoalueet[0].geometry")
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Description

1. Use `checkChangeInYhteystieto` for `KaivuilmoitusData` contacts
2. New implementation of `checkChangesInAreas` - it will check changes inside areas, not just do `equals` comparison
3. Implementations of `Hakemusalue.listChanges`: `equals` check for other than `KaivuilmoitusAlue` and field-by-field comparison for `KaivuilmoitusAlue`
4. Implementation of `Tyoalue.listChanges`
5. Implementation of checking changes in haittojenhallintasuunnitelma
6. Tests for all

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-3321

## Type of change

- [ ] Bug fix 
- [x] New feature 
- [ ] Other

# Instructions for testing
1. Create a kaivuilmoitus and a täydennyspyyntö for it
2. Create täydennys, do changes especially in work areas, haittojenhallintasuunnitelma and contacts
3. Check the returned `muutokset` value when the form is saved

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 

# Other relevant info
Please describe here if there is e.g. some requirements for this change or
 other info that the tester/user needs to know.