### PR TITLE
HAI-3354 Add haittojenhallintasuunnitelma info to the PDF

### DIFF
--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/pdf/Fonts.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/pdf/Fonts.kt
@@ -1,0 +1,42 @@
+package fi.hel.haitaton.hanke.pdf
+
+import com.lowagie.text.Font
+import com.lowagie.text.pdf.BaseFont
+import java.awt.Color
+
+private val baseRegularFont =
+    BaseFont.createFont(
+        "pdf-assets/liberation-sans/LiberationSans-Regular.ttf",
+        BaseFont.IDENTITY_H,
+        BaseFont.EMBEDDED,
+    )
+private val baseBoldFont =
+    BaseFont.createFont(
+        "pdf-assets/liberation-sans/LiberationSans-Bold.ttf",
+        BaseFont.IDENTITY_H,
+        BaseFont.EMBEDDED,
+    )
+
+/**
+ * Font used for the top header of document, text above the main title. The biggest title we have.
+ */
+val headerFont = Font(baseBoldFont, pxToPt(18), Font.NORMAL, Color.BLACK)
+
+/** Font used for the main title of document. The biggest title we have. */
+val titleFont = Font(baseRegularFont, pxToPt(32), Font.NORMAL, Color.BLACK)
+/** Font used for subtitle under the main title. */
+val subtitleFont = Font(baseRegularFont, pxToPt(20), Font.NORMAL, Color.BLACK)
+/** Font used for the title of a section of data. */
+val sectionTitleFont = Font(baseBoldFont, pxToPt(20), Font.NORMAL, Color.BLACK)
+
+/** Font used for the left header column of a data section. */
+val rowHeaderFont = Font(baseBoldFont, pxToPt(14), Font.NORMAL, Color.BLACK)
+/** Font used for the left header column of a data section. */
+val textFont = Font(baseRegularFont, pxToPt(14), Font.NORMAL, Color.BLACK)
+
+/** Font used for showing "Toimet haittojen hallintaan" in haittojenhallintasuunnitelma. */
+val toimetFont = Font(baseBoldFont, pxToPt(16), Font.NORMAL, Color.BLACK)
+
+/** Fonts used when the background is set to a nuisance color. */
+val whiteNuisanceFont = Font(baseRegularFont, pxToPt(16), Font.NORMAL, Color.WHITE)
+val blackNuisanceFont = Font(baseRegularFont, pxToPt(16), Font.NORMAL, Color.BLACK)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/pdf/HaittojenhallintasuunnitelmaPdfEncoder.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/pdf/HaittojenhallintasuunnitelmaPdfEncoder.kt
@@ -5,10 +5,14 @@ import com.lowagie.text.Document
 import com.lowagie.text.Image
 import com.lowagie.text.ImgTemplate
 import com.lowagie.text.Paragraph
+import com.lowagie.text.Phrase
+import fi.hel.haitaton.hanke.domain.Haittojenhallintatyyppi
 import fi.hel.haitaton.hanke.domain.Hanke
 import fi.hel.haitaton.hanke.domain.SavedHankealue
 import fi.hel.haitaton.hanke.hakemus.KaivuilmoitusAlue
 import fi.hel.haitaton.hanke.hakemus.KaivuilmoitusData
+import fi.hel.haitaton.hanke.tormaystarkastelu.Autoliikenneluokittelu
+import fi.hel.haitaton.hanke.tormaystarkastelu.TormaystarkasteluTulos
 import java.time.ZonedDateTime
 import org.springframework.stereotype.Component
 
@@ -28,6 +32,9 @@ class HaittojenhallintasuunnitelmaPdfEncoder(private val mapGenerator: MapGenera
         totalArea: Float?,
         locationIcon: ImgTemplate,
     ) {
+        val hankealueIds = data.areas!!.map { it.hankealueId }.toSet()
+        val hankealueet = hanke.alueet.filter { hankealueIds.contains(it.id) }
+
         document.headerRow(
             "${hanke.nimi} (${hanke.hankeTunnus})",
             rightSide = ZonedDateTime.now().format()!!.trim(),
@@ -37,7 +44,7 @@ class HaittojenhallintasuunnitelmaPdfEncoder(private val mapGenerator: MapGenera
         document.subtitle(data.name)
 
         document.mapHeader("Alueiden sijainti", locationIcon)
-        document.map(data.areas!!, hanke.alueet)
+        document.map(data.areas, hankealueet)
 
         val spacer = Paragraph(Chunk.NEWLINE)
         spacer.spacingBefore = 1f
@@ -64,19 +71,193 @@ class HaittojenhallintasuunnitelmaPdfEncoder(private val mapGenerator: MapGenera
             row("Työn alkupäivämäärä", data.startTime.format())
             row("Työn loppupäivämäärä", data.endTime.format())
         }
+
+        hankealueet.forEach { hankealue ->
+            val kaivuilmoitusalue = data.areas.first { it.hankealueId == hankealue.id }
+            val worstIndexes = kaivuilmoitusalue.worstCasesInTormaystarkastelut()
+
+            document.section(hankealue.nimi) {
+                row("Toimet työalueiden haittojen hallintaan, ${hankealue.nimi}", toimetTitle())
+                row("", nuisanceScore(worstIndexes?.liikennehaittaindeksi?.indeksi))
+                val toimet =
+                    kaivuilmoitusalue.haittojenhallintasuunnitelma[Haittojenhallintatyyppi.YLEINEN]
+                row("", toimet(toimet))
+                row("", "")
+            }
+
+            document.section(null) {
+                row(
+                    "Linja-autojen paikallisliikenne, ${hankealue.nimi}",
+                    map(kaivuilmoitusalue, hankealue) { it?.linjaautoliikenneindeksi },
+                )
+                row("", toimetTitle())
+                row("", nuisanceScore(worstIndexes?.linjaautoliikenneindeksi))
+                val toimet =
+                    kaivuilmoitusalue.haittojenhallintasuunnitelma[
+                            Haittojenhallintatyyppi.LINJAAUTOLIIKENNE]
+                row("", toimet(toimet))
+                row("", "")
+            }
+
+            document.section(null) {
+                row(
+                    "Autoliikenteen ruuhkautuminen, ${hankealue.nimi}",
+                    map(kaivuilmoitusalue, hankealue) { it?.autoliikenne?.indeksi },
+                )
+                row("", toimetTitle())
+                row("", autoliikennehaitat(worstIndexes?.autoliikenne))
+                val toimet =
+                    kaivuilmoitusalue.haittojenhallintasuunnitelma[
+                            Haittojenhallintatyyppi.AUTOLIIKENNE]
+                row("", toimet(toimet))
+                row("", "")
+            }
+
+            document.section(null) {
+                row(
+                    "Pyöräliikenteen merkittävyys, ${hankealue.nimi}",
+                    map(kaivuilmoitusalue, hankealue) { it?.pyoraliikenneindeksi },
+                )
+                row("", toimetTitle())
+                row("", nuisanceScore(worstIndexes?.pyoraliikenneindeksi))
+                val toimet =
+                    kaivuilmoitusalue.haittojenhallintasuunnitelma[
+                            Haittojenhallintatyyppi.PYORALIIKENNE]
+                row("", toimet(toimet))
+                row("", "")
+            }
+
+            document.section(null) {
+                row(
+                    "Raitiovaunuliikenne, ${hankealue.nimi}",
+                    map(kaivuilmoitusalue, hankealue) { it?.raitioliikenneindeksi },
+                )
+                row("", toimetTitle())
+                row("", nuisanceScore(worstIndexes?.raitioliikenneindeksi))
+                val toimet =
+                    kaivuilmoitusalue.haittojenhallintasuunnitelma[
+                            Haittojenhallintatyyppi.RAITIOLIIKENNE]
+                row("", toimet(toimet))
+                row("", "")
+            }
+
+            document.section(null) {
+                row(
+                    "Muut haittojenhallintatoimet, ${hankealue.nimi}",
+                    muutHaitat(kaivuilmoitusalue),
+                )
+                row("", toimetTitle())
+                val toimet =
+                    kaivuilmoitusalue.haittojenhallintasuunnitelma[Haittojenhallintatyyppi.MUUT]
+                row("", toimet(toimet))
+                row("", "")
+            }
+        }
+    }
+
+    private fun toimetTitle(): Phrase =
+        Phrase("Toimet työalueiden haittojen hallintaan", toimetFont)
+
+    private fun nuisanceScore(
+        index: Int?,
+        title: String = "Työalueen haittaindeksi",
+        color: NuisanceColor? = null,
+    ): Paragraph = nuisanceScore(index?.toFloat(), title, color)
+
+    private fun nuisanceScore(
+        index: Float?,
+        title: String = "Työalueen haittaindeksi",
+        color: NuisanceColor? = null,
+    ): Paragraph {
+        val p = Paragraph(title, blackNuisanceFont)
+        val horizontalSpacer = Chunk("     ", blackNuisanceFont)
+        p.add(horizontalSpacer)
+        p.add(indexChunk(index, color))
+        return p
+    }
+
+    private fun toimet(toimet: String?): Paragraph {
+        val kuvaus =
+            toimet?.ifBlank { null } ?: "Haitaton ei ole tunnistanut hankealueelta tätä kohderyhmää"
+
+        return Paragraph(kuvaus, textFont)
+    }
+
+    private fun autoliikennehaitat(haitat: Autoliikenneluokittelu?): Paragraph {
+        val p = Paragraph()
+        p.add(nuisanceScore(haitat?.indeksi))
+        p.add(Chunk.NEWLINE)
+
+        p.add(nuisanceScore(haitat?.katuluokka, "Katuluokka"))
+        p.add(Chunk.NEWLINE)
+
+        p.add(nuisanceScore(haitat?.kaistahaitta, "Vaikutus autoliikenteen kaistamääriin"))
+        p.add(Chunk.NEWLINE)
+
+        p.add(nuisanceScore(haitat?.kaistapituushaitta, "Autoliikenteen kaistavaikutusten pituus"))
+        p.add(Chunk.NEWLINE)
+
+        p.add(nuisanceScore(haitat?.haitanKesto, "Työn kesto"))
+        p.spacingAfter = 0f
+
+        return p
+    }
+
+    private fun muutHaitat(kaivuilmoitusAlue: KaivuilmoitusAlue): Paragraph {
+        val p = Paragraph()
+        p.add(nuisanceScore(kaivuilmoitusAlue.meluhaitta.value, "Melu", NuisanceColor.LAVENDER))
+        p.add(Chunk.NEWLINE)
+
+        p.add(nuisanceScore(kaivuilmoitusAlue.polyhaitta.value, "Pöly", NuisanceColor.LAVENDER))
+        p.add(Chunk.NEWLINE)
+
+        p.add(nuisanceScore(kaivuilmoitusAlue.tarinahaitta.value, "Tärinä", NuisanceColor.LAVENDER))
+        p.spacingAfter = 0f
+        return p
     }
 
     fun Document.map(areas: List<KaivuilmoitusAlue>, hankealueet: List<SavedHankealue>) {
         // The image is better quality, if it's rendered at a higher resolution and then scaled down
         // to fit in the PDF layout.
-        val bytes = mapGenerator.mapWithAreas(areas, hankealueet, MAP_WIDTH * 2, MAP_HEIGHT * 2)
+        val bytes =
+            mapGenerator.mapWithAreas(
+                areas,
+                hankealueet,
+                HEADER_MAP_WIDTH * 2,
+                HEADER_MAP_HEIGHT * 2,
+            ) {
+                it?.liikennehaittaindeksi?.indeksi
+            }
         val image = Image.getInstance(bytes)
-        image.scaleToFit(pxToPt(MAP_WIDTH), pxToPt(MAP_HEIGHT))
+        image.scaleToFit(pxToPt(HEADER_MAP_WIDTH), pxToPt(HEADER_MAP_HEIGHT))
         this.add(image)
     }
 
+    fun map(
+        area: KaivuilmoitusAlue,
+        hankealue: SavedHankealue,
+        selectIndex: (TormaystarkasteluTulos?) -> Float?,
+    ): Image {
+        // The image is better quality, if it's rendered at a higher resolution and then scaled down
+        // to fit in the PDF layout.
+        val bytes =
+            mapGenerator.mapWithAreas(
+                listOf(area),
+                listOf(hankealue),
+                COLUMN_MAP_WIDTH * 2,
+                COLUMN_MAP_HEIGHT * 2,
+                selectIndex,
+            )
+        val image = Image.getInstance(bytes)
+        image.scaleToFit(pxToPt(COLUMN_MAP_WIDTH), pxToPt(COLUMN_MAP_HEIGHT))
+        return image
+    }
+
     companion object {
-        const val MAP_WIDTH = 1110
-        const val MAP_HEIGHT = 400
+        const val HEADER_MAP_WIDTH = 1110
+        const val HEADER_MAP_HEIGHT = 400
+
+        const val COLUMN_MAP_WIDTH = 860
+        const val COLUMN_MAP_HEIGHT = 304
     }
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/pdf/HaittojenhallintasuunnitelmaPdfEncoder.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/pdf/HaittojenhallintasuunnitelmaPdfEncoder.kt
@@ -129,7 +129,7 @@ class HaittojenhallintasuunnitelmaPdfEncoder(private val mapGenerator: MapGenera
 
             document.section(null) {
                 row(
-                    "Raitiovaunuliikenne, ${hankealue.nimi}",
+                    "Raitioliikenne, ${hankealue.nimi}",
                     map(kaivuilmoitusalue, hankealue) { it?.raitioliikenneindeksi },
                 )
                 row("", toimetTitle())

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/pdf/NuisanceColor.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/pdf/NuisanceColor.kt
@@ -1,29 +1,28 @@
 package fi.hel.haitaton.hanke.pdf
 
-import fi.hel.haitaton.hanke.tormaystarkastelu.TormaystarkasteluTulos
+import com.lowagie.text.Font
 import java.awt.Color
 import org.geotools.api.style.Style
 
-enum class NuisanceColor(val color: Color) {
-    BLUE(Color(0, 98, 185)),
-    GRAY(Color(176, 184, 191)),
-    GREEN(Color(0, 146, 70)),
-    YELLOW(Color(255, 218, 7)),
-    RED(Color(196, 18, 62));
+enum class NuisanceColor(val color: Color, val font: Font) {
+    BLUE(Color(0, 98, 185), blackNuisanceFont),
+    GRAY(Color(176, 184, 191), blackNuisanceFont),
+    GREEN(Color(0, 146, 70), whiteNuisanceFont),
+    YELLOW(Color(255, 218, 7), blackNuisanceFont),
+    RED(Color(196, 18, 62), whiteNuisanceFont),
+    LAVENDER(Color(0xe6, 0xef, 0xf8), blackNuisanceFont);
 
     val style: Style by lazy { MapGenerator.buildAreaStyle(color) }
 
     companion object {
-        fun selectColor(tormaystarkasteluTulos: TormaystarkasteluTulos?): NuisanceColor {
-            val maxHaitta = tormaystarkasteluTulos?.liikennehaittaindeksi?.indeksi
-
+        fun selectColor(index: Float?): NuisanceColor {
             return when {
-                maxHaitta == null -> BLUE
-                maxHaitta.isNaN() -> BLUE
-                maxHaitta < 0f -> BLUE
-                maxHaitta == 0f -> GRAY
-                maxHaitta < 3f -> GREEN
-                maxHaitta < 4f -> YELLOW
+                index == null -> BLUE
+                index.isNaN() -> BLUE
+                index < 0f -> BLUE
+                index == 0f -> GRAY
+                index < 3f -> GREEN
+                index < 4f -> YELLOW
                 else -> RED
             }
         }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/pdf/PdfHelpers.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/pdf/PdfHelpers.kt
@@ -3,39 +3,24 @@ package fi.hel.haitaton.hanke.pdf
 import com.lowagie.text.Chunk
 import com.lowagie.text.Document
 import com.lowagie.text.Element
-import com.lowagie.text.Font
+import com.lowagie.text.Image
 import com.lowagie.text.ImgTemplate
 import com.lowagie.text.PageSize
 import com.lowagie.text.Paragraph
 import com.lowagie.text.Phrase
 import com.lowagie.text.Rectangle
-import com.lowagie.text.pdf.BaseFont
 import com.lowagie.text.pdf.PdfContentByte
 import com.lowagie.text.pdf.PdfPTable
 import com.lowagie.text.pdf.PdfTemplate
 import com.lowagie.text.pdf.PdfWriter
 import com.lowagie.text.pdf.draw.VerticalPositionMark
 import fi.hel.haitaton.hanke.getResource
-import java.awt.Color
 import java.awt.Graphics2D
 import java.awt.print.PageFormat
 import java.awt.print.Paper
 import java.io.ByteArrayOutputStream
 import org.apache.batik.transcoder.TranscoderInput
 import org.apache.batik.transcoder.print.PrintTranscoder
-
-private val baseRegularFont =
-    BaseFont.createFont(
-        "pdf-assets/liberation-sans/LiberationSans-Regular.ttf",
-        BaseFont.IDENTITY_H,
-        BaseFont.EMBEDDED,
-    )
-private val baseBoldFont =
-    BaseFont.createFont(
-        "pdf-assets/liberation-sans/LiberationSans-Bold.ttf",
-        BaseFont.IDENTITY_H,
-        BaseFont.EMBEDDED,
-    )
 
 /**
  * A4 paper size in figma is 1190 x 1684 px.
@@ -45,23 +30,6 @@ private val baseBoldFont =
  * So when converting px to pt, we need to multiply by 595/1190 = 0.5 = 842/1684.
  */
 const val PX_TO_PT = 0.5f
-
-/**
- * Font used for the top header of document, text above the main title. The biggest title we have.
- */
-private val headerFont = Font(baseBoldFont, pxToPt(18), Font.NORMAL, Color.BLACK)
-
-/** Font used for the main title of document. The biggest title we have. */
-private val titleFont = Font(baseRegularFont, pxToPt(32), Font.NORMAL, Color.BLACK)
-/** Font used for subtitle under the main title. */
-private val subtitleFont = Font(baseRegularFont, pxToPt(20), Font.NORMAL, Color.BLACK)
-/** Font used for the title of a section of data. */
-private val sectionTitleFont = Font(baseBoldFont, pxToPt(20), Font.NORMAL, Color.BLACK)
-
-/** Font used for the left header column of a data section. */
-private val rowHeaderFont = Font(baseBoldFont, pxToPt(14), Font.NORMAL, Color.BLACK)
-/** Font used for the left header column of a data section. */
-private val textFont = Font(baseRegularFont, pxToPt(14), Font.NORMAL, Color.BLACK)
 
 fun pxToPt(px: Int): Float = px * PX_TO_PT
 
@@ -117,17 +85,30 @@ fun PdfPTable.row(key: String, value: String?) {
     this.addCell(Phrase(value ?: "<Tyhjä>", textFont))
 }
 
+fun PdfPTable.row(key: String, value: Phrase) {
+    this.addCell(Phrase("$key ", rowHeaderFont))
+    this.addCell(value)
+}
+
+fun PdfPTable.row(key: String, image: Image) {
+    this.addCell(Phrase("$key ", rowHeaderFont))
+    this.addCell(image)
+}
+
 fun PdfPTable.rowIfNotBlank(title: String, content: String?) {
     if (!content.isNullOrBlank()) {
         row(title, content)
     }
 }
 
-fun Document.section(sectionTitle: String, addRows: PdfPTable.() -> Unit) {
+fun Document.section(sectionTitle: String?, addRows: PdfPTable.() -> Unit) {
     val paragraph = Paragraph()
     paragraph.keepTogether = true
     paragraph.spacingBefore = pxToPt(-39)
-    paragraph.add(Paragraph(sectionTitle, sectionTitleFont))
+
+    if (!sectionTitle.isNullOrBlank()) {
+        paragraph.add(Paragraph(sectionTitle, sectionTitleFont))
+    }
 
     val table = PdfPTable(2)
     table.widthPercentage = 100f
@@ -140,6 +121,8 @@ fun Document.section(sectionTitle: String, addRows: PdfPTable.() -> Unit) {
     // Set line spacing to 24px
     table.defaultCell.setLeading(pxToPt(24), 0f)
     table.setSpacingBefore(-12f)
+    table.isSplitRows = false
+    table.isSplitLate = true
 
     table.addRows()
     paragraph.add(table)
@@ -149,7 +132,7 @@ fun Document.section(sectionTitle: String, addRows: PdfPTable.() -> Unit) {
 fun createDocument(addContent: (Document, PdfWriter) -> Unit): ByteArray {
     val outputStream = ByteArrayOutputStream()
     val padding = pxToPt(40)
-    val document = Document(PageSize.A4, padding, padding, padding / 2, padding)
+    val document = Document(PageSize.A4, padding, padding, padding, padding)
     val writer = PdfWriter.getInstance(document, outputStream)
     document.open()
     addContent(document, writer)
@@ -177,4 +160,17 @@ fun loadLocationIcon(writer: PdfWriter): ImgTemplate {
     g2.dispose()
 
     return ImgTemplate(template)
+}
+
+fun indexChunk(index: Float?, color: NuisanceColor? = null): Chunk {
+    val formatted =
+        if (index == null) "-"
+        else if (index % 1.0 != 0.0) String.format("%s", index) else String.format("%.0f", index)
+
+    val nuisanceColor = color ?: NuisanceColor.selectColor(index)
+
+    val chunk = Chunk(formatted, nuisanceColor.font)
+    chunk.setBackground(nuisanceColor.color, pxToPt(15), pxToPt(5), pxToPt(15), pxToPt(5))
+    chunk.horizontalScaling
+    return chunk
 }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HaittaFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HaittaFactory.kt
@@ -30,9 +30,6 @@ object HaittaFactory {
             1,
         )
 
-    val TORMAYSTARKASTELUTULOS_WITH_ZEROES =
-        tormaystarkasteluTulos(TORMAYSTARKASTELU_ZERO_AUTOLIIKENNELUOKITTELU, 0f, 0f, 0f)
-
     const val DEFAULT_HHS_YLEINEN = "Yleisten haittojen hallintasuunnitelma"
     const val DEFAULT_HHS_PYORALIIKENNE =
         "Pyöräliikenteelle koituvien haittojen hallintasuunnitelma"

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeFactory.kt
@@ -209,6 +209,7 @@ class HankeFactory(
          * ```
          */
         fun Hanke.withHankealue(
+            id: Int = 1,
             nimi: String = "$HANKEALUE_DEFAULT_NAME 1",
             haittaAlkuPvm: ZonedDateTime? = DateFactory.getStartDatetime(),
             haittaLoppuPvm: ZonedDateTime? = DateFactory.getEndDatetime(),
@@ -220,6 +221,7 @@ class HankeFactory(
             this.tyomaaTyyppi.add(TyomaaTyyppi.MUU)
             val alue =
                 HankealueFactory.create(
+                    id = id,
                     hankeId = this.id,
                     nimi = nimi,
                     haittaAlkuPvm = haittaAlkuPvm,

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/pdf/HaittojenhallintasuunnitelmaPdfEncoderTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/pdf/HaittojenhallintasuunnitelmaPdfEncoderTest.kt
@@ -4,11 +4,15 @@ import assertk.all
 import assertk.assertThat
 import assertk.assertions.contains
 import assertk.assertions.doesNotContain
+import fi.hel.haitaton.hanke.domain.Haittojenhallintasuunnitelma
+import fi.hel.haitaton.hanke.domain.Haittojenhallintatyyppi
 import fi.hel.haitaton.hanke.factory.ApplicationFactory
+import fi.hel.haitaton.hanke.factory.HaittaFactory
 import fi.hel.haitaton.hanke.factory.HakemusFactory
 import fi.hel.haitaton.hanke.factory.HakemusyhteystietoFactory
 import fi.hel.haitaton.hanke.factory.HakemusyhteystietoFactory.withYhteyshenkilo
 import fi.hel.haitaton.hanke.factory.HankeFactory
+import fi.hel.haitaton.hanke.factory.HankealueFactory
 import fi.hel.haitaton.hanke.getResourceAsBytes
 import io.mockk.checkUnnecessaryStub
 import io.mockk.clearAllMocks
@@ -35,7 +39,7 @@ class HaittojenhallintasuunnitelmaPdfEncoderTest {
     @BeforeEach
     fun clearMocks() {
         clearAllMocks()
-        every { mapGenerator.mapWithAreas(any(), any(), any(), any()) } returns blankImage
+        every { mapGenerator.mapWithAreas(any(), any(), any(), any(), any()) } returns blankImage
     }
 
     @AfterEach
@@ -46,11 +50,36 @@ class HaittojenhallintasuunnitelmaPdfEncoderTest {
 
     @Nested
     inner class CreatePdf {
-        val hanke = HankeFactory.create()
+        private val hankealueId = 414
+        private val hankealueNimi = "Nimi hankealueelle"
+        private val hankealue = HankealueFactory.create(id = hankealueId, nimi = hankealueNimi)
+
+        private val hankealueId2 = 5256
+        private val hankealueNimi2 = "Nimi toiselle hankealueelle"
+        private val hankealue2 = HankealueFactory.create(id = hankealueId2, nimi = hankealueNimi2)
+
+        private val hankealueet = listOf(hankealue, hankealue2)
+        private val hanke =
+            HankeFactory.create().apply { alueet = mutableListOf(hankealue, hankealue2) }
+
+        private val hakemusalue =
+            ApplicationFactory.createExcavationNotificationArea(hankealueId = hankealueId)
+        private val haittojenhallintasuunnitelma2: Haittojenhallintasuunnitelma =
+            mapOf(
+                Haittojenhallintatyyppi.YLEINEN to "Yleiset toimet toiselle alueelle",
+                Haittojenhallintatyyppi.AUTOLIIKENNE to "Autoilun toimet toiselle alueelle",
+                Haittojenhallintatyyppi.PYORALIIKENNE to "Pyöräilyn toimet toiselle alueelle",
+            )
+        private val hakemusalue2 =
+            ApplicationFactory.createExcavationNotificationArea(
+                hankealueId = hankealueId2,
+                haittojenhallintasuunnitelma = haittojenhallintasuunnitelma2,
+            )
+        private val hakemusalueet = listOf(hakemusalue, hakemusalue2)
 
         @Test
         fun `created PDF contains title and section headers`() {
-            val hakemusData = HakemusFactory.createKaivuilmoitusData()
+            val hakemusData = HakemusFactory.createKaivuilmoitusData(areas = listOf())
 
             val pdfData = haittojenhallintasuunnitelmaPdfEncoder.createPdf(hanke, hakemusData, 1f)
 
@@ -62,12 +91,13 @@ class HaittojenhallintasuunnitelmaPdfEncoderTest {
                     "Perustiedot",
                     "Alueet",
                 )
-            verifySequence { mapGenerator.mapWithAreas(hakemusData.areas!!, listOf(), 2220, 800) }
+            verifySequence { mapGenerator.mapWithAreas(listOf(), listOf(), 2220, 800, any()) }
         }
 
         @Test
         fun `created PDF contains headers for basic information`() {
-            val hakemusData = HakemusFactory.createKaivuilmoitusData(cableReportDone = false)
+            val hakemusData =
+                HakemusFactory.createKaivuilmoitusData(areas = listOf(), cableReportDone = false)
 
             val pdfData = haittojenhallintasuunnitelmaPdfEncoder.createPdf(hanke, hakemusData, 1f)
 
@@ -80,13 +110,14 @@ class HaittojenhallintasuunnitelmaPdfEncoderTest {
                 contains("Sijoitussopimustunnukset")
                 contains("Työhön vaadittavat pätevyydet")
             }
-            verifySequence { mapGenerator.mapWithAreas(hakemusData.areas!!, listOf(), 2220, 800) }
+            verifySequence { mapGenerator.mapWithAreas(listOf(), listOf(), 2220, 800, any()) }
         }
 
         @Test
         fun `created PDF contains basic information`() {
             val hakemusData =
                 HakemusFactory.createKaivuilmoitusData(
+                    areas = listOf(),
                     constructionWork = true,
                     maintenanceWork = true,
                     emergencyWork = true,
@@ -123,13 +154,14 @@ class HaittojenhallintasuunnitelmaPdfEncoderTest {
                 contains("Sopimus1, Sopimus2")
                 contains("Kyllä")
             }
-            verifySequence { mapGenerator.mapWithAreas(hakemusData.areas!!, listOf(), 2220, 800) }
+            verifySequence { mapGenerator.mapWithAreas(listOf(), listOf(), 2220, 800, any()) }
         }
 
         @Test
         fun `created PDF doesn't have this work involves fields if none are selected`() {
             val hakemusData =
                 HakemusFactory.createKaivuilmoitusData(
+                    areas = listOf(),
                     constructionWork = false,
                     maintenanceWork = false,
                     emergencyWork = false,
@@ -142,12 +174,12 @@ class HaittojenhallintasuunnitelmaPdfEncoderTest {
                 doesNotContain("Olemassaolevan rakenteen kunnossapitotyöstä")
                 doesNotContain("välttämiseksi")
             }
-            verifySequence { mapGenerator.mapWithAreas(hakemusData.areas!!, listOf(), 2220, 800) }
+            verifySequence { mapGenerator.mapWithAreas(listOf(), listOf(), 2220, 800, any()) }
         }
 
         @Test
         fun `created PDF contains headers for area information`() {
-            val hakemusData = HakemusFactory.createKaivuilmoitusData()
+            val hakemusData = HakemusFactory.createKaivuilmoitusData(areas = listOf())
 
             val pdfData = haittojenhallintasuunnitelmaPdfEncoder.createPdf(hanke, hakemusData, 614f)
 
@@ -156,7 +188,7 @@ class HaittojenhallintasuunnitelmaPdfEncoderTest {
                 contains("Työn alkupäivämäärä")
                 contains("Työn loppupäivämäärä")
             }
-            verifySequence { mapGenerator.mapWithAreas(hakemusData.areas!!, listOf(), 2220, 800) }
+            verifySequence { mapGenerator.mapWithAreas(listOf(), listOf(), 2220, 800, any()) }
         }
 
         @Test
@@ -175,7 +207,80 @@ class HaittojenhallintasuunnitelmaPdfEncoderTest {
                 contains("18.11.2022")
                 contains("28.11.2022")
             }
-            verifySequence { mapGenerator.mapWithAreas(hakemusData.areas!!, listOf(), 2220, 800) }
+            verifySequence { mapGenerator.mapWithAreas(listOf(), listOf(), 2220, 800, any()) }
+        }
+
+        @Test
+        fun `contains headers for haittojenhallintasuunnitelma when hankealue matches with hakemusalue`() {
+            val hakemusData = HakemusFactory.createKaivuilmoitusData(areas = hakemusalueet)
+
+            val pdfData = haittojenhallintasuunnitelmaPdfEncoder.createPdf(hanke, hakemusData, 614f)
+
+            assertThat(getPdfAsText(pdfData).replace("\\s+".toRegex(), " ")).all {
+                contains("Toimet työalueiden haittojen hallintaan, $hankealueNimi")
+                contains("Linja-autojen paikallisliikenne, $hankealueNimi")
+                contains("Autoliikenteen ruuhkautuminen, $hankealueNimi")
+                contains("Pyöräliikenteen merkittävyys, $hankealueNimi")
+                contains("Raitiovaunuliikenne, $hankealueNimi")
+                contains("Muut haittojenhallintatoimet, $hankealueNimi")
+                contains("Toimet työalueiden haittojen hallintaan, $hankealueNimi2")
+                contains("Linja-autojen paikallisliikenne, $hankealueNimi2")
+                contains("Autoliikenteen ruuhkautuminen, $hankealueNimi2")
+                contains("Pyöräliikenteen merkittävyys, $hankealueNimi2")
+                contains("Raitiovaunuliikenne, $hankealueNimi2")
+                contains("Muut haittojenhallintatoimet, $hankealueNimi2")
+            }
+            verifySequence {
+                val hakemusalueet1 = listOf(hakemusalue)
+                val hankealueet1 = listOf(hankealue)
+                mapGenerator.mapWithAreas(hakemusalueet, hankealueet, 2220, 800, any())
+                mapGenerator.mapWithAreas(hakemusalueet1, hankealueet1, 1720, 608, any())
+                mapGenerator.mapWithAreas(hakemusalueet1, hankealueet1, 1720, 608, any())
+                mapGenerator.mapWithAreas(hakemusalueet1, hankealueet1, 1720, 608, any())
+                mapGenerator.mapWithAreas(hakemusalueet1, hankealueet1, 1720, 608, any())
+                val hakemusalueet2 = listOf(hakemusalue2)
+                val hankealueet2 = listOf(hankealue2)
+                mapGenerator.mapWithAreas(hakemusalueet2, hankealueet2, 1720, 608, any())
+                mapGenerator.mapWithAreas(hakemusalueet2, hankealueet2, 1720, 608, any())
+                mapGenerator.mapWithAreas(hakemusalueet2, hankealueet2, 1720, 608, any())
+                mapGenerator.mapWithAreas(hakemusalueet2, hankealueet2, 1720, 608, any())
+            }
+        }
+
+        @Test
+        fun `contains texts from haittojenhallintasuunnitelma when hankealue matches with hakemusalue`() {
+            val hakemusData =
+                HakemusFactory.createKaivuilmoitusData(areas = listOf(hakemusalue, hakemusalue2))
+
+            val pdfData = haittojenhallintasuunnitelmaPdfEncoder.createPdf(hanke, hakemusData, 614f)
+
+            assertThat(getPdfAsText(pdfData).replace("\\s+".toRegex(), " ")).all {
+                contains(HaittaFactory.DEFAULT_HHS_YLEINEN)
+                contains(HaittaFactory.DEFAULT_HHS_LINJAAUTOLIIKENNE)
+                contains(HaittaFactory.DEFAULT_HHS_AUTOLIIKENNE)
+                contains(HaittaFactory.DEFAULT_HHS_PYORALIIKENNE)
+                contains(HaittaFactory.DEFAULT_HHS_RAITIOLIIKENNE)
+                contains(HaittaFactory.DEFAULT_HHS_MUUT)
+                contains(haittojenhallintasuunnitelma2[Haittojenhallintatyyppi.YLEINEN]!!)
+                contains(haittojenhallintasuunnitelma2[Haittojenhallintatyyppi.AUTOLIIKENNE]!!)
+                contains(haittojenhallintasuunnitelma2[Haittojenhallintatyyppi.PYORALIIKENNE]!!)
+                contains("Haitaton ei ole tunnistanut hankealueelta tätä kohderyhmää")
+            }
+            verifySequence {
+                val hakemusalueet1 = listOf(hakemusalue)
+                val hankealueet1 = listOf(hankealue)
+                mapGenerator.mapWithAreas(hakemusalueet, hankealueet, 2220, 800, any())
+                mapGenerator.mapWithAreas(hakemusalueet1, hankealueet1, 1720, 608, any())
+                mapGenerator.mapWithAreas(hakemusalueet1, hankealueet1, 1720, 608, any())
+                mapGenerator.mapWithAreas(hakemusalueet1, hankealueet1, 1720, 608, any())
+                mapGenerator.mapWithAreas(hakemusalueet1, hankealueet1, 1720, 608, any())
+                val hakemusalueet2 = listOf(hakemusalue2)
+                val hankealueet2 = listOf(hankealue2)
+                mapGenerator.mapWithAreas(hakemusalueet2, hankealueet2, 1720, 608, any())
+                mapGenerator.mapWithAreas(hakemusalueet2, hankealueet2, 1720, 608, any())
+                mapGenerator.mapWithAreas(hakemusalueet2, hankealueet2, 1720, 608, any())
+                mapGenerator.mapWithAreas(hakemusalueet2, hankealueet2, 1720, 608, any())
+            }
         }
     }
 }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/pdf/HaittojenhallintasuunnitelmaPdfEncoderTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/pdf/HaittojenhallintasuunnitelmaPdfEncoderTest.kt
@@ -221,13 +221,13 @@ class HaittojenhallintasuunnitelmaPdfEncoderTest {
                 contains("Linja-autojen paikallisliikenne, $hankealueNimi")
                 contains("Autoliikenteen ruuhkautuminen, $hankealueNimi")
                 contains("Pyöräliikenteen merkittävyys, $hankealueNimi")
-                contains("Raitiovaunuliikenne, $hankealueNimi")
+                contains("Raitioliikenne, $hankealueNimi")
                 contains("Muut haittojenhallintatoimet, $hankealueNimi")
                 contains("Toimet työalueiden haittojen hallintaan, $hankealueNimi2")
                 contains("Linja-autojen paikallisliikenne, $hankealueNimi2")
                 contains("Autoliikenteen ruuhkautuminen, $hankealueNimi2")
                 contains("Pyöräliikenteen merkittävyys, $hankealueNimi2")
-                contains("Raitiovaunuliikenne, $hankealueNimi2")
+                contains("Raitioliikenne, $hankealueNimi2")
                 contains("Muut haittojenhallintatoimet, $hankealueNimi2")
             }
             verifySequence {

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/pdf/HhsManualTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/pdf/HhsManualTest.kt
@@ -12,6 +12,8 @@ import java.nio.file.Files
 import java.time.ZoneId
 import java.time.ZonedDateTime
 import kotlin.io.path.Path
+import org.geotools.http.HTTPClientFinder
+import org.geotools.http.LoggingHTTPClient
 import org.geotools.ows.wms.WebMapServer
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.params.ParameterizedTest
@@ -27,9 +29,12 @@ import org.junit.jupiter.params.provider.MethodSource
 class HhsManualTest {
 
     private val capabilityUrl =
-        "https://kartta.hel.fi/ws/geoserver/avoindata/wms?REQUEST=GetCapabilities&SERVICE=WMS&VERSION=1.1.1"
+        "https://kartta.hel.fi/ws/geoserver/avoindata/wms?REQUEST=GetCapabilities&SERVICE=WMS"
 
-    private val mapGenerator = MapGenerator(WebMapServer(URI(capabilityUrl).toURL()))
+    private val httpClient =
+        LoggingHTTPClient(HTTPClientFinder.createClient()).apply { isTryGzip = true }
+    private val uri = URI(capabilityUrl).toURL()
+    private val mapGenerator = MapGenerator(WebMapServer(uri, httpClient))
     private val haittojenhallintasuunnitelmaPdfEncoder =
         HaittojenhallintasuunnitelmaPdfEncoder(mapGenerator)
 
@@ -48,12 +53,16 @@ class HhsManualTest {
     private val montaAluetta: List<KaivuilmoitusAlue> =
         "/fi/hel/haitaton/hanke/pdf-test-data/many-areas.json".asJsonResource()
 
+    private val montaHankealuetta: List<KaivuilmoitusAlue> =
+        "/fi/hel/haitaton/hanke/pdf-test-data/many-hankealue.json".asJsonResource()
+
     private fun alueet(): List<Arguments> =
         listOf(
             Arguments.of("pystysuora", pystysuora),
             Arguments.of("vaakasuora", vaakasuora),
             Arguments.of("pieniAlue", pieniAlue),
             Arguments.of("montaAluetta", montaAluetta),
+            Arguments.of("montaHankealuetta", montaHankealuetta),
         )
 
     @ParameterizedTest(name = "{displayName} {0}")

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/pdf/HhsManualTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/pdf/HhsManualTest.kt
@@ -15,6 +15,7 @@ import kotlin.io.path.Path
 import org.geotools.http.HTTPClientFinder
 import org.geotools.http.LoggingHTTPClient
 import org.geotools.ows.wms.WebMapServer
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
@@ -26,6 +27,7 @@ import org.junit.jupiter.params.provider.MethodSource
  * This test should be removed when the HAI-375 story is completed.
  */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@Disabled
 class HhsManualTest {
 
     private val capabilityUrl =

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/pdf/NuisanceColorTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/pdf/NuisanceColorTest.kt
@@ -1,0 +1,89 @@
+package fi.hel.haitaton.hanke.pdf
+
+import assertk.assertThat
+import assertk.assertions.isSameInstanceAs
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class NuisanceColorTest {
+
+    @Nested
+    inner class SelectColorStyle {
+        @Test
+        fun `returns blue when parameter is null`() {
+            val result = NuisanceColor.selectColor(null)
+
+            assertThat(result).isSameInstanceAs(NuisanceColor.BLUE)
+        }
+
+        @Test
+        fun `returns blue when parameter is Not a Number`() {
+            val result = NuisanceColor.selectColor(Float.NaN)
+
+            assertThat(result).isSameInstanceAs(NuisanceColor.BLUE)
+        }
+
+        @Test
+        fun `returns blue when parameter is negative`() {
+            val result = NuisanceColor.selectColor(-0.001f)
+
+            assertThat(result).isSameInstanceAs(NuisanceColor.BLUE)
+        }
+
+        @Test
+        fun `returns gray when index is zero`() {
+            val result = NuisanceColor.selectColor(0f)
+
+            assertThat(result).isSameInstanceAs(NuisanceColor.GRAY)
+        }
+
+        @Test
+        fun `returns green when index is just above zero`() {
+            val result = NuisanceColor.selectColor(0.001f)
+
+            assertThat(result).isSameInstanceAs(NuisanceColor.GREEN)
+        }
+
+        @Test
+        fun `returns green when index is just below three`() {
+            val result = NuisanceColor.selectColor(2.99f)
+
+            assertThat(result).isSameInstanceAs(NuisanceColor.GREEN)
+        }
+
+        @Test
+        fun `returns yellow when index is exactly three`() {
+            val result = NuisanceColor.selectColor(3f)
+
+            assertThat(result).isSameInstanceAs(NuisanceColor.YELLOW)
+        }
+
+        @Test
+        fun `returns yellow when index is just below four`() {
+            val result = NuisanceColor.selectColor(3.999f)
+
+            assertThat(result).isSameInstanceAs(NuisanceColor.YELLOW)
+        }
+
+        @Test
+        fun `returns red when index is exactly four`() {
+            val result = NuisanceColor.selectColor(4.0f)
+
+            assertThat(result).isSameInstanceAs(NuisanceColor.RED)
+        }
+
+        @Test
+        fun `returns red when index is 5`() {
+            val result = NuisanceColor.selectColor(5.0f)
+
+            assertThat(result).isSameInstanceAs(NuisanceColor.RED)
+        }
+
+        @Test
+        fun `returns red when index is way above five`() {
+            val result = NuisanceColor.selectColor(999f)
+
+            assertThat(result).isSameInstanceAs(NuisanceColor.RED)
+        }
+    }
+}

--- a/services/hanke-service/src/test/resources/fi/hel/haitaton/hanke/pdf-test-data/many-hankealue.json
+++ b/services/hanke-service/src/test/resources/fi/hel/haitaton/hanke/pdf-test-data/many-hankealue.json
@@ -446,5 +446,159 @@
       "RAITIOLIIKENNE": "Äiti kyllä koetti sekä nuhteilla että kurilla saattaa heitä työhön ja ahkeruuteen, mutta heidän uppiniskaisuutensa oli jäykkä vastus kaikille hänen yrityksillensä. Oli hän muutoin kelpo vaimo; tunnettu oli hänen suora ja vilpitön ehkä hieman jyrkkä mielensä. Kelpo mies oli myös hänen veljensä, poikien oiva eno, joka nuoruudessaan oli uljaana merimiehenä, purjehtinut kaukaiset meret, nähnyt monta kansaa ja kaupunkia; mutta näkönsäpä kadotti hän viimein, käyden umpisokeaksi, ja vietti ikänsä pimeät päivät Jukolan talossa. Hän silloin usein, veistellen tunteensa viittauksen mukaan kauhoja, lusikoita, kirvesvarsia, kurikkoja ja muita huoneessa tarpeellisia kaluja, kertoili sisarensa pojille tarinoita ja merkillisiä asioita sekä omasta maasta että vieraista valtakunnista, kertoili myös ihmeitä ja tapauksia raamatusta. Näitä hänen jutelmiansa kuultelivat pojat kaikella hartaudella ja painoivat lujasti muistoonsa. Mutta yhtä mieluisasti eivät he kuullelleetkaan äitinsä käskyjä ja nuhteita, vaan olivatpa kovakorvaisia vallan, huolimatta monestakaan pieksiäislöylystä. Useinpa kyllä, huomatessaan selkäsaunan lähestyvän, vilkasi veliparvi karkutielle, saattaen tämän kautta sekä äitillensä että muille murhetta ja kiusaa, ja sillä omaa asiaansa pahentaen.",
       "LINJAAUTOLIIKENNE": "Tässä olkoon kerrottu eräs tapaus veljesten lapsuudesta. He tiesivät kototalonsa riihen alla kananpesän, jonka omistaja oli eräs eukko, kutsuttu »Männistön muoriksi»; sillä hänen pieni mökkinsä seisoi männistössä lähellä Jukolaa. Johtui kerran veljesten mieleen paistetut munat, ja päättivät he lopulta riistää pesän ja lähteä metsään nauttimaan saaliistansa. He täyttivät myös päätöksensä, tyhjensivät pesän ja läksivät yksimielisesti metsään, kuusi veljestä; Eero pyöri silloin vielä äitinsä jalkain juurella. Mutta koska he ehtivät eräälle solisevalle ojalle pimeässä kuusistossa, rakensivat he valkean äyräälle, käärivät munat ryysyihin, kastoivat ne veteen ja panivat paistumaan kihisevään tuhkaan. Ja kun herkut olivat viimein kypsyneet, söivät he maittavan atrian ja astelivat siitä tyytyväisinä kotiansa taas. Mutta kotomäelle ehdittyä, kohtasi heitä hirmumyrsky; sillä olipa jo heidän tekonsa tullut ilmi. Männistön muori ärhenteli ja riehui, ja kiivaalla katsannolla kiirehti veljeksiä vastaan heidän äitinsä, kädessä vinkuva ruoska. Mutta eivätpä mielineetkään pojat käydä kohden tuota vihuria, vaan kääntyivät takaisin ja pakenivat jälleen metsien turvaan, huolimatta äitinsä huudoista."
     }
+  },
+  {
+    "name": "Hankealue 4",
+    "hankealueId": 106,
+    "tyoalueet": [
+      {
+        "geometry": {
+          "type": "Polygon",
+          "crs": {
+            "type": "name",
+            "properties": {
+              "name": "urn:ogc:def:crs:EPSG::3879"
+            }
+          },
+          "coordinates": [
+            [
+              [
+                25497473.99385086,
+                6673378.826759577
+              ],
+              [
+                25497474.784632027,
+                6673378.348939784
+              ],
+              [
+                25497475.573286522,
+                6673379.463177532
+              ],
+              [
+                25497474.421387173,
+                6673380.052215219
+              ],
+              [
+                25497473.99385086,
+                6673378.826759577
+              ]
+            ]
+          ]
+        },
+        "area": 1.4525061049297503,
+        "tormaystarkasteluTulos": {
+          "autoliikenne": {
+            "indeksi": 0,
+            "haitanKesto": 3,
+            "katuluokka": 0,
+            "liikennemaara": 0,
+            "kaistahaitta": 0,
+            "kaistapituushaitta": 0
+          },
+          "pyoraliikenneindeksi": 0,
+          "linjaautoliikenneindeksi": 0,
+          "raitioliikenneindeksi": 0,
+          "liikennehaittaindeksi": {
+            "indeksi": 0,
+            "tyyppi": "LINJAAUTOLIIKENNEINDEKSI"
+          }
+        }
+      }
+    ],
+    "katuosoite": "Kaivokatu 12",
+    "tyonTarkoitukset": [
+      "SAHKO"
+    ],
+    "meluhaitta": "EI_MELUHAITTAA",
+    "polyhaitta": "EI_POLYHAITTAA",
+    "tarinahaitta": "EI_TARINAHAITTAA",
+    "kaistahaitta": "EI_VAIKUTA",
+    "kaistahaittojenPituus": "EI_VAIKUTA_KAISTAJARJESTELYIHIN",
+    "lisatiedot": "",
+    "haittojenhallintasuunnitelma": {
+      "MUUT": "Ei täällä paljoa haittoja pääse syntymään.",
+      "YLEINEN": "Ei täällä paljoa haittoja pääse syntymään.",
+      "AUTOLIIKENNE": "",
+      "PYORALIIKENNE": "",
+      "RAITIOLIIKENNE": "",
+      "LINJAAUTOLIIKENNE": ""
+    }
+  },
+  {
+    "name": "Hankealue 1",
+    "hankealueId": 103,
+    "tyoalueet": [
+      {
+        "geometry": {
+          "type": "Polygon",
+          "crs": {
+            "type": "name",
+            "properties": {
+              "name": "urn:ogc:def:crs:EPSG::3879"
+            }
+          },
+          "coordinates": [
+            [
+              [
+                25496400,
+                6673000
+              ],
+              [
+                25496900,
+                6672950
+              ],
+              [
+                25497000,
+                6673100
+              ],
+              [
+                25496500,
+                6673150
+              ],
+              [
+                25496400,
+                6673000
+              ]
+            ]
+          ]
+        },
+        "area": 17435.08397593583,
+        "tormaystarkasteluTulos": {
+          "autoliikenne": {
+            "indeksi": 2.3,
+            "haitanKesto": 3,
+            "katuluokka": 4,
+            "liikennemaara": 5,
+            "kaistahaitta": 0,
+            "kaistapituushaitta": 0
+          },
+          "pyoraliikenneindeksi": 3,
+          "linjaautoliikenneindeksi": 5,
+          "raitioliikenneindeksi": 5,
+          "liikennehaittaindeksi": {
+            "indeksi": 5,
+            "tyyppi": "LINJAAUTOLIIKENNEINDEKSI"
+          }
+        }
+      }
+    ],
+    "katuosoite": "Kaivokatu 12",
+    "tyonTarkoitukset": [
+      "SAHKO"
+    ],
+    "meluhaitta": "EI_MELUHAITTAA",
+    "polyhaitta": "EI_POLYHAITTAA",
+    "tarinahaitta": "EI_TARINAHAITTAA",
+    "kaistahaitta": "EI_VAIKUTA",
+    "kaistahaittojenPituus": "EI_VAIKUTA_KAISTAJARJESTELYIHIN",
+    "lisatiedot": "",
+    "haittojenhallintasuunnitelma": {
+      "MUUT": "Mieleni minun tekevi, aivoni ajattelevi lähteäni laulamahan, saa'ani sanelemahan, sukuvirttä suoltamahan, lajivirttä laulamahan. Sanat suussani sulavat, puhe'et putoelevat, kielelleni kerkiävät, hampahilleni hajoovat.",
+      "YLEINEN": "Veli kulta, veikkoseni, kaunis kasvinkumppalini! Lähe nyt kanssa laulamahan, saa kera sanelemahan yhtehen yhyttyämme, kahta'alta käytyämme! Harvoin yhtehen yhymme, saamme toinen toisihimme näillä raukoilla rajoilla, poloisilla Pohjan mailla.",
+      "AUTOLIIKENNE": "Lyökämme käsi kätehen, sormet sormien lomahan, lauloaksemme hyviä, parahia pannaksemme, kuulla noien kultaisien, tietä mielitehtoisien, nuorisossa nousevassa, kansassa kasuavassa: noita saamia sanoja, virsiä virittämiä vyöltä vanhan Väinämöisen, alta ahjon Ilmarisen, päästä kalvan Kaukomielen, Joukahaisen jousen tiestä, Pohjan peltojen periltä, Kalevalan kankahilta.",
+      "PYORALIIKENNE": "Niit' ennen isoni lauloi kirvesvartta vuollessansa; niitä äitini opetti väätessänsä värttinätä, minun lasna lattialla eessä polven pyöriessä, maitopartana pahaisna, piimäsuuna pikkaraisna. Sampo ei puuttunut sanoja eikä Louhi luottehia: vanheni sanoihin sampo, katoi Louhi luottehisin, virsihin Vipunen kuoli, Lemminkäinen leikkilöihin.",
+      "RAITIOLIIKENNE": "Viel' on muitaki sanoja, ongelmoita oppimia: tieohesta tempomia, kanervoista katkomia, risukoista riipomia, vesoista vetelemiä, päästä heinän hieromia, raitiolta ratkomia, paimenessa käyessäni, lasna karjanlaitumilla, metisillä mättähillä, kultaisilla kunnahilla, mustan Muurikin jälessä, Kimmon kirjavan keralla.",
+      "LINJAAUTOLIIKENNE": "Vilu mulle virttä virkkoi, sae saatteli runoja. Virttä toista tuulet toivat, meren aaltoset ajoivat. Linnut liitteli sanoja, puien latvat lausehia."
+    }
   }
 ]


### PR DESCRIPTION
# Description

Add the actual haittojenhallintasuunnitelma from the application when creating a new haittojenhallintasuunnitelma PDF. Add a map for each transport mode, colored according to the haitta it causes.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-3354

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
Send a kaivuilmoitus to Allu and check the attachment in Allu. There's also a temporary test that creates example PDFs.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: