### PR TITLE
HAI-3369 Use UBI9 baseimages

### DIFF
--- a/services/hanke-service/Dockerfile-local
+++ b/services/hanke-service/Dockerfile-local
@@ -1,5 +1,7 @@
-FROM public.ecr.aws/docker/library/eclipse-temurin:17 AS build
+FROM registry.access.redhat.com/ubi9/openjdk-17 AS build
 WORKDIR /workspace/app
+
+USER root
 
 COPY gradlew settings.gradle.kts ./
 COPY gradle/ ./gradle/
@@ -10,14 +12,15 @@ RUN --mount=type=cache,target=/root/.gradle ./gradlew --no-daemon :services:hank
 RUN mkdir -p services/hanke-service/build/dependency && \
     (cd services/hanke-service/build/dependency; jar -xf ../libs/*SNAPSHOT.jar)
 
-FROM public.ecr.aws/docker/library/eclipse-temurin:17
+FROM registry.access.redhat.com/ubi9/openjdk-17-runtime
 VOLUME /tmp
+
+WORKDIR /
 
 ARG DEPENDENCY=/workspace/app/services/hanke-service/build/dependency
 COPY --from=build ${DEPENDENCY}/BOOT-INF/lib /app/lib
 COPY --from=build ${DEPENDENCY}/META-INF /app/META-INF
 COPY --from=build ${DEPENDENCY}/BOOT-INF/classes /app
 COPY scripts/wait-for-it.sh ./
-
 
 ENTRYPOINT ["./wait-for-it.sh", "db:5432", "--timeout=50", "--strict", "--", "java", "-cp", "app:app/lib/*", "fi.hel.haitaton.hanke.ApplicationKt"]

--- a/services/hanke-service/Dockerfile-platta
+++ b/services/hanke-service/Dockerfile-platta
@@ -1,7 +1,7 @@
-# Uses different base images for build and run. RedHat Ubi stronger security policies prevent gradle builds.
-
 # Stage 1: Build application
-FROM public.ecr.aws/docker/library/eclipse-temurin:17 AS build
+FROM registry.access.redhat.com/ubi9/openjdk-17 AS build
+
+USER root
 
 # Set the working directory, copy gradle and source code
 WORKDIR /app
@@ -14,7 +14,7 @@ COPY services/hanke-service/src ./services/hanke-service/src
 RUN ./gradlew clean :services:hanke-service:assemble --stacktrace
 
 # Stage 2: Create runtime image
-FROM registry.redhat.io/ubi8/openjdk-17:latest
+FROM registry.access.redhat.com/ubi9/openjdk-17-runtime
 VOLUME /tmp
 WORKDIR /app
 COPY --from=build /app/services/hanke-service/build/libs/hanke-service*SNAPSHOT.jar hanke-service.jar


### PR DESCRIPTION
# Description

Use the recommended Red Hat Universal Base Image 9 -based images from the Red Hat registry as base images for building the hanke-service images.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-3369

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [X] Other