### PR TITLE
HAI-3365 Reset generated hankealueet when cancelling a täydennys

### DIFF
--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
@@ -40,6 +40,7 @@ import fi.hel.haitaton.hanke.valmistumisilmoitus.ValmistumisilmoitusEntity
 import fi.hel.haitaton.hanke.valmistumisilmoitus.ValmistumisilmoitusType
 import java.time.LocalDate
 import java.time.LocalDateTime
+import java.time.ZonedDateTime
 import java.util.UUID
 import kotlin.reflect.KClass
 import mu.KotlinLogging
@@ -815,7 +816,7 @@ class HakemusService(
         if (!hankeEntity.generated) {
             request.areas?.let { areas -> assertGeometryCompatibility(hankeEntity.id, areas) }
         } else if (request is JohtoselvityshakemusUpdateRequest) {
-            updateHankealueet(hankeEntity, request)
+            updateHankealueet(hankeEntity, request.areas, request.startTime, request.endTime)
         }
     }
 
@@ -847,16 +848,14 @@ class HakemusService(
     }
 
     /** Update the hanke areas based on the update request areas. */
-    private fun updateHankealueet(
+    fun updateHankealueet(
         hankeEntity: HankeEntity,
-        updateRequest: JohtoselvityshakemusUpdateRequest,
+        areas: List<JohtoselvitysHakemusalue>?,
+        startTime: ZonedDateTime?,
+        endTime: ZonedDateTime?,
     ) {
         val hankealueet =
-            HankealueService.createHankealueetFromApplicationAreas(
-                updateRequest.areas,
-                updateRequest.startTime,
-                updateRequest.endTime,
-            )
+            HankealueService.createHankealueetFromApplicationAreas(areas, startTime, endTime)
         hankeEntity.alueet.clear()
         hankeEntity.alueet.addAll(
             hankealueService.createAlueetFromCreateRequest(hankealueet, hankeEntity)


### PR DESCRIPTION
# Description

When cancelling a täydennys on a stand-alone johtoselvityshakemus (so the hanke is generated based on the application), reset the geometries of the hanke to match the original application. The hanke geometries are automatically changed if the user makes changes to the täydennys geometries, so they should be returned to the previous state if the täydennys is then cancelled.

Do this whether the täydennys is cancelled by the user or by Allu.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-3365

## Type of change

- [X] Bug fix 
- [ ] New feature 
- [ ] Other

# Instructions for testing
1. Create a täydennyspyyntö on a stand-alone johtoselvityshakemus with a generated hanke.
2. Edit the täydennys and add some new work areas.
3. The hanke should be updated with these areas.
4. Cancel the täydennys.
5. The hanke should be showing the original areas, and not the ones added in the täydennys.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 