### PR TITLE
HAI-3324 Send updated haittojenhallintasuunnitelma with täydennys

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennysServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennysServiceITest.kt
@@ -1050,8 +1050,7 @@ class TaydennysServiceITest(
                     status = ApplicationStatus.HANDLING,
                 )
             val attachments = mutableListOf<Attachment>()
-            every { alluClient.addAttachment(hakemus.alluid!!, capture(attachments)) } throws
-                AlluException()
+            justRun { alluClient.addAttachment(hakemus.alluid!!, capture(attachments)) }
 
             taydennysService.sendTaydennys(taydennys.id, USERNAME)
 
@@ -1088,7 +1087,7 @@ class TaydennysServiceITest(
                     hakemus.alluid!!,
                     status = ApplicationStatus.HANDLING,
                 )
-            justRun { alluClient.addAttachment(hakemus.alluid!!, any()) }
+            every { alluClient.addAttachment(hakemus.alluid!!, any()) } throws AlluException()
 
             val response = taydennysService.sendTaydennys(taydennys.id, USERNAME)
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
@@ -703,7 +703,7 @@ class HakemusService(
         }
     }
 
-    private fun getHaittojenhallintasuunnitelmaPdf(
+    fun getHaittojenhallintasuunnitelmaPdf(
         hankeEntity: HankeEntity,
         data: HakemusData,
     ): Attachment? {


### PR DESCRIPTION
# Description

When sending a täydennys to Allu, also send an updated haittojenhallintasuunnitelma when the application is a kaivuilmoitus. Always generate a new haittojenhallintasuunnitelma, since it also contains other information about the application besides the actual haittojenhallintasuunnitelma.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-3324

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
Send a täydennys to Allu, then check that the new haittojenhallintasuunnitelma is in Allu.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 