### PR TITLE
HAI-2089 Protect hakemusalue in hanke udpates

### DIFF
--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/GeometriaFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/GeometriaFactory.kt
@@ -37,5 +37,14 @@ object GeometriaFactory {
             .asJsonResource<Geometriat>()
             .copy(id = id)
 
+    fun create(id: Int = 1, geometria: Polygon): Geometriat {
+        val geometriat = create(id)
+        geometriat.featureCollection?.apply {
+            val feature = features.first()
+            feature.geometry = geometria
+        }
+        return geometriat
+    }
+
     fun createNew(): NewGeometriat = NewGeometriat(create().featureCollection)
 }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusBuilder.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusBuilder.kt
@@ -1,10 +1,12 @@
 package fi.hel.haitaton.hanke.factory
 
+import fi.hel.haitaton.hanke.COORDINATE_SYSTEM_URN
 import fi.hel.haitaton.hanke.HankeRepository
 import fi.hel.haitaton.hanke.allu.ApplicationStatus
 import fi.hel.haitaton.hanke.domain.SavedHankealue
 import fi.hel.haitaton.hanke.factory.ApplicationFactory.Companion.createCableReportApplicationArea
 import fi.hel.haitaton.hanke.factory.ApplicationFactory.Companion.createExcavationNotificationArea
+import fi.hel.haitaton.hanke.factory.ApplicationFactory.Companion.createTyoalue
 import fi.hel.haitaton.hanke.hakemus.ApplicationContactType
 import fi.hel.haitaton.hanke.hakemus.ApplicationType
 import fi.hel.haitaton.hanke.hakemus.Hakemus
@@ -28,6 +30,8 @@ import fi.hel.haitaton.hanke.permissions.HankekayttajaInput
 import fi.hel.haitaton.hanke.permissions.Kayttooikeustaso
 import java.security.InvalidParameterException
 import java.time.ZonedDateTime
+import org.geojson.Crs
+import org.geojson.Polygon
 
 data class HakemusBuilder(
     private var hakemusEntity: HakemusEntity,
@@ -97,18 +101,30 @@ data class HakemusBuilder(
         return this
     }
 
-    fun withArea(hankealueId: Int? = null) =
-        updateApplicationData(
-            { copy(areas = (areas ?: listOf()).plus(createCableReportApplicationArea())) },
+    fun withArea(hankealueId: Int? = null, geometry: Polygon? = null): HakemusBuilder {
+        val polygon = geometry ?: GeometriaFactory.secondPolygon()
+        return updateApplicationData(
             {
                 copy(
                     areas =
                         (areas ?: listOf()).plus(
-                            createExcavationNotificationArea(hankealueId = hankealueId ?: 0)
+                            createCableReportApplicationArea(geometry = polygon)
+                        )
+                )
+            },
+            {
+                copy(
+                    areas =
+                        (areas ?: listOf()).plus(
+                            createExcavationNotificationArea(
+                                hankealueId = hankealueId ?: 0,
+                                tyoalueet = listOf(createTyoalue(geometry = polygon)),
+                            )
                         )
                 )
             },
         )
+    }
 
     fun withStartTime(time: ZonedDateTime? = DateFactory.getStartDatetime()) =
         updateApplicationData({ copy(startTime = time) }, { copy(startTime = time) })
@@ -186,14 +202,17 @@ data class HakemusBuilder(
     }
 
     /** Set all the fields that need to be set for the application to be valid for sending. */
-    fun withMandatoryFields(hankealue: SavedHankealue? = null): HakemusBuilder =
-        when (hakemusEntity.hakemusEntityData) {
+    fun withMandatoryFields(hankealue: SavedHankealue? = null): HakemusBuilder {
+        val polygon =
+            hankealue?.geometriat?.featureCollection?.features?.single()?.geometry as Polygon?
+        polygon?.crs = Crs().apply { properties = mapOf(Pair("name", COORDINATE_SYSTEM_URN)) }
+        return when (hakemusEntity.hakemusEntityData) {
             is JohtoselvityshakemusEntityData ->
                 withName(ApplicationFactory.DEFAULT_APPLICATION_NAME)
                     .withWorkDescription(ApplicationFactory.DEFAULT_WORK_DESCRIPTION)
                     .withStartTime()
                     .withEndTime()
-                    .withArea()
+                    .withArea(geometry = polygon)
                     .withRockExcavation(false)
                     .hakija()
                     .tyonSuorittaja(founder())
@@ -202,7 +221,7 @@ data class HakemusBuilder(
                     .withWorkDescription(ApplicationFactory.DEFAULT_WORK_DESCRIPTION)
                     .withStartTime()
                     .withEndTime()
-                    .withArea(hankealue?.id)
+                    .withArea(hankealue?.id, polygon)
                     .withCableReports(
                         listOf(ApplicationFactory.DEFAULT_CABLE_REPORT_APPLICATION_IDENTIFIER)
                     )
@@ -212,6 +231,7 @@ data class HakemusBuilder(
                     .tyonSuorittaja(founder())
                     .withInvoicingCustomer()
         }
+    }
 
     /**
      * Make the hakemus appear like it has been just sent. I.e. it has mandatory fields and allu


### PR DESCRIPTION
# Description

When updating a hanke, check that all hakemusalue are still inside valid hankealue. For johtoselvityshakemus this means that every hakemusalue needs to be inside some hankealue. For kaivuilmoitus, each työalue is inside the hankealue it's created for.

This also solves HAI-917 and HAI-2091.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2089

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
Create a hanke with several hankealue. Add a johtoselvityshakemus and a kaivuilmoitus to the hankealue. You should be able to expand the hankealue, but not delete or make them smaller.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 