### PR TITLE
HAI-1243 Refactor `isInsideHankeAlue` to return the matching IDs

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/geometria/GeometriatDaoITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/geometria/GeometriatDaoITest.kt
@@ -2,12 +2,12 @@ package fi.hel.haitaton.hanke.geometria
 
 import assertk.assertAll
 import assertk.assertThat
+import assertk.assertions.containsExactly
 import assertk.assertions.isCloseTo
+import assertk.assertions.isEmpty
 import assertk.assertions.isEqualTo
-import assertk.assertions.isFalse
 import assertk.assertions.isNotNull
 import assertk.assertions.isNull
-import assertk.assertions.isTrue
 import fi.hel.haitaton.hanke.IntegrationTest
 import fi.hel.haitaton.hanke.asJsonResource
 import fi.hel.haitaton.hanke.factory.GeometriaFactory
@@ -107,50 +107,58 @@ internal class GeometriatDaoITest : IntegrationTest() {
     }
 
     @Test
-    fun `isInsideHankeAlueet returns false if there's no hanke with that id`() {
-        val result = geometriatDao.isInsideHankeAlueet(5, aleksanterinPatsas)
+    fun `matchingHankealueet returns empty if there's no hanke with that id`() {
+        val result = geometriatDao.matchingHankealueet(5, aleksanterinPatsas)
 
-        assertThat(result).isFalse()
+        assertThat(result).isEmpty()
     }
 
     @Test
     @Sql("/sql/alueeton-hanke.sql")
-    fun `isInsideHankeAlueet returns false if hanke has no alueet`() {
-        val result = geometriatDao.isInsideHankeAlueet(5, aleksanterinPatsas)
+    fun `matchingHankealueet returns empty if hanke has no alueet`() {
+        val result = geometriatDao.matchingHankealueet(5, aleksanterinPatsas)
 
-        assertThat(result).isFalse()
+        assertThat(result).isEmpty()
     }
 
     @Test
     @Sql("/sql/senaatintorin-hanke.sql")
-    fun `isInsideHankeAlueet returns true when the object is inside a hanke alue`() {
-        val result = geometriatDao.isInsideHankeAlueet(5, aleksanterinPatsas)
+    fun `matchingHankealueet returns hankealue id when the object is inside a hanke alue`() {
+        val result = geometriatDao.matchingHankealueet(5, aleksanterinPatsas)
 
-        assertThat(result).isTrue()
+        assertThat(result).containsExactly(23)
     }
 
     @Test
     @Sql("/sql/senaatintorin-hanke.sql")
-    fun `isInsideHankeAlueet returns false when the object is outside all hanke alueet`() {
-        val result = geometriatDao.isInsideHankeAlueet(5, havisAmanda)
+    fun `matchingHankealueet returns empty when the object is outside all hanke alueet`() {
+        val result = geometriatDao.matchingHankealueet(5, havisAmanda)
 
-        assertThat(result).isFalse()
+        assertThat(result).isEmpty()
     }
 
     @Test
     @Sql("/sql/senaatintorin-hanke.sql")
-    fun `isInsideHankeAlueet returns false when the object is partly outside every hanke alue`() {
-        val result = geometriatDao.isInsideHankeAlueet(5, tuomiokirkonPortaat)
+    fun `matchingHankealueet returns empty when the object is partly outside every hanke alue`() {
+        val result = geometriatDao.matchingHankealueet(5, tuomiokirkonPortaat)
 
-        assertThat(result).isFalse()
+        assertThat(result).isEmpty()
     }
 
     @Test
     @Sql("/sql/senaatintorin-hanke.sql")
-    fun `isInsideHankeAlueet returns true when the object perfectly matches a hanke alue`() {
-        val result = geometriatDao.isInsideHankeAlueet(5, senaatintori)
+    fun `matchingHankealueet returns hankealue id when the object perfectly matches a hanke alue`() {
+        val result = geometriatDao.matchingHankealueet(5, senaatintori)
 
-        assertThat(result).isTrue()
+        assertThat(result).containsExactly(23)
+    }
+
+    @Test
+    @Sql("/sql/monen-alueen-hanke.sql")
+    fun `matchingHankealueet returns all matching hankealue id when there are several hankealue`() {
+        val result = geometriatDao.matchingHankealueet(5, aleksanterinPatsas)
+
+        assertThat(result).containsExactly(23, 24)
     }
 
     private fun getGeometriaCount(): Int? =

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceITest.kt
@@ -714,12 +714,12 @@ class HakemusServiceITest(
             val hanke = hankeRepository.findAll().single()
             hankeRepository.save(hanke.apply { alueet = mutableListOf() })
             assertThat(
-                    geometriatDao.isInsideHankeAlueet(
+                    geometriatDao.matchingHankealueet(
                         hanke.id,
                         areas.single().geometries().single(),
                     )
                 )
-                .isFalse()
+                .isEmpty()
             every { alluClient.create(any()) } returns alluId
             justRun { alluClient.addAttachment(alluId, any()) }
             every { alluClient.getApplicationInformation(alluId) } returns

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
@@ -832,7 +832,7 @@ class HakemusService(
 
     /** For cable report we check that the geometry is inside any of the hanke areas. */
     private fun assertGeometryCompatibility(hankeId: Int, area: JohtoselvitysHakemusalue) {
-        if (!geometriatDao.isInsideHankeAlueet(hankeId, area.geometry))
+        if (geometriatDao.matchingHankealueet(hankeId, area.geometry).isEmpty())
             throw HakemusGeometryNotInsideHankeException(area.geometry)
     }
 

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceTest.kt
@@ -160,7 +160,7 @@ class HakemusServiceTest {
             every { alluClient.create(any()) } returns alluId
             every { alluClient.getApplicationInformation(alluId) } returns
                 AlluFactory.createAlluApplicationResponse()
-            every { geometriatDao.isInsideHankeAlueet(1, any()) } returns true
+            every { geometriatDao.matchingHankealueet(1, any()) } returns listOf(1)
             every { geometriatDao.calculateCombinedArea(any()) } returns 11.0f
             every { geometriatDao.calculateArea(any()) } returns 11.0f
             every { attachmentService.getMetadataList(applicationEntity.id) } returns listOf()
@@ -250,7 +250,7 @@ class HakemusServiceTest {
 
             verifySequence {
                 hakemusRepository.findOneById(3)
-                geometriatDao.isInsideHankeAlueet(1, any())
+                geometriatDao.matchingHankealueet(1, any())
                 attachmentService.getMetadataList(applicationEntity.id)
                 geometriatDao.calculateCombinedArea(any())
                 geometriatDao.calculateArea(any())
@@ -272,14 +272,14 @@ class HakemusServiceTest {
             every { attachmentService.getMetadataList(applicationEntity.id) } returns listOf()
             every { geometriatDao.calculateCombinedArea(any()) } returns 11.0f
             every { alluClient.create(any()) } throws AlluException()
-            every { geometriatDao.isInsideHankeAlueet(1, any()) } returns true
+            every { geometriatDao.matchingHankealueet(1, any()) } returns listOf(1)
             callRealWrapper()
 
             assertThrows<AlluException> { hakemusService.sendHakemus(3, null, USERNAME) }
 
             verifySequence {
                 hakemusRepository.findOneById(3)
-                geometriatDao.isInsideHankeAlueet(1, any())
+                geometriatDao.matchingHankealueet(1, any())
                 attachmentService.getMetadataList(applicationEntity.id)
                 geometriatDao.calculateCombinedArea(any())
                 geometriatDao.calculateArea(any())
@@ -298,7 +298,7 @@ class HakemusServiceTest {
         fun `does not save disclosure logs when allu login fails`() {
             val applicationEntity = applicationEntity()
             every { hakemusRepository.findOneById(3) } returns applicationEntity
-            every { geometriatDao.isInsideHankeAlueet(any(), any()) } returns true
+            every { geometriatDao.matchingHankealueet(1, any()) } returns listOf(1)
             every { geometriatDao.calculateCombinedArea(any()) } returns 11.0f
             every { geometriatDao.calculateArea(any()) } returns 11.0f
             every { attachmentService.getMetadataList(applicationEntity.id) } returns listOf()
@@ -309,7 +309,7 @@ class HakemusServiceTest {
 
             verifySequence {
                 hakemusRepository.findOneById(3)
-                geometriatDao.isInsideHankeAlueet(any(), any())
+                geometriatDao.matchingHankealueet(any(), any())
                 attachmentService.getMetadataList(applicationEntity.id)
                 geometriatDao.calculateCombinedArea(any())
                 geometriatDao.calculateArea(any())
@@ -331,7 +331,7 @@ class HakemusServiceTest {
                 )
             every { hakemusRepository.findOneById(3) } returns applicationEntity
             every { hakemusRepository.save(any()) } answers { firstArg() }
-            every { geometriatDao.isInsideHankeAlueet(1, any()) } returns true
+            every { geometriatDao.matchingHankealueet(1, any()) } returns listOf(1)
             every { geometriatDao.calculateCombinedArea(any()) } returns 11.0f
             every { geometriatDao.calculateArea(any()) } returns 11.0f
             every { attachmentService.getMetadataList(applicationEntity.id) } returns listOf()
@@ -351,7 +351,7 @@ class HakemusServiceTest {
             assertThat(sent.clientApplicationKind).isEqualTo(expectedDescription)
             verifySequence {
                 hakemusRepository.findOneById(3)
-                geometriatDao.isInsideHankeAlueet(1, any())
+                geometriatDao.matchingHankealueet(1, any())
                 attachmentService.getMetadataList(applicationEntity.id)
                 geometriatDao.calculateCombinedArea(any())
                 geometriatDao.calculateArea(any())

--- a/services/hanke-service/src/test/resources/sql/monen-alueen-hanke.sql
+++ b/services/hanke-service/src/test/resources/sql/monen-alueen-hanke.sql
@@ -1,0 +1,170 @@
+-- Create a hanke with several hankealue some of which cover the Senaatintori square
+INSERT INTO hanke (id,
+                   hanketunnus,
+                   nimi,
+                   kuvaus,
+                   vaihe,
+                   onykthanke,
+                   version,
+                   createdbyuserid,
+                   createdat,
+                   modifiedbyuserid,
+                   modifiedat,
+                   tyomaakatuosoite,
+                   status,
+                   generated)
+VALUES (5,
+        'HAI23-5',
+        'Neliöhanke',
+        'Neliöhanke',
+        'OHJELMOINTI',
+        false,
+        1,
+        '5296012a-117d-11ed-96cc-0a580a820245',
+        '2023-03-07 16:24:01.562893',
+        '5296012a-117d-11ed-96cc-0a580a820245',
+        '2023-03-07 16:24:20.847656',
+        'Senaatintori',
+        'DRAFT',
+        false);
+
+INSERT INTO geometriat(id, version, createdbyuserid, createdat)
+VALUES (15, 1, '5296012a-117d-11ed-96cc-0a580a820245', '2023-03-07 16:24:20.842');
+
+-- Geometry from senaatintori.json
+INSERT INTO hankegeometria (id, hankegeometriatid, parametrit, geometria)
+VALUES (25,
+        15,
+        '{
+          "hankeTunnus": "HAI23-5"
+        }',
+        ST_GeomFromGeoJSON('{"type":"Polygon","crs":{"type":"name","properties":{"name":"EPSG:3879"}},"coordinates":[[[25497412.79,6673005.42],[25497281.43,6672999.77],[25497286.55,6672914.96],[25497418.13,6672920.2],[25497412.79,6673005.42]]]}'));
+
+INSERT INTO hankealue(id,
+                      haittaalkupvm,
+                      haittaloppupvm,
+                      kaistahaitta,
+                      kaistapituushaitta,
+                      meluhaitta,
+                      polyhaitta,
+                      tarinahaitta,
+                      geometriat,
+                      hankeid,
+                      nimi)
+VALUES (23,
+        '2024-11-18',
+        '2024-11-24',
+        0,
+        0,
+        0,
+        0,
+        0,
+        15,
+        5,
+        'Senaatintori');
+
+INSERT INTO geometriat(id, version, createdbyuserid, createdat)
+VALUES (16, 1, '5296012a-117d-11ed-96cc-0a580a820245', '2023-03-07 16:24:20.842');
+
+-- Geometry from aleksanterin-patsas.json, inside senaatintori.json
+INSERT INTO hankegeometria (id, hankegeometriatid, parametrit, geometria)
+VALUES (26,
+        16,
+        '{
+          "hankeTunnus": "HAI23-5"
+        }',
+        ST_GeomFromGeoJSON('{"type":"Polygon","crs":{"type":"name","properties":{"name":"urn:ogc:def:crs:EPSG::3879"}},"coordinates":[[[25497359.518652536,6672969.5525672035],[25497339.943859655,6672968.432023809],[25497341.06440305,6672948.857230929],[25497360.63919593,6672949.977774323],[25497359.518652536,6672969.5525672035]]]}'));
+
+INSERT INTO hankealue(id,
+                      haittaalkupvm,
+                      haittaloppupvm,
+                      kaistahaitta,
+                      kaistapituushaitta,
+                      meluhaitta,
+                      polyhaitta,
+                      tarinahaitta,
+                      geometriat,
+                      hankeid,
+                      nimi)
+VALUES (24,
+        '2024-12-18',
+        '2024-12-24',
+        0,
+        0,
+        0,
+        0,
+        0,
+        16,
+        5,
+        'Aleksanterin patsas');
+
+
+INSERT INTO geometriat(id, version, createdbyuserid, createdat)
+VALUES (17, 1, '5296012a-117d-11ed-96cc-0a580a820245', '2023-03-07 16:24:20.842');
+
+-- Geometry from havis-amanda.json, outside senaatintori.json
+INSERT INTO hankegeometria (id, hankegeometriatid, parametrit, geometria)
+VALUES (27,
+        17,
+        '{
+          "hankeTunnus": "HAI23-5"
+        }',
+        ST_GeomFromGeoJSON('{"type":"Polygon","crs":{"type":"name","properties":{"name":"urn:ogc:def:crs:EPSG::3879"}},"coordinates":[[[25497310.408341587,6672755.371221568],[25497292.327081736,6672753.394765861],[25497294.303537443,6672735.313506011],[25497312.384797294,6672737.289961718],[25497310.408341587,6672755.371221568]]]}'));
+
+INSERT INTO hankealue(id,
+                      haittaalkupvm,
+                      haittaloppupvm,
+                      kaistahaitta,
+                      kaistapituushaitta,
+                      meluhaitta,
+                      polyhaitta,
+                      tarinahaitta,
+                      geometriat,
+                      hankeid,
+                      nimi)
+VALUES (27,
+        '2024-12-18',
+        '2024-12-24',
+        0,
+        0,
+        0,
+        0,
+        0,
+        17,
+        5,
+        'Havis Amanda');
+
+INSERT INTO geometriat(id, version, createdbyuserid, createdat)
+VALUES (18, 1, '5296012a-117d-11ed-96cc-0a580a820245', '2023-03-07 16:24:20.842');
+
+-- Geometry from tuomiokirkon-portaat.json, partially outside senaatintori.json
+INSERT INTO hankegeometria (id, hankegeometriatid, parametrit, geometria)
+VALUES (28,
+        18,
+        '{
+          "hankeTunnus": "HAI23-5"
+        }',
+        ST_GeomFromGeoJSON('{"type":"Polygon","crs":{"type":"name","properties":{"name":"urn:ogc:def:crs:EPSG::3879"}},"coordinates":[[[25497382.07123757,6673019.67695647],[25497310.565242782,6673017.308837434],[25497311.48615779,6672996.875358528],[25497382.65218655,6672999.631020797],[25497382.07123757,6673019.67695647]]]}'));
+
+INSERT INTO hankealue(id,
+                      haittaalkupvm,
+                      haittaloppupvm,
+                      kaistahaitta,
+                      kaistapituushaitta,
+                      meluhaitta,
+                      polyhaitta,
+                      tarinahaitta,
+                      geometriat,
+                      hankeid,
+                      nimi)
+VALUES (28,
+        '2024-12-18',
+        '2024-12-24',
+        0,
+        0,
+        0,
+        0,
+        0,
+        18,
+        5,
+        'Tuomiokirkon portaat');


### PR DESCRIPTION
# Description

Refactor `isInsideHankeAlue` to `matchingHankealueet`, so it returns a list of the hankealue IDs that cover the given geometry instead of a boolean whether any exist. This makes the function more versatile, it can be used to check other properties about the hankealueet in code.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1243

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [X] Other