### PR TITLE
HAI-1243 Add validation for hankealue dates against hakemukset

### DIFF
--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusFactory.kt
@@ -54,6 +54,9 @@ class HakemusFactory(
         return builder(userId, applicationEntity, hankeEntity.id)
     }
 
+    fun builder(hankeEntity: HankeEntity, applicationType: ApplicationType): HakemusBuilder =
+        builder(USERNAME, hankeEntity, applicationType)
+
     fun builder(
         hankeEntity: HankeEntity = hankeFactory.builder(USERNAME).withHankealue().saveEntity()
     ) = builder(USERNAME, hankeEntity)


### PR DESCRIPTION
# Description

Decline hanke updates if the dates of hanke areas no longer cover all applications of the hanke.

Consider nulls as unknown values, so all edits are allowed.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1243

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
1. Create a hanke.
2. Add an area to the hanke with dates.
3. Add a hakemus.
4. Use the hankealue dates and geometry for the hakemus.
5. Try to change the hanke area dates. You should be able to extend the dates, but not shrink them under the hakemus dates.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 