### PR TITLE
HAI Refactor GeometriatDao

### DIFF
--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/geometria/GeometriatDao.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/geometria/GeometriatDao.kt
@@ -15,197 +15,88 @@ import org.geojson.GeoJsonObject
 import org.geojson.MultiPolygon
 import org.geojson.Polygon
 import org.springframework.jdbc.core.JdbcOperations
+import org.springframework.jdbc.core.RowMapper
 import org.springframework.stereotype.Component
 
 @Component
 class GeometriatDao(private val jdbcOperations: JdbcOperations) {
 
-    companion object {
-
-        private fun saveHankeGeometriaRows(geometriat: Geometriat, jdbcOperations: JdbcOperations) {
-            val arguments: List<Array<Any>>? =
-                geometriat.featureCollection?.features?.map { feature ->
-                    arrayOf(
-                        geometriat.id!!,
-                        feature.geometry.toJsonString(),
-                        feature.properties?.toJsonString() ?: "null",
-                    )
-                }
-            val argumentTypes = intArrayOf(Types.INTEGER, Types.VARCHAR, Types.OTHER)
-            if (arguments != null) {
-                val originalSrid = geometriat.featureCollection!!.srid()
-                jdbcOperations.batchUpdate(
-                    """
-                    INSERT INTO HankeGeometria (
-                        hankeGeometriatId,
-                        geometria,
-                        parametrit
-                    ) VALUES (
-                        ?,
-                        ${
-                        if (originalSrid == SRID) {
-                            "ST_SetSRID(ST_GeomFromGeoJSON(?), $SRID)"
-                        } else {
-                            "ST_Transform(ST_SetSRID(ST_GeomFromGeoJSON(?), $originalSrid), $SRID)"
-                        }
-                    },
-                        ?
-                    )
-                    """
-                        .trimIndent(),
-                    arguments,
-                    argumentTypes,
-                )
-            }
-        }
-
-        private fun FeatureCollection.srid(): Int {
-            return this.crs?.properties?.get("name")?.toString()?.split("::")?.get(1)?.toInt()
-                ?: SRID
-        }
-
-        private fun updateGeometriat(geometriat: Geometriat, jdbcOperations: JdbcOperations) {
-            jdbcOperations.update(
-                """
-                UPDATE Geometriat
-                SET
-                    version = ?,
-                    modifiedByUserId = ?,
-                    modifiedAt = ?
-                WHERE
-                    id = ?
-            """
-                    .trimIndent()
-            ) { ps ->
-                ps.setInt(1, geometriat.version)
-                if (geometriat.modifiedByUserId != null) {
-                    ps.setString(2, geometriat.modifiedByUserId!!)
-                } else {
-                    ps.setNull(2, Types.INTEGER)
-                }
-                if (geometriat.modifiedAt != null) {
-                    ps.setTimestamp(
-                        3,
-                        Timestamp(geometriat.modifiedAt!!.toInstant().toEpochMilli()),
-                    )
-                } else {
-                    ps.setNull(3, Types.TIMESTAMP)
-                }
-                ps.setInt(4, geometriat.id!!)
-            }
-        }
-
-        private fun deleteGeometriat(geometriat: Geometriat, jdbcOperations: JdbcOperations) {
-            jdbcOperations.update("DELETE FROM Geometriat WHERE id = ?") { ps ->
-                ps.setInt(1, geometriat.id!!)
-            }
-        }
-
-        private fun deleteHankeGeometriaRows(
-            geometriat: Geometriat,
-            jdbcOperations: JdbcOperations,
-        ) {
-            jdbcOperations.execute(
-                "DELETE FROM HankeGeometria WHERE hankeGeometriatId = ${geometriat.id}"
-            )
-        }
-    }
-
     fun createGeometriat(geometriat: Geometriat): Geometriat {
-        with(jdbcOperations) {
-            val id =
-                queryForObject(
-                    """
-                    INSERT INTO Geometriat (
-                        version,
-                        createdByUserId,
-                        createdAt,
-                        modifiedByUserId,
-                        modifiedAt
-                    ) VALUES (
-                        ?,
-                        ?,
-                        ?,
-                        ?,
-                        ?
-                    )
-                    RETURNING id
-                    """
-                        .trimIndent(),
-                    { rs, _ -> rs.getInt(1) },
-                    geometriat.version,
-                    geometriat.createdByUserId,
-                    if (geometriat.createdAt != null) {
-                        Timestamp(geometriat.createdAt!!.toInstant().toEpochMilli())
-                    } else {
-                        null
-                    },
-                    geometriat.modifiedByUserId,
-                    if (geometriat.modifiedAt != null) {
-                        Timestamp(geometriat.modifiedAt!!.toInstant().toEpochMilli())
-                    } else {
-                        null
-                    },
-                )
-            geometriat.id = id
-            saveHankeGeometriaRows(geometriat, this)
-            return geometriat
-        }
+        val query =
+            """
+               INSERT INTO Geometriat (
+                   version,
+                   createdByUserId,
+                   createdAt,
+                   modifiedByUserId,
+                   modifiedAt
+               ) VALUES (
+                   ?,
+                   ?,
+                   ?,
+                   ?,
+                   ?
+               )
+               RETURNING id"""
+                .trimIndent()
+        val id =
+            jdbcOperations.queryForObject(
+                query,
+                { rs, _ -> rs.getInt(1) },
+                geometriat.version,
+                geometriat.createdByUserId,
+                geometriat.createdAt?.let { Timestamp(it.toInstant().toEpochMilli()) },
+                geometriat.modifiedByUserId,
+                geometriat.modifiedAt?.let { Timestamp(it.toInstant().toEpochMilli()) },
+            )
+        geometriat.id = id
+        saveHankeGeometriaRows(geometriat)
+        return geometriat
     }
 
     fun retrieveGeometriat(id: Int): Geometriat? {
-        with(jdbcOperations) {
-            val geometriat =
-                query(
-                        """
-                        SELECT
-                            id,
-                            version,
-                            createdByUserId,
-                            createdAt,
-                            modifiedByUserId,
-                            modifiedAt
-                        FROM Geometriat WHERE id = ?"""
-                            .trimIndent(),
-                        { rs, _ ->
-                            Geometriat(
-                                id = rs.getInt(1),
-                                featureCollection = null,
-                                version = rs.getInt(2),
-                                createdByUserId = rs.getString(3),
-                                createdAt = rs.getTimestamp(4).toInstant().atZone(TZ_UTC),
-                                modifiedByUserId = rs.getString(5),
-                                modifiedAt = rs.getTimestamp(6)?.toInstant()?.atZone(TZ_UTC),
-                            )
-                        },
-                        id,
-                    )
-                    .getOrNull(0)
-            return geometriat?.withFeatureCollection(
-                FeatureCollection().apply {
-                    features = retrieveHankeGeometriaRows(geometriat.id!!, this@with)
-                    crs = Crs().apply { properties = mapOf(Pair("name", COORDINATE_SYSTEM_URN)) }
-                }
+        val query =
+            """
+               SELECT
+                   id,
+                   version,
+                   createdByUserId,
+                   createdAt,
+                   modifiedByUserId,
+                   modifiedAt
+               FROM Geometriat WHERE id = ?"""
+                .trimIndent()
+        val rowMapper = RowMapper { rs, _ ->
+            Geometriat(
+                id = rs.getInt(1),
+                featureCollection = null,
+                version = rs.getInt(2),
+                createdByUserId = rs.getString(3),
+                createdAt = rs.getTimestamp(4).toInstant().atZone(TZ_UTC),
+                modifiedByUserId = rs.getString(5),
+                modifiedAt = rs.getTimestamp(6)?.toInstant()?.atZone(TZ_UTC),
             )
         }
+        val geometriat = jdbcOperations.query(query, rowMapper, id).getOrNull(0)
+        return geometriat?.withFeatureCollection(
+            FeatureCollection().apply {
+                features = retrieveHankeGeometriaRows(geometriat.id!!)
+                crs = Crs().apply { properties = mapOf(Pair("name", COORDINATE_SYSTEM_URN)) }
+            }
+        )
     }
 
     fun validateGeometria(geometria: GeoJsonObject): InvalidDetail? {
         val detailQuery =
             "select valid, reason, ST_AsGeoJSON(location) as location from ST_IsValidDetail(ST_GeomFromGeoJSON(?))"
-
-        return jdbcOperations
-            .query(
-                detailQuery,
-                { rs, _ ->
-                    if (!rs.getBoolean("valid")) {
-                        InvalidDetail(rs.getString("reason"), rs.getString("location"))
-                    } else {
-                        null
-                    }
-                },
-                geometria.toJsonString(),
-            )[0]
+        val rowMapper = RowMapper { rs, _ ->
+            if (!rs.getBoolean("valid")) {
+                InvalidDetail(rs.getString("reason"), rs.getString("location"))
+            } else {
+                null
+            }
+        }
+        return jdbcOperations.query(detailQuery, rowMapper, geometria.toJsonString())[0]
     }
 
     /**
@@ -279,11 +170,8 @@ class GeometriatDao(private val jdbcOperations: JdbcOperations) {
         )
     }
 
-    private fun retrieveHankeGeometriaRows(
-        geometriatId: Int,
-        jdbcOperations: JdbcOperations,
-    ): List<Feature> {
-        return jdbcOperations.query(
+    private fun retrieveHankeGeometriaRows(geometriatId: Int): List<Feature> {
+        val query =
             """
             SELECT
                 ST_AsGeoJSON(geometria),
@@ -293,38 +181,112 @@ class GeometriatDao(private val jdbcOperations: JdbcOperations) {
             WHERE
                 hankeGeometriatId = ?
             """
-                .trimIndent(),
-            { rs, _ ->
-                val geojson = rs.getString(1)
-                val paramjson = rs.getString(2)
-                Feature().apply {
-                    geometry = OBJECT_MAPPER.readValue(geojson)
-                    paramjson?.let { properties = OBJECT_MAPPER.readValue(paramjson) }
-                }
-            },
-            geometriatId,
-        )
+                .trimIndent()
+        val rowMapper = RowMapper { rs, _ ->
+            val geojson = rs.getString(1)
+            val paramjson = rs.getString(2)
+            Feature().apply {
+                geometry = OBJECT_MAPPER.readValue(geojson)
+                paramjson?.let { properties = OBJECT_MAPPER.readValue(paramjson) }
+            }
+        }
+        return jdbcOperations.query(query, rowMapper, geometriatId)
     }
 
     /** Updates geometry rows by FIRST DELETING ALL OF THEM AND THEN CREATING NEW ROWS */
     fun updateGeometriat(geometriat: Geometriat) {
-        with(jdbcOperations) {
-            // update master row
-            updateGeometriat(geometriat, this)
-            // delete old geometry rows
-            deleteHankeGeometriaRows(geometriat, this)
-            // save new geometry rows
-            saveHankeGeometriaRows(geometriat, this)
-        }
+        // update master row
+        updateGeometriatRows(geometriat)
+        // delete old geometry rows
+        deleteHankeGeometriaRows(geometriat)
+        // save new geometry rows
+        saveHankeGeometriaRows(geometriat)
     }
 
     /** Deletes geometry rows BUT DOES NOT DELETE THE MASTER ROW (Geometriat row) */
     fun deleteGeometriat(geometriat: Geometriat) {
-        with(jdbcOperations) {
-            // delete master row, hankegeometria rows are removed with cascading
-            deleteGeometriat(geometriat, this)
+        jdbcOperations.update("DELETE FROM Geometriat WHERE id = ?") { ps ->
+            ps.setInt(1, geometriat.id!!)
         }
     }
 
+    private fun saveHankeGeometriaRows(geometriat: Geometriat) {
+        val arguments: List<Array<Any>>? =
+            geometriat.featureCollection?.features?.map { feature ->
+                arrayOf(
+                    geometriat.id!!,
+                    feature.geometry.toJsonString(),
+                    feature.properties?.toJsonString() ?: "null",
+                )
+            }
+        val argumentTypes = intArrayOf(Types.INTEGER, Types.VARCHAR, Types.OTHER)
+        if (arguments != null) {
+            val originalSrid = geometriat.featureCollection!!.srid()
+            jdbcOperations.batchUpdate(
+                """
+                    INSERT INTO HankeGeometria (
+                        hankeGeometriatId,
+                        geometria,
+                        parametrit
+                    ) VALUES (
+                        ?,
+                        ${
+                    if (originalSrid == SRID) {
+                        "ST_SetSRID(ST_GeomFromGeoJSON(?), $SRID)"
+                    } else {
+                        "ST_Transform(ST_SetSRID(ST_GeomFromGeoJSON(?), $originalSrid), $SRID)"
+                    }
+                },
+                        ?
+                    )
+                    """
+                    .trimIndent(),
+                arguments,
+                argumentTypes,
+            )
+        }
+    }
+
+    private fun updateGeometriatRows(geometriat: Geometriat) {
+        jdbcOperations.update(
+            """
+                UPDATE Geometriat
+                SET
+                    version = ?,
+                    modifiedByUserId = ?,
+                    modifiedAt = ?
+                WHERE
+                    id = ?
+            """
+                .trimIndent()
+        ) { ps ->
+            ps.setInt(1, geometriat.version)
+            if (geometriat.modifiedByUserId != null) {
+                ps.setString(2, geometriat.modifiedByUserId!!)
+            } else {
+                ps.setNull(2, Types.INTEGER)
+            }
+            if (geometriat.modifiedAt != null) {
+                ps.setTimestamp(3, Timestamp(geometriat.modifiedAt!!.toInstant().toEpochMilli()))
+            } else {
+                ps.setNull(3, Types.TIMESTAMP)
+            }
+            ps.setInt(4, geometriat.id!!)
+        }
+    }
+
+    private fun deleteHankeGeometriaRows(geometriat: Geometriat) {
+        jdbcOperations.execute(
+            "DELETE FROM HankeGeometria WHERE hankeGeometriatId = ${geometriat.id}"
+        )
+    }
+
     data class InvalidDetail(val reason: String, val location: String)
+
+    companion object {
+        private fun FeatureCollection.srid(): Int {
+            return this.crs?.properties?.get("name")?.toString()?.split("::")?.get(1)?.toInt()
+                ?: SRID
+        }
+    }
 }


### PR DESCRIPTION
# Description

- Use the jdbcOperations dependency everywhere instead of sometimes passing it as a parameter.
- Move the methods that use jdbcOperations to the class from the companion object.
- Remove `with(jdbcOperations)` blocks, since jdbcOperations is always used just once.
- Move queries and row mappers to separate values, making the query calls simpler.

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [X] Other