### PR TITLE
HAI-3438 Refuse AD tokens without names

### DIFF
--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/profiili/ProfiiliService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/profiili/ProfiiliService.kt
@@ -26,10 +26,10 @@ class ProfiiliService(private val profiiliClient: ProfiiliClient) {
 
     private fun nameFromToken(credentials: Jwt): Names {
         val given: String =
-            credentials.getClaim(JwtClaims.GIVEN_NAME)
+            credentials.getClaim<String?>(JwtClaims.GIVEN_NAME)?.ifBlank { null }
                 ?: throw NameClaimNotFound(JwtClaims.GIVEN_NAME)
         val family: String =
-            credentials.getClaim(JwtClaims.FAMILY_NAME)
+            credentials.getClaim<String?>(JwtClaims.FAMILY_NAME)?.ifBlank { null }
                 ?: throw NameClaimNotFound(JwtClaims.FAMILY_NAME)
         return Names(given, family, given)
     }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/profiili/ProfiiliServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/profiili/ProfiiliServiceTest.kt
@@ -23,6 +23,9 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.NullAndEmptySource
+import org.junit.jupiter.params.provider.ValueSource
 import org.springframework.security.core.Authentication
 import org.springframework.security.core.context.SecurityContext
 import org.springframework.security.oauth2.jwt.Jwt
@@ -131,12 +134,15 @@ class ProfiiliServiceTest {
             }
         }
 
-        @Test
-        fun `throws an exception when given name not found in token`() {
+        @ParameterizedTest
+        @ValueSource(strings = [" ", " \t "])
+        @NullAndEmptySource
+        fun `throws an exception when given name not found in token`(givenName: String?) {
             val jwt =
                 Jwt.withTokenValue(AuthenticationMocks.TOKEN_VALUE)
                     .header("alg", "none")
                     .claim(JwtClaims.AMR, listOf(AmrValues.AD))
+                    .claim(JwtClaims.GIVEN_NAME, givenName)
                     .claim(JwtClaims.FAMILY_NAME, ProfiiliFactory.DEFAULT_LAST_NAME)
                     .build()
             val authentication: Authentication = mockk()
@@ -157,13 +163,16 @@ class ProfiiliServiceTest {
             }
         }
 
-        @Test
-        fun `throws an exception when family name not found in token`() {
+        @ParameterizedTest
+        @ValueSource(strings = [" ", " \t "])
+        @NullAndEmptySource
+        fun `throws an exception when family name not found in token`(familyName: String?) {
             val jwt =
                 Jwt.withTokenValue(AuthenticationMocks.TOKEN_VALUE)
                     .header("alg", "none")
                     .claim(JwtClaims.AMR, listOf(AmrValues.AD))
                     .claim(JwtClaims.GIVEN_NAME, ProfiiliFactory.DEFAULT_GIVEN_NAME)
+                    .claim(JwtClaims.FAMILY_NAME, familyName)
                     .build()
             val authentication: Authentication = mockk()
             every { authentication.credentials } returns jwt

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/security/AdGroupValidatorTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/security/AdGroupValidatorTest.kt
@@ -12,12 +12,16 @@ import fi.hel.haitaton.hanke.test.AuthenticationMocks.TOKEN_VALUE
 import fi.hel.haitaton.hanke.test.USERNAME
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
 import org.junit.jupiter.params.provider.ValueSource
 import org.springframework.security.oauth2.core.OAuth2Error
 import org.springframework.security.oauth2.core.OAuth2TokenValidatorResult
 import org.springframework.security.oauth2.jwt.Jwt
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class AdGroupValidatorTest {
 
     @ParameterizedTest
@@ -57,6 +61,47 @@ class AdGroupValidatorTest {
 
         assertThat(result).isSuccess()
     }
+
+    @ParameterizedTest
+    @MethodSource("emptyNames")
+    fun `fails when AD token has no given name information`(
+        useAdFilter: Boolean,
+        givenName: String?,
+    ) {
+        val validator = validator(useAdFilter)
+        val jwt =
+            AuthenticationMocks.adJwt(
+                adGroups = AuthenticationMocks.DEFAULT_AD_GROUPS,
+                givenName = givenName,
+            )
+
+        val result = validator.validate(jwt)
+
+        assertThat(result).hasError("Missing given_name")
+    }
+
+    @ParameterizedTest
+    @MethodSource("emptyNames")
+    fun `fails when AD token has no family name information`(
+        useAdFilter: Boolean,
+        familyName: String?,
+    ) {
+        val validator = validator(true)
+        val jwt =
+            AuthenticationMocks.adJwt(
+                adGroups = AuthenticationMocks.DEFAULT_AD_GROUPS,
+                familyName = familyName,
+            )
+
+        val result = validator.validate(jwt)
+
+        assertThat(result).hasError("Missing family_name")
+    }
+
+    private fun emptyNames(): List<Arguments> =
+        setOf(null, "", " ", " \t ").flatMap { name ->
+            listOf(Arguments.of(true, name), Arguments.of(false, name))
+        }
 
     @Nested
     inner class WithFilterEnabled {

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/security/AdGroupValidatorTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/security/AdGroupValidatorTest.kt
@@ -86,7 +86,7 @@ class AdGroupValidatorTest {
         useAdFilter: Boolean,
         familyName: String?,
     ) {
-        val validator = validator(true)
+        val validator = validator(useAdFilter)
         val jwt =
             AuthenticationMocks.adJwt(
                 adGroups = AuthenticationMocks.DEFAULT_AD_GROUPS,

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/test/AuthenticationMocks.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/test/AuthenticationMocks.kt
@@ -28,15 +28,22 @@ object AuthenticationMocks {
         every { credentials } returns adJwt(userId)
     }
 
-    fun adJwt(userId: String = USERNAME, adGroups: Collection<String> = DEFAULT_AD_GROUPS): Jwt =
-        Jwt.withTokenValue(TOKEN_VALUE)
-            .header("alg", "none")
-            .subject(userId)
-            .claim(JwtClaims.AMR, listOf(AmrValues.AD))
-            .claim(JwtClaims.GIVEN_NAME, DEFAULT_GIVEN_NAME)
-            .claim(JwtClaims.FAMILY_NAME, DEFAULT_LAST_NAME)
-            .claim(JwtClaims.AD_GROUPS, adGroups)
-            .build()
+    fun adJwt(
+        userId: String = USERNAME,
+        adGroups: Collection<String> = DEFAULT_AD_GROUPS,
+        givenName: String? = DEFAULT_GIVEN_NAME,
+        familyName: String? = DEFAULT_LAST_NAME,
+    ): Jwt {
+        val builder =
+            Jwt.withTokenValue(TOKEN_VALUE)
+                .header("alg", "none")
+                .subject(userId)
+                .claim(JwtClaims.AMR, listOf(AmrValues.AD))
+                .claim(JwtClaims.AD_GROUPS, adGroups)
+        if (givenName != null) builder.claim(JwtClaims.GIVEN_NAME, givenName)
+        if (familyName != null) builder.claim(JwtClaims.FAMILY_NAME, familyName)
+        return builder.build()
+    }
 
     /** When using this, you have to mock ProfiiliClient.getVerifiedName as well. */
     fun suomiFiLoginMock(userId: String = USERNAME): SecurityContext = mockk {


### PR DESCRIPTION
# Description

Add a check to AD token validation that checks that the token has non-blank claims for given and family names. Without them, we don't know who the user is and Haitaton can't add them to a hanke.

Also, add a check to getting a user's validated name that checks that the given and family names are not blank. There was already a check that they are present. The check shouldn't come up now that we don't even allow access to AD users without name claims, but I added it as a defence-in-depth thing.

### Jira Issue: 

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
We don't have an account to test this with, so I trust the unit tests.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 