### PR TITLE
HAI-3427 Add missing email translations for kaivuilmoitus

### DIFF
--- a/email/kaivuilmoitus-paatos.mjml
+++ b/email/kaivuilmoitus-paatos.mjml
@@ -7,9 +7,8 @@
         <mj-section>
             <mj-column>
                 <mj-text mj-class="header-txt">Kaivuilmoitukseen {{applicationIdentifier}} liittyvä päätös on
-                    ladattavissa / Kaivuilmoitukseen {{applicationIdentifier}} liittyvä päätös on
-                    ladattavissa / Kaivuilmoitukseen {{applicationIdentifier}} liittyvä päätös on
-                    ladattavissa
+                    ladattavissa / Beslut om grävningsanmälan {{applicationIdentifier}} kan laddas ner / The decision
+                    concerning an excavation notification {{applicationIdentifier}} can be downloaded
                 </mj-text>
                 <mj-text mj-class="basic-txt">
                     Jättämäänne kaivuilmoitukseen {{applicationIdentifier}} on tehty päätös.
@@ -42,12 +41,11 @@
                 <mj-divider mj-class="language-separator"/>
 
                 <mj-text mj-class="basic-txt">
-                    Jättämäänne kaivuilmoitukseen {{applicationIdentifier}} on tehty päätös.
-                    Lataa päätös Haitattomasta
-                    <a
-                            href="{{baseUrl}}/sv/ansokan/{{applicationId}}">{{baseUrl}}/sv/ansokan/{{applicationId}}
-                    </a>
-                    och läs innehållet i den noggrannt.
+                    Det har fattats beslut om den grävningsanmälan {{applicationIdentifier}} som
+                    du lämnat in. Ladda ner beslutet från
+                    Haitaton (<a
+                        href="{{baseUrl}}/sv/ansokan/{{applicationId}}">{{baseUrl}}/sv/ansokan/{{applicationId}}</a>)
+                    och ta del av dess innehåll noggrant.
                 </mj-text>
                 <mj-text mj-class="basic-txt">
                     Hur lyckades vi? Ge din åsikt <a href="https://ecv.microsoft.com/zepZlZSdnT">här</a>.
@@ -74,10 +72,11 @@
                 <mj-divider mj-class="language-separator"/>
 
                 <mj-text mj-class="basic-txt">
-                    Jättämäänne kaivuilmoitukseen {{applicationIdentifier}} on tehty päätös.
-                    Lataa päätös Haitattomasta <a
-                        href="{{baseUrl}}/en/application/{{applicationId}}">{{baseUrl}}/en/application/{{applicationId}}
-                </a> and read it carefully.
+                    A decision has been made on the excavation notification
+                    {{applicationIdentifier}} you have submitted.
+                    Download the decision from Haitaton (<a
+                            href="{{baseUrl}}/en/application/{{applicationId}}">{{baseUrl}}/en/application/{{applicationId}}</a>)
+                    and read it carefully.
                 </mj-text>
                 <mj-text mj-class="basic-txt">
                     How did we do? Please share your opinion <a

--- a/email/taydennyspyynto-peruttu.mjml
+++ b/email/taydennyspyynto-peruttu.mjml
@@ -7,8 +7,8 @@
         <mj-section>
             <mj-column>
                 <mj-text mj-class="header-txt">
-                    Hakemustasi koskeva täydennyspyyntö on peruttu / Hakemustasi koskeva täydennyspyyntö on peruttu /
-                    Hakemustasi koskeva täydennyspyyntö on peruttu
+                    Hakemustasi koskeva täydennyspyyntö on peruttu / Begäran om komplettering som gäller din ansökan har återtagits /
+                    The request for supplementary information concerning your application has been cancelled
                 </mj-text>
                 <mj-text mj-class="basic-txt">
                     Hakemuksellesi {{hakemusNimi}} ({{hakemustunnus}}) tehty täydennyspyyntö on peruttu käsittelijän
@@ -21,20 +21,22 @@
                 <mj-divider mj-class="language-separator"/>
 
                 <mj-text mj-class="basic-txt">
-                    Hakemuksellesi {{hakemusNimi}} ({{hakemustunnus}}) tehty täydennyspyyntö on peruttu käsittelijän
-                    toimesta. Mahdollinen täydennyspyynnön luonnos on poistettu Haitattomasta ja hakemuksesi on muutettu
-                    takaisin käsittelyssä tilaiseksi:
-                    <a href="{{baseUrl}}/fi/hakemus/{{hakemusId}}">{{baseUrl}}/sv/ansokan/{{hakemusId}}</a>
+                    Begäran om komplettering i din ansökan {{hakemusNimi}}
+                    ({{hakemustunnus}}) har återtagits av handläggaren. Ett eventuellt utkast till begäran
+                    om komplettering har tagits bort från Haitaton och statusen för din ansökan har
+                    ändrats tillbaka till Handläggning pågår:
+                    <a href="{{baseUrl}}/sv/ansokan/{{hakemusId}}">{{baseUrl}}/sv/ansokan/{{hakemusId}}</a>
                 </mj-text>
                 <mj-include path="common/signature-sv.partial"/>
 
                 <mj-divider mj-class="language-separator"/>
 
                 <mj-text mj-class="basic-txt">
-                    Hakemuksellesi {{hakemusNimi}} ({{hakemustunnus}}) tehty täydennyspyyntö on peruttu käsittelijän
-                    toimesta. Mahdollinen täydennyspyynnön luonnos on poistettu Haitattomasta ja hakemuksesi on muutettu
-                    takaisin käsittelyssä tilaiseksi:
-                    <a href="{{baseUrl}}/fi/hakemus/{{hakemusId}}">{{baseUrl}}/en/application/{{hakemusId}}</a>
+                    The request for supplementary information for your application
+                    {{hakemusNimi}} ({{hakemustunnus}}) has been cancelled by the processor.
+                    Possible draft request for supplementary information has been removed from
+                    Haitaton and your application has been returned to preparation:
+                    <a href="{{baseUrl}}/en/application/{{hakemusId}}">{{baseUrl}}/en/application/{{hakemusId}}</a>
                 </mj-text>
                 <mj-include path="common/signature-en.partial"/>
             </mj-column>

--- a/email/taydennyspyynto.mjml
+++ b/email/taydennyspyynto.mjml
@@ -7,8 +7,7 @@
         <mj-section>
             <mj-column>
                 <mj-text mj-class="header-txt">
-                    Hakemuksellesi on tullut täydennyspyyntö / Hakemuksellesi on tullut täydennyspyyntö / Hakemuksellesi
-                    on tullut täydennyspyyntö
+                    Hakemuksellesi on tullut täydennyspyyntö / Din ansökan har fått en begäran om komplettering / There is a request for supplementary information for your application
                 </mj-text>
                 <mj-text mj-class="basic-txt">
                     Hakemuksellesi {{hakemusNimi}} ({{hakemusTunnus}}) on tullut täydennyspyyntö. Käy vastaamassa siihen
@@ -20,8 +19,8 @@
                 <mj-divider mj-class="language-separator"/>
 
                 <mj-text mj-class="basic-txt">
-                    Hakemuksellesi {{hakemusNimi}} ({{hakemusTunnus}}) on tullut täydennyspyyntö. Käy vastaamassa siihen
-                    Haitattomassa:
+                    Din ansökan {{hakemusNimi}} ({{hakemusTunnus}}) har fått en begäran om komplettering. Svara på den
+                    i Haitaton:
                     <a href="{{baseUrl}}/sv/ansokan/{{hakemusId}}">{{baseUrl}}/sv/ansokan/{{hakemusId}}</a>.
                 </mj-text>
                 <mj-include path="common/signature-sv.partial"/>
@@ -29,8 +28,9 @@
                 <mj-divider mj-class="language-separator"/>
 
                 <mj-text mj-class="basic-txt">
-                    Hakemuksellesi {{hakemusNimi}} ({{hakemusTunnus}}) on tullut täydennyspyyntö. Käy vastaamassa siihen
-                    Haitattomassa:
+                    There is a request for supplementary information for your application
+                    {{hakemusNimi}} ({{hakemusTunnus}}). Please reply to it
+                    in Haitaton:
                     <a href="{{baseUrl}}/en/application/{{hakemusId}}">{{baseUrl}}/en/application/{{hakemusId}}</a>.
                 </mj-text>
                 <mj-include path="common/signature-en.partial"/>

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/email/EmailSenderServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/email/EmailSenderServiceITest.kt
@@ -136,7 +136,7 @@ class EmailSenderServiceITest : IntegrationTest() {
             val email = greenMail.firstReceivedMessage()
             assertThat(email.subject)
                 .isEqualTo(
-                    "Haitaton: Kaivuilmoitukseen KP2300001 liittyvä päätös on ladattavissa / Kaivuilmoitukseen KP2300001 liittyvä päätös on ladattavissa / Kaivuilmoitukseen KP2300001 liittyvä päätös on ladattavissa"
+                    "Haitaton: Kaivuilmoitukseen KP2300001 liittyvä päätös on ladattavissa / Beslut om grävningsanmälan KP2300001 kan laddas ner / The decision concerning an excavation notification KP2300001 can be downloaded"
                 )
         }
 
@@ -476,7 +476,7 @@ class EmailSenderServiceITest : IntegrationTest() {
             val email = greenMail.firstReceivedMessage()
             assertThat(email.subject)
                 .isEqualTo(
-                    "Haitaton: Hakemuksellesi on tullut täydennyspyyntö / Hakemuksellesi on tullut täydennyspyyntö / Hakemuksellesi on tullut täydennyspyyntö"
+                    "Haitaton: Hakemuksellesi on tullut täydennyspyyntö / Din ansökan har fått en begäran om komplettering / There is a request for supplementary information for your application"
                 )
         }
 
@@ -493,12 +493,8 @@ class EmailSenderServiceITest : IntegrationTest() {
                 contains(
                     "Käy vastaamassa siihen Haitattomassa: http://localhost:3001/fi/hakemus/13"
                 )
-                contains(
-                    "Käy vastaamassa siihen Haitattomassa: http://localhost:3001/sv/ansokan/13"
-                )
-                contains(
-                    "Käy vastaamassa siihen Haitattomassa: http://localhost:3001/en/application/13"
-                )
+                contains("Svara på den i Haitaton: http://localhost:3001/sv/ansokan/13")
+                contains("Please reply to it in Haitaton: http://localhost:3001/en/application/13")
             }
             assertThat(htmlBody).all {
                 contains(
@@ -508,10 +504,10 @@ class EmailSenderServiceITest : IntegrationTest() {
                     """Käy vastaamassa siihen Haitattomassa: <a href="http://localhost:3001/fi/hakemus/13">http://localhost:3001/fi/hakemus/13</a>"""
                 )
                 contains(
-                    """Käy vastaamassa siihen Haitattomassa: <a href="http://localhost:3001/sv/ansokan/13">http://localhost:3001/sv/ansokan/13</a>"""
+                    """Svara på den i Haitaton: <a href="http://localhost:3001/sv/ansokan/13">http://localhost:3001/sv/ansokan/13</a>"""
                 )
                 contains(
-                    """Käy vastaamassa siihen Haitattomassa: <a href="http://localhost:3001/en/application/13">http://localhost:3001/en/application/13</a>"""
+                    """Please reply to it in Haitaton: <a href="http://localhost:3001/en/application/13">http://localhost:3001/en/application/13</a>"""
                 )
             }
         }

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusHistoryServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusHistoryServiceITest.kt
@@ -253,7 +253,7 @@ class HakemusHistoryServiceITest(
             assertThat(email.allRecipients[0].toString()).isEqualTo(hakija.sahkoposti)
             assertThat(email.subject)
                 .isEqualTo(
-                    "Haitaton: Kaivuilmoitukseen KP2300001 liittyvä päätös on ladattavissa / Kaivuilmoitukseen KP2300001 liittyvä päätös on ladattavissa / Kaivuilmoitukseen KP2300001 liittyvä päätös on ladattavissa"
+                    "Haitaton: Kaivuilmoitukseen KP2300001 liittyvä päätös on ladattavissa / Beslut om grävningsanmälan KP2300001 kan laddas ner / The decision concerning an excavation notification KP2300001 can be downloaded"
                 )
             verifyAlluDownload(applicationStatus)
             verify { alluClient.getApplicationInformation(alluId) }
@@ -345,7 +345,7 @@ class HakemusHistoryServiceITest(
             assertThat(emails).each {
                 it.prop(MimeMessage::getSubject)
                     .isEqualTo(
-                        "Haitaton: Hakemuksellesi on tullut täydennyspyyntö / Hakemuksellesi on tullut täydennyspyyntö / Hakemuksellesi on tullut täydennyspyyntö"
+                        "Haitaton: Hakemuksellesi on tullut täydennyspyyntö / Din ansökan har fått en begäran om komplettering / There is a request for supplementary information for your application"
                     )
             }
             verifySequence { alluClient.getInformationRequest(alluId) }
@@ -470,7 +470,7 @@ class HakemusHistoryServiceITest(
             assertThat(emails).each {
                 it.prop(MimeMessage::getSubject)
                     .isEqualTo(
-                        "Haitaton: Hakemustasi koskeva täydennyspyyntö on peruttu / Hakemustasi koskeva täydennyspyyntö on peruttu / Hakemustasi koskeva täydennyspyyntö on peruttu"
+                        "Haitaton: Hakemustasi koskeva täydennyspyyntö on peruttu / Begäran om komplettering som gäller din ansökan har återtagits / The request for supplementary information concerning your application has been cancelled"
                     )
             }
         }

--- a/services/hanke-service/src/main/resources/email/template/kaivuilmoitus-paatos.html.mustache
+++ b/services/hanke-service/src/main/resources/email/template/kaivuilmoitus-paatos.html.mustache
@@ -67,7 +67,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0;padding:16px 24px 16px 24px;word-break:break-word">
-                        <div style="font-family:Arial;font-size:36px;line-height:43px;text-align:left;color:#000">Kaivuilmoitukseen {{applicationIdentifier}} liittyvä päätös on ladattavissa / Kaivuilmoitukseen {{applicationIdentifier}} liittyvä päätös on ladattavissa / Kaivuilmoitukseen {{applicationIdentifier}} liittyvä päätös on ladattavissa</div>
+                        <div style="font-family:Arial;font-size:36px;line-height:43px;text-align:left;color:#000">Kaivuilmoitukseen {{applicationIdentifier}} liittyvä päätös on ladattavissa / Beslut om grävningsanmälan {{applicationIdentifier}} kan laddas ner / The decision concerning an excavation notification {{applicationIdentifier}} can be downloaded</div>
                       </td>
                     </tr>
                     <tr>
@@ -102,8 +102,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0;padding:16px 24px 0 24px;word-break:break-word">
-                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">Jättämäänne kaivuilmoitukseen {{applicationIdentifier}} on tehty päätös. Lataa päätös Haitattomasta <a href="{{baseUrl}}/sv/ansokan/{{applicationId}}">{{baseUrl}}/sv/ansokan/{{applicationId}}
-                          </a> och läs innehållet i den noggrannt.</div>
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">Det har fattats beslut om den grävningsanmälan {{applicationIdentifier}} som du lämnat in. Ladda ner beslutet från Haitaton (<a href="{{baseUrl}}/sv/ansokan/{{applicationId}}">{{baseUrl}}/sv/ansokan/{{applicationId}}</a>) och ta del av dess innehåll noggrant.</div>
                       </td>
                     </tr>
                     <tr>
@@ -133,8 +132,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0;padding:16px 24px 0 24px;word-break:break-word">
-                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">Jättämäänne kaivuilmoitukseen {{applicationIdentifier}} on tehty päätös. Lataa päätös Haitattomasta <a href="{{baseUrl}}/en/application/{{applicationId}}">{{baseUrl}}/en/application/{{applicationId}}
-                          </a> and read it carefully.</div>
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">A decision has been made on the excavation notification {{applicationIdentifier}} you have submitted. Download the decision from Haitaton (<a href="{{baseUrl}}/en/application/{{applicationId}}">{{baseUrl}}/en/application/{{applicationId}}</a>) and read it carefully.</div>
                       </td>
                     </tr>
                     <tr>

--- a/services/hanke-service/src/main/resources/email/template/kaivuilmoitus-paatos.subject.mustache
+++ b/services/hanke-service/src/main/resources/email/template/kaivuilmoitus-paatos.subject.mustache
@@ -1,1 +1,1 @@
-Haitaton: Kaivuilmoitukseen {{applicationIdentifier}} liittyvä päätös on ladattavissa / Kaivuilmoitukseen {{applicationIdentifier}} liittyvä päätös on ladattavissa / Kaivuilmoitukseen {{applicationIdentifier}} liittyvä päätös on ladattavissa
+Haitaton: Kaivuilmoitukseen {{applicationIdentifier}} liittyvä päätös on ladattavissa / Beslut om grävningsanmälan {{applicationIdentifier}} kan laddas ner / The decision concerning an excavation notification {{applicationIdentifier}} can be downloaded

--- a/services/hanke-service/src/main/resources/email/template/kaivuilmoitus-paatos.text.mustache
+++ b/services/hanke-service/src/main/resources/email/template/kaivuilmoitus-paatos.text.mustache
@@ -11,7 +11,7 @@ luvat@hel.fi
 https://www.hel.fi/fi/kaupunkiymparisto-ja-liikenne/tontit-ja-rakentamisen-luvat/tyomaan-luvat-ja-ohjeet/kaduilla-ja-puistoissa-tehtavat-tyot
 
 
-Jättämäänne kaivuilmoitukseen {{applicationIdentifier}} on tehty päätös. Lataa päätös Haitattomasta ({{baseUrl}}/sv/ansokan/{{applicationId}}) och läs innehållet i den noggrannt.
+Det har fattats beslut om den grävningsanmälan {{applicationIdentifier}} som du lämnat in. Ladda ner beslutet från Haitaton ({{baseUrl}}/sv/ansokan/{{applicationId}}) och ta del av dess innehåll noggrant.
 
 Hur lyckades vi? Ge din åsikt här: https://ecv.microsoft.com/zepZlZSdnT.
 
@@ -24,7 +24,7 @@ luvat@hel.fi
 https://www.hel.fi/sv/stadsmiljo-och-trafik/tomter-och-bygglov/tillstand-och-anvisningar-for-byggplatsen/arbete-pa-gatu-eller-parkomraden
 
 
-Jättämäänne kaivuilmoitukseen {{applicationIdentifier}} on tehty päätös. Lataa päätös Haitattomasta ({{baseUrl}}/en/application/{{applicationId}}) ja tutustu sen sisältöön huolellisesti.
+A decision has been made on the excavation notification {{applicationIdentifier}} you have submitted. Download the decision from Haitaton ({{baseUrl}}/en/application/{{applicationId}}) and read it carefully.
 
 How did we do? Please share your opinion here: https://ecv.microsoft.com/zepZlZSdnT.
 

--- a/services/hanke-service/src/main/resources/email/template/taydennyspyynto-peruttu.html.mustache
+++ b/services/hanke-service/src/main/resources/email/template/taydennyspyynto-peruttu.html.mustache
@@ -67,7 +67,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0;padding:16px 24px 16px 24px;word-break:break-word">
-                        <div style="font-family:Arial;font-size:36px;line-height:43px;text-align:left;color:#000">Hakemustasi koskeva täydennyspyyntö on peruttu / Hakemustasi koskeva täydennyspyyntö on peruttu / Hakemustasi koskeva täydennyspyyntö on peruttu</div>
+                        <div style="font-family:Arial;font-size:36px;line-height:43px;text-align:left;color:#000">Hakemustasi koskeva täydennyspyyntö on peruttu / Begäran om komplettering som gäller din ansökan har återtagits / The request for supplementary information concerning your application has been cancelled</div>
                       </td>
                     </tr>
                     <tr>
@@ -105,7 +105,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0;padding:16px 24px 0 24px;word-break:break-word">
-                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">Hakemuksellesi {{hakemusNimi}} ({{hakemustunnus}}) tehty täydennyspyyntö on peruttu käsittelijän toimesta. Mahdollinen täydennyspyynnön luonnos on poistettu Haitattomasta ja hakemuksesi on muutettu takaisin käsittelyssä tilaiseksi: <a href="{{baseUrl}}/fi/hakemus/{{hakemusId}}">{{baseUrl}}/sv/ansokan/{{hakemusId}}</a></div>
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">Begäran om komplettering i din ansökan {{hakemusNimi}} ({{hakemustunnus}}) har återtagits av handläggaren. Ett eventuellt utkast till begäran om komplettering har tagits bort från Haitaton och statusen för din ansökan har ändrats tillbaka till Handläggning pågår: <a href="{{baseUrl}}/sv/ansokan/{{hakemusId}}">{{baseUrl}}/sv/ansokan/{{hakemusId}}</a></div>
                       </td>
                     </tr>
                     <tr>
@@ -138,7 +138,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0;padding:16px 24px 0 24px;word-break:break-word">
-                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">Hakemuksellesi {{hakemusNimi}} ({{hakemustunnus}}) tehty täydennyspyyntö on peruttu käsittelijän toimesta. Mahdollinen täydennyspyynnön luonnos on poistettu Haitattomasta ja hakemuksesi on muutettu takaisin käsittelyssä tilaiseksi: <a href="{{baseUrl}}/fi/hakemus/{{hakemusId}}">{{baseUrl}}/en/application/{{hakemusId}}</a></div>
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">The request for supplementary information for your application {{hakemusNimi}} ({{hakemustunnus}}) has been cancelled by the processor. Possible draft request for supplementary information has been removed from Haitaton and your application has been returned to preparation: <a href="{{baseUrl}}/en/application/{{hakemusId}}">{{baseUrl}}/en/application/{{hakemusId}}</a></div>
                       </td>
                     </tr>
                     <tr>

--- a/services/hanke-service/src/main/resources/email/template/taydennyspyynto-peruttu.subject.mustache
+++ b/services/hanke-service/src/main/resources/email/template/taydennyspyynto-peruttu.subject.mustache
@@ -1,1 +1,1 @@
-Haitaton: Hakemustasi koskeva täydennyspyyntö on peruttu / Hakemustasi koskeva täydennyspyyntö on peruttu / Hakemustasi koskeva täydennyspyyntö on peruttu
+Haitaton: Hakemustasi koskeva täydennyspyyntö on peruttu / Begäran om komplettering som gäller din ansökan har återtagits / The request for supplementary information concerning your application has been cancelled

--- a/services/hanke-service/src/main/resources/email/template/taydennyspyynto-peruttu.text.mustache
+++ b/services/hanke-service/src/main/resources/email/template/taydennyspyynto-peruttu.text.mustache
@@ -1,15 +1,15 @@
-Hakemustasi koskeva täydennyspyyntö on peruttu / Hakemustasi koskeva täydennyspyyntö on peruttu / Hakemustasi koskeva täydennyspyyntö on peruttu
+Hakemustasi koskeva täydennyspyyntö on peruttu / Begäran om komplettering som gäller din ansökan har återtagits / The request for supplementary information concerning your application has been cancelled
 
 Hakemuksellesi {{hakemusNimi}} ({{hakemustunnus}}) tehty täydennyspyyntö on peruttu käsittelijän toimesta. Mahdollinen täydennyspyynnön luonnos on poistettu Haitattomasta ja hakemuksesi on muutettu takaisin käsittelyssä tilaiseksi: {{baseUrl}}/fi/hakemus/{{hakemusId}}.
 
 {{{signatures.fi}}}
 
 
-Hakemuksellesi {{hakemusNimi}} ({{hakemustunnus}}) tehty täydennyspyyntö on peruttu käsittelijän toimesta. Mahdollinen täydennyspyynnön luonnos on poistettu Haitattomasta ja hakemuksesi on muutettu takaisin käsittelyssä tilaiseksi: {{baseUrl}}/sv/ansokan/{{hakemusId}}.
+Begäran om komplettering i din ansökan {{hakemusNimi}} ({{hakemustunnus}}) har återtagits av handläggaren. Ett eventuellt utkast till begäran om komplettering har tagits bort från Haitaton och statusen för din ansökan har ändrats tillbaka till Handläggning pågår: {{baseUrl}}/sv/ansokan/{{hakemusId}}.
 
 {{{signatures.sv}}}
 
 
-Hakemuksellesi {{hakemusNimi}} ({{hakemustunnus}}) tehty täydennyspyyntö on peruttu käsittelijän toimesta. Mahdollinen täydennyspyynnön luonnos on poistettu Haitattomasta ja hakemuksesi on muutettu takaisin käsittelyssä tilaiseksi: {{baseUrl}}/en/application/{{hakemusId}}.
+The request for supplementary information for your application {{hakemusNimi}} ({{hakemustunnus}}) has been cancelled by the processor. Possible draft request for supplementary information has been removed from Haitaton and your application has been returned to preparation: {{baseUrl}}/en/application/{{hakemusId}}.
 
 {{{signatures.en}}}

--- a/services/hanke-service/src/main/resources/email/template/taydennyspyynto.html.mustache
+++ b/services/hanke-service/src/main/resources/email/template/taydennyspyynto.html.mustache
@@ -67,7 +67,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0;padding:16px 24px 16px 24px;word-break:break-word">
-                        <div style="font-family:Arial;font-size:36px;line-height:43px;text-align:left;color:#000">Hakemuksellesi on tullut täydennyspyyntö / Hakemuksellesi on tullut täydennyspyyntö / Hakemuksellesi on tullut täydennyspyyntö</div>
+                        <div style="font-family:Arial;font-size:36px;line-height:43px;text-align:left;color:#000">Hakemuksellesi on tullut täydennyspyyntö / Din ansökan har fått en begäran om komplettering / There is a request for supplementary information for your application</div>
                       </td>
                     </tr>
                     <tr>
@@ -105,7 +105,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0;padding:16px 24px 0 24px;word-break:break-word">
-                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">Hakemuksellesi {{hakemusNimi}} ({{hakemusTunnus}}) on tullut täydennyspyyntö. Käy vastaamassa siihen Haitattomassa: <a href="{{baseUrl}}/sv/ansokan/{{hakemusId}}">{{baseUrl}}/sv/ansokan/{{hakemusId}}</a>.</div>
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">Din ansökan {{hakemusNimi}} ({{hakemusTunnus}}) har fått en begäran om komplettering. Svara på den i Haitaton: <a href="{{baseUrl}}/sv/ansokan/{{hakemusId}}">{{baseUrl}}/sv/ansokan/{{hakemusId}}</a>.</div>
                       </td>
                     </tr>
                     <tr>
@@ -138,7 +138,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0;padding:16px 24px 0 24px;word-break:break-word">
-                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">Hakemuksellesi {{hakemusNimi}} ({{hakemusTunnus}}) on tullut täydennyspyyntö. Käy vastaamassa siihen Haitattomassa: <a href="{{baseUrl}}/en/application/{{hakemusId}}">{{baseUrl}}/en/application/{{hakemusId}}</a>.</div>
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">There is a request for supplementary information for your application {{hakemusNimi}} ({{hakemusTunnus}}). Please reply to it in Haitaton: <a href="{{baseUrl}}/en/application/{{hakemusId}}">{{baseUrl}}/en/application/{{hakemusId}}</a>.</div>
                       </td>
                     </tr>
                     <tr>

--- a/services/hanke-service/src/main/resources/email/template/taydennyspyynto.subject.mustache
+++ b/services/hanke-service/src/main/resources/email/template/taydennyspyynto.subject.mustache
@@ -1,1 +1,1 @@
-Haitaton: Hakemuksellesi on tullut täydennyspyyntö / Hakemuksellesi on tullut täydennyspyyntö / Hakemuksellesi on tullut täydennyspyyntö
+Haitaton: Hakemuksellesi on tullut täydennyspyyntö / Din ansökan har fått en begäran om komplettering / There is a request for supplementary information for your application

--- a/services/hanke-service/src/main/resources/email/template/taydennyspyynto.text.mustache
+++ b/services/hanke-service/src/main/resources/email/template/taydennyspyynto.text.mustache
@@ -1,15 +1,15 @@
-Hakemuksellesi on tullut täydennyspyyntö / Hakemuksellesi on tullut täydennyspyyntö / Hakemuksellesi on tullut täydennyspyyntö
+Hakemuksellesi on tullut täydennyspyyntö / Din ansökan har fått en begäran om komplettering / Hakemuksellesi on tullut täydennyspyyntö
 
 Hakemuksellesi {{hakemusNimi}} ({{hakemusTunnus}}) on tullut täydennyspyyntö. Käy vastaamassa siihen Haitattomassa: {{baseUrl}}/fi/hakemus/{{hakemusId}}.
 
 {{{signatures.fi}}}
 
 
-Hakemuksellesi {{hakemusNimi}} ({{hakemusTunnus}}) on tullut täydennyspyyntö. Käy vastaamassa siihen Haitattomassa: {{baseUrl}}/sv/ansokan/{{hakemusId}}.
+Din ansökan {{hakemusNimi}} ({{hakemusTunnus}}) har fått en begäran om komplettering. Svara på den i Haitaton: {{baseUrl}}/sv/ansokan/{{hakemusId}}.
 
 {{{signatures.sv}}}
 
 
-Hakemuksellesi {{hakemusNimi}} ({{hakemusTunnus}}) on tullut täydennyspyyntö. Käy vastaamassa siihen Haitattomassa: {{baseUrl}}/en/application/{{hakemusId}}.
+There is a request for supplementary information for your application {{hakemusNimi}} ({{hakemusTunnus}}). Please reply to it in Haitaton: {{baseUrl}}/en/application/{{hakemusId}}.
 
 {{{signatures.en}}}


### PR DESCRIPTION
# Description

Added Swedish and English translations for kaivuilmoitus päätös, täydennyspyyntö and täydennyspyyntö cancellation emails.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-3427

## Type of change

- [ ] Bug fix 
- [x] New feature 
- [ ] Other

# Instructions for testing
1. Create a new or use an existing kaivuilmoitus, send it to Allu
2. In Allu, create a täydennyspyyntö for the kaivuilmoitus
3. After a while check that the email notification is correct with new translations
4. Cancel the täydennyspyyntö in Allu
5. After a while check that the email notification is correct with new translations
6. Create a decision for the kaivuilmoitus in Allu
7. After a while check that the email notification is correct with new translations

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 

# Other relevant info
Please describe here if there is e.g. some requirements for this change or
 other info that the tester/user needs to know.