### PR TITLE
HAI Add test API for triggering Allu updates

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/configuration/MockAlluUpdateService.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/configuration/MockAlluUpdateService.kt
@@ -1,0 +1,11 @@
+package fi.hel.haitaton.hanke.configuration
+
+import fi.hel.haitaton.hanke.hakemus.AlluUpdateService
+import io.mockk.mockk
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class MockAlluUpdateService {
+    @Bean fun alluUpdateService(): AlluUpdateService = mockk()
+}

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/testdata/TestDataControllerDisabledITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/testdata/TestDataControllerDisabledITest.kt
@@ -64,4 +64,24 @@ class TestDataControllerDisabledITest(@Autowired override val mockMvc: MockMvc) 
             verify { testDataService wasNot Called }
         }
     }
+
+    @Nested
+    inner class TriggerAlluUpdates {
+        private val url = "$BASE_URL/trigger-allu"
+
+        @Test
+        @WithAnonymousUser
+        fun `Without user ID returns 404`() {
+            get(url).andExpect(MockMvcResultMatchers.status().isNotFound)
+
+            verify { testDataService wasNot Called }
+        }
+
+        @Test
+        fun `With valid user returns 404`() {
+            get(url).andExpect(MockMvcResultMatchers.status().isNotFound)
+
+            verify { testDataService wasNot Called }
+        }
+    }
 }

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/testdata/TestDataControllerEnabledITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/testdata/TestDataControllerEnabledITest.kt
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.context.annotation.Import
+import org.springframework.http.MediaType
 import org.springframework.security.test.context.support.WithAnonymousUser
 import org.springframework.security.test.context.support.WithMockUser
 import org.springframework.test.context.ActiveProfiles
@@ -61,6 +62,26 @@ class TestDataControllerEnabledITest(@Autowired override val mockMvc: MockMvc) :
             post(url).andExpect(MockMvcResultMatchers.status().isOk)
 
             verifyAll { testDataService.unlinkApplicationsFromAllu() }
+        }
+    }
+
+    @Nested
+    inner class TriggerAlluUpdates {
+        private val url = "$BASE_URL/trigger-allu"
+
+        @Test
+        @WithAnonymousUser
+        fun `Without user ID calls service normally`() {
+            get(url, MediaType.TEXT_PLAIN).andExpect(MockMvcResultMatchers.status().isOk)
+
+            verifyAll { testDataService.triggerAlluUpdates() }
+        }
+
+        @Test
+        fun `With valid user calls service`() {
+            get(url, MediaType.TEXT_PLAIN).andExpect(MockMvcResultMatchers.status().isOk)
+
+            verifyAll { testDataService.triggerAlluUpdates() }
         }
     }
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/DisclosureLoggingAspect.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/DisclosureLoggingAspect.kt
@@ -83,6 +83,9 @@ class DisclosureLoggingAspect(private val disclosureLogService: DisclosureLogSer
             is List<*> -> logResultList(result.filterNotNull())
             is Map<*, *> -> logResultList(result.values.filterNotNull())
 
+            // Used for returning system info. Won't contain personal information.
+            is String -> return
+
             // Throw an exception if nothing matches. This will ensure we specify whether a new
             // response type can contain personal information or not.
             else -> throw UnknownResponseTypeException(result::class)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/security/AccessRules.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/security/AccessRules.kt
@@ -26,6 +26,7 @@ object AccessRules {
                         "/swagger-ui.html",
                         "/swagger-ui/**",
                         "/v3/api-docs/**",
+                        "/testdata/trigger-allu",
                     )
                     .permitAll()
                     .requestMatchers(HttpMethod.POST, "/testdata/unlink-applications")

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/testdata/TestDataController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/testdata/TestDataController.kt
@@ -5,8 +5,12 @@ import mu.KotlinLogging
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.context.event.ApplicationReadyEvent
 import org.springframework.context.event.EventListener
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseBody
 import org.springframework.web.bind.annotation.RestController
 
 private val logger = KotlinLogging.logger {}
@@ -14,9 +18,7 @@ private val logger = KotlinLogging.logger {}
 @RestController
 @RequestMapping("/testdata")
 @ConditionalOnProperty(name = ["haitaton.testdata.enabled"], havingValue = "true")
-class TestDataController(
-    private val testDataService: TestDataService,
-) {
+class TestDataController(private val testDataService: TestDataService) {
 
     @EventListener(ApplicationReadyEvent::class)
     fun logWarning() {
@@ -31,11 +33,19 @@ class TestDataController(
                 "can be re-sent to allu whenever. This endpoint can be used to unlink all " +
                 "applications from Allu after Allu wipes all of it's data during test " +
                 "environment update. Allu will re-issue the same IDs, causing collisions " +
-                "in Haitaton."
+                "in Haitaton.",
     )
     @PostMapping("/unlink-applications")
     fun unlinkApplicationsFromAllu() {
         testDataService.unlinkApplicationsFromAllu()
         logger.warn { "Unlinked all applications from Allu." }
+    }
+
+    @Operation(summary = "Trigger Allu updates")
+    @GetMapping("/trigger-allu")
+    @ResponseBody
+    fun triggerAllu(): ResponseEntity<String> {
+        testDataService.triggerAlluUpdates()
+        return ResponseEntity.ok().contentType(MediaType.TEXT_PLAIN).body("Allu updates done.")
     }
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/testdata/TestDataService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/testdata/TestDataService.kt
@@ -4,6 +4,7 @@ import fi.hel.haitaton.hanke.attachment.application.ApplicationAttachmentContent
 import fi.hel.haitaton.hanke.attachment.azure.Container
 import fi.hel.haitaton.hanke.attachment.common.FileClient
 import fi.hel.haitaton.hanke.attachment.common.TaydennysAttachmentRepository
+import fi.hel.haitaton.hanke.hakemus.AlluUpdateService
 import fi.hel.haitaton.hanke.hakemus.HakemusRepository
 import fi.hel.haitaton.hanke.paatos.PaatosEntity
 import fi.hel.haitaton.hanke.paatos.PaatosRepository
@@ -24,6 +25,7 @@ class TestDataService(
     private val paatosRepository: PaatosRepository,
     private val attachmentContentService: ApplicationAttachmentContentService,
     private val fileClient: FileClient,
+    private val alluUpdateService: AlluUpdateService,
 ) {
     @Transactional
     fun unlinkApplicationsFromAllu() {
@@ -43,6 +45,12 @@ class TestDataService(
 
         logger.warn { "Removing all päätökset and täydennykset." }
         paatosRepository.findAll().forEach { deletePaatosWithAttachments(it) }
+    }
+
+    fun triggerAlluUpdates() {
+        logger.info { "Manually triggered Allu updates..." }
+        alluUpdateService.checkApplicationStatuses()
+        logger.info { "Manual Allu updates done." }
     }
 
     private fun deletePaatosWithAttachments(paatosEntity: PaatosEntity) {


### PR DESCRIPTION
# Description

Add an API that, when called, immediately retrieves the latest application history from Allu and updates the application statuses accordingly. The update is executed using the same code as the timed updates, ensuring that the last update time is refreshed and that the mutex safeguards against simultaneous updates.

Waiting for the next Allu history update can be frustrating when testing the Haitaton code. This functionality allows us to update and observe the effects in Haitaton instantly.

The endpoint is a GET, making it easy to call. You may use a shell alias that invokes it with cURL, a bookmark in your browser, or a custom shortcut in your IDE.

The endpoint can also be invoked from E2E tests, which often have to wait for a status update from Allu. In the johtoselvitys täydennys test alone, calling this endpoint after each Allu operation saved an average of just over 30 seconds.

This endpoint is only accessible in test environments, similar to other TestData endpoints.

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [X] Other

# Instructions for testing
1. Do something visible in Haitaton after an Allu update, like a decision or a täydennyspyyntö.
2. Call [http://localhost:3001/api/testdata/trigger-allu](http://localhost:3001/api/testdata/trigger-allu)
3. Check Haitaton to see the result.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 