### PR TITLE
HAI-3400 Add API for updating a muutosilmoitus

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/IntegrationTestConfiguration.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/IntegrationTestConfiguration.kt
@@ -18,6 +18,7 @@ import fi.hel.haitaton.hanke.hakemus.HakemusService
 import fi.hel.haitaton.hanke.logging.AuditLogRepository
 import fi.hel.haitaton.hanke.logging.DisclosureLogService
 import fi.hel.haitaton.hanke.logging.DisclosureLoggingAspect
+import fi.hel.haitaton.hanke.muutosilmoitus.MuutosilmoitusAuthorizer
 import fi.hel.haitaton.hanke.muutosilmoitus.MuutosilmoitusService
 import fi.hel.haitaton.hanke.paatos.PaatosAuthorizer
 import fi.hel.haitaton.hanke.paatos.PaatosService
@@ -98,6 +99,8 @@ class IntegrationTestConfiguration {
     @Bean fun hanketunnusService(): HanketunnusService = mockk()
 
     @Bean fun jdbcOperations(): JdbcOperations = mockk()
+
+    @Bean fun muutosilmoitusAuthorizer(): MuutosilmoitusAuthorizer = mockk()
 
     @Bean fun muutosilmoitusService(): MuutosilmoitusService = mockk()
 

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/muutosilmoitus/MuutosilmoitusAuthorizerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/muutosilmoitus/MuutosilmoitusAuthorizerITest.kt
@@ -1,0 +1,96 @@
+package fi.hel.haitaton.hanke.muutosilmoitus
+
+import assertk.all
+import assertk.assertFailure
+import assertk.assertThat
+import assertk.assertions.hasClass
+import assertk.assertions.isTrue
+import assertk.assertions.messageContains
+import fi.hel.haitaton.hanke.IntegrationTest
+import fi.hel.haitaton.hanke.factory.HakemusFactory
+import fi.hel.haitaton.hanke.factory.HankeFactory
+import fi.hel.haitaton.hanke.factory.MuutosilmoitusFactory
+import fi.hel.haitaton.hanke.hakemus.HakemusNotFoundException
+import fi.hel.haitaton.hanke.permissions.Kayttooikeustaso
+import fi.hel.haitaton.hanke.permissions.PermissionCode
+import fi.hel.haitaton.hanke.permissions.PermissionService
+import fi.hel.haitaton.hanke.test.USERNAME
+import java.util.UUID
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+
+class MuutosilmoitusAuthorizerITest(
+    @Autowired private val authorizer: MuutosilmoitusAuthorizer,
+    @Autowired private val muutosilmoitusFactory: MuutosilmoitusFactory,
+    @Autowired private val hakemusFactory: HakemusFactory,
+    @Autowired private val hankeFactory: HankeFactory,
+    @Autowired private val permissionService: PermissionService,
+) : IntegrationTest() {
+    @Nested
+    inner class Authorize {
+
+        @Test
+        fun `throws exception when muutosilmoitus is not found`() {
+            val muutosilmoitusId = UUID.fromString("8a6248bc-d562-4074-b016-e8074e4cea43")
+
+            val failure = assertFailure {
+                authorizer.authorize(muutosilmoitusId, PermissionCode.VIEW.name)
+            }
+
+            failure.all {
+                hasClass(MuutosilmoitusNotFoundException::class.java)
+                messageContains(muutosilmoitusId.toString())
+                messageContains("Muutosilmoitus not found")
+            }
+        }
+
+        @Test
+        fun `throws exception when user doesn't have the required permission for the muutosilmoitus`() {
+            val hanke = hankeFactory.saveMinimal()
+            permissionService.create(hanke.id, USERNAME, Kayttooikeustaso.KATSELUOIKEUS)
+            val hakemus = hakemusFactory.builder(hanke).saveEntity()
+            val muutosilmoitus = muutosilmoitusFactory.builder(hakemus).saveEntity()
+
+            val failure = assertFailure {
+                authorizer.authorize(muutosilmoitus.id, PermissionCode.EDIT_APPLICATIONS.name)
+            }
+
+            failure.all {
+                hasClass(HakemusNotFoundException::class)
+                messageContains(hakemus.id.toString())
+            }
+        }
+
+        @Test
+        fun `returns false when user has the a permission to a different hanke`() {
+            val hanke = hankeFactory.saveMinimal()
+            permissionService.create(hanke.id, USERNAME, Kayttooikeustaso.HAKEMUSASIOINTI)
+            val otherHanke = hankeFactory.saveMinimal()
+            val hakemus = hakemusFactory.builder(otherHanke).saveEntity()
+            val muutosilmoitus = muutosilmoitusFactory.builder(hakemus).saveEntity()
+
+            val failure = assertFailure {
+                authorizer.authorize(muutosilmoitus.id, PermissionCode.EDIT_APPLICATIONS.name)
+            }
+
+            failure.all {
+                hasClass(HakemusNotFoundException::class)
+                messageContains(hakemus.id.toString())
+            }
+        }
+
+        @Test
+        fun `returns true when user has the correct permission`() {
+            val hanke = hankeFactory.saveMinimal()
+            permissionService.create(hanke.id, USERNAME, Kayttooikeustaso.HAKEMUSASIOINTI)
+            val hakemus = hakemusFactory.builder(hanke).saveEntity()
+            val muutosilmoitus = muutosilmoitusFactory.builder(hakemus).saveEntity()
+
+            val result =
+                authorizer.authorize(muutosilmoitus.id, PermissionCode.EDIT_APPLICATIONS.name)
+
+            assertThat(result).isTrue()
+        }
+    }
+}

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/muutosilmoitus/UpdateMuutosilmoitusITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/muutosilmoitus/UpdateMuutosilmoitusITest.kt
@@ -276,7 +276,7 @@ class UpdateMuutosilmoitusITest(
     @ParameterizedTest
     @EnumSource(ApplicationType::class)
     fun `doesn't send email when the caller adds themself as contact`(type: ApplicationType) {
-        val muutosilmoitus = muutosilmoitusFactory.builder().withAreas(listOf()).save()
+        val muutosilmoitus = muutosilmoitusFactory.builder(type).withAreas(listOf()).save()
         val hankeId = hakemusRepository.getReferenceById(muutosilmoitus.hakemusId).hanke.id
         val permission = permissionService.findPermission(hankeId, USERNAME)!!
         val founder = hankekayttajaRepository.findByPermissionId(permission.id)!!

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/muutosilmoitus/UpdateMuutosilmoitusITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/muutosilmoitus/UpdateMuutosilmoitusITest.kt
@@ -1,0 +1,975 @@
+package fi.hel.haitaton.hanke.muutosilmoitus
+
+import assertk.all
+import assertk.assertFailure
+import assertk.assertThat
+import assertk.assertions.contains
+import assertk.assertions.containsExactly
+import assertk.assertions.containsExactlyInAnyOrder
+import assertk.assertions.extracting
+import assertk.assertions.hasClass
+import assertk.assertions.hasSize
+import assertk.assertions.isEmpty
+import assertk.assertions.isEqualTo
+import assertk.assertions.isInstanceOf
+import assertk.assertions.isNotNull
+import assertk.assertions.isNull
+import assertk.assertions.isTrue
+import assertk.assertions.messageContains
+import assertk.assertions.prop
+import assertk.assertions.single
+import com.icegreen.greenmail.configuration.GreenMailConfiguration
+import com.icegreen.greenmail.junit5.GreenMailExtension
+import com.icegreen.greenmail.util.ServerSetupTest
+import fi.hel.haitaton.hanke.HankeEntity
+import fi.hel.haitaton.hanke.HankeRepository
+import fi.hel.haitaton.hanke.IntegrationTest
+import fi.hel.haitaton.hanke.allu.AlluClient
+import fi.hel.haitaton.hanke.allu.CustomerType
+import fi.hel.haitaton.hanke.asJsonResource
+import fi.hel.haitaton.hanke.email.textBody
+import fi.hel.haitaton.hanke.factory.ApplicationFactory
+import fi.hel.haitaton.hanke.factory.DateFactory
+import fi.hel.haitaton.hanke.factory.GeometriaFactory
+import fi.hel.haitaton.hanke.factory.HakemusFactory
+import fi.hel.haitaton.hanke.factory.HakemusUpdateRequestFactory
+import fi.hel.haitaton.hanke.factory.HakemusUpdateRequestFactory.withArea
+import fi.hel.haitaton.hanke.factory.HakemusUpdateRequestFactory.withContractor
+import fi.hel.haitaton.hanke.factory.HakemusUpdateRequestFactory.withCustomer
+import fi.hel.haitaton.hanke.factory.HakemusUpdateRequestFactory.withCustomerWithContactsRequest
+import fi.hel.haitaton.hanke.factory.HakemusUpdateRequestFactory.withDates
+import fi.hel.haitaton.hanke.factory.HakemusUpdateRequestFactory.withInvoicingCustomer
+import fi.hel.haitaton.hanke.factory.HakemusUpdateRequestFactory.withName
+import fi.hel.haitaton.hanke.factory.HakemusUpdateRequestFactory.withRequiredCompetence
+import fi.hel.haitaton.hanke.factory.HakemusUpdateRequestFactory.withWorkDescription
+import fi.hel.haitaton.hanke.factory.HakemusyhteystietoFactory
+import fi.hel.haitaton.hanke.factory.HankeFactory
+import fi.hel.haitaton.hanke.factory.HankeKayttajaFactory
+import fi.hel.haitaton.hanke.factory.MuutosilmoitusFactory
+import fi.hel.haitaton.hanke.factory.MuutosilmoitusFactory.Companion.toUpdateRequest
+import fi.hel.haitaton.hanke.findByType
+import fi.hel.haitaton.hanke.firstReceivedMessage
+import fi.hel.haitaton.hanke.hakemus.ApplicationContactType.TYON_SUORITTAJA
+import fi.hel.haitaton.hanke.hakemus.ApplicationType
+import fi.hel.haitaton.hanke.hakemus.HakemusGeometryException
+import fi.hel.haitaton.hanke.hakemus.HakemusGeometryNotInsideHankeException
+import fi.hel.haitaton.hanke.hakemus.HakemusRepository
+import fi.hel.haitaton.hanke.hakemus.Hakemusyhteystieto
+import fi.hel.haitaton.hanke.hakemus.InvalidHakemusyhteyshenkiloException
+import fi.hel.haitaton.hanke.hakemus.InvalidHakemusyhteystietoException
+import fi.hel.haitaton.hanke.hakemus.InvalidHiddenRegistryKey
+import fi.hel.haitaton.hanke.hakemus.JohtoselvityshakemusData
+import fi.hel.haitaton.hanke.hakemus.KaivuilmoitusAlue
+import fi.hel.haitaton.hanke.hakemus.KaivuilmoitusData
+import fi.hel.haitaton.hanke.hakemus.KaivuilmoitusUpdateRequest
+import fi.hel.haitaton.hanke.hakemus.Laskutusyhteystieto
+import fi.hel.haitaton.hanke.hakemus.Tyoalue
+import fi.hel.haitaton.hanke.logging.AuditLogRepository
+import fi.hel.haitaton.hanke.logging.ObjectType
+import fi.hel.haitaton.hanke.permissions.HankekayttajaRepository
+import fi.hel.haitaton.hanke.permissions.PermissionService
+import fi.hel.haitaton.hanke.test.USERNAME
+import fi.hel.haitaton.hanke.toJsonString
+import fi.hel.haitaton.hanke.tormaystarkastelu.Autoliikenneluokittelu
+import fi.hel.haitaton.hanke.tormaystarkastelu.TormaystarkasteluTulos
+import io.mockk.checkUnnecessaryStub
+import io.mockk.clearAllMocks
+import io.mockk.confirmVerified
+import java.time.ZonedDateTime
+import java.util.UUID
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+import org.junit.jupiter.params.provider.NullSource
+import org.junit.jupiter.params.provider.ValueSource
+import org.springframework.beans.factory.annotation.Autowired
+
+class UpdateMuutosilmoitusITest(
+    @Autowired private val muutosilmoitusService: MuutosilmoitusService,
+    @Autowired private val permissionService: PermissionService,
+    @Autowired private val hakemusRepository: HakemusRepository,
+    @Autowired private val hankekayttajaRepository: HankekayttajaRepository,
+    @Autowired private val hankeRepository: HankeRepository,
+    @Autowired private val auditLogRepository: AuditLogRepository,
+    @Autowired private val muutosilmoitusFactory: MuutosilmoitusFactory,
+    @Autowired private val hakemusFactory: HakemusFactory,
+    @Autowired private val hankeFactory: HankeFactory,
+    @Autowired private val hankeKayttajaFactory: HankeKayttajaFactory,
+    @Autowired private val alluClient: AlluClient,
+) : IntegrationTest() {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val greenMail: GreenMailExtension =
+            GreenMailExtension(ServerSetupTest.SMTP)
+                .withConfiguration(GreenMailConfiguration.aConfig().withDisabledAuthentication())
+    }
+
+    @BeforeEach
+    fun clearMocks() {
+        clearAllMocks()
+    }
+
+    @AfterEach
+    fun checkMocks() {
+        checkUnnecessaryStub()
+        confirmVerified(alluClient)
+    }
+
+    @ParameterizedTest
+    @EnumSource(ApplicationType::class)
+    fun `throws exception when the muutosilmoitus does not exist`(type: ApplicationType) {
+        val request = HakemusUpdateRequestFactory.createFilledUpdateRequest(type)
+        val muutosilmoitusId = UUID.fromString("21404863-edc8-4c28-8d14-35ffc06c04eb")
+
+        val exception = assertFailure {
+            muutosilmoitusService.update(muutosilmoitusId, request, USERNAME)
+        }
+
+        exception.all {
+            hasClass(MuutosilmoitusNotFoundException::class)
+            messageContains("id=21404863-edc8-4c28-8d14-35ffc06c04eb")
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(ApplicationType::class)
+    fun `throws exception when the muutosilmoitus has been sent already`(type: ApplicationType) {
+        val muutosilmoitus =
+            muutosilmoitusFactory
+                .builder(type)
+                .withSent(DateFactory.getStartDatetime().toOffsetDateTime())
+                .save()
+        val request = muutosilmoitus.toUpdateRequest()
+
+        val exception = assertFailure {
+            muutosilmoitusService.update(muutosilmoitus.id, request, USERNAME)
+        }
+
+        exception.all {
+            hasClass(MuutosilmoitusAlreadySentException::class)
+            messageContains("Muutosilmoitus is already sent to Allu")
+            messageContains(
+                "Muutosilmoitus: (id=${muutosilmoitus.id}, hakemusId=${muutosilmoitus.hakemusId})"
+            )
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(ApplicationType::class)
+    fun `throws exception when the request has different type than the saved muutosilmoitus`(
+        type: ApplicationType
+    ) {
+        val muutosilmoitus = muutosilmoitusFactory.builder(type).save()
+        val otherType = ApplicationType.entries.first { it != type }
+        val request = HakemusUpdateRequestFactory.createFilledUpdateRequest(otherType)
+
+        val exception = assertFailure {
+            muutosilmoitusService.update(muutosilmoitus.id, request, USERNAME)
+        }
+
+        exception.all {
+            hasClass(IncompatibleMuutosilmoitusUpdateException::class)
+            messageContains("Invalid update request for muutosilmoitus")
+            messageContains("existing type=$type")
+            messageContains("requested type=$otherType")
+            messageContains(
+                "Muutosilmoitus: (id=${muutosilmoitus.id}, hakemusId=${muutosilmoitus.hakemusId})"
+            )
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(ApplicationType::class)
+    fun `does not create a new audit log entry when the muutosilmoitus has not changed`(
+        type: ApplicationType
+    ) {
+        val muutosilmoitus = muutosilmoitusFactory.builder(type).save()
+        val request = muutosilmoitus.toUpdateRequest()
+        auditLogRepository.deleteAll()
+
+        muutosilmoitusService.update(muutosilmoitus.id, request, USERNAME)
+
+        assertThat(auditLogRepository.findByType(ObjectType.MUUTOSILMOITUS)).isEmpty()
+    }
+
+    @ParameterizedTest
+    @EnumSource(ApplicationType::class)
+    fun `throws exception when the request has a persisted contact but the muutosilmoitus does not`(
+        type: ApplicationType
+    ) {
+        val muutosilmoitus = muutosilmoitusFactory.builder(type).withoutYhteystiedot().save()
+        val requestYhteystietoId = UUID.randomUUID()
+        val request =
+            muutosilmoitus
+                .toUpdateRequest()
+                .withCustomerWithContactsRequest(CustomerType.COMPANY, requestYhteystietoId)
+
+        val exception = assertFailure {
+            muutosilmoitusService.update(muutosilmoitus.id, request, USERNAME)
+        }
+
+        exception.all {
+            hasClass(InvalidHakemusyhteystietoException::class)
+            messageContains("Invalid hakemusyhteystieto received when updating hakemus")
+            messageContains("yhteystietoId=null")
+            messageContains("newId=$requestYhteystietoId")
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(ApplicationType::class)
+    fun `throws exception when the request has different persisted contact than the application`(
+        type: ApplicationType
+    ) {
+        val hakemus = hakemusFactory.builder(type).hakija().saveEntity()
+        val muutosilmoitus = muutosilmoitusFactory.builder(hakemus).save()
+        val originalYhteystietoId = muutosilmoitus.hakemusData.yhteystiedot().single().id
+        val requestYhteystietoId = UUID.fromString("ad2173c5-eda4-43e2-8457-7974d74319e8")
+        val request =
+            muutosilmoitus
+                .toUpdateRequest()
+                .withCustomer(CustomerType.COMPANY, requestYhteystietoId)
+
+        val exception = assertFailure {
+            muutosilmoitusService.update(muutosilmoitus.id, request, USERNAME)
+        }
+
+        exception.all {
+            hasClass(InvalidHakemusyhteystietoException::class)
+            messageContains("Invalid hakemusyhteystieto received when updating hakemus")
+            messageContains("yhteystietoId=$originalYhteystietoId")
+            messageContains("newId=$requestYhteystietoId")
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(ApplicationType::class)
+    fun `throws exception when the request has a contact that is not a user on hanke`(
+        type: ApplicationType
+    ) {
+        val hakemus = hakemusFactory.builder(type).hakija().saveEntity()
+        val muutosilmoitus = muutosilmoitusFactory.builder(hakemus).save()
+        val originalYhteystietoId = muutosilmoitus.hakemusData.yhteystiedot().single().id
+        val requestHankekayttajaId = UUID.fromString("598e1383-0720-4fd4-8449-21fd759aa457")
+        val request =
+            muutosilmoitus
+                .toUpdateRequest()
+                .withCustomer(CustomerType.COMPANY, originalYhteystietoId, requestHankekayttajaId)
+
+        val exception = assertFailure {
+            muutosilmoitusService.update(muutosilmoitus.id, request, USERNAME)
+        }
+
+        exception.all {
+            hasClass(InvalidHakemusyhteyshenkiloException::class)
+            messageContains("Invalid hanke user/users received when updating hakemus")
+            messageContains("invalidHankeKayttajaIds=[$requestHankekayttajaId]")
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(ApplicationType::class)
+    fun `doesn't send email when the caller adds themself as contact`(type: ApplicationType) {
+        val muutosilmoitus = muutosilmoitusFactory.builder().withAreas(listOf()).save()
+        val hankeId = hakemusRepository.getReferenceById(muutosilmoitus.hakemusId).hanke.id
+        val permission = permissionService.findPermission(hankeId, USERNAME)!!
+        val founder = hankekayttajaRepository.findByPermissionId(permission.id)!!
+        val request =
+            muutosilmoitus
+                .toUpdateRequest()
+                .withCustomer(CustomerType.COMPANY, null, founder.id)
+                .withContractor(CustomerType.COMPANY, null, founder.id)
+
+        muutosilmoitusService.update(muutosilmoitus.id, request, USERNAME)
+
+        assertThat(greenMail.receivedMessages).isEmpty()
+    }
+
+    @Nested
+    inner class WithJohtoselvitys {
+
+        private val intersectingArea =
+            ApplicationFactory.createCableReportApplicationArea(
+                name = "area",
+                geometry =
+                    "/fi/hel/haitaton/hanke/geometria/intersecting-polygon.json".asJsonResource(),
+            )
+
+        private val notInHankeArea =
+            ApplicationFactory.createCableReportApplicationArea(
+                name = "area",
+                geometry = GeometriaFactory.polygon(),
+            )
+
+        @Test
+        fun `throws exception when there are invalid geometry in areas`() {
+            val muutosilmoitus = muutosilmoitusFactory.builder(ApplicationType.CABLE_REPORT).save()
+            val request = muutosilmoitus.toUpdateRequest().withArea(intersectingArea)
+
+            val exception = assertFailure {
+                muutosilmoitusService.update(muutosilmoitus.id, request, USERNAME)
+            }
+
+            exception.all {
+                hasClass(HakemusGeometryException::class)
+                messageContains("Invalid geometry received when updating hakemus")
+                messageContains("reason=Self-intersection")
+                messageContains(
+                    "location={\"type\":\"Point\",\"coordinates\":[25494009.65639264,6679886.142116806]}"
+                )
+            }
+        }
+
+        @Test
+        fun `throws exception when area is not inside hanke area`() {
+            val muutosilmoitus = muutosilmoitusFactory.builder(ApplicationType.CABLE_REPORT).save()
+            val request = muutosilmoitus.toUpdateRequest().withArea(notInHankeArea)
+
+            val exception = assertFailure {
+                muutosilmoitusService.update(muutosilmoitus.id, request, USERNAME)
+            }
+
+            exception.all {
+                hasClass(HakemusGeometryNotInsideHankeException::class)
+                messageContains("Hakemus geometry doesn't match any hankealue")
+                messageContains("geometry=${notInHankeArea.geometry.toJsonString()}")
+            }
+        }
+
+        @Test
+        fun `saves updated data and creates an audit log`() {
+            val hakemusEntity =
+                hakemusFactory
+                    .builder(ApplicationType.CABLE_REPORT)
+                    .hakija()
+                    .withWorkDescription("Old work description")
+                    .saveEntity()
+            val muutosilmoitus = muutosilmoitusFactory.builder(hakemusEntity).save()
+            val yhteystieto = muutosilmoitus.hakemusData.yhteystiedot().single()
+            val perustajaId = yhteystieto.yhteyshenkilot.single().hankekayttajaId
+            val hanke = hankeRepository.findAll().single()
+            val newKayttaja = hankeKayttajaFactory.saveUser(hanke.id)
+            val newDescription = "New work description"
+            val request =
+                muutosilmoitus
+                    .toUpdateRequest()
+                    .withCustomer(CustomerType.COMPANY, yhteystieto.id, perustajaId, newKayttaja.id)
+                    .withWorkDescription(newDescription)
+            auditLogRepository.deleteAll()
+
+            val updatedMuutosilmoitus =
+                muutosilmoitusService.update(muutosilmoitus.id, request, USERNAME)
+
+            assertThat(updatedMuutosilmoitus.hakemusData)
+                .isInstanceOf(JohtoselvityshakemusData::class)
+                .all {
+                    prop(JohtoselvityshakemusData::workDescription).isEqualTo(newDescription)
+                    prop(JohtoselvityshakemusData::customerWithContacts)
+                        .isNotNull()
+                        .prop(Hakemusyhteystieto::yhteyshenkilot)
+                        .extracting { it.hankekayttajaId }
+                        .containsExactlyInAnyOrder(perustajaId, newKayttaja.id)
+                }
+            val applicationLogs = auditLogRepository.findByType(ObjectType.MUUTOSILMOITUS)
+            assertThat(applicationLogs).hasSize(1)
+
+            val hakemus = hakemusRepository.findAll().single()
+            val persistedMuutosilmoitus = muutosilmoitusService.find(hakemus.id)!!
+            assertThat(persistedMuutosilmoitus.hakemusData)
+                .isInstanceOf(JohtoselvityshakemusData::class)
+                .all {
+                    prop(JohtoselvityshakemusData::workDescription).isEqualTo(newDescription)
+                    prop(JohtoselvityshakemusData::customerWithContacts)
+                        .isNotNull()
+                        .prop(Hakemusyhteystieto::yhteyshenkilot)
+                        .extracting { it.hankekayttajaId }
+                        .containsExactlyInAnyOrder(perustajaId, newKayttaja.id)
+                }
+        }
+
+        @Test
+        fun `removes existing yhteyshenkilot from an yhteystieto`() {
+            val hanke = hankeFactory.builder(USERNAME).withHankealue().saveEntity()
+            val kayttaja1 = hankeKayttajaFactory.saveUser(hanke.id)
+            val kayttaja2 = hankeKayttajaFactory.saveUser(hanke.id, sahkoposti = "other@email")
+            val hakemusEntity =
+                hakemusFactory
+                    .builder(ApplicationType.CABLE_REPORT)
+                    .hakija()
+                    .tyonSuorittaja(kayttaja1, kayttaja2)
+                    .saveEntity()
+            val muutosilmoitus = muutosilmoitusFactory.builder(hakemusEntity).save()
+            val tyonSuorittajaId =
+                muutosilmoitus.hakemusData.yhteystiedot().first { it.rooli == TYON_SUORITTAJA }.id
+            val request =
+                muutosilmoitus
+                    .toUpdateRequest()
+                    .withContractor(
+                        CustomerType.COMPANY,
+                        tyonSuorittajaId,
+                        hankekayttajaIds = arrayOf(),
+                    )
+
+            val updatedMuutosilmoitus =
+                muutosilmoitusService.update(muutosilmoitus.id, request, USERNAME)
+
+            assertThat(updatedMuutosilmoitus.hakemusData)
+                .isInstanceOf(JohtoselvityshakemusData::class)
+                .prop(JohtoselvityshakemusData::contractorWithContacts)
+                .isNotNull()
+                .prop(Hakemusyhteystieto::yhteyshenkilot)
+                .isEmpty()
+
+            val hakemus = hakemusRepository.findAll().single()
+            val persistedMuutosilmoitus = muutosilmoitusService.find(hakemus.id)!!
+            assertThat(persistedMuutosilmoitus.hakemusData)
+                .isInstanceOf(JohtoselvityshakemusData::class)
+                .prop(JohtoselvityshakemusData::contractorWithContacts)
+                .isNotNull()
+                .prop(Hakemusyhteystieto::yhteyshenkilot)
+                .isEmpty()
+        }
+
+        @Test
+        fun `adds a new yhteystieto and an yhteyshenkilo for it at the same time`() {
+            val hanke = hankeFactory.builder().withHankealue().saveEntity()
+            val hakemusEntity =
+                hakemusFactory.builder(USERNAME, hanke, ApplicationType.CABLE_REPORT).saveEntity()
+            val muutosilmoitus = muutosilmoitusFactory.builder(hakemusEntity).save()
+            val newKayttaja = hankeKayttajaFactory.saveUser(hanke.id)
+            assertThat(muutosilmoitus.hakemusData.customerWithContacts).isNull()
+            val request =
+                muutosilmoitus
+                    .toUpdateRequest()
+                    .withCustomer(
+                        CustomerType.COMPANY,
+                        yhteystietoId = null,
+                        hankekayttajaIds = arrayOf(newKayttaja.id),
+                    )
+
+            val updatedMuutosilmoitus =
+                muutosilmoitusService.update(muutosilmoitus.id, request, USERNAME)
+
+            assertThat(updatedMuutosilmoitus.hakemusData)
+                .isInstanceOf(JohtoselvityshakemusData::class)
+                .prop(JohtoselvityshakemusData::customerWithContacts)
+                .isNotNull()
+                .prop(Hakemusyhteystieto::yhteyshenkilot)
+                .extracting { it.hankekayttajaId }
+                .containsExactly(newKayttaja.id)
+
+            val hakemus = hakemusRepository.findAll().single()
+            val persistedMuutosilmoitus = muutosilmoitusService.find(hakemus.id)!!
+            assertThat(persistedMuutosilmoitus.hakemusData)
+                .isInstanceOf(JohtoselvityshakemusData::class)
+                .prop(JohtoselvityshakemusData::customerWithContacts)
+                .isNotNull()
+                .prop(Hakemusyhteystieto::yhteyshenkilot)
+                .extracting { it.hankekayttajaId }
+                .containsExactly(newKayttaja.id)
+        }
+
+        @Test
+        fun `sends email to new contacts`() {
+            val hanke = hankeFactory.builder(USERNAME).withHankealue().saveEntity()
+            val hakemus =
+                hakemusFactory.builder(hanke, ApplicationType.CABLE_REPORT).hakija().saveEntity()
+            val muutosilmoitus = muutosilmoitusFactory.builder(hakemus).save()
+            val yhteystietoId = muutosilmoitus.hakemusData.yhteystiedot().single().id
+            val newKayttaja = hankeKayttajaFactory.saveUser(hanke.id)
+            val request =
+                muutosilmoitus
+                    .toUpdateRequest()
+                    .withCustomer(CustomerType.COMPANY, yhteystietoId, newKayttaja.id)
+                    .withContractor(CustomerType.COMPANY, null, newKayttaja.id)
+
+            muutosilmoitusService.update(muutosilmoitus.id, request, USERNAME)
+
+            val email = greenMail.firstReceivedMessage()
+            assertThat(email.allRecipients.single().toString()).isEqualTo(newKayttaja.sahkoposti)
+            assertThat(email.subject)
+                .isEqualTo(
+                    "Haitaton: Sinut on lisätty hakemukselle / Du har lagts till i en ansökan / You have been added to an application"
+                )
+            assertThat(email.textBody())
+                .contains(
+                    "laatimassa johtoselvityshakemusta hankkeelle \"${hanke.nimi}\" (${hanke.hankeTunnus})"
+                )
+        }
+
+        @Test
+        fun `doesn't change project name when application name is changed`() {
+            val hakemus =
+                hakemusFactory.builderWithGeneratedHanke(nimi = "An application").saveEntity()
+            val muutosilmoitus = muutosilmoitusFactory.builder(hakemus).save()
+            val request = muutosilmoitus.toUpdateRequest().withName("New name")
+
+            muutosilmoitusService.update(muutosilmoitus.id, request, USERNAME)
+
+            assertThat(hankeRepository.findAll().single()).all {
+                prop(HankeEntity::nimi).isEqualTo("An application")
+            }
+        }
+    }
+
+    @Nested
+    inner class WithKaivuilmoitus {
+
+        private val notInHankeArea =
+            ApplicationFactory.createExcavationNotificationArea(
+                name = "area",
+                tyoalueet = listOf(ApplicationFactory.createTyoalue(GeometriaFactory.polygon())),
+            )
+
+        @Test
+        fun `throws exception when area is not inside hanke area`() {
+            val hanke = hankeFactory.builder(USERNAME).withHankealue().save()
+            val hankeEntity = hankeRepository.findAll().single()
+            val hakemus =
+                hakemusFactory
+                    .builder(USERNAME, hankeEntity, ApplicationType.EXCAVATION_NOTIFICATION)
+                    .saveEntity()
+            val muutosilmoitus = muutosilmoitusFactory.builder(hakemus).save()
+            val hankealueId = hanke.alueet.single().id!!
+            val area = notInHankeArea.copy(hankealueId = hankealueId)
+            val request = muutosilmoitus.toUpdateRequest().withArea(area)
+
+            val exception = assertFailure {
+                muutosilmoitusService.update(muutosilmoitus.id, request, USERNAME)
+            }
+
+            exception.all {
+                hasClass(HakemusGeometryNotInsideHankeException::class)
+                messageContains("Hakemus geometry is outside the associated hankealue")
+                messageContains(
+                    "geometry=${notInHankeArea.tyoalueet.single().geometry.toJsonString()}"
+                )
+            }
+        }
+
+        @Test
+        fun `throws exception when area references non-existent hankealue`() {
+            val hanke = hankeFactory.builder(USERNAME).withHankealue().save()
+            val hankeEntity = hankeRepository.findAll().single()
+            val hakemus =
+                hakemusFactory
+                    .builder(USERNAME, hankeEntity, ApplicationType.EXCAVATION_NOTIFICATION)
+                    .saveEntity()
+            val muutosilmoitus = muutosilmoitusFactory.builder(hakemus).save()
+            val hankealueId = hanke.alueet.single().id!! + 1000
+            val area =
+                ApplicationFactory.createExcavationNotificationArea(hankealueId = hankealueId)
+            val request = muutosilmoitus.toUpdateRequest().withArea(area)
+
+            val exception = assertFailure {
+                muutosilmoitusService.update(muutosilmoitus.id, request, USERNAME)
+            }
+
+            exception.all {
+                hasClass(HakemusGeometryNotInsideHankeException::class)
+                messageContains("Hakemus geometry is outside the associated hankealue")
+                messageContains("hankealue=$hankealueId")
+                messageContains("geometry=${area.tyoalueet.single().geometry.toJsonString()}")
+            }
+        }
+
+        @Test
+        fun `saves updated data and creates an audit log`() {
+            val hanke = hankeFactory.builder(USERNAME).withHankealue().save()
+            val hankeEntity = hankeRepository.findAll().single()
+            val hakemusEntity =
+                hakemusFactory
+                    .builder(USERNAME, hankeEntity, ApplicationType.EXCAVATION_NOTIFICATION)
+                    .hakija()
+                    .withWorkDescription("Old work description")
+                    .saveEntity()
+            val muutosilmoitus = muutosilmoitusFactory.builder(hakemusEntity).save()
+            val yhteystieto = muutosilmoitus.hakemusData.yhteystiedot().single()
+            val kayttajaId = yhteystieto.yhteyshenkilot.single().hankekayttajaId
+            val newKayttaja = hankeKayttajaFactory.saveUser(hanke.id)
+            val area =
+                ApplicationFactory.createExcavationNotificationArea(
+                    hankealueId = hanke.alueet.single().id!!
+                )
+            val newDescription = "New work description"
+            val request =
+                muutosilmoitus
+                    .toUpdateRequest()
+                    .withCustomerWithContactsRequest(
+                        CustomerType.COMPANY,
+                        yhteystieto.id,
+                        kayttajaId,
+                        newKayttaja.id,
+                    )
+                    .withWorkDescription(newDescription)
+                    .withRequiredCompetence(true)
+                    .withDates(ZonedDateTime.now(), ZonedDateTime.now().plusDays(1))
+                    .withArea(area)
+            auditLogRepository.deleteAll()
+
+            val updatedMuutosilmoitus =
+                muutosilmoitusService.update(muutosilmoitus.id, request, USERNAME)
+
+            assertThat(updatedMuutosilmoitus.hakemusData)
+                .isInstanceOf(KaivuilmoitusData::class)
+                .all {
+                    prop(KaivuilmoitusData::workDescription).isEqualTo(newDescription)
+                    prop(KaivuilmoitusData::requiredCompetence).isTrue()
+                    prop(KaivuilmoitusData::customerWithContacts)
+                        .isNotNull()
+                        .prop(Hakemusyhteystieto::yhteyshenkilot)
+                        .extracting { it.hankekayttajaId }
+                        .containsExactlyInAnyOrder(kayttajaId, newKayttaja.id)
+                    prop(KaivuilmoitusData::areas)
+                        .isNotNull()
+                        .single()
+                        .transform { it.withoutTormaystarkastelut() }
+                        .isEqualTo(area.withoutTormaystarkastelut())
+                }
+
+            assertThat(auditLogRepository.findByType(ObjectType.MUUTOSILMOITUS)).hasSize(1)
+
+            val hakemus = hakemusRepository.findAll().single()
+            val persistedMuutosilmoitus = muutosilmoitusService.find(hakemus.id)!!
+            assertThat(persistedMuutosilmoitus.hakemusData)
+                .isInstanceOf(KaivuilmoitusData::class)
+                .all {
+                    prop(KaivuilmoitusData::workDescription).isEqualTo(newDescription)
+                    prop(KaivuilmoitusData::requiredCompetence).isTrue()
+                    prop(KaivuilmoitusData::customerWithContacts)
+                        .isNotNull()
+                        .prop(Hakemusyhteystieto::yhteyshenkilot)
+                        .extracting { it.hankekayttajaId }
+                        .containsExactlyInAnyOrder(kayttajaId, newKayttaja.id)
+                    prop(KaivuilmoitusData::areas)
+                        .isNotNull()
+                        .single()
+                        .transform { it.withoutTormaystarkastelut() }
+                        .isEqualTo(area.withoutTormaystarkastelut())
+                }
+        }
+
+        @Test
+        fun `removes existing yhteyshenkilot from an yhteystieto`() {
+            val hanke = hankeFactory.builder(USERNAME).withHankealue().saveEntity()
+            val kayttaja1 = hankeKayttajaFactory.saveUser(hanke.id)
+            val kayttaja2 = hankeKayttajaFactory.saveUser(hanke.id, sahkoposti = "other@email")
+            val hakemus =
+                hakemusFactory
+                    .builder(USERNAME, hanke, ApplicationType.EXCAVATION_NOTIFICATION)
+                    .hakija()
+                    .tyonSuorittaja(kayttaja1, kayttaja2)
+                    .saveEntity()
+            val muutosilmoitus = muutosilmoitusFactory.builder(hakemus).save()
+            val tyonSuorittajaId =
+                muutosilmoitus.hakemusData.yhteystiedot().first { it.rooli == TYON_SUORITTAJA }.id
+            val request =
+                muutosilmoitus
+                    .toUpdateRequest()
+                    .withContractor(
+                        CustomerType.COMPANY,
+                        tyonSuorittajaId,
+                        hankekayttajaIds = arrayOf(),
+                    )
+
+            val updatedMuutosilmoitus =
+                muutosilmoitusService.update(muutosilmoitus.id, request, USERNAME)
+
+            assertThat(updatedMuutosilmoitus.hakemusData)
+                .isInstanceOf(KaivuilmoitusData::class)
+                .prop(KaivuilmoitusData::contractorWithContacts)
+                .isNotNull()
+                .prop(Hakemusyhteystieto::yhteyshenkilot)
+                .isEmpty()
+        }
+
+        @Test
+        fun `adds a new yhteystieto and an yhteyshenkilo for it at the same time`() {
+            val hanke = hankeFactory.builder(USERNAME).withHankealue().saveEntity()
+            val newKayttaja = hankeKayttajaFactory.saveUser(hanke.id)
+            val hakemusEntity =
+                hakemusFactory
+                    .builder(USERNAME, hanke, ApplicationType.EXCAVATION_NOTIFICATION)
+                    .saveEntity()
+            val muutosilmoitus = muutosilmoitusFactory.builder(hakemusEntity).save()
+            assertThat(muutosilmoitus.hakemusData.customerWithContacts).isNull()
+            val request =
+                muutosilmoitus
+                    .toUpdateRequest()
+                    .withCustomer(
+                        CustomerType.COMPANY,
+                        yhteystietoId = null,
+                        hankekayttajaIds = arrayOf(newKayttaja.id),
+                    )
+
+            val updatedMuutosilmoitus =
+                muutosilmoitusService.update(muutosilmoitus.id, request, USERNAME)
+
+            assertThat(updatedMuutosilmoitus.hakemusData)
+                .isInstanceOf(KaivuilmoitusData::class)
+                .prop(KaivuilmoitusData::customerWithContacts)
+                .isNotNull()
+                .prop(Hakemusyhteystieto::yhteyshenkilot)
+                .extracting { it.hankekayttajaId }
+                .containsExactly(newKayttaja.id)
+
+            val hakemus = hakemusRepository.findAll().single()
+            val persistedMuutosilmoitus = muutosilmoitusService.find(hakemus.id)!!
+            assertThat(persistedMuutosilmoitus.hakemusData)
+                .isInstanceOf(KaivuilmoitusData::class)
+                .prop(KaivuilmoitusData::customerWithContacts)
+                .isNotNull()
+                .prop(Hakemusyhteystieto::yhteyshenkilot)
+                .extracting { it.hankekayttajaId }
+                .containsExactly(newKayttaja.id)
+        }
+
+        @Test
+        fun `throws exception when an existing yhteystieto has registry key hidden but different type in the request`() {
+            val hakemus =
+                hakemusFactory
+                    .builder(ApplicationType.EXCAVATION_NOTIFICATION)
+                    .hakija(HakemusyhteystietoFactory.create(tyyppi = CustomerType.COMPANY))
+                    .saveEntity()
+            val muutosilmoitus = muutosilmoitusFactory.builder(hakemus).save()
+            val yhteystietoId = muutosilmoitus.hakemusData.customerWithContacts!!.id
+            val request =
+                muutosilmoitus
+                    .toUpdateRequest()
+                    .withCustomer(
+                        CustomerType.PERSON,
+                        yhteystietoId,
+                        registryKey = null,
+                        registryKeyHidden = true,
+                    )
+
+            val failure = assertFailure {
+                muutosilmoitusService.update(muutosilmoitus.id, request, USERNAME)
+            }
+
+            failure.all {
+                hasClass(InvalidHiddenRegistryKey::class)
+                messageContains("RegistryKeyHidden used in an incompatible way")
+                messageContains("New customer type doesn't match the old")
+                messageContains("New=PERSON")
+                messageContains("Old=COMPANY")
+            }
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = ["Something completely different"])
+        @NullSource
+        fun `keeps old customer registry key when registry key hidden is true`(
+            newRegistryKey: String?
+        ) {
+            val henkilotunnus = "090626-885W"
+            val hakemusEntity =
+                hakemusFactory
+                    .builder(ApplicationType.EXCAVATION_NOTIFICATION)
+                    .hakija(
+                        HakemusyhteystietoFactory.create(
+                            tyyppi = CustomerType.PERSON,
+                            registryKey = henkilotunnus,
+                        )
+                    )
+                    .saveEntity()
+            val muutosilmoitus = muutosilmoitusFactory.builder(hakemusEntity).save()
+            val yhteystietoId = muutosilmoitus.hakemusData.customerWithContacts!!.id
+            val request =
+                muutosilmoitus
+                    .toUpdateRequest()
+                    .withCustomer(
+                        CustomerType.PERSON,
+                        yhteystietoId,
+                        registryKey = newRegistryKey,
+                        registryKeyHidden = true,
+                    )
+
+            val result = muutosilmoitusService.update(muutosilmoitus.id, request, USERNAME)
+
+            assertThat(result.hakemusData)
+                .isInstanceOf(KaivuilmoitusData::class)
+                .prop(KaivuilmoitusData::customerWithContacts)
+                .isNotNull()
+                .prop(Hakemusyhteystieto::registryKey)
+                .isEqualTo(henkilotunnus)
+
+            val hakemus = hakemusRepository.findAll().single()
+            val persistedMuutosilmoitus = muutosilmoitusService.find(hakemus.id)!!
+            assertThat(persistedMuutosilmoitus.hakemusData)
+                .isInstanceOf(KaivuilmoitusData::class)
+                .prop(KaivuilmoitusData::customerWithContacts)
+                .isNotNull()
+                .prop(Hakemusyhteystieto::registryKey)
+                .isEqualTo(henkilotunnus)
+        }
+
+        @Test
+        fun `throws exception when an existing laskutusyhteystieto has registry key hidden but different type in the request`() {
+            val hakemus =
+                hakemusFactory
+                    .builder(ApplicationType.EXCAVATION_NOTIFICATION)
+                    .withInvoicingCustomer(ApplicationFactory.createCompanyInvoicingCustomer())
+                    .saveEntity()
+            val muutosilmoitus = muutosilmoitusFactory.builder(hakemus).save()
+            val request =
+                (muutosilmoitus.toUpdateRequest() as KaivuilmoitusUpdateRequest)
+                    .withInvoicingCustomer(
+                        CustomerType.PERSON,
+                        registryKey = null,
+                        registryKeyHidden = true,
+                    )
+
+            val failure = assertFailure {
+                muutosilmoitusService.update(muutosilmoitus.id, request, USERNAME)
+            }
+
+            failure.all {
+                hasClass(InvalidHiddenRegistryKey::class)
+                messageContains("RegistryKeyHidden used in an incompatible way")
+                messageContains("New invoicing customer type doesn't match the old")
+                messageContains("New=PERSON")
+                messageContains("Old=COMPANY")
+            }
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = ["Something completely different"])
+        @NullSource
+        fun `keeps old invoicing customer registry key when registry key hidden is true`(
+            newRegistryKey: String?
+        ) {
+            val henkilotunnus = ApplicationFactory.DEFAULT_HENKILOTUNNUS
+            val hakemusEntity =
+                hakemusFactory
+                    .builder(ApplicationType.EXCAVATION_NOTIFICATION)
+                    .withInvoicingCustomer(ApplicationFactory.createPersonInvoicingCustomer())
+                    .saveEntity()
+            val muutosilmoitus = muutosilmoitusFactory.builder(hakemusEntity).save()
+            val request =
+                (muutosilmoitus.toUpdateRequest() as KaivuilmoitusUpdateRequest)
+                    .withInvoicingCustomer(
+                        CustomerType.PERSON,
+                        registryKey = newRegistryKey,
+                        registryKeyHidden = true,
+                    )
+
+            val result = muutosilmoitusService.update(muutosilmoitus.id, request, USERNAME)
+
+            assertThat(result.hakemusData)
+                .isInstanceOf(KaivuilmoitusData::class)
+                .prop(KaivuilmoitusData::invoicingCustomer)
+                .isNotNull()
+                .prop(Laskutusyhteystieto::registryKey)
+                .isEqualTo(henkilotunnus)
+            val hakemus = hakemusRepository.findAll().single()
+            val persistedMuutosilmoitus = muutosilmoitusService.find(hakemus.id)!!
+            assertThat(persistedMuutosilmoitus.hakemusData)
+                .isInstanceOf(KaivuilmoitusData::class)
+                .prop(KaivuilmoitusData::invoicingCustomer)
+                .isNotNull()
+                .prop(Laskutusyhteystieto::registryKey)
+                .isEqualTo(henkilotunnus)
+        }
+
+        @Test
+        fun `sends email for new contacts`() {
+            val hanke = hankeFactory.builder(USERNAME).withHankealue().saveEntity()
+            val hakemus =
+                hakemusFactory
+                    .builder(USERNAME, hanke, ApplicationType.EXCAVATION_NOTIFICATION)
+                    .hakija()
+                    .saveEntity()
+            val muutosilmoitus = muutosilmoitusFactory.builder(hakemus).save()
+            val yhteystietoId = muutosilmoitus.hakemusData.yhteystiedot().single().id
+            val newKayttaja = hankeKayttajaFactory.saveUser(hanke.id)
+            val request =
+                muutosilmoitus
+                    .toUpdateRequest()
+                    .withCustomer(CustomerType.COMPANY, yhteystietoId, newKayttaja.id)
+                    .withContractor(CustomerType.COMPANY, null, newKayttaja.id)
+
+            muutosilmoitusService.update(muutosilmoitus.id, request, USERNAME)
+
+            val email = greenMail.firstReceivedMessage()
+            assertThat(email.allRecipients.single().toString()).isEqualTo(newKayttaja.sahkoposti)
+            assertThat(email.subject)
+                .isEqualTo(
+                    "Haitaton: Sinut on lisätty hakemukselle / Du har lagts till i en ansökan / You have been added to an application"
+                )
+            assertThat(email.textBody())
+                .contains(
+                    "laatimassa kaivuilmoitusta hankkeelle \"${hanke.nimi}\" (${hanke.hankeTunnus})"
+                )
+        }
+
+        @Test
+        fun `calculates tormaystarkastelu for work areas`() {
+            val hanke = hankeFactory.builder(USERNAME).withHankealue().save()
+            val hankeEntity = hankeRepository.findAll().single()
+            val hakemusEntity =
+                hakemusFactory
+                    .builder(USERNAME, hankeEntity, ApplicationType.EXCAVATION_NOTIFICATION)
+                    .saveEntity()
+            val muutosilmoitus = muutosilmoitusFactory.builder(hakemusEntity).save()
+            val area =
+                ApplicationFactory.createExcavationNotificationArea(
+                    hankealueId = hanke.alueet.single().id!!
+                )
+            val request =
+                muutosilmoitus
+                    .toUpdateRequest()
+                    .withDates(ZonedDateTime.now(), ZonedDateTime.now().plusDays(1))
+                    .withArea(area)
+            val expectedTormaystarkasteluTulos =
+                TormaystarkasteluTulos(
+                    autoliikenne =
+                        Autoliikenneluokittelu(
+                            indeksi = 2.8f,
+                            haitanKesto = 1,
+                            katuluokka = 4,
+                            liikennemaara = 5,
+                            kaistahaitta = 1,
+                            kaistapituushaitta = 2,
+                        ),
+                    pyoraliikenneindeksi = 3.0f,
+                    linjaautoliikenneindeksi = 3.0f,
+                    raitioliikenneindeksi = 5.0f,
+                )
+
+            val result = muutosilmoitusService.update(muutosilmoitus.id, request, USERNAME)
+
+            assertThat(result.hakemusData)
+                .isInstanceOf(KaivuilmoitusData::class)
+                .prop(KaivuilmoitusData::areas)
+                .isNotNull()
+                .single()
+                .prop(KaivuilmoitusAlue::tyoalueet)
+                .isNotNull()
+                .single()
+                .prop(Tyoalue::tormaystarkasteluTulos)
+                .isNotNull()
+                .isEqualTo(expectedTormaystarkasteluTulos)
+
+            val hakemus = hakemusRepository.findAll().single()
+            val persistedMuutosilmoitus = muutosilmoitusService.find(hakemus.id)!!
+            assertThat(persistedMuutosilmoitus.hakemusData)
+                .isInstanceOf(KaivuilmoitusData::class)
+                .prop(KaivuilmoitusData::areas)
+                .isNotNull()
+                .single()
+                .prop(KaivuilmoitusAlue::tyoalueet)
+                .isNotNull()
+                .single()
+                .prop(Tyoalue::tormaystarkasteluTulos)
+                .isNotNull()
+                .isEqualTo(expectedTormaystarkasteluTulos)
+        }
+    }
+}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeError.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeError.kt
@@ -58,7 +58,9 @@ enum class HankeError(val errorMessage: String) {
     HAI4007("Verified name not found in Profiili"),
     HAI5001("Decision not found"),
     HAI6001("Taydennys not found"),
-    HAI6002("Taydennys has no changes");
+    HAI6002("Taydennys has no changes"),
+    HAI7001("Muutosilmoitus not found"),
+    HAI7002("Muutosilmoitus is already sent to Allu, operation prohibited.");
 
     val errorCode: String
         get() = name

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/HasYhteystietoEntities.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/HasYhteystietoEntities.kt
@@ -1,0 +1,17 @@
+package fi.hel.haitaton.hanke.domain
+
+import fi.hel.haitaton.hanke.hakemus.ApplicationContactType
+import fi.hel.haitaton.hanke.hakemus.YhteyshenkiloEntity
+import fi.hel.haitaton.hanke.hakemus.YhteystietoEntity
+import fi.hel.haitaton.hanke.permissions.HankekayttajaEntity
+
+interface HasYhteystietoEntities<H : YhteyshenkiloEntity> {
+    val yhteystiedot: Map<ApplicationContactType, YhteystietoEntity<H>>
+
+    /** Returns all distinct contact users. */
+    fun allContactUsers(): List<HankekayttajaEntity> =
+        yhteystiedot.values
+            .flatMap { it.yhteyshenkilot }
+            .map { it.hankekayttaja }
+            .distinctBy { it.id }
+}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusEntity.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusEntity.kt
@@ -2,7 +2,7 @@ package fi.hel.haitaton.hanke.hakemus
 
 import fi.hel.haitaton.hanke.HankeEntity
 import fi.hel.haitaton.hanke.allu.ApplicationStatus
-import fi.hel.haitaton.hanke.permissions.HankekayttajaEntity
+import fi.hel.haitaton.hanke.domain.HasYhteystietoEntities
 import fi.hel.haitaton.hanke.valmistumisilmoitus.ValmistumisilmoitusEntity
 import io.hypersistence.utils.hibernate.type.json.JsonType
 import jakarta.persistence.CascadeType
@@ -43,7 +43,8 @@ data class HakemusEntity(
     )
     @MapKey(name = "rooli")
     @BatchSize(size = 100)
-    var yhteystiedot: MutableMap<ApplicationContactType, HakemusyhteystietoEntity> = mutableMapOf(),
+    override var yhteystiedot: MutableMap<ApplicationContactType, HakemusyhteystietoEntity> =
+        mutableMapOf(),
     @OneToMany(
         fetch = FetchType.LAZY,
         mappedBy = "hakemus",
@@ -52,7 +53,7 @@ data class HakemusEntity(
     )
     @BatchSize(size = 100)
     val valmistumisilmoitukset: MutableList<ValmistumisilmoitusEntity> = mutableListOf(),
-) : HakemusIdentifier {
+) : HakemusIdentifier, HasYhteystietoEntities<HakemusyhteyshenkiloEntity> {
     fun toMetadata(): HakemusMetaData =
         HakemusMetaData(
             id = id,
@@ -69,7 +70,8 @@ data class HakemusEntity(
             when (hakemusEntityData) {
                 is JohtoselvityshakemusEntityData ->
                     (this.hakemusEntityData as JohtoselvityshakemusEntityData).toHakemusData(
-                        yhteystiedot)
+                        yhteystiedot
+                    )
                 is KaivuilmoitusEntityData ->
                     (this.hakemusEntityData as KaivuilmoitusEntityData).toHakemusData(yhteystiedot)
             }
@@ -86,11 +88,4 @@ data class HakemusEntity(
                 valmistumisilmoitukset.map { it.toDomain() }.groupBy { it.type },
         )
     }
-
-    /** Returns all distinct contact users for this application. */
-    fun allContactUsers(): List<HankekayttajaEntity> =
-        yhteystiedot.values
-            .flatMap { it.yhteyshenkilot }
-            .map { it.hankekayttaja }
-            .distinctBy { it.id }
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
@@ -17,6 +17,7 @@ import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType
 import fi.hel.haitaton.hanke.attachment.taydennys.TaydennysAttachmentMetadataService
 import fi.hel.haitaton.hanke.daysBetween
 import fi.hel.haitaton.hanke.domain.Hankevaihe
+import fi.hel.haitaton.hanke.domain.HasYhteystietoEntities
 import fi.hel.haitaton.hanke.email.ApplicationNotificationEmail
 import fi.hel.haitaton.hanke.geometria.GeometriatDao
 import fi.hel.haitaton.hanke.getCurrentTimeUTCAsLocalTime
@@ -990,12 +991,21 @@ class HakemusService(
         )
 
     private fun sendHakemusNotifications(
+        updatedEntity: HakemusEntity,
+        excludedUserIds: Set<UUID>,
+        userId: String,
+    ) {
+        sendHakemusNotifications(updatedEntity, updatedEntity, excludedUserIds, userId)
+    }
+
+    fun <H : YhteyshenkiloEntity> sendHakemusNotifications(
+        updatedEntity: HasYhteystietoEntities<H>,
         hakemusEntity: HakemusEntity,
         excludedUserIds: Set<UUID>,
         userId: String,
     ) {
         val newContacts =
-            hakemusEntity.allContactUsers().filterNot { excludedUserIds.contains(it.id) }
+            updatedEntity.allContactUsers().filterNot { excludedUserIds.contains(it.id) }
         if (newContacts.isNotEmpty()) {
             sendHakemusNotifications(newContacts, hakemusEntity, userId)
         }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/muutosilmoitus/MuutosilmoitusAuthorizer.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/muutosilmoitus/MuutosilmoitusAuthorizer.kt
@@ -1,0 +1,27 @@
+package fi.hel.haitaton.hanke.muutosilmoitus
+
+import fi.hel.haitaton.hanke.HankeRepository
+import fi.hel.haitaton.hanke.hakemus.HakemusAuthorizer
+import fi.hel.haitaton.hanke.permissions.Authorizer
+import fi.hel.haitaton.hanke.permissions.PermissionService
+import java.util.UUID
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+class MuutosilmoitusAuthorizer(
+    permissionService: PermissionService,
+    hankeRepository: HankeRepository,
+    private val muutosilmoitusRepository: MuutosilmoitusRepository,
+    private val hakemusAuthorizer: HakemusAuthorizer,
+) : Authorizer(permissionService, hankeRepository) {
+
+    @Transactional(readOnly = true)
+    fun authorize(id: UUID, permissionCode: String): Boolean {
+        val muutosilmoitus =
+            muutosilmoitusRepository.findByIdOrNull(id) ?: throw MuutosilmoitusNotFoundException(id)
+
+        return hakemusAuthorizer.authorizeHakemusId(muutosilmoitus.hakemusId, permissionCode)
+    }
+}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/muutosilmoitus/MuutosilmoitusController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/muutosilmoitus/MuutosilmoitusController.kt
@@ -1,18 +1,30 @@
 package fi.hel.haitaton.hanke.muutosilmoitus
 
 import fi.hel.haitaton.hanke.HankeError
+import fi.hel.haitaton.hanke.HankeErrorDetail
 import fi.hel.haitaton.hanke.currentUserId
+import fi.hel.haitaton.hanke.hakemus.HakemusUpdateRequest
+import fi.hel.haitaton.hanke.hakemus.InvalidHakemusDataException
+import fi.hel.haitaton.hanke.hakemus.ValidHakemusUpdateRequest
+import io.swagger.v3.oas.annotations.Hidden
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.ExampleObject
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
+import java.util.UUID
 import mu.KotlinLogging
+import org.springframework.http.HttpStatus
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 
 private val logger = KotlinLogging.logger {}
@@ -40,7 +52,7 @@ class MuutosilmoitusController(private val muutosilmoitusService: Muutosilmoitus
     @ApiResponses(
         value =
             [
-                ApiResponse(description = "The created täydennys", responseCode = "200"),
+                ApiResponse(description = "The created muutosilmoitus", responseCode = "200"),
                 ApiResponse(
                     description = "The application was in the wrong status.",
                     responseCode = "409",
@@ -58,5 +70,97 @@ class MuutosilmoitusController(private val muutosilmoitusService: Muutosilmoitus
         val muutosilmoitus = muutosilmoitusService.create(id, currentUserId())
         logger.info { "Created the muutosilmoitus. ${muutosilmoitus.logString()}" }
         return muutosilmoitus.toResponse()
+    }
+
+    @PutMapping("/muutosilmoitukset/{id}")
+    @Operation(
+        summary = "Update a muutosilmoitus",
+        description =
+            """
+               Returns the updated muutosilmoitus.
+               The muutosilmoitus can be updated until it has been sent to Allu.
+               If the muutosilmoitus hasn't changed since the last update, nothing more is done.
+            """,
+    )
+    @ApiResponses(
+        value =
+            [
+                ApiResponse(description = "The updated muutosilmoitus", responseCode = "200"),
+                ApiResponse(
+                    description = "Request contains invalid data",
+                    responseCode = "400",
+                    content =
+                        [
+                            Content(
+                                schema =
+                                    Schema(oneOf = [HankeErrorDetail::class, HankeError::class]),
+                                examples =
+                                    [
+                                        ExampleObject(
+                                            name = "Validation error",
+                                            summary = "Validation error example",
+                                            value = "{hankeError: 'HAI2008', errorPaths: ['name']}",
+                                        ),
+                                        ExampleObject(
+                                            name = "Incompatible request",
+                                            summary = "Incompatible request example",
+                                            value = "{hankeError: 'HAI2002'}",
+                                        ),
+                                    ],
+                            )
+                        ],
+                ),
+                ApiResponse(
+                    description = "A muutosilmoitus was not found with the given id",
+                    responseCode = "404",
+                    content = [Content(schema = Schema(implementation = HankeError::class))],
+                ),
+                ApiResponse(
+                    description =
+                        "The muutosilmoitus has already been sent to Allu and can not be updated",
+                    responseCode = "409",
+                    content = [Content(schema = Schema(implementation = HankeError::class))],
+                ),
+            ]
+    )
+    @PreAuthorize("@muutosilmoitusAuthorizer.authorize(#id, 'EDIT_APPLICATIONS')")
+    fun update(
+        @PathVariable id: UUID,
+        @ValidHakemusUpdateRequest @RequestBody request: HakemusUpdateRequest,
+    ): MuutosilmoitusResponse =
+        muutosilmoitusService.update(id, request, currentUserId()).toResponse()
+
+    @ExceptionHandler(InvalidHakemusDataException::class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @Hidden
+    fun invalidHakemusDataException(ex: InvalidHakemusDataException): HankeErrorDetail {
+        logger.warn(ex) { ex.message }
+        return HankeErrorDetail(hankeError = HankeError.HAI2008, errorPaths = ex.errorPaths)
+    }
+
+    @ExceptionHandler(MuutosilmoitusAlreadySentException::class)
+    @ResponseStatus(HttpStatus.CONFLICT)
+    @Hidden
+    fun muutosilmoitusAlreadySentException(ex: MuutosilmoitusAlreadySentException): HankeError {
+        logger.warn(ex) { ex.message }
+        return HankeError.HAI7002
+    }
+
+    @ExceptionHandler(IncompatibleMuutosilmoitusUpdateException::class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @Hidden
+    fun incompatibleMuutosilmoitusUpdateException(
+        ex: IncompatibleMuutosilmoitusUpdateException
+    ): HankeError {
+        logger.warn(ex) { ex.message }
+        return HankeError.HAI2002
+    }
+
+    @ExceptionHandler(MuutosilmoitusNotFoundException::class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    @Hidden
+    fun muutosilmoitusNotFoundException(ex: MuutosilmoitusNotFoundException): HankeError {
+        logger.warn(ex) { ex.message }
+        return HankeError.HAI7001
     }
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/muutosilmoitus/MuutosilmoitusController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/muutosilmoitus/MuutosilmoitusController.kt
@@ -42,8 +42,7 @@ class MuutosilmoitusController(private val muutosilmoitusService: Muutosilmoitus
                 with a copy of the data the application has.
 
                 The application needs to be in DECISION or OPERATIONAL_CONDITION
-                status and there needs to be an open information request for the
-                application.
+                status.
 
                 For the time being, creating a muutosilmoitus is only supported
                 for excavation notifications.

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/muutosilmoitus/MuutosilmoitusEntity.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/muutosilmoitus/MuutosilmoitusEntity.kt
@@ -1,5 +1,6 @@
 package fi.hel.haitaton.hanke.muutosilmoitus
 
+import fi.hel.haitaton.hanke.domain.HasYhteystietoEntities
 import fi.hel.haitaton.hanke.hakemus.ApplicationContactType
 import fi.hel.haitaton.hanke.hakemus.HakemusEntityData
 import fi.hel.haitaton.hanke.hakemus.Hakemusyhteystieto
@@ -36,9 +37,10 @@ class MuutosilmoitusEntity(
     )
     @MapKey(name = "rooli")
     @BatchSize(size = 100)
-    var yhteystiedot: MutableMap<ApplicationContactType, MuutosilmoituksenYhteystietoEntity> =
+    override var yhteystiedot:
+        MutableMap<ApplicationContactType, MuutosilmoituksenYhteystietoEntity> =
         mutableMapOf(),
-) : MuutosilmoitusIdentifier {
+) : MuutosilmoitusIdentifier, HasYhteystietoEntities<MuutosilmoituksenYhteyshenkiloEntity> {
     fun toDomain(): Muutosilmoitus {
         val yhteystiedot: Map<ApplicationContactType, Hakemusyhteystieto> =
             yhteystiedot.mapValues { it.value.toDomain() }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/muutosilmoitus/MuutosilmoitusService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/muutosilmoitus/MuutosilmoitusService.kt
@@ -1,16 +1,24 @@
 package fi.hel.haitaton.hanke.muutosilmoitus
 
 import fi.hel.haitaton.hanke.allu.ApplicationStatus
+import fi.hel.haitaton.hanke.hakemus.ApplicationContactType
 import fi.hel.haitaton.hanke.hakemus.ApplicationType
+import fi.hel.haitaton.hanke.hakemus.CustomerWithContactsRequest
 import fi.hel.haitaton.hanke.hakemus.HakemusEntity
 import fi.hel.haitaton.hanke.hakemus.HakemusInWrongStatusException
 import fi.hel.haitaton.hanke.hakemus.HakemusNotFoundException
 import fi.hel.haitaton.hanke.hakemus.HakemusRepository
+import fi.hel.haitaton.hanke.hakemus.HakemusService
+import fi.hel.haitaton.hanke.hakemus.HakemusService.Companion.toExistingYhteystietoEntity
+import fi.hel.haitaton.hanke.hakemus.HakemusUpdateRequest
 import fi.hel.haitaton.hanke.hakemus.HakemusyhteyshenkiloEntity
 import fi.hel.haitaton.hanke.hakemus.HakemusyhteystietoEntity
 import fi.hel.haitaton.hanke.hakemus.WrongHakemusTypeException
 import fi.hel.haitaton.hanke.logging.MuutosilmoitusLoggingService
+import fi.hel.haitaton.hanke.permissions.HankeKayttajaService
+import java.util.UUID
 import mu.KotlinLogging
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -21,6 +29,8 @@ class MuutosilmoitusService(
     private val muutosilmoitusRepository: MuutosilmoitusRepository,
     private val hakemusRepository: HakemusRepository,
     private val loggingService: MuutosilmoitusLoggingService,
+    private val hakemusService: HakemusService,
+    private val hankeKayttajaService: HankeKayttajaService,
 ) {
 
     @Transactional(readOnly = true)
@@ -49,6 +59,149 @@ class MuutosilmoitusService(
         val saved = createFromHakemus(hakemus).toDomain()
         loggingService.logCreate(saved, currentUserId)
         return saved
+    }
+
+    @Transactional
+    fun update(id: UUID, request: HakemusUpdateRequest, currentUserId: String): Muutosilmoitus {
+        logger.info("Updating muutosilmoitus id=$id")
+
+        val entity =
+            muutosilmoitusRepository.findByIdOrNull(id) ?: throw MuutosilmoitusNotFoundException(id)
+        if (entity.sent != null) throw MuutosilmoitusAlreadySentException(entity)
+        val originalMuutosilmoitus = entity.toDomain()
+
+        logger.info { "The muutosilmoitus to update is ${entity.logString()}" }
+
+        assertUpdateCompatible(entity, request)
+
+        if (!request.hasChanges(originalMuutosilmoitus.hakemusData)) {
+            logger.info("Not updating unchanged hakemus data. ${entity.id}")
+            return originalMuutosilmoitus
+        }
+
+        hakemusService.assertGeometryValidity(request.areas)
+
+        val hakemusEntity = hakemusRepository.getReferenceById(entity.hakemusId)
+        hakemusService.assertYhteystiedotValidity(hakemusEntity.hanke, entity.yhteystiedot, request)
+        hakemusService.assertOrUpdateHankealueet(hakemusEntity.hanke, request)
+
+        val originalContactUserIds = entity.allContactUsers().map { it.id }.toSet()
+        val updatedMuutosilmoitusEntity = saveWithUpdate(entity, request, hakemusEntity.hanke.id)
+        hakemusService.sendHakemusNotifications(
+            updatedMuutosilmoitusEntity,
+            hakemusEntity,
+            originalContactUserIds,
+            currentUserId,
+        )
+
+        logger.info("Updated muutosilmoitus. ${updatedMuutosilmoitusEntity.logString()}")
+        val updatedMuutosilmoitus = updatedMuutosilmoitusEntity.toDomain()
+        loggingService.logUpdate(originalMuutosilmoitus, updatedMuutosilmoitus, currentUserId)
+
+        return updatedMuutosilmoitus
+    }
+
+    private fun assertUpdateCompatible(
+        entity: MuutosilmoitusEntity,
+        request: HakemusUpdateRequest,
+    ) {
+        if (entity.hakemusData.applicationType != request.applicationType) {
+            throw IncompatibleMuutosilmoitusUpdateException(
+                entity,
+                entity.hakemusData.applicationType,
+                request.applicationType,
+            )
+        }
+    }
+
+    /** Creates a new [MuutosilmoitusEntity] based on the given [request] and saves it. */
+    private fun saveWithUpdate(
+        muutosilmoitusEntity: MuutosilmoitusEntity,
+        request: HakemusUpdateRequest,
+        hankeId: Int,
+    ): MuutosilmoitusEntity {
+        logger.info {
+            "Creating and saving new muutosilmoitus data. ${muutosilmoitusEntity.logString()}"
+        }
+        muutosilmoitusEntity.hakemusData = request.toEntityData(muutosilmoitusEntity.hakemusData)
+        updateYhteystiedot(muutosilmoitusEntity, request.customersByRole(), hankeId)
+
+        hakemusService.updateTormaystarkastelut(muutosilmoitusEntity.hakemusData)?.let {
+            muutosilmoitusEntity.hakemusData = it
+        }
+        return muutosilmoitusRepository.save(muutosilmoitusEntity)
+    }
+
+    private fun updateYhteystiedot(
+        muutosilmoitusEntity: MuutosilmoitusEntity,
+        newYhteystiedot: Map<ApplicationContactType, CustomerWithContactsRequest?>,
+        hankeId: Int,
+    ) {
+        ApplicationContactType.entries.forEach { rooli ->
+            updateYhteystieto(rooli, muutosilmoitusEntity, newYhteystiedot[rooli], hankeId)?.let {
+                muutosilmoitusEntity.yhteystiedot[rooli] = it
+            } ?: muutosilmoitusEntity.yhteystiedot.remove(rooli)
+        }
+    }
+
+    private fun updateYhteystieto(
+        rooli: ApplicationContactType,
+        muutosilmoitusEntity: MuutosilmoitusEntity,
+        customerWithContactsRequest: CustomerWithContactsRequest?,
+        hankeId: Int,
+    ): MuutosilmoituksenYhteystietoEntity? {
+        if (customerWithContactsRequest == null) {
+            // customer was deleted
+            return null
+        }
+        return muutosilmoitusEntity.yhteystiedot[rooli]?.let {
+            val newHenkilot = customerWithContactsRequest.toExistingYhteystietoEntity(it)
+            newHenkilot.map { hankekayttajaId ->
+                it.yhteyshenkilot.add(
+                    newMuutosilmoituksenYhteyshenkiloEntity(hankekayttajaId, it, hankeId)
+                )
+            }
+            it
+        }
+            ?: customerWithContactsRequest.toNewMuutosilmoituksenYhteystietoEntity(
+                rooli,
+                muutosilmoitusEntity,
+                hankeId,
+            )
+    }
+
+    private fun CustomerWithContactsRequest.toNewMuutosilmoituksenYhteystietoEntity(
+        rooli: ApplicationContactType,
+        muutosilmoitusEntity: MuutosilmoitusEntity,
+        hankeId: Int,
+    ) =
+        MuutosilmoituksenYhteystietoEntity(
+                tyyppi = customer.type,
+                rooli = rooli,
+                nimi = customer.name,
+                sahkoposti = customer.email,
+                puhelinnumero = customer.phone,
+                registryKey = customer.registryKey,
+                muutosilmoitus = muutosilmoitusEntity,
+            )
+            .apply {
+                yhteyshenkilot.addAll(
+                    contacts.map {
+                        newMuutosilmoituksenYhteyshenkiloEntity(it.hankekayttajaId, this, hankeId)
+                    }
+                )
+            }
+
+    private fun newMuutosilmoituksenYhteyshenkiloEntity(
+        hankekayttajaId: UUID,
+        yhteystietoEntity: MuutosilmoituksenYhteystietoEntity,
+        hankeId: Int,
+    ): MuutosilmoituksenYhteyshenkiloEntity {
+        return MuutosilmoituksenYhteyshenkiloEntity(
+            yhteystieto = yhteystietoEntity,
+            hankekayttaja = hankeKayttajaService.getKayttajaForHanke(hankekayttajaId, hankeId),
+            tilaaja = false,
+        )
     }
 
     private fun createFromHakemus(hakemus: HakemusEntity): MuutosilmoitusEntity {
@@ -99,3 +252,18 @@ class MuutosilmoitusService(
             )
     }
 }
+
+class MuutosilmoitusNotFoundException(id: UUID) :
+    RuntimeException("Muutosilmoitus not found. id=$id")
+
+class MuutosilmoitusAlreadySentException(muutosilmoitus: MuutosilmoitusIdentifier) :
+    RuntimeException("Muutosilmoitus is already sent to Allu. ${muutosilmoitus.logString()}")
+
+class IncompatibleMuutosilmoitusUpdateException(
+    entity: MuutosilmoitusEntity,
+    existingType: ApplicationType,
+    requestedType: ApplicationType,
+) :
+    RuntimeException(
+        "Invalid update request for muutosilmoitus. existing type=$existingType, requested type=$requestedType. ${entity.logString()}"
+    )

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennysEntity.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennysEntity.kt
@@ -1,12 +1,12 @@
 package fi.hel.haitaton.hanke.taydennys
 
+import fi.hel.haitaton.hanke.domain.HasYhteystietoEntities
 import fi.hel.haitaton.hanke.hakemus.ApplicationContactType
 import fi.hel.haitaton.hanke.hakemus.ApplicationType
 import fi.hel.haitaton.hanke.hakemus.HakemusEntityData
 import fi.hel.haitaton.hanke.hakemus.Hakemusyhteystieto
 import fi.hel.haitaton.hanke.hakemus.JohtoselvityshakemusEntityData
 import fi.hel.haitaton.hanke.hakemus.KaivuilmoitusEntityData
-import fi.hel.haitaton.hanke.permissions.HankekayttajaEntity
 import io.hypersistence.utils.hibernate.type.json.JsonType
 import jakarta.persistence.CascadeType
 import jakarta.persistence.Column
@@ -43,9 +43,9 @@ class TaydennysEntity(
     )
     @MapKey(name = "rooli")
     @BatchSize(size = 100)
-    var yhteystiedot: MutableMap<ApplicationContactType, TaydennysyhteystietoEntity> =
+    override var yhteystiedot: MutableMap<ApplicationContactType, TaydennysyhteystietoEntity> =
         mutableMapOf(),
-) : TaydennysIdentifier {
+) : TaydennysIdentifier, HasYhteystietoEntities<TaydennysyhteyshenkiloEntity> {
 
     fun toDomain(): Taydennys {
         val yhteystiedot: Map<ApplicationContactType, Hakemusyhteystieto> =
@@ -72,11 +72,4 @@ class TaydennysEntity(
     override fun hakemusId(): Long = taydennyspyynto.applicationId
 
     override fun hakemustyyppi(): ApplicationType = hakemusData.applicationType
-
-    /** Returns all distinct contact users for this täydennys. */
-    fun allContactUsers(): List<HankekayttajaEntity> =
-        yhteystiedot.values
-            .flatMap { it.yhteyshenkilot }
-            .map { it.hankekayttaja }
-            .distinctBy { it.id }
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennysService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennysService.kt
@@ -279,7 +279,7 @@ class TaydennysService(
 
         val originalContactUserIds = taydennysEntity.allContactUsers().map { it.id }.toSet()
         val updatedTaydennysEntity = saveWithUpdate(taydennysEntity, request, hanke.id)
-        sendHakemusNotifications(
+        hakemusService.sendHakemusNotifications(
             updatedTaydennysEntity,
             hakemusEntity,
             originalContactUserIds,
@@ -391,48 +391,6 @@ class TaydennysService(
             tilaaja = false,
         )
     }
-
-    private fun sendHakemusNotifications(
-        taydennysEntity: TaydennysEntity,
-        hakemusEntity: HakemusEntity,
-        excludedUserIds: Set<UUID>,
-        userId: String,
-    ) {
-        val newContacts =
-            taydennysEntity.allContactUsers().filterNot { excludedUserIds.contains(it.id) }
-        if (newContacts.isNotEmpty()) {
-            hakemusService.sendHakemusNotifications(newContacts, hakemusEntity, userId)
-        }
-    }
-
-    private fun createYhteystieto(
-        yhteystieto: HakemusyhteystietoEntity,
-        taydennys: TaydennysEntity,
-    ): TaydennysyhteystietoEntity =
-        TaydennysyhteystietoEntity(
-                tyyppi = yhteystieto.tyyppi,
-                rooli = yhteystieto.rooli,
-                nimi = yhteystieto.nimi,
-                sahkoposti = yhteystieto.sahkoposti,
-                puhelinnumero = yhteystieto.puhelinnumero,
-                registryKey = yhteystieto.registryKey,
-                taydennys = taydennys,
-            )
-            .apply {
-                yhteyshenkilot.addAll(
-                    yhteystieto.yhteyshenkilot.map { createYhteyshenkilo(it, this) }
-                )
-            }
-
-    private fun createYhteyshenkilo(
-        yhteyshenkilo: HakemusyhteyshenkiloEntity,
-        yhteystieto: TaydennysyhteystietoEntity,
-    ) =
-        TaydennysyhteyshenkiloEntity(
-            taydennysyhteystieto = yhteystieto,
-            hankekayttaja = yhteyshenkilo.hankekayttaja,
-            tilaaja = yhteyshenkilo.tilaaja,
-        )
 
     private fun sendTaydennysToAllu(
         taydennys: Taydennys,
@@ -572,6 +530,35 @@ class TaydennysService(
     }
 
     companion object {
+
+        private fun createYhteystieto(
+            yhteystieto: HakemusyhteystietoEntity,
+            taydennys: TaydennysEntity,
+        ): TaydennysyhteystietoEntity =
+            TaydennysyhteystietoEntity(
+                    tyyppi = yhteystieto.tyyppi,
+                    rooli = yhteystieto.rooli,
+                    nimi = yhteystieto.nimi,
+                    sahkoposti = yhteystieto.sahkoposti,
+                    puhelinnumero = yhteystieto.puhelinnumero,
+                    registryKey = yhteystieto.registryKey,
+                    taydennys = taydennys,
+                )
+                .apply {
+                    yhteyshenkilot.addAll(
+                        yhteystieto.yhteyshenkilot.map { createYhteyshenkilo(it, this) }
+                    )
+                }
+
+        private fun createYhteyshenkilo(
+            yhteyshenkilo: HakemusyhteyshenkiloEntity,
+            yhteystieto: TaydennysyhteystietoEntity,
+        ) =
+            TaydennysyhteyshenkiloEntity(
+                taydennysyhteystieto = yhteystieto,
+                hankekayttaja = yhteyshenkilo.hankekayttaja,
+                tilaaja = yhteyshenkilo.tilaaja,
+            )
 
         fun mergeTaydennysToHakemus(taydennys: TaydennysEntity, hakemus: HakemusEntity) {
             hakemus.hakemusEntityData = taydennys.hakemusData

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusUpdateRequestFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusUpdateRequestFactory.kt
@@ -124,7 +124,8 @@ object HakemusUpdateRequestFactory {
                     createExcavationNotificationArea(
                         "Hankealue 1",
                         tyoalueet = listOf(createTyoalue(GeometriaFactory.polygon())),
-                    )),
+                    )
+                ),
             customerWithContacts =
                 createCustomerWithContactsRequest(
                     CustomerType.COMPANY,
@@ -153,7 +154,7 @@ object HakemusUpdateRequestFactory {
         customerType: CustomerType = CustomerType.COMPANY,
         yhteystietoId: UUID? = UUID.randomUUID(),
         registryKey: String?,
-        vararg hankekayttajaIds: UUID
+        vararg hankekayttajaIds: UUID,
     ) =
         CustomerWithContactsRequest(
             createCustomer(
@@ -167,7 +168,7 @@ object HakemusUpdateRequestFactory {
     fun createCustomerWithContactsRequest(
         customerType: CustomerType = CustomerType.COMPANY,
         yhteystietoId: UUID? = UUID.randomUUID(),
-        vararg hankekayttajaIds: UUID
+        vararg hankekayttajaIds: UUID,
     ) =
         createCustomerWithContactsRequest(
             customerType = customerType,
@@ -223,17 +224,19 @@ object HakemusUpdateRequestFactory {
     fun HakemusUpdateRequest.withCustomerWithContactsRequest(
         type: CustomerType,
         yhteystietoId: UUID? = UUID.randomUUID(),
-        vararg hankekayttajaIds: UUID
+        vararg hankekayttajaIds: UUID,
     ) =
         when (this) {
             is JohtoselvityshakemusUpdateRequest ->
                 this.copy(
                     customerWithContacts =
-                        createCustomerWithContactsRequest(type, yhteystietoId, *hankekayttajaIds))
+                        createCustomerWithContactsRequest(type, yhteystietoId, *hankekayttajaIds)
+                )
             is KaivuilmoitusUpdateRequest ->
                 this.copy(
                     customerWithContacts =
-                        createCustomerWithContactsRequest(type, yhteystietoId, *hankekayttajaIds))
+                        createCustomerWithContactsRequest(type, yhteystietoId, *hankekayttajaIds)
+                )
         }
 
     fun HakemusUpdateRequest.withCustomer(
@@ -244,7 +247,7 @@ object HakemusUpdateRequestFactory {
         phone: String = DEFAULT_CUSTOMER_PHONE,
         registryKey: String? = DEFAULT_CUSTOMER_REGISTRY_KEY,
         registryKeyHidden: Boolean = false,
-        vararg hankekayttajaIds: UUID
+        vararg hankekayttajaIds: UUID,
     ) =
         when (this) {
             is JohtoselvityshakemusUpdateRequest ->
@@ -260,7 +263,8 @@ object HakemusUpdateRequestFactory {
                                 registryKey = registryKey,
                             ),
                             hankekayttajaIds.map { ContactRequest(it) },
-                        ))
+                        )
+                )
             is KaivuilmoitusUpdateRequest ->
                 this.copy(
                     customerWithContacts =
@@ -275,8 +279,24 @@ object HakemusUpdateRequestFactory {
                                 registryKeyHidden = registryKeyHidden,
                             ),
                             hankekayttajaIds.map { ContactRequest(it) },
-                        ))
+                        )
+                )
         }
+
+    fun HakemusUpdateRequest.withCustomer(
+        type: CustomerType = CustomerType.COMPANY,
+        yhteystietoId: UUID? = UUID.randomUUID(),
+        vararg hankekayttajaIds: UUID,
+    ) =
+        withCustomer(
+            type = type,
+            yhteystietoId = yhteystietoId,
+            name = DEFAULT_CUSTOMER_NAME,
+            email = DEFAULT_CUSTOMER_EMAIL,
+            phone = DEFAULT_CUSTOMER_PHONE,
+            registryKey = DEFAULT_CUSTOMER_REGISTRY_KEY,
+            hankekayttajaIds = hankekayttajaIds,
+        )
 
     fun HakemusUpdateRequest.withName(name: String) =
         when (this) {
@@ -338,7 +358,8 @@ object HakemusUpdateRequestFactory {
                     postalAddress = postalAddressRequest,
                     email = email,
                     phone = phone,
-                ))
+                )
+        )
 
     fun HakemusUpdateRequest.withContractor(
         type: CustomerType = CustomerType.COMPANY,
@@ -347,7 +368,7 @@ object HakemusUpdateRequestFactory {
         email: String = DEFAULT_CUSTOMER_EMAIL,
         phone: String = DEFAULT_CUSTOMER_PHONE,
         registryKey: String = DEFAULT_CUSTOMER_REGISTRY_KEY,
-        vararg hankekayttajaIds: UUID
+        vararg hankekayttajaIds: UUID,
     ) =
         when (this) {
             is JohtoselvityshakemusUpdateRequest ->
@@ -363,7 +384,8 @@ object HakemusUpdateRequestFactory {
                                 registryKey = registryKey,
                             ),
                             hankekayttajaIds.map { ContactRequest(it) },
-                        ))
+                        )
+                )
             is KaivuilmoitusUpdateRequest ->
                 this.copy(
                     contractorWithContacts =
@@ -377,28 +399,14 @@ object HakemusUpdateRequestFactory {
                                 registryKey = registryKey,
                             ),
                             hankekayttajaIds.map { ContactRequest(it) },
-                        ))
+                        )
+                )
         }
-
-    fun HakemusUpdateRequest.withCustomer(
-        type: CustomerType = CustomerType.COMPANY,
-        yhteystietoId: UUID? = UUID.randomUUID(),
-        vararg hankekayttajaIds: UUID
-    ) =
-        withCustomer(
-            type = type,
-            yhteystietoId = yhteystietoId,
-            name = DEFAULT_CUSTOMER_NAME,
-            email = DEFAULT_CUSTOMER_EMAIL,
-            phone = DEFAULT_CUSTOMER_PHONE,
-            registryKey = DEFAULT_CUSTOMER_REGISTRY_KEY,
-            hankekayttajaIds = hankekayttajaIds,
-        )
 
     fun HakemusUpdateRequest.withContractor(
         type: CustomerType = CustomerType.COMPANY,
         yhteystietoId: UUID? = UUID.randomUUID(),
-        vararg hankekayttajaIds: UUID
+        vararg hankekayttajaIds: UUID,
     ) =
         withContractor(
             type = type,
@@ -410,20 +418,33 @@ object HakemusUpdateRequestFactory {
             hankekayttajaIds = hankekayttajaIds,
         )
 
-    fun JohtoselvityshakemusUpdateRequest.withWorkDescription(workDescription: String) =
-        this.copy(workDescription = workDescription)
+    fun HakemusUpdateRequest.withTimes(startTime: ZonedDateTime?, endTime: ZonedDateTime?) =
+        when (this) {
+            is JohtoselvityshakemusUpdateRequest ->
+                this.copy(startTime = startTime, endTime = endTime)
+            is KaivuilmoitusUpdateRequest -> this.copy(startTime = startTime, endTime = endTime)
+        }
 
-    fun JohtoselvityshakemusUpdateRequest.withTimes(
-        startTime: ZonedDateTime?,
-        endTime: ZonedDateTime?
-    ) = this.copy(startTime = startTime, endTime = endTime)
+    fun HakemusUpdateRequest.withRegistryKey(registryKey: String) =
+        when (this) {
+            is JohtoselvityshakemusUpdateRequest ->
+                this.copy(
+                    customerWithContacts =
+                        this.customerWithContacts?.copy(
+                            customer =
+                                this.customerWithContacts!!.customer.copy(registryKey = registryKey)
+                        )
+                )
 
-    fun JohtoselvityshakemusUpdateRequest.withRegistryKey(registryKey: String) =
-        this.copy(
-            customerWithContacts =
-                this.customerWithContacts?.copy(
-                    customer =
-                        this.customerWithContacts!!.customer.copy(registryKey = registryKey)))
+            is KaivuilmoitusUpdateRequest ->
+                this.copy(
+                    customerWithContacts =
+                        this.customerWithContacts?.copy(
+                            customer =
+                                this.customerWithContacts!!.customer.copy(registryKey = registryKey)
+                        )
+                )
+        }
 
     fun Hakemus.toUpdateRequest(): HakemusUpdateRequest =
         this.toResponse().applicationData.toJsonString().parseJson()


### PR DESCRIPTION
# Description

Add an API for updating a muutosilmoitus. The muutosilmoitus can't be sent yet. Handle both johtoselvityshakemus and kaivuilmoitus, even though currently a muutosilmoitus can be only created for a kaivuilmoitus.

Also add a missing test: a muutosilmoitus can be only created for a kaivuilmoitus.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-3400

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
After creating a muutosilmoitus, use [Swagger UI](http://localhost:3001/api/swagger-ui/index.html#/muutosilmoitus-controller/update_1) to modify it.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: