### PR TITLE
HAI-3402 Add muutosilmoitukset to hankkeen hakemukset

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusControllerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusControllerITest.kt
@@ -164,7 +164,8 @@ class HakemusControllerITest(@Autowired override val mockMvc: MockMvc) : Control
                 )
                 .andExpect(jsonPath("$.paatokset").isMap())
                 .andExpect(jsonPath("$.paatokset").isEmpty())
-                .andExpect(jsonPath("$.taydennyspyynto").value(null))
+                .andExpect(jsonPath("$.taydennyspyynto").doesNotHaveJsonPath())
+                .andExpect(jsonPath("$.muutosilmoitus").doesNotHaveJsonPath())
 
             verifySequence {
                 authorizer.authorizeHakemusId(id, PermissionCode.VIEW.name)
@@ -649,7 +650,7 @@ class HakemusControllerITest(@Autowired override val mockMvc: MockMvc) : Control
                     .andExpect(status().isOk)
                     .andExpect(jsonPath("$.applications[*].applicationData.areas").hasJsonPath())
                     .andExpect(jsonPath("$.applications[0].muutosilmoitus").exists())
-                    .andExpect(jsonPath("$.applications[1].muutosilmoitus").value(null))
+                    .andExpect(jsonPath("$.applications[1].muutosilmoitus").doesNotHaveJsonPath())
                     .andReturnBody()
 
             assertThat(response.applications).isNotEmpty()

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusControllerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusControllerITest.kt
@@ -2,6 +2,8 @@ package fi.hel.haitaton.hanke.hakemus
 
 import assertk.all
 import assertk.assertThat
+import assertk.assertions.each
+import assertk.assertions.extracting
 import assertk.assertions.isEmpty
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNotEmpty
@@ -32,6 +34,7 @@ import fi.hel.haitaton.hanke.factory.HakemusUpdateRequestFactory.withRegistryKey
 import fi.hel.haitaton.hanke.factory.HakemusUpdateRequestFactory.withTimes
 import fi.hel.haitaton.hanke.factory.HakemusUpdateRequestFactory.withWorkDescription
 import fi.hel.haitaton.hanke.factory.HankeFactory
+import fi.hel.haitaton.hanke.factory.MuutosilmoitusFactory
 import fi.hel.haitaton.hanke.factory.PaatosFactory
 import fi.hel.haitaton.hanke.factory.PaperDecisionReceiverFactory
 import fi.hel.haitaton.hanke.factory.TaydennysAttachmentFactory
@@ -383,6 +386,46 @@ class HakemusControllerITest(@Autowired override val mockMvc: MockMvc) : Control
             }
         }
 
+        @ParameterizedTest
+        @EnumSource(ApplicationType::class)
+        fun `returns muutosilmoitus and writes it to disclosure logs when it exists`(
+            applicationType: ApplicationType
+        ) {
+            val hakemus =
+                HakemusFactory.create(
+                    id = id,
+                    applicationType = applicationType,
+                    hankeTunnus = HANKE_TUNNUS,
+                )
+            val muutosilmoitus =
+                MuutosilmoitusFactory.create(
+                    hakemusId = hakemus.id,
+                    hakemusData = hakemus.applicationData,
+                )
+            every { hakemusService.getWithExtras(id) } returns
+                hakemus.withExtras(muutosilmoitus = muutosilmoitus)
+            every { authorizer.authorizeHakemusId(id, PermissionCode.VIEW.name) } returns true
+
+            get(url)
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.muutosilmoitus").exists())
+                .andExpect(
+                    jsonPath("$.muutosilmoitus.id")
+                        .value(MuutosilmoitusFactory.DEFAULT_ID.toString())
+                )
+                .andExpect(
+                    jsonPath("$.muutosilmoitus.applicationData.applicationType")
+                        .value(applicationType.name)
+                )
+
+            verifySequence {
+                authorizer.authorizeHakemusId(id, PermissionCode.VIEW.name)
+                hakemusService.getWithExtras(id)
+                disclosureLogService.saveForHakemusResponse(any(), USERNAME)
+                disclosureLogService.saveForMuutosilmoitus(muutosilmoitus.toResponse(), USERNAME)
+            }
+        }
+
         @Test
         fun `returns valmistumisilmoitukset with a kaivuilmoitus`() {
             val hakemus =
@@ -401,6 +444,8 @@ class HakemusControllerITest(@Autowired override val mockMvc: MockMvc) : Control
             every { authorizer.authorizeHakemusId(id, PermissionCode.VIEW.name) } returns true
             every { hakemusService.getWithExtras(id) } returns hakemus.withExtras()
 
+            // Jackson can't deserialize HakemusWithExtrasResponse because of the @JsonUnwrapped, so
+            // deserialize to HakemusResponse and check the basic fields from it.
             val response: HakemusResponse = get(url).andExpect(status().isOk).andReturnBody()
 
             assertThat(response.valmistumisilmoitukset).isNotNull().all {
@@ -520,7 +565,7 @@ class HakemusControllerITest(@Autowired override val mockMvc: MockMvc) : Control
 
         @Test
         @WithAnonymousUser
-        fun `Without authenticated user return unauthorized (401) `() {
+        fun `returns 401 when user is unauthenticated`() {
             get(url)
                 .andExpect(SecurityMockMvcResultMatchers.unauthenticated())
                 .andExpect(status().isUnauthorized)
@@ -528,23 +573,23 @@ class HakemusControllerITest(@Autowired override val mockMvc: MockMvc) : Control
         }
 
         @Test
-        fun `With unknown hanke tunnus return 404`() {
+        fun `return 404 when hanketunnus is unknown`() {
             every {
                 authorizer.authorizeHankeTunnus(HANKE_TUNNUS, PermissionCode.VIEW.name)
             } returns true
-            every { hakemusService.hankkeenHakemukset(HANKE_TUNNUS) } throws
+            every { hakemusService.hankkeenHakemuksetWithMuutosilmoitukset(HANKE_TUNNUS) } throws
                 HankeNotFoundException(HANKE_TUNNUS)
 
             get(url).andExpect(status().isNotFound).andExpect(hankeError(HankeError.HAI1001))
 
             verifySequence {
                 authorizer.authorizeHankeTunnus(HANKE_TUNNUS, PermissionCode.VIEW.name)
-                hakemusService.hankkeenHakemukset(HANKE_TUNNUS)
+                hakemusService.hankkeenHakemuksetWithMuutosilmoitukset(HANKE_TUNNUS)
             }
         }
 
         @Test
-        fun `When user does not have permission return 404`() {
+        fun `returns 404 when user does not have permission for the hanke`() {
             every { authorizer.authorizeHankeTunnus(HANKE_TUNNUS, PermissionCode.VIEW.name) } throws
                 HankeNotFoundException(HANKE_TUNNUS)
 
@@ -556,8 +601,9 @@ class HakemusControllerITest(@Autowired override val mockMvc: MockMvc) : Control
         }
 
         @Test
-        fun `With no applications return empty list`() {
-            every { hakemusService.hankkeenHakemukset(HANKE_TUNNUS) } returns emptyList()
+        fun `returns empty list when there are no applications`() {
+            every { hakemusService.hankkeenHakemuksetWithMuutosilmoitukset(HANKE_TUNNUS) } returns
+                emptyList()
             every {
                 authorizer.authorizeHankeTunnus(HANKE_TUNNUS, PermissionCode.VIEW.name)
             } returns true
@@ -568,12 +614,12 @@ class HakemusControllerITest(@Autowired override val mockMvc: MockMvc) : Control
             assertThat(response.applications).isEmpty()
             verifySequence {
                 authorizer.authorizeHankeTunnus(HANKE_TUNNUS, PermissionCode.VIEW.name)
-                hakemusService.hankkeenHakemukset(HANKE_TUNNUS)
+                hakemusService.hankkeenHakemuksetWithMuutosilmoitukset(HANKE_TUNNUS)
             }
         }
 
         @Test
-        fun `With known hanketunnus return applications`() {
+        fun `return applications without areas when areas parameter not specified`() {
             val cableReportApplicationResponses =
                 HakemusFactory.createSeveral(2, applicationType = ApplicationType.CABLE_REPORT)
             val excavationNotificationResponses =
@@ -581,27 +627,50 @@ class HakemusControllerITest(@Autowired override val mockMvc: MockMvc) : Control
                     2,
                     applicationType = ApplicationType.EXCAVATION_NOTIFICATION,
                 )
-            val hakemukset = cableReportApplicationResponses + excavationNotificationResponses
-            every { hakemusService.hankkeenHakemukset(HANKE_TUNNUS) } returns hakemukset
+            val hakemukset =
+                (cableReportApplicationResponses + excavationNotificationResponses).map {
+                    val muutosilmoitus =
+                        if (it.id == 1L)
+                            MuutosilmoitusFactory.create(
+                                hakemusType = it.applicationType,
+                                hakemusId = it.id,
+                            )
+                        else null
+                    Pair(it, muutosilmoitus)
+                }
+            every { hakemusService.hankkeenHakemuksetWithMuutosilmoitukset(HANKE_TUNNUS) } returns
+                hakemukset
             every {
                 authorizer.authorizeHankeTunnus(HANKE_TUNNUS, PermissionCode.VIEW.name)
             } returns true
 
             val response: HankkeenHakemuksetResponse =
-                get(url).andExpect(status().isOk).andReturnBody()
+                get(url)
+                    .andExpect(status().isOk)
+                    .andExpect(jsonPath("$.applications[*].applicationData.areas").hasJsonPath())
+                    .andExpect(jsonPath("$.applications[0].muutosilmoitus").exists())
+                    .andExpect(jsonPath("$.applications[1].muutosilmoitus").value(null))
+                    .andReturnBody()
 
             assertThat(response.applications).isNotEmpty()
+            assertThat(response.applications)
+                .extracting { it.applicationData.areas }
+                .each { it.isNull() }
             val expected =
-                HankkeenHakemuksetResponse(hakemukset.map { HankkeenHakemusResponse(it) })
+                HankkeenHakemuksetResponse(
+                    hakemukset.map { (hakemus, muutosilmoitus) ->
+                        HankkeenHakemusResponse(hakemus, muutosilmoitus)
+                    }
+                )
             assertThat(response).isEqualTo(expected)
             verifySequence {
                 authorizer.authorizeHankeTunnus(HANKE_TUNNUS, PermissionCode.VIEW.name)
-                hakemusService.hankkeenHakemukset(HANKE_TUNNUS)
+                hakemusService.hankkeenHakemuksetWithMuutosilmoitukset(HANKE_TUNNUS)
             }
         }
 
         @Test
-        fun `With areas included return application areas`() {
+        fun `returns application areas when areas parameter is true`() {
             val cableReportApplicationResponses =
                 HakemusFactory.createSeveral(2, applicationType = ApplicationType.CABLE_REPORT)
             val excavationNotificationResponses =
@@ -609,8 +678,12 @@ class HakemusControllerITest(@Autowired override val mockMvc: MockMvc) : Control
                     2,
                     applicationType = ApplicationType.EXCAVATION_NOTIFICATION,
                 )
-            val hakemukset = cableReportApplicationResponses + excavationNotificationResponses
-            every { hakemusService.hankkeenHakemukset(HANKE_TUNNUS) } returns hakemukset
+            val hakemukset =
+                (cableReportApplicationResponses + excavationNotificationResponses).map {
+                    Pair(it, null)
+                }
+            every { hakemusService.hankkeenHakemuksetWithMuutosilmoitukset(HANKE_TUNNUS) } returns
+                hakemukset
             every {
                 authorizer.authorizeHankeTunnus(HANKE_TUNNUS, PermissionCode.VIEW.name)
             } returns true
@@ -622,11 +695,11 @@ class HakemusControllerITest(@Autowired override val mockMvc: MockMvc) : Control
                 assertThat(response.applications[i].applicationData.areas)
                     .isNotNull()
                     .single()
-                    .isEqualTo(hakemukset[i].applicationData.areas?.single())
+                    .isEqualTo(hakemukset[i].first.applicationData.areas?.single())
             }
             verifySequence {
                 authorizer.authorizeHankeTunnus(HANKE_TUNNUS, PermissionCode.VIEW.name)
-                hakemusService.hankkeenHakemukset(HANKE_TUNNUS)
+                hakemusService.hankkeenHakemuksetWithMuutosilmoitukset(HANKE_TUNNUS)
             }
         }
     }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Constants.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Constants.kt
@@ -1,8 +1,5 @@
 package fi.hel.haitaton.hanke
 
-import com.fasterxml.jackson.databind.SerializationFeature
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import java.time.ZoneOffset
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
@@ -11,11 +8,7 @@ const val SRID = 3879
 
 const val COORDINATE_SYSTEM_URN = "urn:ogc:def:crs:EPSG::$SRID"
 
-val OBJECT_MAPPER =
-    jacksonObjectMapper().apply {
-        this.registerModule(JavaTimeModule())
-        this.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
-    }
+val OBJECT_MAPPER = createObjectMapper()
 
 val TZ_UTC: ZoneOffset = ZoneOffset.UTC
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Utils.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Utils.kt
@@ -1,5 +1,9 @@
 package fi.hel.haitaton.hanke
 
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import fi.hel.haitaton.hanke.domain.HasId
 import java.time.LocalDateTime
 import java.time.ZonedDateTime
@@ -14,6 +18,11 @@ private val logger = KotlinLogging.logger {}
 
 private val businessIdRegex = "^(\\d{7})-(\\d)\$".toRegex()
 private val businessIdMultipliers = listOf(7, 9, 10, 5, 8, 4, 2)
+
+fun createObjectMapper(): ObjectMapper =
+    jacksonObjectMapper()
+        .registerModule(JavaTimeModule())
+        .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
 
 /**
  * Helper for mapping and sorting data to existing collections.

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusController.kt
@@ -109,10 +109,12 @@ class HakemusController(
         logger.info {
             "Finding applications for hanke $hankeTunnus with areas ${if (areas) "included" else "excluded"}"
         }
-        val hakemukset = hakemusService.hankkeenHakemukset(hankeTunnus)
+        val hakemukset = hakemusService.hankkeenHakemuksetWithMuutosilmoitukset(hankeTunnus)
         logger.info { "Found ${hakemukset.size} applications for hanke $hankeTunnus" }
         return HankkeenHakemuksetResponse(
-            hakemukset.map { hakemus -> HankkeenHakemusResponse(hakemus, areas) }
+            hakemukset.map { (hakemus, muutosilmoitus) ->
+                HankkeenHakemusResponse(hakemus, muutosilmoitus, areas)
+            }
         )
     }
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusRepository.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusRepository.kt
@@ -1,5 +1,6 @@
 package fi.hel.haitaton.hanke.hakemus
 
+import fi.hel.haitaton.hanke.muutosilmoitus.MuutosilmoitusEntity
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
@@ -12,4 +13,12 @@ interface HakemusRepository : JpaRepository<HakemusEntity, Long> {
     fun getAllAlluIds(): List<Int>
 
     fun getOneByAlluid(alluid: Int): HakemusEntity?
+
+    @Query(
+        """SELECT new kotlin.Pair(a, m)
+           FROM HakemusEntity a
+           LEFT JOIN MuutosilmoitusEntity m ON m.hakemusId = a.id
+           WHERE a.hanke.id = :hankeId"""
+    )
+    fun findWithMuutosilmoitukset(hankeId: Int): List<Pair<HakemusEntity, MuutosilmoitusEntity?>>
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
@@ -24,6 +24,7 @@ import fi.hel.haitaton.hanke.hakemus.HakemusDataMapper.toAlluData
 import fi.hel.haitaton.hanke.logging.DisclosureLogService
 import fi.hel.haitaton.hanke.logging.HakemusLoggingService
 import fi.hel.haitaton.hanke.logging.HankeLoggingService
+import fi.hel.haitaton.hanke.muutosilmoitus.Muutosilmoitus
 import fi.hel.haitaton.hanke.muutosilmoitus.MuutosilmoitusRepository
 import fi.hel.haitaton.hanke.paatos.PaatosService
 import fi.hel.haitaton.hanke.pdf.EnrichedKaivuilmoitusalue
@@ -109,6 +110,19 @@ class HakemusService(
             hankeRepository.findByHankeTunnus(hankeTunnus)
                 ?: throw HankeNotFoundException(hankeTunnus)
         return hanke.hakemukset.map { it.toHakemus() }
+    }
+
+    @Transactional(readOnly = true)
+    fun hankkeenHakemuksetWithMuutosilmoitukset(
+        hankeTunnus: String
+    ): List<Pair<Hakemus, Muutosilmoitus?>> {
+        val hankeIdentifier =
+            hankeRepository.findOneByHankeTunnus(hankeTunnus)
+                ?: throw HankeNotFoundException(hankeTunnus)
+        return hakemusRepository.findWithMuutosilmoitukset(hankeIdentifier.id).map {
+            (hakemus, muutosilmoitus) ->
+            Pair(hakemus.toHakemus(), muutosilmoitus?.toDomain())
+        }
     }
 
     @Transactional

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusWithExtras.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusWithExtras.kt
@@ -1,5 +1,7 @@
 package fi.hel.haitaton.hanke.hakemus
 
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonInclude.Include
 import com.fasterxml.jackson.annotation.JsonUnwrapped
 import fi.hel.haitaton.hanke.muutosilmoitus.Muutosilmoitus
 import fi.hel.haitaton.hanke.muutosilmoitus.MuutosilmoitusResponse
@@ -27,8 +29,9 @@ data class HakemusWithExtras(
         )
 }
 
+@JsonInclude(Include.NON_NULL)
 data class HakemusWithExtrasResponse(
-    @JsonUnwrapped val hakemus: HakemusResponse,
+    @JsonUnwrapped @JsonInclude(Include.ALWAYS) val hakemus: HakemusResponse,
     val paatokset: Map<String, List<PaatosResponse>>,
     val taydennyspyynto: TaydennyspyyntoResponse?,
     val taydennys: TaydennysWithExtrasResponse?,

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HankkeenHakemuksetResponse.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HankkeenHakemuksetResponse.kt
@@ -1,7 +1,10 @@
 package fi.hel.haitaton.hanke.hakemus
 
 import fi.hel.haitaton.hanke.allu.ApplicationStatus
+import fi.hel.haitaton.hanke.muutosilmoitus.Muutosilmoitus
+import java.time.OffsetDateTime
 import java.time.ZonedDateTime
+import java.util.UUID
 
 data class HankkeenHakemuksetResponse(val applications: List<HankkeenHakemusResponse>)
 
@@ -12,9 +15,11 @@ data class HankkeenHakemusResponse(
     val applicationIdentifier: String?,
     val applicationType: ApplicationType,
     val applicationData: HankkeenHakemusDataResponse,
+    val muutosilmoitus: HankkeenHakemusMuutosilmoitusResponse?,
 ) {
     constructor(
         hakemus: Hakemus,
+        muutosilmoitus: Muutosilmoitus?,
         includeAreas: Boolean = false,
     ) : this(
         hakemus.id,
@@ -28,6 +33,7 @@ data class HankkeenHakemusResponse(
             is KaivuilmoitusData ->
                 HankkeenHakemusDataResponse(hakemus.applicationData, includeAreas)
         },
+        muutosilmoitus?.let { HankkeenHakemusMuutosilmoitusResponse(muutosilmoitus, includeAreas) },
     )
 }
 
@@ -55,5 +61,24 @@ data class HankkeenHakemusDataResponse(
         kaivuilmoitusEntityData.startTime,
         kaivuilmoitusEntityData.endTime,
         if (includeAreas) kaivuilmoitusEntityData.areas else null,
+    )
+}
+
+data class HankkeenHakemusMuutosilmoitusResponse(
+    val id: UUID,
+    val sent: OffsetDateTime?,
+    val hakemusdata: HankkeenHakemusDataResponse,
+) {
+    constructor(
+        muutosilmoitus: Muutosilmoitus,
+        includeAreas: Boolean,
+    ) : this(
+        id = muutosilmoitus.id,
+        sent = muutosilmoitus.sent,
+        hakemusdata =
+            when (val data = muutosilmoitus.hakemusData) {
+                is JohtoselvityshakemusData -> HankkeenHakemusDataResponse(data, includeAreas)
+                is KaivuilmoitusData -> HankkeenHakemusDataResponse(data, includeAreas)
+            },
     )
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HankkeenHakemuksetResponse.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HankkeenHakemuksetResponse.kt
@@ -1,5 +1,7 @@
 package fi.hel.haitaton.hanke.hakemus
 
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonInclude.Include
 import fi.hel.haitaton.hanke.allu.ApplicationStatus
 import fi.hel.haitaton.hanke.muutosilmoitus.Muutosilmoitus
 import java.time.OffsetDateTime
@@ -15,7 +17,7 @@ data class HankkeenHakemusResponse(
     val applicationIdentifier: String?,
     val applicationType: ApplicationType,
     val applicationData: HankkeenHakemusDataResponse,
-    val muutosilmoitus: HankkeenHakemusMuutosilmoitusResponse?,
+    @JsonInclude(Include.NON_NULL) val muutosilmoitus: HankkeenHakemusMuutosilmoitusResponse?,
 ) {
     constructor(
         hakemus: Hakemus,

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/MuutosilmoitusFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/MuutosilmoitusFactory.kt
@@ -71,7 +71,7 @@ class MuutosilmoitusFactory(
         val DEFAULT_ID: UUID = UUID.fromString("7df81277-2e36-4082-8687-0421c20d341e")
 
         fun create(
-            id: UUID = TaydennysFactory.DEFAULT_ID,
+            id: UUID = DEFAULT_ID,
             hakemusType: ApplicationType = ApplicationType.EXCAVATION_NOTIFICATION,
             hakemusId: Long = 1L,
             sent: OffsetDateTime? = null,
@@ -79,7 +79,7 @@ class MuutosilmoitusFactory(
         ) = Muutosilmoitus(id, hakemusId, sent, hakemusData)
 
         fun createEntity(
-            id: UUID = TaydennysFactory.DEFAULT_ID,
+            id: UUID = DEFAULT_ID,
             hakemusId: Long = ApplicationFactory.DEFAULT_APPLICATION_ID,
             sent: OffsetDateTime? = null,
             hakemusData: HakemusEntityData =

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusDataDeserializer.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusDataDeserializer.kt
@@ -11,13 +11,11 @@ class HakemusDataDeserializer : JsonDeserializer<HakemusData>() {
         val root = parser.readValueAsTree<ObjectNode>()
 
         val dataClass =
-            when (val typeString = root.path("applicationType").textValue()) {
-                ApplicationType.CABLE_REPORT.name -> JohtoselvityshakemusData::class.java
-                ApplicationType.EXCAVATION_NOTIFICATION.name -> KaivuilmoitusData::class.java
-                else -> throw IllegalArgumentException("Unsupported application type $typeString")
+            when (ApplicationType.valueOf(root.path("applicationType").textValue())) {
+                ApplicationType.CABLE_REPORT -> JohtoselvityshakemusData::class.java
+                ApplicationType.EXCAVATION_NOTIFICATION -> KaivuilmoitusData::class.java
             }
 
-        val hakemusData = OBJECT_MAPPER.treeToValue(root, dataClass)
-        return hakemusData
+        return OBJECT_MAPPER.treeToValue(root, dataClass)
     }
 }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusDataResponseDeserializer.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusDataResponseDeserializer.kt
@@ -14,14 +14,11 @@ class HakemusDataResponseDeserializer : JsonDeserializer<HakemusDataResponse>() 
         val root = parser.readValueAsTree<ObjectNode>()
 
         val dataClass =
-            when (val typeString = root.path("applicationType").textValue()) {
-                ApplicationType.CABLE_REPORT.name -> JohtoselvitysHakemusDataResponse::class.java
-                ApplicationType.EXCAVATION_NOTIFICATION.name ->
-                    KaivuilmoitusDataResponse::class.java
-                else -> throw IllegalArgumentException("Unsupported application type $typeString")
+            when (ApplicationType.valueOf(root.path("applicationType").textValue())) {
+                ApplicationType.CABLE_REPORT -> JohtoselvitysHakemusDataResponse::class.java
+                ApplicationType.EXCAVATION_NOTIFICATION -> KaivuilmoitusDataResponse::class.java
             }
 
-        val hakemusData = OBJECT_MAPPER.treeToValue(root, dataClass)
-        return hakemusData
+        return OBJECT_MAPPER.treeToValue(root, dataClass)
     }
 }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusResponseDeserializer.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusResponseDeserializer.kt
@@ -1,55 +1,36 @@
 package fi.hel.haitaton.hanke.hakemus
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.core.JsonParser
 import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.JsonDeserializer
+import com.fasterxml.jackson.databind.module.SimpleModule
 import com.fasterxml.jackson.databind.node.ObjectNode
-import fi.hel.haitaton.hanke.OBJECT_MAPPER
-import fi.hel.haitaton.hanke.allu.ApplicationStatus
-import fi.hel.haitaton.hanke.valmistumisilmoitus.ValmistumisilmoitusResponse
-import fi.hel.haitaton.hanke.valmistumisilmoitus.ValmistumisilmoitusType
+import fi.hel.haitaton.hanke.createObjectMapper
 
 class HakemusResponseDeserializer : JsonDeserializer<HakemusResponse>() {
     override fun deserialize(
         jsonParser: JsonParser,
-        deserializationContext: DeserializationContext
+        deserializationContext: DeserializationContext,
     ): HakemusResponse {
         val root = jsonParser.readValueAsTree<ObjectNode>()
-        val basicHakemus = OBJECT_MAPPER.treeToValue(root, BasicResponse::class.java)
-
         val dataClass =
-            when (basicHakemus.applicationType) {
+            when (ApplicationType.valueOf(root.path("applicationType").textValue())) {
                 ApplicationType.CABLE_REPORT -> JohtoselvitysHakemusDataResponse::class.java
                 ApplicationType.EXCAVATION_NOTIFICATION -> KaivuilmoitusDataResponse::class.java
             }
 
-        val dataNode = root.path("applicationData") as ObjectNode
-        val hakemusData = OBJECT_MAPPER.treeToValue(dataNode, dataClass)
-        return basicHakemus.toHakemusResponse(hakemusData)
-    }
+        // Create a new object mapper without the custom deserializers.
+        // Stops an infinite call loop on this method.
+        // Ignore unknown properties, since HakemusWithExtrasResponse is deserialized to this class
+        // in some tests.
+        val mapper = createObjectMapper().disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
 
-    @JsonIgnoreProperties(ignoreUnknown = true)
-    data class BasicResponse(
-        val id: Long,
-        val alluid: Int?,
-        val alluStatus: ApplicationStatus?,
-        val applicationIdentifier: String?,
-        val applicationType: ApplicationType,
-        val hankeTunnus: String,
-        val valmistumisilmoitukset:
-            Map<ValmistumisilmoitusType, List<ValmistumisilmoitusResponse>>?,
-    ) {
-        fun toHakemusResponse(hakemusData: HakemusDataResponse) =
-            HakemusResponse(
-                id,
-                alluid,
-                alluStatus,
-                applicationIdentifier,
-                applicationType,
-                hakemusData,
-                hankeTunnus,
-                valmistumisilmoitukset,
-            )
+        // Deserialize all instances of HakemusDataResponse according to applicationType.
+        mapper.registerModule(
+            SimpleModule().addAbstractTypeMapping(HakemusDataResponse::class.java, dataClass)
+        )
+
+        return mapper.treeToValue(root, HakemusResponse::class.java)
     }
 }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/HankkeenHakemusResponseDeserializer.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/HankkeenHakemusResponseDeserializer.kt
@@ -1,13 +1,11 @@
 package fi.hel.haitaton.hanke.hakemus
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.core.JsonParser
 import com.fasterxml.jackson.databind.DeserializationContext
 import com.fasterxml.jackson.databind.JsonDeserializer
+import com.fasterxml.jackson.databind.module.SimpleModule
 import com.fasterxml.jackson.databind.node.ObjectNode
-import fi.hel.haitaton.hanke.OBJECT_MAPPER
-import fi.hel.haitaton.hanke.allu.ApplicationStatus
-import java.time.ZonedDateTime
+import fi.hel.haitaton.hanke.createObjectMapper
 
 class HankkeenHakemusResponseDeserializer : JsonDeserializer<HankkeenHakemusResponse>() {
     override fun deserialize(
@@ -15,64 +13,21 @@ class HankkeenHakemusResponseDeserializer : JsonDeserializer<HankkeenHakemusResp
         deserializationContext: DeserializationContext,
     ): HankkeenHakemusResponse {
         val root = jsonParser.readValueAsTree<ObjectNode>()
-        val basicApplication = OBJECT_MAPPER.treeToValue(root, BasicResponse::class.java)
-        val dataNode = root.path("applicationData") as ObjectNode
-        val basicApplicationData =
-            OBJECT_MAPPER.treeToValue(dataNode, BasicDataResponse::class.java)
-        val areasNode = dataNode.path("areas")
-        val areas =
-            areasNode.map { areaNode ->
-                deserializeHakemusalue(areaNode as ObjectNode, basicApplication.applicationType)
+        val alueType =
+            when (ApplicationType.valueOf(root.path("applicationType").textValue())) {
+                ApplicationType.CABLE_REPORT -> JohtoselvitysHakemusalue::class
+                ApplicationType.EXCAVATION_NOTIFICATION -> KaivuilmoitusAlue::class
             }
-        return basicApplication.toHankkeenHakemusResponse(
-            basicApplicationData.toHankkeenHakemusDataResponse(areas)
+
+        // Create a new object mapper without the custom deserializers.
+        // Stops an infinite call loop on this method.
+        val mapper = createObjectMapper()
+
+        // Deserialize all instances of Hakemusalue according to applicationType.
+        mapper.registerModule(
+            SimpleModule().addAbstractTypeMapping(Hakemusalue::class.java, alueType.java)
         )
-    }
 
-    private fun deserializeHakemusalue(
-        areaNode: ObjectNode,
-        applicationType: ApplicationType,
-    ): Hakemusalue {
-        return when (applicationType) {
-            ApplicationType.CABLE_REPORT ->
-                OBJECT_MAPPER.treeToValue(areaNode, JohtoselvitysHakemusalue::class.java)
-            ApplicationType.EXCAVATION_NOTIFICATION ->
-                OBJECT_MAPPER.treeToValue(areaNode, KaivuilmoitusAlue::class.java)
-        }
-    }
-
-    @JsonIgnoreProperties(ignoreUnknown = true)
-    data class BasicResponse(
-        val id: Long,
-        val alluid: Int?,
-        val alluStatus: ApplicationStatus?,
-        val applicationIdentifier: String?,
-        val applicationType: ApplicationType,
-    ) {
-        fun toHankkeenHakemusResponse(hakemusData: HankkeenHakemusDataResponse) =
-            HankkeenHakemusResponse(
-                id,
-                alluid,
-                alluStatus,
-                applicationIdentifier,
-                applicationType,
-                hakemusData,
-            )
-    }
-
-    @JsonIgnoreProperties(ignoreUnknown = true)
-    data class BasicDataResponse(
-        val name: String,
-        val startTime: ZonedDateTime?,
-        val endTime: ZonedDateTime?,
-        val pendingOnClient: Boolean,
-    ) {
-        fun toHankkeenHakemusDataResponse(areas: List<Hakemusalue>) =
-            HankkeenHakemusDataResponse(
-                name,
-                startTime,
-                endTime,
-                if (areas.isNotEmpty()) areas else null,
-            )
+        return mapper.treeToValue(root, HankkeenHakemusResponse::class.java)
     }
 }


### PR DESCRIPTION
# Description

Add any muutosilmoitus under hakemus for the list of hankkeen hakemukset.

Also, simplify some test deserializers by using a new ObjectMapper instance that has a hard mapping for the required interface types.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-3402

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
With a kaivuilmoitus that has a muutosilmoitus, look at the response when opening the related hanke page.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 