### PR TITLE
HAI-789 Add decisions to hankkeen hakemukset

### DIFF
--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusController.kt
@@ -109,13 +109,9 @@ class HakemusController(
         logger.info {
             "Finding applications for hanke $hankeTunnus with areas ${if (areas) "included" else "excluded"}"
         }
-        val hakemukset = hakemusService.hankkeenHakemuksetWithMuutosilmoitukset(hankeTunnus)
+        val hakemukset = hakemusService.hankkeenHakemuksetResponses(hankeTunnus, areas)
         logger.info { "Found ${hakemukset.size} applications for hanke $hankeTunnus" }
-        return HankkeenHakemuksetResponse(
-            hakemukset.map { (hakemus, muutosilmoitus) ->
-                HankkeenHakemusResponse(hakemus, muutosilmoitus, areas)
-            }
-        )
+        return HankkeenHakemuksetResponse(hakemukset)
     }
 
     @PostMapping("/hakemukset")

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/paatos/PaatosRepository.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/paatos/PaatosRepository.kt
@@ -10,6 +10,8 @@ import org.springframework.stereotype.Repository
 interface PaatosRepository : JpaRepository<PaatosEntity, UUID> {
     fun findByHakemusId(hakemusId: Long): List<PaatosEntity>
 
+    fun findByHakemusIdIn(hakemusIds: Collection<Long>): List<PaatosEntity>
+
     @Modifying
     @Query("UPDATE PaatosEntity SET tila = :tila WHERE hakemustunnus = :hakemustunnus")
     fun markReplacedByHakemustunnus(hakemustunnus: String, tila: PaatosTila = PaatosTila.KORVATTU)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/paatos/PaatosService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/paatos/PaatosService.kt
@@ -29,6 +29,10 @@ class PaatosService(
     fun findByHakemusId(hakemusId: Long): List<Paatos> =
         paatosRepository.findByHakemusId(hakemusId).map { it.toDomain() }
 
+    @Transactional(readOnly = true)
+    fun findByHakemusIds(hakemusIds: Collection<Long>): List<Paatos> =
+        paatosRepository.findByHakemusIdIn(hakemusIds).map { it.toDomain() }
+
     @Transactional
     fun markReplaced(hakemustunnus: String) {
         paatosRepository.markReplacedByHakemustunnus(hakemustunnus)
@@ -47,29 +51,19 @@ class PaatosService(
         val pdfData = alluClient.getDecisionPdf(alluId)
 
         val filename = "${event.applicationIdentifier}-paatos.pdf"
-        createPaatos(
-            pdfData,
-            filename,
-            hakemus,
-            PaatosTyyppi.PAATOS,
-        )
+        createPaatos(pdfData, filename, hakemus, PaatosTyyppi.PAATOS)
     }
 
     @Transactional
     fun saveKaivuilmoituksenToiminnallinenKunto(
         hakemus: HakemusIdentifier,
-        event: ApplicationStatusEvent
+        event: ApplicationStatusEvent,
     ) {
         val alluId = hakemus.alluid!!
         val pdfData = alluClient.getOperationalConditionPdf(alluId)
 
         val filename = "${event.applicationIdentifier}-toiminnallinen-kunto.pdf"
-        createPaatos(
-            pdfData,
-            filename,
-            hakemus,
-            PaatosTyyppi.TOIMINNALLINEN_KUNTO,
-        )
+        createPaatos(pdfData, filename, hakemus, PaatosTyyppi.TOIMINNALLINEN_KUNTO)
     }
 
     @Transactional
@@ -78,12 +72,7 @@ class PaatosService(
         val pdfData = alluClient.getWorkFinishedPdf(alluId)
 
         val filename = "${event.applicationIdentifier}-tyo-valmis.pdf"
-        createPaatos(
-            pdfData,
-            filename,
-            hakemus,
-            PaatosTyyppi.TYO_VALMIS,
-        )
+        createPaatos(pdfData, filename, hakemus, PaatosTyyppi.TYO_VALMIS)
     }
 
     private fun createPaatos(
@@ -115,7 +104,8 @@ class PaatosService(
                 loppupaiva = applicationResponse.endTime.toLocalDate(),
                 blobLocation = path,
                 size = pdfData.size,
-            ))
+            )
+        )
     }
 
     private fun uploadPaatos(pdfData: ByteArray, filename: String, hakemusId: Long): String {

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/ApplicationFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/ApplicationFactory.kt
@@ -137,6 +137,12 @@ class ApplicationFactory(
                 ApplicationType.EXCAVATION_NOTIFICATION -> createBlankExcavationNotificationData()
             }
 
+        fun createHakemusEntityData(type: ApplicationType): HakemusEntityData =
+            when (type) {
+                ApplicationType.CABLE_REPORT -> createCableReportApplicationData()
+                ApplicationType.EXCAVATION_NOTIFICATION -> createExcavationNotificationData()
+            }
+
         fun createCableReportApplicationData(
             name: String = DEFAULT_APPLICATION_NAME,
             areas: List<JohtoselvitysHakemusalue>? = listOf(createCableReportApplicationArea()),

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusFactory.kt
@@ -17,6 +17,9 @@ import fi.hel.haitaton.hanke.hakemus.HakemusWithExtras
 import fi.hel.haitaton.hanke.hakemus.HakemusyhteyshenkiloRepository
 import fi.hel.haitaton.hanke.hakemus.Hakemusyhteystieto
 import fi.hel.haitaton.hanke.hakemus.HakemusyhteystietoRepository
+import fi.hel.haitaton.hanke.hakemus.HankkeenHakemusDataResponse
+import fi.hel.haitaton.hanke.hakemus.HankkeenHakemusMuutosilmoitusResponse
+import fi.hel.haitaton.hanke.hakemus.HankkeenHakemusResponse
 import fi.hel.haitaton.hanke.hakemus.JohtoselvitysHakemusalue
 import fi.hel.haitaton.hanke.hakemus.JohtoselvityshakemusData
 import fi.hel.haitaton.hanke.hakemus.KaivuilmoitusAlue
@@ -25,6 +28,7 @@ import fi.hel.haitaton.hanke.hakemus.Laskutusyhteystieto
 import fi.hel.haitaton.hanke.hakemus.PaperDecisionReceiver
 import fi.hel.haitaton.hanke.hakemus.PostalAddress
 import fi.hel.haitaton.hanke.muutosilmoitus.Muutosilmoitus
+import fi.hel.haitaton.hanke.muutosilmoitus.MuutosilmoitusEntity
 import fi.hel.haitaton.hanke.paatos.Paatos
 import fi.hel.haitaton.hanke.permissions.HankeKayttajaService
 import fi.hel.haitaton.hanke.taydennys.TaydennysWithExtras
@@ -129,8 +133,63 @@ class HakemusFactory(
                 valmistumisilmoitukset = valmistumisilmoitukset.groupBy { it.type },
             )
 
-        fun createSeveral(n: Long, applicationType: ApplicationType) =
-            (1..n).map { i -> create(id = i, applicationType = applicationType) }
+        fun createSeveralHankkeenHakemusResponses(
+            includeAreas: Boolean
+        ): List<HankkeenHakemusResponse> =
+            listOf(
+                createHankkeenHakemusResponse(
+                    1,
+                    ApplicationType.CABLE_REPORT,
+                    MuutosilmoitusFactory.createEntity(),
+                    includeAreas,
+                ),
+                createHankkeenHakemusResponse(2, ApplicationType.CABLE_REPORT, null, includeAreas),
+                createHankkeenHakemusResponse(
+                    3,
+                    ApplicationType.EXCAVATION_NOTIFICATION,
+                    MuutosilmoitusFactory.createEntity(),
+                    includeAreas,
+                ),
+                createHankkeenHakemusResponse(
+                    4,
+                    ApplicationType.EXCAVATION_NOTIFICATION,
+                    null,
+                    includeAreas,
+                ),
+            )
+
+        fun createHankkeenHakemusResponse(
+            id: Long = 1,
+            applicationType: ApplicationType = ApplicationType.CABLE_REPORT,
+            muutosilmoitus: MuutosilmoitusEntity? = null,
+            includeAreas: Boolean = false,
+        ): HankkeenHakemusResponse {
+            val data =
+                when (applicationType) {
+                    ApplicationType.CABLE_REPORT ->
+                        HankkeenHakemusDataResponse(
+                            ApplicationFactory.createCableReportApplicationData(),
+                            includeAreas,
+                        )
+                    ApplicationType.EXCAVATION_NOTIFICATION ->
+                        HankkeenHakemusDataResponse(
+                            ApplicationFactory.createExcavationNotificationData(),
+                            includeAreas,
+                        )
+                }
+
+            return HankkeenHakemusResponse(
+                id = id,
+                alluid = null,
+                alluStatus = null,
+                applicationIdentifier = null,
+                applicationType = applicationType,
+                applicationData = data,
+                muutosilmoitus =
+                    muutosilmoitus?.let { HankkeenHakemusMuutosilmoitusResponse(it, includeAreas) },
+                paatokset = mapOf(),
+            )
+        }
 
         fun createHakemusData(type: ApplicationType): HakemusData =
             when (type) {


### PR DESCRIPTION
# Description

In the response, add a list of all the decisions of each hakemus.

Also, make fetching hankkeen hakemukset marginally faster by eliminating the need to fetch contacts for the hakemus and the muutosilmoitus.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-789

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
With a kaivuilmoitus with decisions, open the hakemus list. It should show the download links.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 