### PR TITLE
HAI Unlinking applications deletes muutosilmoitukset

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/testdata/TestDataServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/testdata/TestDataServiceITest.kt
@@ -14,12 +14,14 @@ import fi.hel.haitaton.hanke.attachment.azure.Container
 import fi.hel.haitaton.hanke.attachment.common.MockFileClient
 import fi.hel.haitaton.hanke.factory.HakemusFactory
 import fi.hel.haitaton.hanke.factory.HankeFactory
+import fi.hel.haitaton.hanke.factory.MuutosilmoitusFactory
 import fi.hel.haitaton.hanke.factory.PaatosFactory
 import fi.hel.haitaton.hanke.factory.TaydennysAttachmentFactory
 import fi.hel.haitaton.hanke.factory.TaydennysFactory
 import fi.hel.haitaton.hanke.hakemus.HakemusEntity
 import fi.hel.haitaton.hanke.hakemus.HakemusEntityData
 import fi.hel.haitaton.hanke.hakemus.HakemusRepository
+import fi.hel.haitaton.hanke.muutosilmoitus.MuutosilmoitusRepository
 import fi.hel.haitaton.hanke.paatos.PaatosRepository
 import fi.hel.haitaton.hanke.taydennys.TaydennysRepository
 import fi.hel.haitaton.hanke.taydennys.TaydennyspyyntoRepository
@@ -36,11 +38,13 @@ class TestDataServiceITest : IntegrationTest() {
     @Autowired private lateinit var paatosRepository: PaatosRepository
     @Autowired private lateinit var taydennysRepository: TaydennysRepository
     @Autowired private lateinit var taydennyspyyntoRepository: TaydennyspyyntoRepository
+    @Autowired private lateinit var muutosilmoitusRepository: MuutosilmoitusRepository
     @Autowired private lateinit var hakemusFactory: HakemusFactory
     @Autowired private lateinit var hankeFactory: HankeFactory
     @Autowired private lateinit var paatosFactory: PaatosFactory
     @Autowired private lateinit var taydennysFactory: TaydennysFactory
     @Autowired private lateinit var taydennysAttachmentFactory: TaydennysAttachmentFactory
+    @Autowired private lateinit var muutosilmoitusFactory: MuutosilmoitusFactory
     @Autowired private lateinit var fileClient: MockFileClient
 
     @Nested
@@ -123,6 +127,15 @@ class TestDataServiceITest : IntegrationTest() {
             testDataService.unlinkApplicationsFromAllu()
 
             assertThat(fileClient.listBlobs(Container.PAATOKSET)).isEmpty()
+        }
+
+        @Test
+        fun `deletes muutosilmoitukset`() {
+            muutosilmoitusFactory.builder().save()
+
+            testDataService.unlinkApplicationsFromAllu()
+
+            assertThat(muutosilmoitusRepository.findAll()).isEmpty()
         }
     }
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/testdata/TestDataService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/testdata/TestDataService.kt
@@ -6,6 +6,7 @@ import fi.hel.haitaton.hanke.attachment.common.FileClient
 import fi.hel.haitaton.hanke.attachment.common.TaydennysAttachmentRepository
 import fi.hel.haitaton.hanke.hakemus.AlluUpdateService
 import fi.hel.haitaton.hanke.hakemus.HakemusRepository
+import fi.hel.haitaton.hanke.muutosilmoitus.MuutosilmoitusRepository
 import fi.hel.haitaton.hanke.paatos.PaatosEntity
 import fi.hel.haitaton.hanke.paatos.PaatosRepository
 import fi.hel.haitaton.hanke.taydennys.TaydennyspyyntoRepository
@@ -23,6 +24,7 @@ class TestDataService(
     private val taydennyspyyntoRepository: TaydennyspyyntoRepository,
     private val taydennysAttachmentRepository: TaydennysAttachmentRepository,
     private val paatosRepository: PaatosRepository,
+    private val muutosilmoitusRepository: MuutosilmoitusRepository,
     private val attachmentContentService: ApplicationAttachmentContentService,
     private val fileClient: FileClient,
     private val alluUpdateService: AlluUpdateService,
@@ -45,6 +47,9 @@ class TestDataService(
 
         logger.warn { "Removing all päätökset and täydennykset." }
         paatosRepository.findAll().forEach { deletePaatosWithAttachments(it) }
+
+        logger.warn { "Removing all muutosilmoitukset." }
+        muutosilmoitusRepository.deleteAll()
     }
 
     fun triggerAlluUpdates() {


### PR DESCRIPTION
# Description

`testdata/unlink-applications` endpoint deletes all muutosilmoitus

### Jira Issue: 

## Type of change

- [ ] Bug fix 
- [x] New feature 
- [ ] Other

# Instructions for testing
1. Have a kaivuilmoitus with muutosilmoitus
2. Call http://localhost:3001/api/swagger-ui/index.html#/test-data-controller/unlinkApplicationsFromAllu
3. Check that there is no more muutosilmoitus in database

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 

# Other relevant info
Please describe here if there is e.g. some requirements for this change or
 other info that the tester/user needs to know.