### PR TITLE
HAI Rename hakemusdata to applicationData

### DIFF
--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HankkeenHakemuksetResponse.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HankkeenHakemuksetResponse.kt
@@ -69,7 +69,7 @@ data class HankkeenHakemusDataResponse(
 data class HankkeenHakemusMuutosilmoitusResponse(
     val id: UUID,
     val sent: OffsetDateTime?,
-    val hakemusdata: HankkeenHakemusDataResponse,
+    val applicationData: HankkeenHakemusDataResponse,
 ) {
     constructor(
         muutosilmoitus: Muutosilmoitus,
@@ -77,7 +77,7 @@ data class HankkeenHakemusMuutosilmoitusResponse(
     ) : this(
         id = muutosilmoitus.id,
         sent = muutosilmoitus.sent,
-        hakemusdata =
+        applicationData =
             when (val data = muutosilmoitus.hakemusData) {
                 is JohtoselvityshakemusData -> HankkeenHakemusDataResponse(data, includeAreas)
                 is KaivuilmoitusData -> HankkeenHakemusDataResponse(data, includeAreas)


### PR DESCRIPTION
# Description

Renamed `HankkeenHakemusMuutosilmoitusResponse.hakemusdata` to `applicationData` to be uniform with `MuutosilmoitusResponse`.

### Jira Issue: 

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [x] Other

# Instructions for testing
Please describe tests how this change or new feature can be tested.

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 

# Other relevant info
Please describe here if there is e.g. some requirements for this change or
 other info that the tester/user needs to know.