### PR TITLE
HAI-3406 Add API for deleting a muutosilmoitus

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/muutosilmoitus/MuutosilmoitusControllerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/muutosilmoitus/MuutosilmoitusControllerITest.kt
@@ -43,6 +43,7 @@ import io.mockk.checkUnnecessaryStub
 import io.mockk.clearAllMocks
 import io.mockk.confirmVerified
 import io.mockk.every
+import io.mockk.justRun
 import io.mockk.verifySequence
 import java.time.ZonedDateTime
 import java.util.UUID
@@ -61,6 +62,7 @@ import org.springframework.security.test.context.support.WithAnonymousUser
 import org.springframework.security.test.context.support.WithMockUser
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
 @WebMvcTest(controllers = [MuutosilmoitusController::class])
@@ -454,6 +456,76 @@ class MuutosilmoitusControllerITest(
                 muutosilmoitusAuthorizer.authorize(id, PermissionCode.EDIT_APPLICATIONS.name)
                 muutosilmoitusService.update(id, request, USERNAME)
                 disclosureLogService.saveForMuutosilmoitus(muutosilmoitus.toResponse(), USERNAME)
+            }
+        }
+    }
+
+    @Nested
+    inner class Delete {
+        private val url = "/muutosilmoitukset/$id"
+
+        @Test
+        @WithAnonymousUser
+        fun `returns 401 when user is unknown`() {
+            delete(url).andExpect(status().isUnauthorized).andExpect(hankeError(HankeError.HAI0001))
+
+            verifySequence { muutosilmoitusService wasNot Called }
+        }
+
+        @Test
+        fun `returns 404 when no muutosilmoitus`() {
+            every {
+                muutosilmoitusAuthorizer.authorize(id, PermissionCode.EDIT_APPLICATIONS.name)
+            } throws MuutosilmoitusNotFoundException(id)
+
+            delete(url).andExpect(status().isNotFound).andExpect(hankeError(HankeError.HAI7001))
+
+            verifySequence {
+                muutosilmoitusAuthorizer.authorize(id, PermissionCode.EDIT_APPLICATIONS.name)
+            }
+        }
+
+        @Test
+        fun `returns 404 when no application`() {
+            every {
+                muutosilmoitusAuthorizer.authorize(id, PermissionCode.EDIT_APPLICATIONS.name)
+            } throws HakemusNotFoundException(1L)
+
+            delete(url).andExpect(status().isNotFound).andExpect(hankeError(HankeError.HAI2001))
+
+            verifySequence {
+                muutosilmoitusAuthorizer.authorize(id, PermissionCode.EDIT_APPLICATIONS.name)
+            }
+        }
+
+        @Test
+        fun `returns 409 when muutosilmoitus has been sent already`() {
+            every {
+                muutosilmoitusAuthorizer.authorize(id, PermissionCode.EDIT_APPLICATIONS.name)
+            } returns true
+            every { muutosilmoitusService.delete(id, USERNAME) } throws
+                MuutosilmoitusAlreadySentException(MuutosilmoitusFactory.create(id = id))
+
+            delete(url).andExpect(status().isConflict).andExpect(hankeError(HankeError.HAI7002))
+
+            verifySequence {
+                muutosilmoitusAuthorizer.authorize(id, PermissionCode.EDIT_APPLICATIONS.name)
+                muutosilmoitusService.delete(id, USERNAME)
+            }
+        }
+
+        @Test
+        fun `returns 204 when muutosilmoitus is deleted`() {
+            every {
+                muutosilmoitusAuthorizer.authorize(id, PermissionCode.EDIT_APPLICATIONS.name)
+            } returns true
+            justRun { muutosilmoitusService.delete(id, USERNAME) }
+
+            delete(url).andExpect(status().isNoContent).andExpect(content().string(""))
+
+            verifySequence {
+                muutosilmoitusAuthorizer.authorize(id, PermissionCode.EDIT_APPLICATIONS.name)
+                muutosilmoitusService.delete(id, USERNAME)
             }
         }
     }

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/muutosilmoitus/MuutosilmoitusServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/muutosilmoitus/MuutosilmoitusServiceITest.kt
@@ -4,35 +4,54 @@ import assertk.all
 import assertk.assertFailure
 import assertk.assertThat
 import assertk.assertions.hasClass
+import assertk.assertions.hasSize
+import assertk.assertions.isEmpty
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNotNull
 import assertk.assertions.isNull
 import assertk.assertions.messageContains
 import assertk.assertions.prop
 import assertk.assertions.single
+import fi.hel.haitaton.hanke.HankeService
 import fi.hel.haitaton.hanke.IntegrationTest
 import fi.hel.haitaton.hanke.allu.AlluClient
 import fi.hel.haitaton.hanke.allu.ApplicationStatus
+import fi.hel.haitaton.hanke.factory.ApplicationFactory
+import fi.hel.haitaton.hanke.factory.DateFactory
+import fi.hel.haitaton.hanke.factory.GeometriaFactory
 import fi.hel.haitaton.hanke.factory.HakemusFactory
+import fi.hel.haitaton.hanke.factory.MuutosilmoitusFactory
+import fi.hel.haitaton.hanke.factory.MuutosilmoitusFactory.Companion.toUpdateRequest
 import fi.hel.haitaton.hanke.hakemus.ApplicationType
 import fi.hel.haitaton.hanke.hakemus.HakemusInWrongStatusException
 import fi.hel.haitaton.hanke.hakemus.HakemusNotFoundException
+import fi.hel.haitaton.hanke.hakemus.HakemusRepository
+import fi.hel.haitaton.hanke.hakemus.HakemusService
+import fi.hel.haitaton.hanke.hakemus.JohtoselvityshakemusData
+import fi.hel.haitaton.hanke.hakemus.JohtoselvityshakemusUpdateRequest
 import fi.hel.haitaton.hanke.hakemus.WrongHakemusTypeException
 import fi.hel.haitaton.hanke.logging.AuditLogRepository
+import fi.hel.haitaton.hanke.logging.AuditLogTarget
 import fi.hel.haitaton.hanke.logging.ObjectType
 import fi.hel.haitaton.hanke.logging.Operation
+import fi.hel.haitaton.hanke.permissions.HankekayttajaRepository
+import fi.hel.haitaton.hanke.test.Asserts.hasSameGeometryAs
 import fi.hel.haitaton.hanke.test.AuditLogEntryEntityAsserts.hasId
+import fi.hel.haitaton.hanke.test.AuditLogEntryEntityAsserts.hasNoObjectAfter
 import fi.hel.haitaton.hanke.test.AuditLogEntryEntityAsserts.hasNoObjectBefore
 import fi.hel.haitaton.hanke.test.AuditLogEntryEntityAsserts.hasObjectAfter
+import fi.hel.haitaton.hanke.test.AuditLogEntryEntityAsserts.hasObjectBefore
 import fi.hel.haitaton.hanke.test.AuditLogEntryEntityAsserts.hasTargetType
 import fi.hel.haitaton.hanke.test.AuditLogEntryEntityAsserts.hasUserActor
 import fi.hel.haitaton.hanke.test.AuditLogEntryEntityAsserts.isSuccess
 import fi.hel.haitaton.hanke.test.AuditLogEntryEntityAsserts.withTarget
+import fi.hel.haitaton.hanke.test.TestUtils
 import fi.hel.haitaton.hanke.test.USERNAME
 import fi.hel.haitaton.hanke.test.resetCustomerIds
 import io.mockk.checkUnnecessaryStub
 import io.mockk.clearAllMocks
 import io.mockk.confirmVerified
+import java.util.UUID
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
@@ -40,11 +59,20 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.data.jpa.domain.AbstractPersistable_.id
 
 class MuutosilmoitusServiceITest(
     @Autowired private val muutosilmoitusService: MuutosilmoitusService,
+    @Autowired private val hakemusService: HakemusService,
+    @Autowired private val hankeService: HankeService,
     @Autowired private val hakemusFactory: HakemusFactory,
+    @Autowired private val muutosilmoitusFactory: MuutosilmoitusFactory,
     @Autowired private val auditLogRepository: AuditLogRepository,
+    @Autowired private val hakemusRepository: HakemusRepository,
+    @Autowired private val hankekayttajaRepository: HankekayttajaRepository,
+    @Autowired private val muutosilmoitusRepository: MuutosilmoitusRepository,
+    @Autowired private val yhteystietoRepository: MuutosilmoituksenYhteystietoRepository,
+    @Autowired private val yhteyshenkiloRepository: MuutosilmoituksenYhteyshenkiloRepository,
     @Autowired private val alluClient: AlluClient,
 ) : IntegrationTest() {
 
@@ -202,6 +230,120 @@ class MuutosilmoitusServiceITest(
                     hasObjectAfter(result)
                 }
             }
+        }
+    }
+
+    @Nested
+    inner class Delete {
+        @Test
+        fun `throws exception when muutosilmoitus is not found`() {
+            val id = UUID.fromString("51329a46-60a5-429d-a86e-b81ecbe26e60")
+
+            val failure = assertFailure { muutosilmoitusService.delete(id, USERNAME) }
+
+            failure.all {
+                hasClass(MuutosilmoitusNotFoundException::class)
+                messageContains("Muutosilmoitus not found")
+                messageContains("id=$id")
+            }
+        }
+
+        @Test
+        fun `throws exception when muutosilmoitus has already been sent`() {
+            val muutosilmoitus =
+                muutosilmoitusFactory
+                    .builder()
+                    .withSent(DateFactory.getStartDatetime().toOffsetDateTime())
+                    .saveEntity()
+
+            val failure = assertFailure {
+                muutosilmoitusService.delete(muutosilmoitus.id, USERNAME)
+            }
+
+            failure.all {
+                hasClass(MuutosilmoitusAlreadySentException::class)
+                messageContains("Muutosilmoitus is already sent to Allu")
+                messageContains("id=${muutosilmoitus.id}")
+            }
+        }
+
+        @Test
+        fun `deletes muutosilmoitus`() {
+            val muutosilmoitus = muutosilmoitusFactory.builder().saveEntity()
+            assertThat(muutosilmoitusRepository.findAll()).hasSize(1)
+
+            muutosilmoitusService.delete(muutosilmoitus.id, USERNAME)
+
+            assertThat(muutosilmoitusRepository.findAll()).isEmpty()
+        }
+
+        @Test
+        fun `writes the deleted muutosilmoitus to audit log`() {
+            TestUtils.addMockedRequestIp()
+            val muutosilmoitus = muutosilmoitusFactory.builder().save()
+            auditLogRepository.deleteAll()
+
+            muutosilmoitusService.delete(muutosilmoitus.id, USERNAME)
+
+            assertThat(auditLogRepository.findAll()).single().isSuccess(Operation.DELETE) {
+                hasUserActor(USERNAME, TestUtils.mockedIp)
+                withTarget {
+                    prop(AuditLogTarget::id).isEqualTo(muutosilmoitus.id.toString())
+                    prop(AuditLogTarget::type).isEqualTo(ObjectType.MUUTOSILMOITUS)
+                    hasObjectBefore(muutosilmoitus)
+                    hasNoObjectAfter()
+                }
+            }
+        }
+
+        @Test
+        fun `deletes yhteystiedot and yhteyshenkilot but no hankekayttaja`() {
+            val muutosilmoitus =
+                muutosilmoitusFactory
+                    .builder()
+                    .hakija()
+                    .rakennuttaja()
+                    .tyonSuorittaja()
+                    .asianhoitaja()
+                    .saveEntity()
+            assertThat(muutosilmoitusRepository.findAll()).hasSize(1)
+            assertThat(yhteystietoRepository.findAll()).hasSize(4)
+            assertThat(yhteyshenkiloRepository.findAll()).hasSize(4)
+            assertThat(hankekayttajaRepository.count())
+                .isEqualTo(5) // Hanke founder + one kayttaja for each role
+
+            muutosilmoitusService.delete(muutosilmoitus.id, USERNAME)
+
+            assertThat(muutosilmoitusRepository.findAll()).isEmpty()
+            assertThat(yhteystietoRepository.findAll()).isEmpty()
+            assertThat(yhteyshenkiloRepository.findAll()).isEmpty()
+            assertThat(hankekayttajaRepository.count())
+                .isEqualTo(5) // Hanke founder + one kayttaja for each role
+        }
+
+        @Test
+        fun `resets the hankealueet when the hanke is a generated one`() {
+            val hakemusEntity =
+                hakemusFactory.builderWithGeneratedHanke().withMandatoryFields().saveEntity()
+            val hakemus = hakemusService.getById(hakemusEntity.id)
+            val muutosilmoitus = muutosilmoitusFactory.builder(hakemusEntity).save()
+            val newAreas =
+                listOf(
+                    ApplicationFactory.createCableReportApplicationArea(
+                        geometry = GeometriaFactory.polygon()
+                    ),
+                    ApplicationFactory.createCableReportApplicationArea(
+                        geometry = GeometriaFactory.thirdPolygon()
+                    ),
+                )
+            val update = muutosilmoitus.toUpdateRequest() as JohtoselvityshakemusUpdateRequest
+            muutosilmoitusService.update(muutosilmoitus.id, update.copy(areas = newAreas), USERNAME)
+            assertThat(hankeService.loadHanke(hakemus.hankeTunnus)!!).hasSameGeometryAs(newAreas)
+
+            muutosilmoitusService.delete(muutosilmoitus.id, USERNAME)
+
+            assertThat(hankeService.loadHanke(hakemus.hankeTunnus)!!)
+                .hasSameGeometryAs((hakemus.applicationData as JohtoselvityshakemusData).areas!!)
         }
     }
 }

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennysControllerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennysControllerITest.kt
@@ -610,13 +610,13 @@ class TaydennysControllerITest(@Autowired override val mockMvc: MockMvc) : Contr
         }
 
         @Test
-        fun `deletes taydennys`() {
+        fun `returns 204 when taydennys is deleted`() {
             every {
                 taydennysAuthorizer.authorize(id, PermissionCode.EDIT_APPLICATIONS.name)
             } returns true
             justRun { taydennysService.delete(id, USERNAME) }
 
-            delete(url).andExpect(status().isOk).andExpect(content().string(""))
+            delete(url).andExpect(status().isNoContent).andExpect(content().string(""))
 
             verifySequence {
                 taydennysAuthorizer.authorize(id, PermissionCode.EDIT_APPLICATIONS.name)

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennysServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennysServiceITest.kt
@@ -51,8 +51,8 @@ import fi.hel.haitaton.hanke.hakemus.ApplicationType
 import fi.hel.haitaton.hanke.hakemus.HakemusDataMapper.toAlluData
 import fi.hel.haitaton.hanke.hakemus.HakemusInWrongStatusException
 import fi.hel.haitaton.hanke.hakemus.HakemusService
+import fi.hel.haitaton.hanke.hakemus.Hakemusalue
 import fi.hel.haitaton.hanke.hakemus.InvalidHakemusDataException
-import fi.hel.haitaton.hanke.hakemus.JohtoselvitysHakemusalue
 import fi.hel.haitaton.hanke.hakemus.JohtoselvityshakemusData
 import fi.hel.haitaton.hanke.hakemus.JohtoselvityshakemusUpdateRequest
 import fi.hel.haitaton.hanke.hasSameElementsAs
@@ -1176,7 +1176,7 @@ class TaydennysServiceITest(
 
     private fun assertHankeHasSameGeometryAsHakemus(
         hanketunnus: String,
-        hakemusalueet: List<JohtoselvitysHakemusalue>,
+        hakemusalueet: List<Hakemusalue>,
     ) {
         val hanke = hankeService.loadHanke(hanketunnus)!!
         val hankeCoordinates =
@@ -1185,6 +1185,6 @@ class TaydennysServiceITest(
                 .map { it.geometry as Polygon }
                 .map { it.coordinates }
         assertThat(hankeCoordinates)
-            .hasSameElementsAs(hakemusalueet.map { it.geometry.coordinates })
+            .hasSameElementsAs(hakemusalueet.map { it.geometries().flatMap { g -> g.coordinates } })
     }
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Persistence.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Persistence.kt
@@ -4,6 +4,7 @@ import fi.hel.haitaton.hanke.attachment.common.HankeAttachmentEntity
 import fi.hel.haitaton.hanke.domain.HankeStatus
 import fi.hel.haitaton.hanke.domain.Hankevaihe
 import fi.hel.haitaton.hanke.domain.HasId
+import fi.hel.haitaton.hanke.domain.Loggable
 import fi.hel.haitaton.hanke.domain.TyomaaTyyppi
 import fi.hel.haitaton.hanke.hakemus.HakemusEntity
 import jakarta.persistence.CascadeType
@@ -55,21 +56,21 @@ class HankeEntity(
         fetch = FetchType.LAZY,
         mappedBy = "hanke",
         cascade = [CascadeType.ALL],
-        orphanRemoval = true
+        orphanRemoval = true,
     )
     var yhteystiedot: MutableList<HankeYhteystietoEntity> = mutableListOf(),
     @OneToMany(
         fetch = FetchType.LAZY,
         mappedBy = "hanke",
         cascade = [CascadeType.ALL],
-        orphanRemoval = true
+        orphanRemoval = true,
     )
     var alueet: MutableList<HankealueEntity> = mutableListOf(),
     @OneToMany(
         fetch = FetchType.LAZY,
         mappedBy = "hanke",
         cascade = [CascadeType.ALL],
-        orphanRemoval = true
+        orphanRemoval = true,
     )
     var liitteet: MutableList<HankeAttachmentEntity> = mutableListOf(),
 ) : HankeIdentifier {
@@ -124,11 +125,11 @@ interface HankeRepository : JpaRepository<HankeEntity, Int> {
     fun findAllByStatus(status: HankeStatus): List<HankeEntity>
 }
 
-interface HankeIdentifier : HasId<Int> {
+interface HankeIdentifier : HasId<Int>, Loggable {
     override val id: Int
     val hankeTunnus: String
 
-    fun logString() = "Hanke: (id=${id}, tunnus=${hankeTunnus})"
+    override fun logString() = "Hanke: (id=${id}, tunnus=${hankeTunnus})"
 }
 
 enum class CounterType {
@@ -179,7 +180,7 @@ interface IdCounterRepository : JpaRepository<IdCounter, CounterType> {
             WHERE counterType = :counterType
             RETURNING counterType, value
             """,
-        nativeQuery = true
+        nativeQuery = true,
     )
     fun incrementAndGet(counterType: String): List<IdCounter>
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/Loggable.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/Loggable.kt
@@ -1,0 +1,5 @@
+package fi.hel.haitaton.hanke.domain
+
+fun interface Loggable {
+    fun logString(): String
+}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/Hakemus.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/Hakemus.kt
@@ -3,6 +3,7 @@ package fi.hel.haitaton.hanke.hakemus
 import fi.hel.haitaton.hanke.allu.ApplicationStatus
 import fi.hel.haitaton.hanke.checkChange
 import fi.hel.haitaton.hanke.domain.HasId
+import fi.hel.haitaton.hanke.domain.Loggable
 import fi.hel.haitaton.hanke.valmistumisilmoitus.Valmistumisilmoitus
 import fi.hel.haitaton.hanke.valmistumisilmoitus.ValmistumisilmoitusType
 import java.time.ZonedDateTime
@@ -277,13 +278,13 @@ data class KaivuilmoitusData(
     }
 }
 
-interface HakemusIdentifier : HasId<Long> {
+interface HakemusIdentifier : HasId<Long>, Loggable {
     override val id: Long
     val alluid: Int?
     val applicationIdentifier: String?
     val applicationType: ApplicationType
 
-    fun logString() =
+    override fun logString() =
         "Hakemus: (id=$id, alluId=$alluid, identifier=$applicationIdentifier, type=$applicationType)"
 }
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/muutosilmoitus/MuutosilmoitusIdentifier.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/muutosilmoitus/MuutosilmoitusIdentifier.kt
@@ -1,11 +1,12 @@
 package fi.hel.haitaton.hanke.muutosilmoitus
 
 import fi.hel.haitaton.hanke.domain.HasId
+import fi.hel.haitaton.hanke.domain.Loggable
 import java.util.UUID
 
-interface MuutosilmoitusIdentifier : HasId<UUID> {
+interface MuutosilmoitusIdentifier : HasId<UUID>, Loggable {
     override val id: UUID
     val hakemusId: Long
 
-    fun logString() = "Muutosilmoitus: (id=$id, hakemusId=$hakemusId)"
+    override fun logString() = "Muutosilmoitus: (id=$id, hakemusId=$hakemusId)"
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennysController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennysController.kt
@@ -134,11 +134,12 @@ class TaydennysController(private val taydennysService: TaydennysService) {
         taydennysService.sendTaydennys(id, currentUserId()).toResponse()
 
     @DeleteMapping("/taydennykset/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
     @Operation(summary = "Delete a täydennys", description = "Deletes a täydennys.")
     @ApiResponses(
         value =
             [
-                ApiResponse(description = "Täydennys deleted, no body", responseCode = "200"),
+                ApiResponse(description = "Täydennys deleted, no body", responseCode = "204"),
                 ApiResponse(
                     description = "A täydennys was not found with the given id",
                     responseCode = "404",
@@ -148,7 +149,9 @@ class TaydennysController(private val taydennysService: TaydennysService) {
     )
     @PreAuthorize("@taydennysAuthorizer.authorize(#id, 'EDIT_APPLICATIONS')")
     fun delete(@PathVariable id: UUID) {
+        logger.info { "Deleting täydennys with id $id..." }
         taydennysService.delete(id, currentUserId())
+        logger.info { "Deleted täydennys with id $id." }
     }
 
     @ExceptionHandler(InvalidHakemusDataException::class)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennysIdentifier.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennysIdentifier.kt
@@ -1,10 +1,11 @@
 package fi.hel.haitaton.hanke.taydennys
 
 import fi.hel.haitaton.hanke.domain.HasId
+import fi.hel.haitaton.hanke.domain.Loggable
 import fi.hel.haitaton.hanke.hakemus.ApplicationType
 import java.util.UUID
 
-interface TaydennysIdentifier : HasId<UUID> {
+interface TaydennysIdentifier : HasId<UUID>, Loggable {
     override val id: UUID
 
     fun taydennyspyyntoId(): UUID
@@ -15,14 +16,15 @@ interface TaydennysIdentifier : HasId<UUID> {
 
     fun hakemustyyppi(): ApplicationType
 
-    fun logString() =
+    override fun logString() =
         "Täydennys: (" +
             listOf(
                     "id=$id",
                     "täydennyspyyntö=${taydennyspyyntoId()}",
                     "täydennyspyyntöAlluId=${taydennyspyyntoAlluId()}",
                     "hakemusId=${hakemusId()}",
-                    "hakemustyyppi=${hakemustyyppi()}")
+                    "hakemustyyppi=${hakemustyyppi()}",
+                )
                 .joinToString() +
             ")"
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennysService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennysService.kt
@@ -146,7 +146,7 @@ class TaydennysService(
         }
 
         taydennysRepository.findByApplicationId(application.id)?.also {
-            resetAreasIfHankeGenerated(it)
+            hakemusService.resetAreasIfHankeGenerated(it.hakemusId(), it)
 
             logger.info { "A täydennys was found. Removing it." }
             attachmentService.deleteAllAttachments(it)
@@ -505,7 +505,7 @@ class TaydennysService(
         val taydennysEntity =
             taydennysRepository.findByIdOrNull(id) ?: throw TaydennysNotFoundException(id)
 
-        resetAreasIfHankeGenerated(taydennysEntity)
+        hakemusService.resetAreasIfHankeGenerated(taydennysEntity.hakemusId(), taydennysEntity)
 
         attachmentService.deleteAllAttachments(taydennysEntity)
         val taydennys = taydennysEntity.toDomain()

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/MuutosilmoitusBuilder.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/MuutosilmoitusBuilder.kt
@@ -1,24 +1,32 @@
 package fi.hel.haitaton.hanke.factory
 
+import fi.hel.haitaton.hanke.hakemus.ApplicationContactType
 import fi.hel.haitaton.hanke.hakemus.HakemusEntityData
 import fi.hel.haitaton.hanke.hakemus.Hakemusalue
 import fi.hel.haitaton.hanke.hakemus.JohtoselvitysHakemusalue
 import fi.hel.haitaton.hanke.hakemus.JohtoselvityshakemusEntityData
 import fi.hel.haitaton.hanke.hakemus.KaivuilmoitusAlue
 import fi.hel.haitaton.hanke.hakemus.KaivuilmoitusEntityData
+import fi.hel.haitaton.hanke.muutosilmoitus.MuutosilmoituksenYhteyshenkiloEntity
 import fi.hel.haitaton.hanke.muutosilmoitus.MuutosilmoituksenYhteyshenkiloRepository
+import fi.hel.haitaton.hanke.muutosilmoitus.MuutosilmoituksenYhteystietoEntity
 import fi.hel.haitaton.hanke.muutosilmoitus.Muutosilmoitus
 import fi.hel.haitaton.hanke.muutosilmoitus.MuutosilmoitusEntity
 import fi.hel.haitaton.hanke.muutosilmoitus.MuutosilmoitusRepository
 import fi.hel.haitaton.hanke.muutosilmoitus.MuutosilmoitusService
+import fi.hel.haitaton.hanke.permissions.HankekayttajaEntity
+import fi.hel.haitaton.hanke.permissions.HankekayttajaInput
+import fi.hel.haitaton.hanke.permissions.Kayttooikeustaso
 import java.security.InvalidParameterException
 import java.time.OffsetDateTime
 
 class MuutosilmoitusBuilder(
     private var muutosilmoitusEntity: MuutosilmoitusEntity,
+    private var hankeId: Int,
     private val muutosilmoitusService: MuutosilmoitusService,
     private val muutosilmoitusRepository: MuutosilmoitusRepository,
     private val yhteyshenkiloRepository: MuutosilmoituksenYhteyshenkiloRepository,
+    private val hankeKayttajaFactory: HankeKayttajaFactory,
 ) {
 
     fun save(): Muutosilmoitus = muutosilmoitusService.find(saveEntity().hakemusId)!!
@@ -63,6 +71,85 @@ class MuutosilmoitusBuilder(
         muutosilmoitusEntity.yhteystiedot = mutableMapOf()
         return this
     }
+
+    fun hakija(
+        yhteystieto: MuutosilmoituksenYhteystietoEntity =
+            MuutosilmoitusFactory.createYhteystietoEntity(
+                muutosilmoitusEntity,
+                rooli = ApplicationContactType.HAKIJA,
+            ),
+        vararg yhteyshenkilot: HankekayttajaEntity =
+            arrayOf(kayttaja(HankeKayttajaFactory.KAYTTAJA_INPUT_HAKIJA)),
+    ): MuutosilmoitusBuilder =
+        yhteystieto(ApplicationContactType.HAKIJA, yhteystieto, *yhteyshenkilot)
+
+    fun rakennuttaja(
+        yhteystieto: MuutosilmoituksenYhteystietoEntity =
+            MuutosilmoitusFactory.createYhteystietoEntity(
+                muutosilmoitusEntity,
+                rooli = ApplicationContactType.RAKENNUTTAJA,
+            ),
+        vararg yhteyshenkilot: HankekayttajaEntity =
+            arrayOf(kayttaja(HankeKayttajaFactory.KAYTTAJA_INPUT_RAKENNUTTAJA)),
+    ): MuutosilmoitusBuilder =
+        yhteystieto(ApplicationContactType.RAKENNUTTAJA, yhteystieto, *yhteyshenkilot)
+
+    fun tyonSuorittaja(
+        yhteystieto: MuutosilmoituksenYhteystietoEntity =
+            MuutosilmoitusFactory.createYhteystietoEntity(
+                muutosilmoitusEntity,
+                rooli = ApplicationContactType.TYON_SUORITTAJA,
+            ),
+        vararg yhteyshenkilot: HankekayttajaEntity =
+            arrayOf(kayttaja(HankeKayttajaFactory.KAYTTAJA_INPUT_SUORITTAJA)),
+    ): MuutosilmoitusBuilder =
+        yhteystieto(ApplicationContactType.TYON_SUORITTAJA, yhteystieto, *yhteyshenkilot)
+
+    fun asianhoitaja(
+        yhteystieto: MuutosilmoituksenYhteystietoEntity =
+            MuutosilmoitusFactory.createYhteystietoEntity(
+                muutosilmoitusEntity,
+                rooli = ApplicationContactType.ASIANHOITAJA,
+            ),
+        vararg yhteyshenkilot: HankekayttajaEntity =
+            arrayOf(kayttaja(HankeKayttajaFactory.KAYTTAJA_INPUT_ASIANHOITAJA)),
+    ): MuutosilmoitusBuilder =
+        yhteystieto(ApplicationContactType.ASIANHOITAJA, yhteystieto, *yhteyshenkilot)
+
+    private fun yhteystieto(
+        rooli: ApplicationContactType,
+        yhteystietoEntity: MuutosilmoituksenYhteystietoEntity =
+            MuutosilmoitusFactory.createYhteystietoEntity(muutosilmoitusEntity),
+        vararg yhteyshenkilot: HankekayttajaEntity,
+    ): MuutosilmoitusBuilder {
+        val yhteyshenkiloEntities =
+            yhteyshenkilot.map { createYhteyshenkiloEntity(yhteystietoEntity, it) }
+        yhteystietoEntity.yhteyshenkilot.addAll(yhteyshenkiloEntities)
+        muutosilmoitusEntity.yhteystiedot[rooli] = yhteystietoEntity
+
+        return this
+    }
+
+    private fun kayttaja(
+        kayttajaInput: HankekayttajaInput,
+        kayttooikeustaso: Kayttooikeustaso = Kayttooikeustaso.KATSELUOIKEUS,
+    ): HankekayttajaEntity =
+        hankeKayttajaFactory.findOrSaveIdentifiedUser(
+            hankeId,
+            kayttajaInput,
+            kayttooikeustaso = kayttooikeustaso,
+        )
+
+    private fun createYhteyshenkiloEntity(
+        yhteystietoEntity: MuutosilmoituksenYhteystietoEntity,
+        kayttaja: HankekayttajaEntity,
+        tilaaja: Boolean = false,
+    ) =
+        MuutosilmoituksenYhteyshenkiloEntity(
+            hankekayttaja = kayttaja,
+            yhteystieto = yhteystietoEntity,
+            tilaaja = tilaaja,
+        )
 
     private fun updateApplicationData(
         onCableReport: JohtoselvityshakemusEntityData.() -> JohtoselvityshakemusEntityData,

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/MuutosilmoitusFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/MuutosilmoitusFactory.kt
@@ -1,6 +1,7 @@
 package fi.hel.haitaton.hanke.factory
 
 import fi.hel.haitaton.hanke.allu.ApplicationStatus
+import fi.hel.haitaton.hanke.allu.CustomerType
 import fi.hel.haitaton.hanke.hakemus.ApplicationContactType
 import fi.hel.haitaton.hanke.hakemus.ApplicationType
 import fi.hel.haitaton.hanke.hakemus.HakemusData
@@ -27,6 +28,7 @@ class MuutosilmoitusFactory(
     private val muutosilmoitusRepository: MuutosilmoitusRepository,
     private val yhteyshenkiloRepository: MuutosilmoituksenYhteyshenkiloRepository,
     private val hakemusFactory: HakemusFactory,
+    private val hankeKayttajaFactory: HankeKayttajaFactory,
 ) {
 
     fun builder(
@@ -76,15 +78,20 @@ class MuutosilmoitusFactory(
                     muutosilmoituksenYhteystieto
                 }
                 .toMutableMap()
-        return builder(entity)
+        return builder(entity, hakemus.hanke.id)
     }
 
-    private fun builder(muutosilmoitusEntity: MuutosilmoitusEntity): MuutosilmoitusBuilder =
+    private fun builder(
+        muutosilmoitusEntity: MuutosilmoitusEntity,
+        hankeId: Int,
+    ): MuutosilmoitusBuilder =
         MuutosilmoitusBuilder(
             muutosilmoitusEntity,
+            hankeId,
             muutosilmoitusService,
             muutosilmoitusRepository,
             yhteyshenkiloRepository,
+            hankeKayttajaFactory,
         )
 
     companion object {
@@ -106,6 +113,25 @@ class MuutosilmoitusFactory(
                 ApplicationFactory.createBlankExcavationNotificationData(),
             yhteystiedot: Map<ApplicationContactType, MuutosilmoituksenYhteystietoEntity> = mapOf(),
         ) = MuutosilmoitusEntity(id, hakemusId, sent, hakemusData, yhteystiedot.toMutableMap())
+
+        fun createYhteystietoEntity(
+            muutosilmoitus: MuutosilmoitusEntity,
+            tyyppi: CustomerType = CustomerType.COMPANY,
+            rooli: ApplicationContactType = ApplicationContactType.HAKIJA,
+            nimi: String = HakemusyhteystietoFactory.DEFAULT_NIMI,
+            sahkoposti: String = HakemusyhteystietoFactory.DEFAULT_SAHKOPOSTI,
+            puhelinnumero: String = HakemusyhteystietoFactory.DEFAULT_PUHELINNUMERO,
+            ytunnus: String? = HakemusyhteystietoFactory.DEFAULT_YTUNNUS,
+        ): MuutosilmoituksenYhteystietoEntity =
+            MuutosilmoituksenYhteystietoEntity(
+                tyyppi = tyyppi,
+                rooli = rooli,
+                nimi = nimi,
+                sahkoposti = sahkoposti,
+                puhelinnumero = puhelinnumero,
+                registryKey = ytunnus,
+                muutosilmoitus = muutosilmoitus,
+            )
 
         fun Muutosilmoitus.toUpdateRequest(): HakemusUpdateRequest =
             this.toResponse().applicationData.toJsonString().parseJson()

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/muutosilmoitus/MuutosilmoituksenYhteystietoRepository.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/muutosilmoitus/MuutosilmoituksenYhteystietoRepository.kt
@@ -1,0 +1,7 @@
+package fi.hel.haitaton.hanke.muutosilmoitus
+
+import java.util.UUID
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface MuutosilmoituksenYhteystietoRepository :
+    JpaRepository<MuutosilmoituksenYhteystietoEntity, UUID>

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/test/Asserts.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/test/Asserts.kt
@@ -16,8 +16,11 @@ import assertk.assertions.prop
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.node.NullNode
 import com.fasterxml.jackson.databind.node.TextNode
+import fi.hel.haitaton.hanke.domain.Hanke
+import fi.hel.haitaton.hanke.hakemus.Hakemusalue
 import fi.hel.haitaton.hanke.hakemus.PostalAddress
 import fi.hel.haitaton.hanke.hakemus.StreetAddress
+import fi.hel.haitaton.hanke.hasSameElementsAs
 import fi.hel.haitaton.hanke.validation.ValidationResult
 import fi.hel.haitaton.hanke.zonedDateTime
 import jakarta.mail.internet.MimeMessage
@@ -27,8 +30,23 @@ import java.time.OffsetDateTime
 import java.time.ZonedDateTime
 import java.time.temporal.TemporalAmount
 import java.util.UUID
+import org.geojson.Polygon
 
 object Asserts {
+
+    fun Assert<Hanke>.hasSameGeometryAs(hakemusalueet: List<Hakemusalue>) {
+        given { hanke ->
+            val hankeCoordinates =
+                hanke.alueet
+                    .flatMap { it.geometriat!!.featureCollection!!.features }
+                    .map { it.geometry as Polygon }
+                    .map { it.coordinates }
+            assertThat(hankeCoordinates)
+                .hasSameElementsAs(
+                    hakemusalueet.map { it.geometries().flatMap { g -> g.coordinates } }
+                )
+        }
+    }
 
     fun Assert<OffsetDateTime?>.isRecent(offset: TemporalAmount = Duration.ofMinutes(1)) {
         val now = OffsetDateTime.now()


### PR DESCRIPTION
# Description

Don't delete the muutosilmoitus if it has been already sent to Allu.

Also change delete täydennys API to return 204 on success instead of 200.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-3406

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
Create a muutosilmoitus. Call the delete API from [Swagger UI](http://localhost:3001/api/swagger-ui/index.html#/muutosilmoitus-controller/delete_1).

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 