### PR TITLE
HAI-3369 Use UBI9 baseimages

### DIFF
--- a/services/hanke-service/Dockerfile-local
+++ b/services/hanke-service/Dockerfile-local
@@ -1,5 +1,7 @@
-FROM public.ecr.aws/docker/library/eclipse-temurin:17 AS build
+FROM registry.access.redhat.com/ubi9/openjdk-17:latest AS build
 WORKDIR /workspace/app
+
+USER root
 
 COPY gradlew settings.gradle.kts ./
 COPY gradle/ ./gradle/
@@ -10,8 +12,10 @@ RUN --mount=type=cache,target=/root/.gradle ./gradlew --no-daemon :services:hank
 RUN mkdir -p services/hanke-service/build/dependency && \
     (cd services/hanke-service/build/dependency; jar -xf ../libs/*SNAPSHOT.jar)
 
-FROM public.ecr.aws/docker/library/eclipse-temurin:17
+FROM registry.access.redhat.com/ubi9/openjdk-17-runtime:latest
 VOLUME /tmp
+
+WORKDIR /
 
 ARG DEPENDENCY=/workspace/app/services/hanke-service/build/dependency
 COPY --from=build ${DEPENDENCY}/BOOT-INF/lib /app/lib
@@ -19,5 +23,9 @@ COPY --from=build ${DEPENDENCY}/META-INF /app/META-INF
 COPY --from=build ${DEPENDENCY}/BOOT-INF/classes /app
 COPY scripts/wait-for-it.sh ./
 
+# Fix RuntimeException: Fontconfig head is null
+USER root
+RUN microdnf -y install fontconfig && microdnf clean all
+USER default
 
 ENTRYPOINT ["./wait-for-it.sh", "db:5432", "--timeout=50", "--strict", "--", "java", "-cp", "app:app/lib/*", "fi.hel.haitaton.hanke.ApplicationKt"]

--- a/services/hanke-service/Dockerfile-platta
+++ b/services/hanke-service/Dockerfile-platta
@@ -1,7 +1,7 @@
-# Uses different base images for build and run. RedHat Ubi stronger security policies prevent gradle builds.
-
 # Stage 1: Build application
-FROM public.ecr.aws/docker/library/eclipse-temurin:17 AS build
+FROM registry.access.redhat.com/ubi9/openjdk-17:latest AS build
+
+USER root
 
 # Set the working directory, copy gradle and source code
 WORKDIR /app
@@ -14,9 +14,15 @@ COPY services/hanke-service/src ./services/hanke-service/src
 RUN ./gradlew clean :services:hanke-service:assemble --stacktrace
 
 # Stage 2: Create runtime image
-FROM registry.redhat.io/ubi8/openjdk-17:latest
+FROM registry.access.redhat.com/ubi9/openjdk-17-runtime:latest
 VOLUME /tmp
 WORKDIR /app
 COPY --from=build /app/services/hanke-service/build/libs/hanke-service*SNAPSHOT.jar hanke-service.jar
 EXPOSE 8080 8081
+
+# Fix RuntimeException: Fontconfig head is null
+USER root
+RUN microdnf -y install fontconfig && microdnf clean all
+USER default
+
 CMD [ "sh", "-c", "java $JAVA_OPTS -Djava.security.egd=file:/dev/urandom -jar hanke-service.jar" ]

--- a/services/hanke-service/src/main/resources/application.yml
+++ b/services/hanke-service/src/main/resources/application.yml
@@ -100,7 +100,7 @@ server:
 spring:
   datasource:
     password: ${HAITATON_PASSWORD:haitaton}
-    url: jdbc:postgresql://${HAITATON_HOST:localhost}:${HAITATON_PORT:5432}/${HAITATON_DATABASE:haitaton}
+    url: jdbc:postgresql://${HAITATON_HOST:localhost}:${HAITATON_PORT:5432}/${HAITATON_DATABASE:haitaton}${HAITATON_DATABASE_PARAMS:}
     username: ${HAITATON_USER:haitaton_user}
   jpa:
     hibernate:
@@ -112,7 +112,7 @@ spring:
     show-sql: false
   liquibase:
     password: ${HAITATON_PASSWORD:haitaton}
-    url: jdbc:postgresql://${HAITATON_HOST:localhost}:${HAITATON_PORT:5432}/${HAITATON_DATABASE:haitaton}
+    url: jdbc:postgresql://${HAITATON_HOST:localhost}:${HAITATON_PORT:5432}/${HAITATON_DATABASE:haitaton}${HAITATON_DATABASE_PARAMS:}
     user: ${HAITATON_USER:haitaton_user}
   mail:
     host: ${MAIL_SENDER_HOST:localhost}


### PR DESCRIPTION
# Description

Use the recommended Red Hat Universal Base Image 9 -based images from the Red Hat registry as base images for building the hanke-service images.

Add a new environment parameter for adding parameters to the database URL. These are needed to circumvent a TLS certificate issue when connecting to Azure DBs.

Add fontconfig to the runtime system to solve a RuntimeException when creating a haittojenhallintasuunnitelma-PDF.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-3369

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [X] Other

# Other relevant info
Third time's the charm? The two earlier commits had to be reverted because something went wrong with them. This time, I deployed this branch to see if everything worked correctly. I ran the e2e tests against the deployed branches and they passed.