### PR TITLE
HAI-3455 Add attachment to changed fields with other changes (#986)

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennysServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennysServiceITest.kt
@@ -737,6 +737,33 @@ class TaydennysServiceITest(
         }
 
         @Test
+        fun `adds attachment to changed fields when taydennys has attachments`() {
+            val taydennys = taydennysFactory.builder().withWorkDescription("New description").save()
+            val attachment =
+                attachmentFactory.save(taydennys = taydennys).withContent().value.toDomain()
+            val taydennyspyynto = taydennyspyyntoRepository.findAll().single()
+            val hakemus = hakemusService.getById(taydennyspyynto.applicationId)
+            justRun { alluClient.respondToInformationRequest(any(), any(), any(), any()) }
+            justRun { alluClient.addAttachment(any(), any()) }
+            every { alluClient.getApplicationInformation(hakemus.alluid!!) } returns
+                AlluFactory.createAlluApplicationResponse(alluId)
+
+            taydennysService.sendTaydennys(taydennys.id, USERNAME)
+
+            verifySequence {
+                alluClient.addAttachment(any(), eq(attachment.toAlluAttachment(PDF_BYTES)))
+                alluClient.respondToInformationRequest(
+                    hakemus.alluid!!,
+                    taydennyspyynto.alluId,
+                    taydennys.hakemusData.toAlluData(hakemus.hankeTunnus),
+                    setOf(InformationRequestFieldKey.OTHER, InformationRequestFieldKey.ATTACHMENT),
+                )
+                alluClient.addAttachment(any(), withName(FORM_DATA_PDF_FILENAME))
+                alluClient.getApplicationInformation(hakemus.alluid!!)
+            }
+        }
+
+        @Test
         fun `transfers attachments from taydennys to hakemus`() {
             val taydennys = taydennysFactory.builder().save()
             val attachment =

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/AlluClient.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/AlluClient.kt
@@ -246,7 +246,8 @@ class AlluClient(
         updatedFields: Set<InformationRequestFieldKey>,
     ) {
         logger.info {
-            "Responding to information request. Application: $alluApplicationId, request: $requestId. Updated field keys are: ${updatedFields.joinToString()}"
+            "Responding to information request. Application: $alluApplicationId, " +
+                "request: $requestId. Updated field keys are: ${updatedFields.joinToString()}"
         }
 
         val path =

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennysService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennysService.kt
@@ -191,10 +191,10 @@ class TaydennysService(
         val attachments = attachmentService.getMetadataList(taydennysEntity.id)
 
         val changes =
-            taydennys.hakemusData.listChanges(hakemus.toHakemus().applicationData).ifEmpty {
-                if (attachments.isEmpty()) throw NoChangesException(taydennysEntity, hakemus)
-                else listOf("attachment")
-            }
+            taydennys.hakemusData
+                .listChanges(hakemus.toHakemus().applicationData)
+                .let { if (attachments.isEmpty()) it else it + "attachment" }
+                .ifEmpty { throw NoChangesException(taydennysEntity, hakemus) }
 
         if (hakemus.alluStatus != ApplicationStatus.WAITING_INFORMATION) {
             throw HakemusInWrongStatusException(


### PR DESCRIPTION
# Description

Täydennys changed fields have included attachments only when it's the only change on the täydennys. (Except for when a kaivuilmoitus has changes in its haittojenhallintasuunnitelma, but that is a separate mechanism.)

This means that the handler in Allu might not notice that an attachment has been added, since it's not shown when processing the täydennys.

Fix this by including 'attachment' in the changed fields also when there are other fields.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-3455

## Type of change

- [X] Bug fix 
- [ ] New feature 
- [ ] Other

# Instructions for testing
Replication instructions are on the ticket.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 