### PR TITLE
HAI-3408 Add API for sending muutosilmoitus

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/allu/AlluClientITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/allu/AlluClientITests.kt
@@ -440,6 +440,50 @@ class AlluClientITests {
     }
 
     @Nested
+    inner class ReportChange {
+        private val alluid = 3211
+
+        @Test
+        fun `calls the right address when the hakemus is a johtoselvityshakemus`() {
+            val applicationData = AlluFactory.createCableReportApplicationData()
+            val fields =
+                setOf(InformationRequestFieldKey.GEOMETRY, InformationRequestFieldKey.CONTRACTOR)
+            mockWebServer.enqueue(MockResponse().setResponseCode(200))
+
+            service.reportChange(alluid, applicationData, fields)
+
+            val request = mockWebServer.takeRequest()
+            assertThat(request.method).isEqualTo("POST")
+            assertThat(request.path).isEqualTo("/v2/cablereports/$alluid/reportchange")
+            val expectedBody = InformationRequestResponse(applicationData, fields).toJsonString()
+            val actualBody = request.body.readUtf8()
+            JSONAssert.assertEquals(expectedBody, actualBody, JSONCompareMode.NON_EXTENSIBLE)
+            assertThat(request.getHeader("Authorization")).isEqualTo("Bearer $authToken")
+        }
+
+        @Test
+        fun `calls the right address when the hakemus is a kaivuilmoitus`() {
+            val applicationData = AlluFactory.createExcavationNotificationData()
+            val fields =
+                setOf(
+                    InformationRequestFieldKey.WORK_DESCRIPTION,
+                    InformationRequestFieldKey.ATTACHMENT,
+                )
+            mockWebServer.enqueue(MockResponse().setResponseCode(200))
+
+            service.reportChange(alluid, applicationData, fields)
+
+            val request = mockWebServer.takeRequest()
+            assertThat(request.method).isEqualTo("POST")
+            assertThat(request.path).isEqualTo("/v2/excavationannouncements/$alluid/reportchange")
+            val expectedBody = InformationRequestResponse(applicationData, fields).toJsonString()
+            val actualBody = request.body.readUtf8()
+            JSONAssert.assertEquals(expectedBody, actualBody, JSONCompareMode.NON_EXTENSIBLE)
+            assertThat(request.getHeader("Authorization")).isEqualTo("Bearer $authToken")
+        }
+    }
+
+    @Nested
     inner class GetDecisionPdf {
         @Test
         fun `returns PDF file as bytes`() {

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/muutosilmoitus/MuutosilmoitusControllerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/muutosilmoitus/MuutosilmoitusControllerITest.kt
@@ -28,6 +28,7 @@ import fi.hel.haitaton.hanke.hakemus.HakemusGeometryException
 import fi.hel.haitaton.hanke.hakemus.HakemusGeometryNotInsideHankeException
 import fi.hel.haitaton.hanke.hakemus.HakemusInWrongStatusException
 import fi.hel.haitaton.hanke.hakemus.HakemusNotFoundException
+import fi.hel.haitaton.hanke.hakemus.InvalidHakemusDataException
 import fi.hel.haitaton.hanke.hakemus.InvalidHakemusyhteyshenkiloException
 import fi.hel.haitaton.hanke.hakemus.InvalidHakemusyhteystietoException
 import fi.hel.haitaton.hanke.hakemus.InvalidHiddenRegistryKey
@@ -36,6 +37,7 @@ import fi.hel.haitaton.hanke.hakemus.andVerifyRegistryKeys
 import fi.hel.haitaton.hanke.hankeError
 import fi.hel.haitaton.hanke.logging.DisclosureLogService
 import fi.hel.haitaton.hanke.permissions.PermissionCode
+import fi.hel.haitaton.hanke.taydennys.NoChangesException
 import fi.hel.haitaton.hanke.test.USERNAME
 import fi.hel.haitaton.hanke.toJsonString
 import io.mockk.Called
@@ -526,6 +528,138 @@ class MuutosilmoitusControllerITest(
             verifySequence {
                 muutosilmoitusAuthorizer.authorize(id, PermissionCode.EDIT_APPLICATIONS.name)
                 muutosilmoitusService.delete(id, USERNAME)
+            }
+        }
+    }
+
+    @Nested
+    inner class Send {
+        private val url = "/muutosilmoitukset/$id/laheta"
+
+        @Test
+        @WithAnonymousUser
+        fun `returns 401 when unknown user`() {
+            post(url).andExpect(status().isUnauthorized)
+        }
+
+        @Test
+        fun `returns 404 when muutosilmoitus doesn't exist`() {
+            every {
+                muutosilmoitusAuthorizer.authorize(id, PermissionCode.EDIT_APPLICATIONS.name)
+            } throws MuutosilmoitusNotFoundException(id)
+
+            post(url).andExpect(status().isNotFound)
+        }
+
+        @Test
+        fun `returns 404 when user doesn't have access to the muutosilmoitus`() {
+            every {
+                muutosilmoitusAuthorizer.authorize(id, PermissionCode.EDIT_APPLICATIONS.name)
+            } throws HakemusNotFoundException(hakemusId)
+
+            post(url).andExpect(status().isNotFound)
+        }
+
+        @Test
+        fun `returns 409 when muutosilmoitus has already been sent`() {
+            every {
+                muutosilmoitusAuthorizer.authorize(id, PermissionCode.EDIT_APPLICATIONS.name)
+            } returns true
+            every { muutosilmoitusService.send(id, null, USERNAME) } throws
+                MuutosilmoitusAlreadySentException(MuutosilmoitusFactory.create(id = id))
+
+            post(url).andExpect(status().isConflict).andExpect(hankeError(HankeError.HAI7002))
+
+            verifySequence {
+                muutosilmoitusAuthorizer.authorize(id, PermissionCode.EDIT_APPLICATIONS.name)
+                muutosilmoitusService.send(id, null, USERNAME)
+            }
+        }
+
+        @Test
+        fun `returns 409 when there are no changes in the muutosilmoitus`() {
+            every {
+                muutosilmoitusAuthorizer.authorize(id, PermissionCode.EDIT_APPLICATIONS.name)
+            } returns true
+            every { muutosilmoitusService.send(id, null, USERNAME) } throws
+                NoChangesException(
+                    "muutosilmoitus",
+                    MuutosilmoitusFactory.createEntity(),
+                    HakemusFactory.create(),
+                )
+
+            post(url).andExpect(status().isConflict).andExpect(hankeError(HankeError.HAI7003))
+
+            verifySequence {
+                muutosilmoitusAuthorizer.authorize(id, PermissionCode.EDIT_APPLICATIONS.name)
+                muutosilmoitusService.send(id, null, USERNAME)
+            }
+        }
+
+        @Test
+        fun `returns 409 when the hakemus is in the wrong state`() {
+            every {
+                muutosilmoitusAuthorizer.authorize(id, PermissionCode.EDIT_APPLICATIONS.name)
+            } returns true
+            every { muutosilmoitusService.send(id, null, USERNAME) } throws
+                HakemusInWrongStatusException(
+                    HakemusFactory.create(),
+                    ApplicationStatus.HANDLING,
+                    listOf(ApplicationStatus.DECISION, ApplicationStatus.OPERATIONAL_CONDITION),
+                )
+
+            post(url).andExpect(status().isConflict).andExpect(hankeError(HankeError.HAI2015))
+
+            verifySequence {
+                muutosilmoitusAuthorizer.authorize(id, PermissionCode.EDIT_APPLICATIONS.name)
+                muutosilmoitusService.send(id, null, USERNAME)
+            }
+        }
+
+        @Test
+        fun `returns 400 when the data fails validation`() {
+            every {
+                muutosilmoitusAuthorizer.authorize(id, PermissionCode.EDIT_APPLICATIONS.name)
+            } returns true
+            every { muutosilmoitusService.send(id, null, USERNAME) } throws
+                InvalidHakemusDataException(listOf("rockExcavation"))
+
+            post(url).andExpect(status().isBadRequest).andExpect(hankeError(HankeError.HAI2008))
+
+            verifySequence {
+                muutosilmoitusAuthorizer.authorize(id, PermissionCode.EDIT_APPLICATIONS.name)
+                muutosilmoitusService.send(id, null, USERNAME)
+            }
+        }
+
+        @Test
+        fun `returns 400 when the geometry is outside hanke geometry`() {
+            every {
+                muutosilmoitusAuthorizer.authorize(id, PermissionCode.EDIT_APPLICATIONS.name)
+            } returns true
+            every { muutosilmoitusService.send(id, null, USERNAME) } throws
+                HakemusGeometryNotInsideHankeException(GeometriaFactory.polygon())
+
+            post(url).andExpect(status().isBadRequest).andExpect(hankeError(HankeError.HAI2007))
+
+            verifySequence {
+                muutosilmoitusAuthorizer.authorize(id, PermissionCode.EDIT_APPLICATIONS.name)
+                muutosilmoitusService.send(id, null, USERNAME)
+            }
+        }
+
+        @Test
+        fun `returns 204 with no content`() {
+            every {
+                muutosilmoitusAuthorizer.authorize(id, PermissionCode.EDIT_APPLICATIONS.name)
+            } returns true
+            justRun { muutosilmoitusService.send(id, null, USERNAME) }
+
+            post(url).andExpect(status().isNoContent).andExpect(content().string(""))
+
+            verifySequence {
+                muutosilmoitusAuthorizer.authorize(id, PermissionCode.EDIT_APPLICATIONS.name)
+                muutosilmoitusService.send(id, null, USERNAME)
             }
         }
     }

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/muutosilmoitus/MuutosilmoitusServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/muutosilmoitus/MuutosilmoitusServiceITest.kt
@@ -16,17 +16,25 @@ import fi.hel.haitaton.hanke.HankeService
 import fi.hel.haitaton.hanke.IntegrationTest
 import fi.hel.haitaton.hanke.allu.AlluClient
 import fi.hel.haitaton.hanke.allu.ApplicationStatus
+import fi.hel.haitaton.hanke.allu.InformationRequestFieldKey
+import fi.hel.haitaton.hanke.domain.Haittojenhallintatyyppi
 import fi.hel.haitaton.hanke.factory.ApplicationFactory
 import fi.hel.haitaton.hanke.factory.DateFactory
 import fi.hel.haitaton.hanke.factory.GeometriaFactory
+import fi.hel.haitaton.hanke.factory.HaittaFactory
+import fi.hel.haitaton.hanke.factory.HaittaFactory.DEFAULT_HHS_PYORALIIKENNE
 import fi.hel.haitaton.hanke.factory.HakemusFactory
+import fi.hel.haitaton.hanke.factory.HakemusFactory.Companion.withPaperDecisionReceiver
 import fi.hel.haitaton.hanke.factory.MuutosilmoitusFactory
 import fi.hel.haitaton.hanke.factory.MuutosilmoitusFactory.Companion.toUpdateRequest
+import fi.hel.haitaton.hanke.factory.PaperDecisionReceiverFactory
+import fi.hel.haitaton.hanke.findByType
 import fi.hel.haitaton.hanke.hakemus.ApplicationType
+import fi.hel.haitaton.hanke.hakemus.HakemusDataMapper.toAlluData
 import fi.hel.haitaton.hanke.hakemus.HakemusInWrongStatusException
 import fi.hel.haitaton.hanke.hakemus.HakemusNotFoundException
-import fi.hel.haitaton.hanke.hakemus.HakemusRepository
 import fi.hel.haitaton.hanke.hakemus.HakemusService
+import fi.hel.haitaton.hanke.hakemus.InvalidHakemusDataException
 import fi.hel.haitaton.hanke.hakemus.JohtoselvityshakemusData
 import fi.hel.haitaton.hanke.hakemus.JohtoselvityshakemusUpdateRequest
 import fi.hel.haitaton.hanke.hakemus.WrongHakemusTypeException
@@ -34,8 +42,11 @@ import fi.hel.haitaton.hanke.logging.AuditLogRepository
 import fi.hel.haitaton.hanke.logging.AuditLogTarget
 import fi.hel.haitaton.hanke.logging.ObjectType
 import fi.hel.haitaton.hanke.logging.Operation
+import fi.hel.haitaton.hanke.pdf.withName
 import fi.hel.haitaton.hanke.permissions.HankekayttajaRepository
+import fi.hel.haitaton.hanke.taydennys.NoChangesException
 import fi.hel.haitaton.hanke.test.Asserts.hasSameGeometryAs
+import fi.hel.haitaton.hanke.test.Asserts.isRecent
 import fi.hel.haitaton.hanke.test.AuditLogEntryEntityAsserts.hasId
 import fi.hel.haitaton.hanke.test.AuditLogEntryEntityAsserts.hasNoObjectAfter
 import fi.hel.haitaton.hanke.test.AuditLogEntryEntityAsserts.hasNoObjectBefore
@@ -51,6 +62,10 @@ import fi.hel.haitaton.hanke.test.resetCustomerIds
 import io.mockk.checkUnnecessaryStub
 import io.mockk.clearAllMocks
 import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.justRun
+import io.mockk.verifySequence
+import java.time.OffsetDateTime
 import java.util.UUID
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
@@ -59,7 +74,6 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.data.jpa.domain.AbstractPersistable_.id
 
 class MuutosilmoitusServiceITest(
     @Autowired private val muutosilmoitusService: MuutosilmoitusService,
@@ -68,7 +82,6 @@ class MuutosilmoitusServiceITest(
     @Autowired private val hakemusFactory: HakemusFactory,
     @Autowired private val muutosilmoitusFactory: MuutosilmoitusFactory,
     @Autowired private val auditLogRepository: AuditLogRepository,
-    @Autowired private val hakemusRepository: HakemusRepository,
     @Autowired private val hankekayttajaRepository: HankekayttajaRepository,
     @Autowired private val muutosilmoitusRepository: MuutosilmoitusRepository,
     @Autowired private val yhteystietoRepository: MuutosilmoituksenYhteystietoRepository,
@@ -344,6 +357,293 @@ class MuutosilmoitusServiceITest(
 
             assertThat(hankeService.loadHanke(hakemus.hankeTunnus)!!)
                 .hasSameGeometryAs((hakemus.applicationData as JohtoselvityshakemusData).areas!!)
+        }
+    }
+
+    @Nested
+    inner class Send {
+        private val startTime = DateFactory.getStartDatetime().minusDays(1)
+
+        @Test
+        fun `throws exception when muutosilmoitus is not found`() {
+            val failure = assertFailure {
+                muutosilmoitusService.send(
+                    UUID.fromString("d754f2b7-2e96-4983-bbf8-1e1d34bc0c81"),
+                    null,
+                    USERNAME,
+                )
+            }
+
+            failure.all {
+                hasClass(MuutosilmoitusNotFoundException::class)
+                messageContains("id=d754f2b7-2e96-4983-bbf8-1e1d34bc0c81")
+                messageContains("Muutosilmoitus not found")
+            }
+        }
+
+        @Test
+        fun `throws exception when muutosilmoitus has already been sent`() {
+            val muutosilmoitus =
+                muutosilmoitusFactory
+                    .builder()
+                    .withSent(OffsetDateTime.parse("2024-03-06T16:28:01Z"))
+                    .save()
+
+            val failure = assertFailure {
+                muutosilmoitusService.send(muutosilmoitus.id, null, USERNAME)
+            }
+
+            failure.all {
+                hasClass(MuutosilmoitusAlreadySentException::class)
+                messageContains("id=${muutosilmoitus.id}")
+                messageContains("Muutosilmoitus is already sent to Allu")
+            }
+        }
+
+        @Test
+        fun `throws exception if the muutosilmoitus is identical to the hakemus`() {
+            val muutosilmoitus = muutosilmoitusFactory.builder().save()
+
+            val failure = assertFailure {
+                muutosilmoitusService.send(muutosilmoitus.id, null, USERNAME)
+            }
+
+            failure.all {
+                hasClass(NoChangesException::class)
+                messageContains("Not sending a muutosilmoitus without any changes")
+                messageContains("id=${muutosilmoitus.id}")
+            }
+        }
+
+        @Test
+        fun `throws exception when the muutosilmoitus fails validation`() {
+            val muutosilmoitus = muutosilmoitusFactory.builder().withStartTime(null).save()
+
+            val failure = assertFailure {
+                muutosilmoitusService.send(muutosilmoitus.id, null, USERNAME)
+            }
+
+            failure.all {
+                hasClass(InvalidHakemusDataException::class)
+                messageContains("Application contains invalid data")
+                messageContains("Errors at paths: applicationData.startTime")
+            }
+        }
+
+        @Test
+        fun `sends the data to Allu with list of changed fields`() {
+            val hakemus =
+                hakemusFactory
+                    .builder(ApplicationType.EXCAVATION_NOTIFICATION)
+                    .withMandatoryFields()
+                    .withStatus(ApplicationStatus.DECISION)
+                    .saveEntity()
+            val hanke = hankeService.loadHankeById(hakemus.hanke.id)!!
+            val area =
+                ApplicationFactory.createExcavationNotificationArea(
+                    hankealueId = hanke.alueet.single().id!!,
+                    haittojenhallintasuunnitelma =
+                        HaittaFactory.createHaittojenhallintasuunnitelma(
+                            Haittojenhallintatyyppi.PYORALIIKENNE to
+                                "$DEFAULT_HHS_PYORALIIKENNE. Muutettu."
+                        ),
+                )
+            val muutosilmoitus =
+                muutosilmoitusFactory
+                    .builder(hakemus)
+                    .withStartTime(startTime)
+                    .withEndTime(DateFactory.getEndDatetime().plusDays(1))
+                    .withConstructionWork(true)
+                    .withMaintenanceWork(true)
+                    .withWorkDescription("New description")
+                    .withCustomerReference("New Reference")
+                    .withAreas(listOf(area))
+                    .save()
+            justRun { alluClient.reportChange(any(), any(), any()) }
+            justRun { alluClient.addAttachment(any(), any()) }
+
+            muutosilmoitusService.send(muutosilmoitus.id, null, USERNAME)
+
+            verifySequence {
+                alluClient.reportChange(
+                    hakemus.alluid!!,
+                    muutosilmoitus.hakemusData.toAlluData(hanke.hankeTunnus),
+                    setOf(
+                        InformationRequestFieldKey.START_TIME,
+                        InformationRequestFieldKey.END_TIME,
+                        InformationRequestFieldKey.OTHER,
+                        InformationRequestFieldKey.INVOICING_CUSTOMER,
+                        InformationRequestFieldKey.ATTACHMENT,
+                    ),
+                )
+                alluClient.addAttachment(any(), withName(FORM_DATA_PDF_FILENAME))
+                alluClient.addAttachment(any(), withName(HHS_PDF_FILENAME))
+            }
+        }
+
+        @Test
+        fun `sets the sent field`() {
+            val hakemus =
+                hakemusFactory
+                    .builder(ApplicationType.EXCAVATION_NOTIFICATION)
+                    .withMandatoryFields()
+                    .withStatus(ApplicationStatus.DECISION)
+                    .saveEntity()
+            val hanke = hankeService.loadHankeById(hakemus.hanke.id)!!
+            val area =
+                ApplicationFactory.createExcavationNotificationArea(
+                    hankealueId = hanke.alueet.single().id!!,
+                    haittojenhallintasuunnitelma =
+                        HaittaFactory.createHaittojenhallintasuunnitelma(),
+                )
+            val muutosilmoitus =
+                muutosilmoitusFactory
+                    .builder(hakemus)
+                    .withWorkDescription("New description")
+                    .withAreas(listOf(area))
+                    .save()
+            justRun { alluClient.reportChange(any(), any(), any()) }
+            justRun { alluClient.addAttachment(any(), any()) }
+
+            muutosilmoitusService.send(muutosilmoitus.id, null, USERNAME)
+
+            val updatedEntity = muutosilmoitusRepository.getReferenceById(muutosilmoitus.id)
+            assertThat(updatedEntity.sent).isNotNull().isRecent()
+            verifySequence {
+                alluClient.reportChange(any(), any(), setOf(InformationRequestFieldKey.OTHER))
+                alluClient.addAttachment(any(), withName(FORM_DATA_PDF_FILENAME))
+                alluClient.addAttachment(any(), withName(HHS_PDF_FILENAME))
+            }
+        }
+
+        @Test
+        fun `sends geometry as changed field if there is a change to kaivuilmoitus work area`() {
+            val hakemus =
+                hakemusFactory
+                    .builder(ApplicationType.EXCAVATION_NOTIFICATION)
+                    .withMandatoryFields()
+                    .withStatus(ApplicationStatus.WAITING_INFORMATION)
+                    .saveEntity()
+            val hanke = hankeService.loadHankeById(hakemus.hanke.id)!!
+            val area =
+                ApplicationFactory.createExcavationNotificationArea(
+                    hankealueId = hanke.alueet.single().id!!,
+                    tyoalueet =
+                        listOf(
+                            ApplicationFactory.createTyoalue(
+                                geometry = GeometriaFactory.fourthPolygon()
+                            )
+                        ),
+                )
+            val muutosilmoitus =
+                muutosilmoitusFactory.builder(hakemus).withAreas(listOf(area)).save()
+            justRun { alluClient.reportChange(any(), any(), any()) }
+            justRun { alluClient.addAttachment(any(), any()) }
+
+            muutosilmoitusService.send(muutosilmoitus.id, null, USERNAME)
+
+            verifySequence {
+                alluClient.reportChange(
+                    hakemus.alluid!!,
+                    muutosilmoitus.hakemusData.toAlluData(hakemus.hanke.hankeTunnus),
+                    setOf(InformationRequestFieldKey.GEOMETRY),
+                )
+                alluClient.addAttachment(any(), withName(FORM_DATA_PDF_FILENAME))
+                alluClient.addAttachment(any(), withName(HHS_PDF_FILENAME))
+            }
+        }
+
+        @Test
+        fun `saves audit logs when request decision on paper`() {
+            val hakemus =
+                hakemusFactory
+                    .builder(ApplicationType.EXCAVATION_NOTIFICATION)
+                    .withMandatoryFields()
+                    .withStatus(ApplicationStatus.DECISION)
+                    .saveEntity()
+            val hanke = hankeService.loadHankeById(hakemus.hanke.id)!!
+            val area =
+                ApplicationFactory.createExcavationNotificationArea(
+                    hankealueId = hanke.alueet.single().id!!,
+                    haittojenhallintasuunnitelma =
+                        HaittaFactory.createHaittojenhallintasuunnitelma(),
+                )
+            val muutosilmoitus =
+                muutosilmoitusFactory
+                    .builder(hakemus)
+                    .withWorkDescription("New description")
+                    .withAreas(listOf(area))
+                    .save()
+            val paperDecisionReceiver = PaperDecisionReceiverFactory.default
+            justRun { alluClient.reportChange(any(), any(), any()) }
+            justRun { alluClient.addAttachment(any(), any()) }
+            every { alluClient.sendSystemComment(hakemus.alluid!!, any()) } returns 4
+            auditLogRepository.deleteAll()
+
+            muutosilmoitusService.send(muutosilmoitus.id, paperDecisionReceiver, USERNAME)
+
+            val expectedDataAfter =
+                muutosilmoitus.hakemusData.withPaperDecisionReceiver(paperDecisionReceiver)
+            val createdLogs = auditLogRepository.findByType(ObjectType.MUUTOSILMOITUS)
+            assertThat(createdLogs).single().isSuccess(Operation.UPDATE) {
+                hasUserActor(USERNAME)
+                withTarget {
+                    hasObjectBefore(muutosilmoitus)
+                    hasObjectAfter(muutosilmoitus.copy(hakemusData = expectedDataAfter))
+                }
+            }
+            verifySequence {
+                alluClient.reportChange(any(), any(), any())
+                alluClient.addAttachment(any(), withName(FORM_DATA_PDF_FILENAME))
+                alluClient.addAttachment(any(), withName(HHS_PDF_FILENAME))
+                alluClient.sendSystemComment(hakemus.alluid!!, PAPER_DECISION_MSG)
+            }
+        }
+
+        @Test
+        fun `clears paper decision when it's null`() {
+            val hakemus =
+                hakemusFactory
+                    .builder(ApplicationType.EXCAVATION_NOTIFICATION)
+                    .withMandatoryFields()
+                    .withStatus(ApplicationStatus.DECISION)
+                    .withPaperReceiver()
+                    .saveEntity()
+            val hanke = hankeService.loadHankeById(hakemus.hanke.id)!!
+            val area =
+                ApplicationFactory.createExcavationNotificationArea(
+                    hankealueId = hanke.alueet.single().id!!,
+                    haittojenhallintasuunnitelma =
+                        HaittaFactory.createHaittojenhallintasuunnitelma(),
+                )
+            val muutosilmoitus =
+                muutosilmoitusFactory
+                    .builder(hakemus)
+                    .withWorkDescription("New description")
+                    .withAreas(listOf(area))
+                    .save()
+            justRun { alluClient.reportChange(any(), any(), any()) }
+            justRun { alluClient.addAttachment(any(), any()) }
+            auditLogRepository.deleteAll()
+
+            muutosilmoitusService.send(muutosilmoitus.id, null, USERNAME)
+
+            val expectedDataAfter = muutosilmoitus.hakemusData.withPaperDecisionReceiver(null)
+            val createdLogs = auditLogRepository.findByType(ObjectType.MUUTOSILMOITUS)
+            assertThat(createdLogs).single().isSuccess(Operation.UPDATE) {
+                hasUserActor(USERNAME)
+                withTarget {
+                    hasObjectBefore(muutosilmoitus)
+                    hasObjectAfter(muutosilmoitus.copy(hakemusData = expectedDataAfter))
+                }
+            }
+            val updatedMuutosilmoitus = muutosilmoitusRepository.findAll().single()
+            assertThat(updatedMuutosilmoitus.hakemusData.paperDecisionReceiver).isNull()
+            verifySequence {
+                alluClient.reportChange(any(), any(), any())
+                alluClient.addAttachment(any(), withName(FORM_DATA_PDF_FILENAME))
+                alluClient.addAttachment(any(), withName(HHS_PDF_FILENAME))
+            }
         }
     }
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeError.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeError.kt
@@ -60,7 +60,8 @@ enum class HankeError(val errorMessage: String) {
     HAI6001("Taydennys not found"),
     HAI6002("Taydennys has no changes"),
     HAI7001("Muutosilmoitus not found"),
-    HAI7002("Muutosilmoitus is already sent to Allu, operation prohibited.");
+    HAI7002("Muutosilmoitus is already sent to Allu, operation prohibited."),
+    HAI7003("Muutosilmoitus has no changes");
 
     val errorCode: String
         get() = name

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/AlluClient.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/AlluClient.kt
@@ -263,6 +263,28 @@ class AlluClient(
         post(path, request).toBodilessEntity().timeout(defaultTimeout).block()
     }
 
+    fun reportChange(
+        alluApplicationId: Int,
+        applicationData: AlluApplicationData,
+        updatedFields: Set<InformationRequestFieldKey>,
+    ) {
+        logger.info {
+            "Sending a change report. Application: $alluApplicationId. " +
+                "Updated field keys are: ${updatedFields.joinToString()}"
+        }
+
+        val path =
+            when (applicationData) {
+                is AlluCableReportApplicationData -> "cablereports/$alluApplicationId/reportchange"
+                is AlluExcavationNotificationData ->
+                    "excavationannouncements/$alluApplicationId/reportchange"
+            }
+
+        // Allu uses the same data model for reporting changes and information request responses.
+        val request = InformationRequestResponse(applicationData, updatedFields)
+        post(path, request).toBodilessEntity().timeout(defaultTimeout).block()
+    }
+
     fun getDecisionPdf(alluApplicationId: Int): ByteArray {
         logger.info { "Fetching decision pdf for application $alluApplicationId." }
         val requestPath = "cablereports/$alluApplicationId/decision"

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/InformationRequest.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/InformationRequest.kt
@@ -33,6 +33,13 @@ enum class InformationRequestFieldKey {
     OTHER;
 
     companion object {
+        fun fromHaitatonFieldNames(names: List<String>, applicationType: ApplicationType) =
+            names
+                .mapNotNull {
+                    InformationRequestFieldKey.fromHaitatonFieldName(it, applicationType)
+                }
+                .toSet()
+
         fun fromHaitatonFieldName(
             name: String,
             applicationType: ApplicationType,

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
@@ -659,7 +659,13 @@ class HakemusService(
     ): Int {
         val formAttachment =
             getApplicationDataAsPdf(applicationId, hankeEntity.hankeTunnus, hakemusData)
-        val hhsAttachment = getHaittojenhallintasuunnitelmaPdf(hankeEntity, hakemusData)
+        val hhsAttachment =
+            getHaittojenhallintasuunnitelmaPdf(
+                hankeEntity,
+                hakemusData,
+                HHS_PDF_FILENAME,
+                "Haittojenhallintasuunnitelma from Haitaton, dated ${LocalDateTime.now()}.",
+            )
 
         val alluId = alluAction()
 
@@ -682,13 +688,21 @@ class HakemusService(
     ): Attachment {
         logger.info { "Creating a PDF from the hakemus data for data attachment." }
         val attachments = attachmentService.getMetadataList(applicationId)
-        return getApplicationDataAsPdf(hankeTunnus, attachments, data)
+        return getApplicationDataAsPdf(
+            hankeTunnus,
+            attachments,
+            data,
+            FORM_DATA_PDF_FILENAME,
+            "Original form data from Haitaton, dated ${LocalDateTime.now()}.",
+        )
     }
 
     fun getApplicationDataAsPdf(
         hankeTunnus: String,
         attachments: List<ApplicationAttachmentMetadata>,
         data: HakemusData,
+        filename: String,
+        description: String,
     ): Attachment {
         val totalArea =
             geometriatDao.calculateCombinedArea(data.areas?.flatMap { it.geometries() } ?: listOf())
@@ -710,8 +724,8 @@ class HakemusService(
             AttachmentMetadata(
                 id = null,
                 mimeType = MediaType.APPLICATION_PDF_VALUE,
-                name = FORM_DATA_PDF_FILENAME,
-                description = "Original form data from Haitaton, dated ${LocalDateTime.now()}.",
+                name = filename,
+                description = description,
             )
         logger.info { "Created the PDF for data attachment." }
         return Attachment(attachmentMetadata, pdfData)
@@ -740,6 +754,8 @@ class HakemusService(
     fun getHaittojenhallintasuunnitelmaPdf(
         hankeEntity: HankeEntity,
         data: HakemusData,
+        filename: String,
+        description: String,
     ): Attachment? {
         if (data !is KaivuilmoitusData) return null
         logger.info { "Creating a PDF from haittojenhallintasuunnitelma." }
@@ -755,9 +771,8 @@ class HakemusService(
             AttachmentMetadata(
                 id = null,
                 mimeType = MediaType.APPLICATION_PDF_VALUE,
-                name = HHS_PDF_FILENAME,
-                description =
-                    "Haittojenhallintasuunnitelma from Haitaton, dated ${LocalDateTime.now()}.",
+                name = filename,
+                description = description,
             )
         logger.info { "Created the PDF from haittojenhallintasuunnitelma." }
         return Attachment(attachmentMetadata, pdfData)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/muutosilmoitus/HasUploadFormDataPdf.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/muutosilmoitus/HasUploadFormDataPdf.kt
@@ -1,0 +1,54 @@
+package fi.hel.haitaton.hanke.muutosilmoitus
+
+import fi.hel.haitaton.hanke.allu.AlluClient
+import fi.hel.haitaton.hanke.allu.Attachment
+import fi.hel.haitaton.hanke.attachment.application.ApplicationAttachmentService
+import fi.hel.haitaton.hanke.hakemus.HakemusData
+import fi.hel.haitaton.hanke.hakemus.HakemusIdentifier
+import fi.hel.haitaton.hanke.hakemus.HakemusService
+import java.time.LocalDateTime
+import mu.KotlinLogging
+
+private val logger = KotlinLogging.logger {}
+
+/**
+ * Interface for sharing `uploadFormDataPdf` between services without passing dependencies and
+ * static names as parameters.
+ */
+interface HasUploadFormDataPdf {
+    val alluClient: AlluClient
+    val hakemusAttachmentService: ApplicationAttachmentService
+    val hakemusService: HakemusService
+
+    val entityNameForLogs: String
+    val formDataPdfFilename: String
+
+    fun formDataDescription(now: LocalDateTime): String
+
+    fun uploadFormDataPdf(hakemus: HakemusIdentifier, hankeTunnus: String, data: HakemusData) {
+        val formAttachment = createPdfFromHakemusData(hakemus, hankeTunnus, data)
+        try {
+            alluClient.addAttachment(hakemus.alluid!!, formAttachment)
+        } catch (e: Exception) {
+            logger.error(e) {
+                "Error while uploading form data PDF attachment for $entityNameForLogs. Continuing anyway. ${hakemus.logString()}"
+            }
+        }
+    }
+
+    private fun createPdfFromHakemusData(
+        hakemus: HakemusIdentifier,
+        hankeTunnus: String,
+        data: HakemusData,
+    ): Attachment {
+        logger.info { "Creating a PDF from the hakemus data for data attachment." }
+        val attachments = hakemusAttachmentService.getMetadataList(hakemus.id)
+        return hakemusService.getApplicationDataAsPdf(
+            hankeTunnus,
+            attachments,
+            data,
+            formDataPdfFilename,
+            formDataDescription(LocalDateTime.now()),
+        )
+    }
+}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/muutosilmoitus/HasUploadHaittojenhallintasuunnitelmaPdf.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/muutosilmoitus/HasUploadHaittojenhallintasuunnitelmaPdf.kt
@@ -1,0 +1,53 @@
+package fi.hel.haitaton.hanke.muutosilmoitus
+
+import fi.hel.haitaton.hanke.HankeEntity
+import fi.hel.haitaton.hanke.allu.AlluClient
+import fi.hel.haitaton.hanke.allu.Attachment
+import fi.hel.haitaton.hanke.hakemus.HakemusData
+import fi.hel.haitaton.hanke.hakemus.HakemusIdentifier
+import fi.hel.haitaton.hanke.hakemus.HakemusService
+import java.time.LocalDateTime
+import mu.KotlinLogging
+
+private val logger = KotlinLogging.logger {}
+
+/**
+ * Interface for sharing `uploadHaittojenhallintasuunnitelmaPdf` between services without passing
+ * dependencies and static names as parameters.
+ */
+interface HasUploadHaittojenhallintasuunnitelmaPdf {
+    val alluClient: AlluClient
+    val hakemusService: HakemusService
+
+    val entityNameForLogs: String
+    val hhsPdfFilename: String
+
+    fun hhsDescription(now: LocalDateTime): String
+
+    fun uploadHaittojenhallintasuunnitelmaPdf(
+        hakemus: HakemusIdentifier,
+        hanke: HankeEntity,
+        data: HakemusData,
+    ) {
+        createHaittojenhallintasuunnitelmaPdf(hanke, data)?.let {
+            try {
+                alluClient.addAttachment(hakemus.alluid!!, it)
+            } catch (e: Exception) {
+                logger.error(e) {
+                    "Error while uploading haittojenhallintasuunnitelma PDF attachment for $entityNameForLogs. Continuing anyway. ${hakemus.logString()}"
+                }
+            }
+        }
+    }
+
+    private fun createHaittojenhallintasuunnitelmaPdf(
+        hanke: HankeEntity,
+        data: HakemusData,
+    ): Attachment? =
+        hakemusService.getHaittojenhallintasuunnitelmaPdf(
+            hanke,
+            data,
+            hhsPdfFilename,
+            hhsDescription(LocalDateTime.now()),
+        )
+}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/muutosilmoitus/MuutosilmoitusService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/muutosilmoitus/MuutosilmoitusService.kt
@@ -1,10 +1,17 @@
 package fi.hel.haitaton.hanke.muutosilmoitus
 
+import fi.hel.haitaton.hanke.HankeEntity
+import fi.hel.haitaton.hanke.allu.AlluClient
 import fi.hel.haitaton.hanke.allu.ApplicationStatus
+import fi.hel.haitaton.hanke.allu.InformationRequestFieldKey
+import fi.hel.haitaton.hanke.attachment.application.ApplicationAttachmentService
 import fi.hel.haitaton.hanke.hakemus.ApplicationContactType
 import fi.hel.haitaton.hanke.hakemus.ApplicationType
 import fi.hel.haitaton.hanke.hakemus.CustomerWithContactsRequest
+import fi.hel.haitaton.hanke.hakemus.HakemusDataMapper.toAlluData
+import fi.hel.haitaton.hanke.hakemus.HakemusDataValidator
 import fi.hel.haitaton.hanke.hakemus.HakemusEntity
+import fi.hel.haitaton.hanke.hakemus.HakemusIdentifier
 import fi.hel.haitaton.hanke.hakemus.HakemusInWrongStatusException
 import fi.hel.haitaton.hanke.hakemus.HakemusNotFoundException
 import fi.hel.haitaton.hanke.hakemus.HakemusRepository
@@ -13,9 +20,14 @@ import fi.hel.haitaton.hanke.hakemus.HakemusService.Companion.toExistingYhteysti
 import fi.hel.haitaton.hanke.hakemus.HakemusUpdateRequest
 import fi.hel.haitaton.hanke.hakemus.HakemusyhteyshenkiloEntity
 import fi.hel.haitaton.hanke.hakemus.HakemusyhteystietoEntity
+import fi.hel.haitaton.hanke.hakemus.PaperDecisionReceiver
 import fi.hel.haitaton.hanke.hakemus.WrongHakemusTypeException
+import fi.hel.haitaton.hanke.logging.DisclosureLogService
 import fi.hel.haitaton.hanke.logging.MuutosilmoitusLoggingService
 import fi.hel.haitaton.hanke.permissions.HankeKayttajaService
+import fi.hel.haitaton.hanke.taydennys.NoChangesException
+import java.time.LocalDateTime
+import java.time.OffsetDateTime
 import java.util.UUID
 import mu.KotlinLogging
 import org.springframework.data.repository.findByIdOrNull
@@ -24,14 +36,32 @@ import org.springframework.transaction.annotation.Transactional
 
 private val logger = KotlinLogging.logger {}
 
+const val FORM_DATA_PDF_FILENAME = "haitaton-form-data-muutosilmoitus.pdf"
+const val HHS_PDF_FILENAME = "haitaton-haittojenhallintasuunnitelma-muutosilmoitus.pdf"
+const val PAPER_DECISION_MSG =
+    "Asiakas haluaa korvaavan päätöksen myös paperisena. Liitteessä " +
+        "$FORM_DATA_PDF_FILENAME on päätöksen toimitukseen liittyvät osoitetiedot."
+
 @Service
 class MuutosilmoitusService(
     private val muutosilmoitusRepository: MuutosilmoitusRepository,
     private val hakemusRepository: HakemusRepository,
     private val loggingService: MuutosilmoitusLoggingService,
-    private val hakemusService: HakemusService,
+    override val hakemusService: HakemusService,
+    override val hakemusAttachmentService: ApplicationAttachmentService,
     private val hankeKayttajaService: HankeKayttajaService,
-) {
+    private val disclosureLogService: DisclosureLogService,
+    override val alluClient: AlluClient,
+) : HasUploadFormDataPdf, HasUploadHaittojenhallintasuunnitelmaPdf {
+    override val entityNameForLogs: String = "muutosilmoitus"
+    override val formDataPdfFilename: String = FORM_DATA_PDF_FILENAME
+    override val hhsPdfFilename: String = HHS_PDF_FILENAME
+
+    override fun formDataDescription(now: LocalDateTime): String =
+        "Muutosilmoitus form data from Haitaton, dated $now."
+
+    override fun hhsDescription(now: LocalDateTime): String =
+        "Haittojenhallintasuunnitelma from Haitaton muutosilmoitus, dated $now."
 
     @Transactional(readOnly = true)
     fun find(hakemusId: Long): Muutosilmoitus? =
@@ -118,6 +148,47 @@ class MuutosilmoitusService(
         val muutosilmoitus = muutosilmoitusEntity.toDomain()
         muutosilmoitusRepository.delete(muutosilmoitusEntity)
         loggingService.logDelete(muutosilmoitus, currentUserId)
+    }
+
+    @Transactional
+    fun send(id: UUID, paperDecisionReceiver: PaperDecisionReceiver?, currentUserId: String) {
+        val entity =
+            muutosilmoitusRepository.findByIdOrNull(id) ?: throw MuutosilmoitusNotFoundException(id)
+
+        if (entity.sent != null) throw MuutosilmoitusAlreadySentException(entity)
+
+        val muutosilmoitusBefore = entity.toDomain()
+        entity.hakemusData = entity.hakemusData.copy(paperDecisionReceiver = paperDecisionReceiver)
+        val muutosilmoitus = entity.toDomain()
+        loggingService.logUpdate(muutosilmoitusBefore, muutosilmoitus, currentUserId)
+
+        val hakemus = hakemusRepository.getReferenceById(entity.hakemusId)
+        val hanke = hakemus.hanke
+
+        logger.info(
+            "Sending muutosilmoitus to Allu ${muutosilmoitus.logString()} " +
+                "${hakemus.logString()} ${hanke.logString()}"
+        )
+
+        val changes =
+            muutosilmoitus.hakemusData.listChanges(hakemus.toHakemus().applicationData).ifEmpty {
+                throw NoChangesException(entityNameForLogs, entity, hakemus)
+            }
+
+        HakemusDataValidator.ensureValidForSend(muutosilmoitus.hakemusData)
+
+        if (!hanke.generated) {
+            entity.hakemusData.areas?.let { areas ->
+                hakemusService.assertGeometryCompatibility(hanke.id, areas)
+            }
+        }
+
+        logger.info("Sending muutosilmoitus id=$id")
+        sendMuutosilmoitusToAllu(muutosilmoitus, hakemus, hanke, changes)
+
+        entity.sent = OffsetDateTime.now()
+
+        logger.info("Muutosilmoitus sent. ${entity.logString()} ${hakemus.logString()}")
     }
 
     private fun assertUpdateCompatible(
@@ -238,6 +309,30 @@ class MuutosilmoitusService(
         )
 
         return muutosilmoitus
+    }
+
+    private fun sendMuutosilmoitusToAllu(
+        muutosilmoitus: Muutosilmoitus,
+        hakemus: HakemusIdentifier,
+        hanke: HankeEntity,
+        muutokset: List<String>,
+    ) {
+        val updatedFieldKeys =
+            InformationRequestFieldKey.fromHaitatonFieldNames(
+                muutokset,
+                muutosilmoitus.hakemusData.applicationType,
+            )
+        val alluData = muutosilmoitus.hakemusData.toAlluData(hanke.hankeTunnus)
+
+        disclosureLogService.withDisclosureLogging(hakemus.id, alluData) {
+            alluClient.reportChange(hakemus.alluid!!, alluData, updatedFieldKeys)
+        }
+        uploadFormDataPdf(hakemus, hanke.hankeTunnus, muutosilmoitus.hakemusData)
+        uploadHaittojenhallintasuunnitelmaPdf(hakemus, hanke, muutosilmoitus.hakemusData)
+
+        if (muutosilmoitus.hakemusData.paperDecisionReceiver != null) {
+            alluClient.sendSystemComment(hakemus.alluid!!, PAPER_DECISION_MSG)
+        }
     }
 
     companion object {

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusFactory.kt
@@ -310,6 +310,14 @@ class HakemusFactory(
             muutosilmoitus: MuutosilmoitusWithExtras? = null,
         ) = HakemusWithExtras(this, paatokset, taydennyspyynto, taydennys, muutosilmoitus)
 
+        fun HakemusData.withPaperDecisionReceiver(
+            paperDecisionReceiver: PaperDecisionReceiver?
+        ): HakemusData =
+            when (this) {
+                is JohtoselvityshakemusData -> copy(paperDecisionReceiver = paperDecisionReceiver)
+                is KaivuilmoitusData -> copy(paperDecisionReceiver = paperDecisionReceiver)
+            }
+
         fun hakemusDataForRegistryKeyTest(tyyppi: CustomerType): KaivuilmoitusData {
             val hakija =
                 HakemusyhteystietoFactory.createPerson(tyyppi = tyyppi, registryKey = "280341-912F")

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/MuutosilmoitusBuilder.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/MuutosilmoitusBuilder.kt
@@ -19,6 +19,7 @@ import fi.hel.haitaton.hanke.permissions.HankekayttajaInput
 import fi.hel.haitaton.hanke.permissions.Kayttooikeustaso
 import java.security.InvalidParameterException
 import java.time.OffsetDateTime
+import java.time.ZonedDateTime
 
 class MuutosilmoitusBuilder(
     private var muutosilmoitusEntity: MuutosilmoitusEntity,
@@ -51,6 +52,30 @@ class MuutosilmoitusBuilder(
                 if (areas.any { it !is KaivuilmoitusAlue }) throw InvalidParameterException()
                 copy(areas = areas.filterIsInstance<KaivuilmoitusAlue>())
             },
+        )
+
+    fun withStartTime(startTime: ZonedDateTime?) =
+        updateApplicationData({ copy(startTime = startTime) }, { copy(startTime = startTime) })
+
+    fun withEndTime(endTime: ZonedDateTime?) =
+        updateApplicationData({ copy(endTime = endTime) }, { copy(endTime = endTime) })
+
+    fun withConstructionWork(constructionWork: Boolean) =
+        updateApplicationData(
+            { copy(constructionWork = constructionWork) },
+            { copy(constructionWork = constructionWork) },
+        )
+
+    fun withMaintenanceWork(maintenanceWork: Boolean) =
+        updateApplicationData(
+            { copy(maintenanceWork = maintenanceWork) },
+            { copy(maintenanceWork = maintenanceWork) },
+        )
+
+    fun withCustomerReference(customerReference: String) =
+        updateApplicationData(
+            { invalidHakemusType() },
+            { copy(customerReference = customerReference) },
         )
 
     fun withWorkDescription(description: String) =

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/TaydennysBuilder.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/TaydennysBuilder.kt
@@ -68,14 +68,9 @@ data class TaydennysBuilder(
             { copy(workDescription = description) },
         )
 
-    fun withStreetAddress(streetAddress: String): TaydennysBuilder =
+    fun withStreetAddress(address: String): TaydennysBuilder =
         updateApplicationData(
-            {
-                copy(
-                    postalAddress =
-                        postalAddress?.copy(streetAddress = StreetAddress(streetAddress))
-                )
-            },
+            { copy(postalAddress = postalAddress?.copy(streetAddress = StreetAddress(address))) },
             { invalidHakemusType() },
         )
 


### PR DESCRIPTION
# Description

Add API for sending muutosilmoitus to Allu. The muutosilmoitus is marked sent by setting the `sent` field. A sent muutosilmoitus cannot be re-sent.

The API accepts a paper decision receiver in the request body. It's added to the form data PDF attachment sent to Allu and a message is added about requesting the decision on paper. If the body is not added, any previous paper decision receiver is removed from the muutosilmoitus.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-3408

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
- Add a kaivuilmoitus and create a decision for it.
- Create a muutosilmoitus and change some values.
- Use [Swagger UI](http://localhost:3001/api/swagger-ui/index.html#/muutosilmoitus-controller/send_1) to send the muutosilmoitus.
- Check that Allu shows the information you updated.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 