### PR TITLE
HAI-151 Merge muutosilmoitus to hakemus

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/muutosilmoitus/UpdateMuutosilmoitusITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/muutosilmoitus/UpdateMuutosilmoitusITest.kt
@@ -29,7 +29,6 @@ import fi.hel.haitaton.hanke.allu.CustomerType
 import fi.hel.haitaton.hanke.asJsonResource
 import fi.hel.haitaton.hanke.email.textBody
 import fi.hel.haitaton.hanke.factory.ApplicationFactory
-import fi.hel.haitaton.hanke.factory.DateFactory
 import fi.hel.haitaton.hanke.factory.GeometriaFactory
 import fi.hel.haitaton.hanke.factory.HakemusFactory
 import fi.hel.haitaton.hanke.factory.HakemusUpdateRequestFactory
@@ -140,11 +139,7 @@ class UpdateMuutosilmoitusITest(
     @ParameterizedTest
     @EnumSource(ApplicationType::class)
     fun `throws exception when the muutosilmoitus has been sent already`(type: ApplicationType) {
-        val muutosilmoitus =
-            muutosilmoitusFactory
-                .builder(type)
-                .withSent(DateFactory.getStartDatetime().toOffsetDateTime())
-                .save()
+        val muutosilmoitus = muutosilmoitusFactory.builder(type).withSent().save()
         val request = muutosilmoitus.toUpdateRequest()
 
         val exception = assertFailure {

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/HasYhteystietoEntities.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/HasYhteystietoEntities.kt
@@ -1,6 +1,7 @@
 package fi.hel.haitaton.hanke.domain
 
 import fi.hel.haitaton.hanke.hakemus.ApplicationContactType
+import fi.hel.haitaton.hanke.hakemus.HakemusEntity
 import fi.hel.haitaton.hanke.hakemus.YhteyshenkiloEntity
 import fi.hel.haitaton.hanke.hakemus.YhteystietoEntity
 import fi.hel.haitaton.hanke.permissions.HankekayttajaEntity
@@ -14,4 +15,18 @@ interface HasYhteystietoEntities<H : YhteyshenkiloEntity> {
             .flatMap { it.yhteyshenkilot }
             .map { it.hankekayttaja }
             .distinctBy { it.id }
+
+    fun mergeYhteystiedotToHakemus(hakemus: HakemusEntity) {
+        for (contactType in ApplicationContactType.entries) {
+            val yhteystieto = yhteystiedot[contactType]
+            val hakemusyhteystieto = hakemus.yhteystiedot[contactType]
+            if (yhteystieto == null) {
+                hakemus.yhteystiedot.remove(contactType)
+            } else if (hakemusyhteystieto == null) {
+                hakemus.yhteystiedot[contactType] = yhteystieto.toHakemusyhteystieto(hakemus)
+            } else {
+                yhteystieto.mergeToHakemusyhteystieto(hakemusyhteystieto)
+            }
+        }
+    }
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusHistoryService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusHistoryService.kt
@@ -7,6 +7,7 @@ import fi.hel.haitaton.hanke.allu.ApplicationStatusEvent
 import fi.hel.haitaton.hanke.email.InformationRequestEmail
 import fi.hel.haitaton.hanke.email.JohtoselvitysCompleteEmail
 import fi.hel.haitaton.hanke.email.KaivuilmoitusDecisionEmail
+import fi.hel.haitaton.hanke.muutosilmoitus.MuutosilmoitusService
 import fi.hel.haitaton.hanke.paatos.PaatosService
 import fi.hel.haitaton.hanke.permissions.HankeKayttajaService
 import fi.hel.haitaton.hanke.permissions.PermissionCode
@@ -26,6 +27,7 @@ class HakemusHistoryService(
     private val taydennysService: TaydennysService,
     private val paatosService: PaatosService,
     private val hankeKayttajaService: HankeKayttajaService,
+    private val muutosilmoitusService: MuutosilmoitusService,
     private val applicationEventPublisher: ApplicationEventPublisher,
 ) {
     @Transactional(readOnly = true) fun getAllAlluIds() = hakemusRepository.getAllAlluIds()
@@ -73,6 +75,7 @@ class HakemusHistoryService(
 
         when (event.newStatus) {
             ApplicationStatus.DECISION -> {
+                muutosilmoitusService.mergeMuutosilmoitusToHakemusIfItExists(application)
                 updateStatus()
                 sendDecisionReadyEmails(application, event.applicationIdentifier)
                 if (application.applicationType == ApplicationType.EXCAVATION_NOTIFICATION) {

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/YhteystietoEntity.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/YhteystietoEntity.kt
@@ -35,11 +35,67 @@ interface YhteystietoEntity<H : YhteyshenkiloEntity> {
                         puhelin = yhteyshenkilo.hankekayttaja.puhelin,
                         tilaaja = yhteyshenkilo.tilaaja,
                     )
-                })
+                },
+        )
+
+    fun toHakemusyhteystieto(hakemus: HakemusEntity): HakemusyhteystietoEntity {
+        val hakemusyhteystieto =
+            HakemusyhteystietoEntity(
+                tyyppi = tyyppi,
+                rooli = rooli,
+                nimi = nimi,
+                sahkoposti = sahkoposti,
+                puhelinnumero = puhelinnumero,
+                registryKey = registryKey,
+                application = hakemus,
+            )
+
+        for (yhteyshenkilo in yhteyshenkilot) {
+            hakemusyhteystieto.yhteyshenkilot.add(
+                yhteyshenkilo.toHakemusYhteyshenkilo(hakemusyhteystieto)
+            )
+        }
+
+        return hakemusyhteystieto
+    }
+
+    fun mergeToHakemusyhteystieto(hakemusyhteystieto: HakemusyhteystietoEntity) {
+        hakemusyhteystieto.tyyppi = tyyppi
+        hakemusyhteystieto.nimi = nimi
+        hakemusyhteystieto.sahkoposti = sahkoposti
+        hakemusyhteystieto.puhelinnumero = puhelinnumero
+        hakemusyhteystieto.registryKey = registryKey
+
+        val muutosilmoitusHankekayttajaIds = yhteyshenkilot.map { it.hankekayttaja.id }
+        hakemusyhteystieto.yhteyshenkilot.removeAll {
+            !muutosilmoitusHankekayttajaIds.contains(it.hankekayttaja.id)
+        }
+
+        for (yhteyshenkilo in yhteyshenkilot) {
+            val hakemusyhteyshenkilo =
+                hakemusyhteystieto.yhteyshenkilot.find {
+                    it.hankekayttaja.id == yhteyshenkilo.hankekayttaja.id
+                }
+            if (hakemusyhteyshenkilo != null) {
+                hakemusyhteyshenkilo.tilaaja = yhteyshenkilo.tilaaja
+            } else {
+                hakemusyhteystieto.yhteyshenkilot.add(
+                    yhteyshenkilo.toHakemusYhteyshenkilo(hakemusyhteystieto)
+                )
+            }
+        }
+    }
 }
 
 interface YhteyshenkiloEntity {
     val id: UUID
     var hankekayttaja: HankekayttajaEntity
     var tilaaja: Boolean
+
+    fun toHakemusYhteyshenkilo(yhteystieto: HakemusyhteystietoEntity): HakemusyhteyshenkiloEntity =
+        HakemusyhteyshenkiloEntity(
+            hakemusyhteystieto = yhteystieto,
+            hankekayttaja = hankekayttaja,
+            tilaaja = tilaaja,
+        )
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennysService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennysService.kt
@@ -491,88 +491,8 @@ class TaydennysService(
 
         fun mergeTaydennysToHakemus(taydennys: TaydennysEntity, hakemus: HakemusEntity) {
             hakemus.hakemusEntityData = taydennys.hakemusData
-
-            for (contactType in ApplicationContactType.entries) {
-                val yhteystieto = taydennys.yhteystiedot[contactType]
-                val hakemusyhteystieto = hakemus.yhteystiedot[contactType]
-                if (yhteystieto == null) {
-                    hakemus.yhteystiedot.remove(contactType)
-                } else if (hakemusyhteystieto == null) {
-                    hakemus.yhteystiedot[contactType] =
-                        createHakemusyhteystietoFromTaydennysyhteystieto(yhteystieto, hakemus)
-                } else {
-                    mergeTaydennysyhteystietoToHakemusyhteystieto(yhteystieto, hakemusyhteystieto)
-                }
-            }
+            taydennys.mergeYhteystiedotToHakemus(hakemus)
         }
-
-        private fun mergeTaydennysyhteystietoToHakemusyhteystieto(
-            taydennysyhteystieto: TaydennysyhteystietoEntity,
-            hakemusyhteystieto: HakemusyhteystietoEntity,
-        ) {
-            hakemusyhteystieto.tyyppi = taydennysyhteystieto.tyyppi
-            hakemusyhteystieto.nimi = taydennysyhteystieto.nimi
-            hakemusyhteystieto.sahkoposti = taydennysyhteystieto.sahkoposti
-            hakemusyhteystieto.puhelinnumero = taydennysyhteystieto.puhelinnumero
-            hakemusyhteystieto.registryKey = taydennysyhteystieto.registryKey
-
-            val taydennysHankekayttajaIds =
-                taydennysyhteystieto.yhteyshenkilot.map { it.hankekayttaja.id }
-            hakemusyhteystieto.yhteyshenkilot.removeAll {
-                !taydennysHankekayttajaIds.contains(it.hankekayttaja.id)
-            }
-
-            for (yhteyshenkilo in taydennysyhteystieto.yhteyshenkilot) {
-                val hakemusyhteyshenkilo =
-                    hakemusyhteystieto.yhteyshenkilot.find {
-                        it.hankekayttaja.id == yhteyshenkilo.hankekayttaja.id
-                    }
-                if (hakemusyhteyshenkilo != null) {
-                    hakemusyhteyshenkilo.tilaaja = yhteyshenkilo.tilaaja
-                } else {
-                    hakemusyhteystieto.yhteyshenkilot.add(
-                        createHakemusYhteyshenkiloFromTaydennysyhteyshenkilo(
-                            yhteyshenkilo,
-                            hakemusyhteystieto,
-                        )
-                    )
-                }
-            }
-        }
-
-        private fun createHakemusyhteystietoFromTaydennysyhteystieto(
-            yhteystieto: TaydennysyhteystietoEntity,
-            hakemus: HakemusEntity,
-        ): HakemusyhteystietoEntity =
-            HakemusyhteystietoEntity(
-                    tyyppi = yhteystieto.tyyppi,
-                    rooli = yhteystieto.rooli,
-                    nimi = yhteystieto.nimi,
-                    sahkoposti = yhteystieto.sahkoposti,
-                    puhelinnumero = yhteystieto.puhelinnumero,
-                    registryKey = yhteystieto.registryKey,
-                    application = hakemus,
-                )
-                .apply {
-                    for (yhteyshenkilo in yhteystieto.yhteyshenkilot) {
-                        yhteyshenkilot.add(
-                            createHakemusYhteyshenkiloFromTaydennysyhteyshenkilo(
-                                yhteyshenkilo,
-                                this,
-                            )
-                        )
-                    }
-                }
-
-        private fun createHakemusYhteyshenkiloFromTaydennysyhteyshenkilo(
-            yhteyshenkilo: TaydennysyhteyshenkiloEntity,
-            yhteystieto: HakemusyhteystietoEntity,
-        ): HakemusyhteyshenkiloEntity =
-            HakemusyhteyshenkiloEntity(
-                hakemusyhteystieto = yhteystieto,
-                hankekayttaja = yhteyshenkilo.hankekayttaja,
-                tilaaja = yhteyshenkilo.tilaaja,
-            )
     }
 }
 

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/MuutosilmoitusBuilder.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/MuutosilmoitusBuilder.kt
@@ -87,7 +87,9 @@ class MuutosilmoitusBuilder(
     fun withAdditionalInfo(info: String) =
         updateApplicationData({ invalidHakemusType() }, { copy(additionalInfo = info) })
 
-    fun withSent(sent: OffsetDateTime?): MuutosilmoitusBuilder {
+    fun withSent(
+        sent: OffsetDateTime? = MuutosilmoitusFactory.DEFAULT_SENT
+    ): MuutosilmoitusBuilder {
         muutosilmoitusEntity.sent = sent
         return this
     }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/MuutosilmoitusFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/MuutosilmoitusFactory.kt
@@ -17,6 +17,8 @@ import fi.hel.haitaton.hanke.muutosilmoitus.MuutosilmoitusRepository
 import fi.hel.haitaton.hanke.muutosilmoitus.MuutosilmoitusService
 import fi.hel.haitaton.hanke.muutosilmoitus.MuutosilmoitusWithExtras
 import fi.hel.haitaton.hanke.parseJson
+import fi.hel.haitaton.hanke.permissions.HankekayttajaEntity
+import fi.hel.haitaton.hanke.permissions.PermissionEntity
 import fi.hel.haitaton.hanke.toJsonString
 import java.time.OffsetDateTime
 import java.util.UUID
@@ -96,6 +98,7 @@ class MuutosilmoitusFactory(
 
     companion object {
         val DEFAULT_ID: UUID = UUID.fromString("7df81277-2e36-4082-8687-0421c20d341e")
+        val DEFAULT_SENT: OffsetDateTime = OffsetDateTime.parse("2024-03-06T16:28:01Z")
 
         fun create(
             id: UUID = DEFAULT_ID,
@@ -138,5 +141,43 @@ class MuutosilmoitusFactory(
 
         fun Muutosilmoitus.withExtras(muutokset: List<String> = listOf()) =
             MuutosilmoitusWithExtras(id, hakemusId, sent, hakemusData, muutokset)
+
+        fun createYhteyshenkiloEntity(
+            hankeId: Int,
+            yhteystieto: MuutosilmoituksenYhteystietoEntity,
+            id: UUID = UUID.randomUUID(),
+            etunimi: String = HakemusyhteyshenkiloFactory.DEFAULT_ETUNIMI,
+            sukunimi: String = HakemusyhteyshenkiloFactory.DEFAULT_SUKUNIMI,
+            sahkoposti: String = HakemusyhteyshenkiloFactory.DEFAULT_SAHKOPOSTI,
+            puhelin: String = HakemusyhteyshenkiloFactory.DEFAULT_PUHELIN,
+            tilaaja: Boolean = HakemusyhteyshenkiloFactory.DEFAULT_TILAAJA,
+            permission: PermissionEntity = PermissionFactory.createEntity(),
+        ): MuutosilmoituksenYhteyshenkiloEntity =
+            MuutosilmoituksenYhteyshenkiloEntity(
+                id = id,
+                yhteystieto = yhteystieto,
+                hankekayttaja =
+                    HankekayttajaEntity(
+                        id = id,
+                        hankeId = hankeId,
+                        etunimi = etunimi,
+                        sukunimi = sukunimi,
+                        sahkoposti = sahkoposti,
+                        puhelin = puhelin,
+                        permission = permission,
+                    ),
+                tilaaja = tilaaja,
+            )
+
+        fun createYhteyshenkiloEntity(
+            yhteystieto: MuutosilmoituksenYhteystietoEntity,
+            hankekayttaja: HankekayttajaEntity,
+            tilaaja: Boolean,
+        ): MuutosilmoituksenYhteyshenkiloEntity =
+            MuutosilmoituksenYhteyshenkiloEntity(
+                yhteystieto = yhteystieto,
+                hankekayttaja = hankekayttaja,
+                tilaaja = tilaaja,
+            )
     }
 }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/muutosilmoitus/MuutosilmoitusServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/muutosilmoitus/MuutosilmoitusServiceTest.kt
@@ -1,0 +1,280 @@
+package fi.hel.haitaton.hanke.muutosilmoitus
+
+import assertk.all
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotEqualTo
+import assertk.assertions.isNotNull
+import assertk.assertions.isNull
+import assertk.assertions.prop
+import assertk.assertions.single
+import fi.hel.haitaton.hanke.factory.ApplicationFactory
+import fi.hel.haitaton.hanke.factory.HakemusFactory
+import fi.hel.haitaton.hanke.factory.HakemusyhteyshenkiloFactory
+import fi.hel.haitaton.hanke.factory.HakemusyhteystietoFactory
+import fi.hel.haitaton.hanke.factory.HankeKayttajaFactory
+import fi.hel.haitaton.hanke.factory.MuutosilmoitusFactory
+import fi.hel.haitaton.hanke.hakemus.ApplicationContactType
+import fi.hel.haitaton.hanke.hakemus.HakemusyhteyshenkiloEntity
+import fi.hel.haitaton.hanke.hakemus.HakemusyhteystietoEntity
+import java.util.UUID
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class MuutosilmoitusServiceTest {
+
+    @Nested
+    inner class MergeMuutosilmoitusToHakemus {
+
+        @Test
+        fun `updates hakemus data from the muutosilmoitus`() {
+            val baseData = ApplicationFactory.createCableReportApplicationData()
+            val hakemusData = baseData.copy(areas = listOf())
+            val hakemus = HakemusFactory.createEntity(hakemusEntityData = hakemusData)
+            val muutosilmoitusData =
+                baseData.copy(
+                    startTime = baseData.startTime!!.minusDays(1),
+                    endTime = baseData.endTime!!.plusDays(1),
+                )
+            val muutosilmoitus =
+                MuutosilmoitusFactory.createEntity(hakemusData = muutosilmoitusData)
+
+            MuutosilmoitusService.mergeMuutosilmoitusToHakemus(muutosilmoitus, hakemus)
+
+            assertThat(hakemus.hakemusEntityData).isEqualTo(muutosilmoitusData)
+        }
+
+        @Test
+        fun `removes yhteystieto from hakemus when not present in muutosilmoitus`() {
+            val hakemus = HakemusFactory.createEntity()
+            hakemus.yhteystiedot[ApplicationContactType.RAKENNUTTAJA] =
+                HakemusyhteystietoFactory.createEntity(application = hakemus)
+            val muutosilmoitus = MuutosilmoitusFactory.createEntity()
+            muutosilmoitus.yhteystiedot.remove(ApplicationContactType.RAKENNUTTAJA)
+
+            MuutosilmoitusService.mergeMuutosilmoitusToHakemus(muutosilmoitus, hakemus)
+
+            assertThat(hakemus.yhteystiedot[ApplicationContactType.RAKENNUTTAJA]).isNull()
+        }
+
+        @Test
+        fun `creates yhteystieto to hakemus when new one added in muutosilmoitus`() {
+            val hakemus = HakemusFactory.createEntity()
+            hakemus.yhteystiedot.remove(ApplicationContactType.RAKENNUTTAJA)
+            val muutosilmoitus = MuutosilmoitusFactory.createEntity()
+            val yhteystieto =
+                MuutosilmoitusFactory.createYhteystietoEntity(
+                    muutosilmoitus = muutosilmoitus,
+                    rooli = ApplicationContactType.RAKENNUTTAJA,
+                )
+            val yhteyshenkilo =
+                MuutosilmoitusFactory.createYhteyshenkiloEntity(hakemus.hanke.id, yhteystieto)
+            yhteystieto.yhteyshenkilot.add(yhteyshenkilo)
+            muutosilmoitus.yhteystiedot[ApplicationContactType.RAKENNUTTAJA] = yhteystieto
+
+            MuutosilmoitusService.mergeMuutosilmoitusToHakemus(muutosilmoitus, hakemus)
+
+            assertThat(hakemus.yhteystiedot[ApplicationContactType.RAKENNUTTAJA]).isNotNull().all {
+                prop(HakemusyhteystietoEntity::id).isNotEqualTo(yhteystieto.id)
+                prop(HakemusyhteystietoEntity::application).isEqualTo(hakemus)
+                prop(HakemusyhteystietoEntity::tyyppi).isEqualTo(yhteystieto.tyyppi)
+                prop(HakemusyhteystietoEntity::rooli).isEqualTo(ApplicationContactType.RAKENNUTTAJA)
+                prop(HakemusyhteystietoEntity::nimi).isEqualTo(yhteystieto.nimi)
+                prop(HakemusyhteystietoEntity::sahkoposti).isEqualTo(yhteystieto.sahkoposti)
+                prop(HakemusyhteystietoEntity::puhelinnumero).isEqualTo(yhteystieto.puhelinnumero)
+                prop(HakemusyhteystietoEntity::registryKey).isEqualTo(yhteystieto.registryKey)
+                prop(HakemusyhteystietoEntity::yhteyshenkilot).single().all {
+                    prop(HakemusyhteyshenkiloEntity::id).isNotEqualTo(yhteyshenkilo.id)
+                    prop(HakemusyhteyshenkiloEntity::hankekayttaja)
+                        .isEqualTo(yhteyshenkilo.hankekayttaja)
+                    prop(HakemusyhteyshenkiloEntity::tilaaja).isEqualTo(yhteyshenkilo.tilaaja)
+                }
+            }
+        }
+
+        @Test
+        fun `updates the existing yhteystieto in hakemus when updated in muutosilmoitus`() {
+            val hakemus = HakemusFactory.createEntity()
+            val hankeId = hakemus.hanke.id
+            val hakemusyhteystieto =
+                HakemusyhteystietoFactory.createEntity(
+                    application = hakemus,
+                    rooli = ApplicationContactType.RAKENNUTTAJA,
+                )
+            hakemus.yhteystiedot[ApplicationContactType.RAKENNUTTAJA] = hakemusyhteystieto
+
+            val muutosilmoitus = MuutosilmoitusFactory.createEntity()
+            val yhteystieto =
+                MuutosilmoitusFactory.createYhteystietoEntity(
+                    muutosilmoitus = muutosilmoitus,
+                    rooli = ApplicationContactType.RAKENNUTTAJA,
+                    nimi = "New name",
+                    sahkoposti = "new@email",
+                )
+            val yhteyshenkilo =
+                MuutosilmoitusFactory.createYhteyshenkiloEntity(hankeId, yhteystieto)
+            yhteystieto.yhteyshenkilot.add(yhteyshenkilo)
+            muutosilmoitus.yhteystiedot[ApplicationContactType.RAKENNUTTAJA] = yhteystieto
+
+            MuutosilmoitusService.mergeMuutosilmoitusToHakemus(muutosilmoitus, hakemus)
+
+            assertThat(hakemus.yhteystiedot[ApplicationContactType.RAKENNUTTAJA]).isNotNull().all {
+                prop(HakemusyhteystietoEntity::id).isNotEqualTo(yhteystieto.id)
+                prop(HakemusyhteystietoEntity::id).isEqualTo(hakemusyhteystieto.id)
+                prop(HakemusyhteystietoEntity::application).isEqualTo(hakemus)
+                prop(HakemusyhteystietoEntity::tyyppi).isEqualTo(yhteystieto.tyyppi)
+                prop(HakemusyhteystietoEntity::rooli).isEqualTo(ApplicationContactType.RAKENNUTTAJA)
+                prop(HakemusyhteystietoEntity::nimi).isEqualTo(yhteystieto.nimi)
+                prop(HakemusyhteystietoEntity::sahkoposti).isEqualTo(yhteystieto.sahkoposti)
+                prop(HakemusyhteystietoEntity::yhteyshenkilot).single().all {
+                    prop(HakemusyhteyshenkiloEntity::id).isNotEqualTo(yhteyshenkilo.id)
+                    prop(HakemusyhteyshenkiloEntity::hankekayttaja)
+                        .isEqualTo(yhteyshenkilo.hankekayttaja)
+                    prop(HakemusyhteyshenkiloEntity::tilaaja).isEqualTo(yhteyshenkilo.tilaaja)
+                }
+            }
+        }
+
+        @Test
+        fun `uses the existing yhteyshenkilo when the muutosilmoitus references the same hankekayttaja`() {
+            val hakemus = HakemusFactory.createEntity()
+            val hankeId = hakemus.hanke.id
+            val hakemusyhteystieto =
+                HakemusyhteystietoFactory.createEntity(
+                    application = hakemus,
+                    rooli = ApplicationContactType.RAKENNUTTAJA,
+                )
+            val sally =
+                HankeKayttajaFactory.createEntity(
+                    hankeId = hankeId,
+                    etunimi = "Sally",
+                    sukunimi = "Stable",
+                )
+            val hakemusyhteyshenkilo =
+                HakemusyhteyshenkiloFactory.createEntity(hakemusyhteystieto, sally, false)
+            hakemusyhteystieto.yhteyshenkilot.add(hakemusyhteyshenkilo)
+            hakemus.yhteystiedot[ApplicationContactType.RAKENNUTTAJA] = hakemusyhteystieto
+
+            val muutosilmoitus = MuutosilmoitusFactory.createEntity()
+            val yhteystieto =
+                MuutosilmoitusFactory.createYhteystietoEntity(
+                    muutosilmoitus = muutosilmoitus,
+                    rooli = ApplicationContactType.RAKENNUTTAJA,
+                )
+            val yhteyshenkilo =
+                MuutosilmoitusFactory.createYhteyshenkiloEntity(yhteystieto, sally, false)
+            yhteystieto.yhteyshenkilot.add(yhteyshenkilo)
+            muutosilmoitus.yhteystiedot[ApplicationContactType.RAKENNUTTAJA] = yhteystieto
+
+            MuutosilmoitusService.mergeMuutosilmoitusToHakemus(muutosilmoitus, hakemus)
+
+            assertThat(hakemus.yhteystiedot[ApplicationContactType.RAKENNUTTAJA]).isNotNull().all {
+                prop(HakemusyhteystietoEntity::yhteyshenkilot).single().all {
+                    prop(HakemusyhteyshenkiloEntity::id).isNotEqualTo(yhteyshenkilo.id)
+                    prop(HakemusyhteyshenkiloEntity::id).isEqualTo(hakemusyhteyshenkilo.id)
+                    prop(HakemusyhteyshenkiloEntity::hankekayttaja)
+                        .isEqualTo(yhteyshenkilo.hankekayttaja)
+                    prop(HakemusyhteyshenkiloEntity::tilaaja).isEqualTo(yhteyshenkilo.tilaaja)
+                }
+            }
+        }
+
+        @Test
+        fun `updates the yhteyshenkilo when the muutosilmoitus references the same hankekayttaja`() {
+            val hakemus = HakemusFactory.createEntity()
+            val hankeId = hakemus.hanke.id
+            val hakemusyhteystieto =
+                HakemusyhteystietoFactory.createEntity(
+                    application = hakemus,
+                    rooli = ApplicationContactType.RAKENNUTTAJA,
+                )
+            val tapio =
+                HankeKayttajaFactory.createEntity(
+                    hankeId = hankeId,
+                    etunimi = "Tapio",
+                    sukunimi = "Tilaaja",
+                )
+            val hakemusyhteyshenkilo =
+                HakemusyhteyshenkiloFactory.createEntity(hakemusyhteystieto, tapio, false)
+            hakemusyhteystieto.yhteyshenkilot.add(hakemusyhteyshenkilo)
+            hakemus.yhteystiedot[ApplicationContactType.RAKENNUTTAJA] = hakemusyhteystieto
+
+            val muutosilmoitus = MuutosilmoitusFactory.createEntity()
+            val yhteystieto =
+                MuutosilmoitusFactory.createYhteystietoEntity(
+                    muutosilmoitus = muutosilmoitus,
+                    rooli = ApplicationContactType.RAKENNUTTAJA,
+                )
+            val yhteyshenkilo =
+                MuutosilmoitusFactory.createYhteyshenkiloEntity(yhteystieto, tapio, true)
+            yhteystieto.yhteyshenkilot.add(yhteyshenkilo)
+            muutosilmoitus.yhteystiedot[ApplicationContactType.RAKENNUTTAJA] = yhteystieto
+
+            MuutosilmoitusService.mergeMuutosilmoitusToHakemus(muutosilmoitus, hakemus)
+
+            assertThat(hakemus.yhteystiedot[ApplicationContactType.RAKENNUTTAJA]).isNotNull().all {
+                prop(HakemusyhteystietoEntity::yhteyshenkilot).single().all {
+                    prop(HakemusyhteyshenkiloEntity::id).isNotEqualTo(yhteyshenkilo.id)
+                    prop(HakemusyhteyshenkiloEntity::id).isEqualTo(hakemusyhteyshenkilo.id)
+                    prop(HakemusyhteyshenkiloEntity::hankekayttaja)
+                        .isEqualTo(yhteyshenkilo.hankekayttaja)
+                    prop(HakemusyhteyshenkiloEntity::tilaaja).isEqualTo(true)
+                }
+            }
+        }
+
+        @Test
+        fun `removes an yhteyshenkilo from the hakemus when they have been removed from the muutosilmoitus`() {
+            val hakemus = HakemusFactory.createEntity()
+            val hankeId = hakemus.hanke.id
+            val hakemusyhteystieto =
+                HakemusyhteystietoFactory.createEntity(
+                    application = hakemus,
+                    rooli = ApplicationContactType.RAKENNUTTAJA,
+                )
+            val sally =
+                HankeKayttajaFactory.createEntity(
+                    id = UUID.fromString("2b4bff3f-40c0-4a02-b320-12a8636b467f"),
+                    hankeId = hankeId,
+                    etunimi = "Sally",
+                    sukunimi = "Stable",
+                )
+            val danny =
+                HankeKayttajaFactory.createEntity(
+                    id = UUID.fromString("0f703fc1-7b96-4c9f-81ae-545dceb1e8cd"),
+                    hankeId = hankeId,
+                    etunimi = "Danny",
+                    sukunimi = "Deletable",
+                )
+            val hakemusyhteyshenkilot =
+                listOf(sally, danny).map {
+                    HakemusyhteyshenkiloFactory.createEntity(hakemusyhteystieto, it, false)
+                }
+            hakemusyhteyshenkilot.forEach { hakemusyhteystieto.yhteyshenkilot.add(it) }
+            hakemus.yhteystiedot[ApplicationContactType.RAKENNUTTAJA] = hakemusyhteystieto
+
+            val muutosilmoitus = MuutosilmoitusFactory.createEntity()
+            val yhteystieto =
+                MuutosilmoitusFactory.createYhteystietoEntity(
+                    muutosilmoitus = muutosilmoitus,
+                    rooli = ApplicationContactType.RAKENNUTTAJA,
+                )
+            val yhteyshenkilo =
+                MuutosilmoitusFactory.createYhteyshenkiloEntity(yhteystieto, sally, true)
+            yhteystieto.yhteyshenkilot.add(yhteyshenkilo)
+            muutosilmoitus.yhteystiedot[ApplicationContactType.RAKENNUTTAJA] = yhteystieto
+
+            MuutosilmoitusService.mergeMuutosilmoitusToHakemus(muutosilmoitus, hakemus)
+
+            assertThat(hakemus.yhteystiedot[ApplicationContactType.RAKENNUTTAJA]).isNotNull().all {
+                prop(HakemusyhteystietoEntity::yhteyshenkilot).single().all {
+                    prop(HakemusyhteyshenkiloEntity::id).isNotEqualTo(yhteyshenkilo.id)
+                    prop(HakemusyhteyshenkiloEntity::id).isEqualTo(hakemusyhteyshenkilot[0].id)
+                    prop(HakemusyhteyshenkiloEntity::hankekayttaja)
+                        .isEqualTo(yhteyshenkilo.hankekayttaja)
+                    prop(HakemusyhteyshenkiloEntity::tilaaja).isEqualTo(true)
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Description

Merge the data from muutosilmoitus to hakemus when the hakemus gets a replacement decision. The muutosilmoitus is deleted afterwards.

Suppose - for some reason - the hakemus gets a replacement decision with a muutosilmoitus that hasn't been sent yet. In that case, the decision can't be a reaction to the muutosilmoitus, so do nothing with it.

Use the yhteystieto interfaces to implement a lot of the merging behaviour, since the behaviour is the same for both täydennys and muutosilmoitus.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-151

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
1. Create a muutosilmoitus with some changes.
2. Send it to Allu.
3. In Allu, process the muutosilmoitus and create a replacement decision.
4. In Haitaton, check that the changes from the muutosilmoitus are visible on the hakemus and that it no longer has a muutosilmoitus.
5. Create a muutosilmoitus with different changes and repeat steps 2-4.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 