### PR TITLE
HAI-712 Merge muutosilmoitus to hakemus on täydennyspyyntö

### DIFF
--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusHistoryService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusHistoryService.kt
@@ -117,6 +117,7 @@ class HakemusHistoryService(
                 paatosService.markReplaced(event.applicationIdentifier)
             }
             ApplicationStatus.WAITING_INFORMATION -> {
+                muutosilmoitusService.mergeMuutosilmoitusToHakemusIfItExists(application)
                 updateStatus()
                 taydennysService.saveTaydennyspyyntoFromAllu(application)?.also {
                     sendInformationRequestEmails(application, event.applicationIdentifier)

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusBuilder.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HakemusBuilder.kt
@@ -156,7 +156,13 @@ data class HakemusBuilder(
         emergencyWork: Boolean = false,
     ): HakemusBuilder =
         updateApplicationData(
-            { throw InvalidParameterException("Not available for cable reports.") },
+            {
+                copy(
+                    constructionWork = constructionWork,
+                    maintenanceWork = maintenanceWork,
+                    emergencyWork = emergencyWork,
+                )
+            },
             {
                 copy(
                     constructionWork = constructionWork,

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/MuutosilmoitusBuilder.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/MuutosilmoitusBuilder.kt
@@ -42,6 +42,8 @@ class MuutosilmoitusBuilder(
         return savedMuutosilmoitus
     }
 
+    fun withName(name: String) = updateApplicationData({ copy(name = name) }, { copy(name = name) })
+
     fun withAreas(areas: List<Hakemusalue>) =
         updateApplicationData(
             {

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/MuutosilmoitusFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/MuutosilmoitusFactory.kt
@@ -34,13 +34,15 @@ class MuutosilmoitusFactory(
 ) {
 
     fun builder(
-        type: ApplicationType = ApplicationType.EXCAVATION_NOTIFICATION
+        type: ApplicationType = ApplicationType.EXCAVATION_NOTIFICATION,
+        status: ApplicationStatus = ApplicationStatus.DECISION,
+        alluId: Int = TaydennyspyyntoFactory.DEFAULT_ALLU_ID,
     ): MuutosilmoitusBuilder {
         val hakemusEntity: HakemusEntity =
             hakemusFactory
                 .builder(type)
                 .withMandatoryFields()
-                .withStatus(ApplicationStatus.WAITING_INFORMATION)
+                .withStatus(ApplicationStatus.WAITING_INFORMATION, alluId)
                 .saveEntity()
 
         return builder(hakemusEntity)


### PR DESCRIPTION
# Description

When a täydennyspyyntö is received from Allu, merge any muutosilmoitus to the hakemus if it has one. This loses the information that the täydennys is for a muutosilmoitus, except that the hakemus already has a decision. The täydennys can be filled and sent like normal.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-712

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
1. Create a muutosilmoitus for a kaivuilmoitus.
2. Send it to Allu.
3. In Allu, start processing the muutosilmoitus and request a täydennyspyyntö.
4. In Haitaton, the hakemus should be in 'Odottaa täydennystä' state but the previous decision should be visible.
5. Fill in a täydennys and send it.
6. In Allu, process the täydennys and create a decision.
7. In Haitaton, the hakemus should have a new identifier and decision.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 