### PR TITLE
HAI-3412 Share attachment creation between services

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentControllerITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentControllerITests.kt
@@ -72,7 +72,7 @@ class HankeAttachmentControllerITests(@Autowired override val mockMvc: MockMvc) 
 
     @Test
     fun `getMetadataList when valid request should return metadata list`() {
-        val data = (1..3).map { HankeAttachmentFactory.createDto(fileName = "${it}file.pdf") }
+        val data = (1..3).map { HankeAttachmentFactory.create(fileName = "${it}file.pdf") }
         every { authorizer.authorizeHankeTunnus(HANKE_TUNNUS, VIEW.name) } returns true
         every { hankeAttachmentService.getMetadataList(HANKE_TUNNUS) } returns data
 
@@ -178,7 +178,7 @@ class HankeAttachmentControllerITests(@Autowired override val mockMvc: MockMvc) 
 
     private fun postAttachment(
         hankeTunnus: String = HANKE_TUNNUS,
-        file: MockMultipartFile = testFile()
+        file: MockMultipartFile = testFile(),
     ): ResultActions {
         return mockMvc.perform(multipart("/hankkeet/$hankeTunnus/liitteet").file(file).with(csrf()))
     }
@@ -191,7 +191,7 @@ class HankeAttachmentControllerITests(@Autowired override val mockMvc: MockMvc) 
 
 @WebMvcTest(
     HankeAttachmentController::class,
-    properties = ["haitaton.features.hanke-editing=false"]
+    properties = ["haitaton.features.hanke-editing=false"],
 )
 @Import(IntegrationTestConfiguration::class)
 @ActiveProfiles("test")

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentMetadataServiceITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentMetadataServiceITests.kt
@@ -21,7 +21,7 @@ import fi.hel.haitaton.hanke.attachment.DEFAULT_SIZE
 import fi.hel.haitaton.hanke.attachment.FILE_NAME_PDF
 import fi.hel.haitaton.hanke.attachment.common.AttachmentInvalidException
 import fi.hel.haitaton.hanke.attachment.common.HankeAttachmentEntity
-import fi.hel.haitaton.hanke.attachment.common.HankeAttachmentMetadataDto
+import fi.hel.haitaton.hanke.attachment.common.HankeAttachmentMetadata
 import fi.hel.haitaton.hanke.attachment.common.HankeAttachmentRepository
 import fi.hel.haitaton.hanke.factory.HankeAttachmentFactory
 import fi.hel.haitaton.hanke.factory.HankeFactory
@@ -68,7 +68,7 @@ class HankeAttachmentMetadataServiceITests(
                 d.transform { it.fileName }.endsWith(FILE_NAME_PDF)
                 d.transform { it.createdByUserId }.isEqualTo(USERNAME)
                 d.transform { it.createdAt }.isNotNull()
-                d.transform { it.hankeTunnus }.isEqualTo(hanke.hankeTunnus)
+                d.transform { it.hanketunnus }.isEqualTo(hanke.hankeTunnus)
                 d.transform { it.contentType }.isEqualTo(APPLICATION_PDF_VALUE)
                 d.transform { it.size }.isEqualTo(DEFAULT_SIZE)
             }
@@ -92,13 +92,13 @@ class HankeAttachmentMetadataServiceITests(
                 )
 
             assertThat(result).all {
-                prop(HankeAttachmentMetadataDto::id).isNotNull()
-                prop(HankeAttachmentMetadataDto::createdByUserId).isEqualTo(USERNAME)
-                prop(HankeAttachmentMetadataDto::fileName).isEqualTo(FILE_NAME_PDF)
-                prop(HankeAttachmentMetadataDto::createdAt).isRecent()
-                prop(HankeAttachmentMetadataDto::hankeTunnus).isEqualTo(hanke.hankeTunnus)
-                prop(HankeAttachmentMetadataDto::contentType).isEqualTo(APPLICATION_PDF_VALUE)
-                prop(HankeAttachmentMetadataDto::size).isEqualTo(DEFAULT_SIZE)
+                prop(HankeAttachmentMetadata::id).isNotNull()
+                prop(HankeAttachmentMetadata::createdByUserId).isEqualTo(USERNAME)
+                prop(HankeAttachmentMetadata::fileName).isEqualTo(FILE_NAME_PDF)
+                prop(HankeAttachmentMetadata::createdAt).isRecent()
+                prop(HankeAttachmentMetadata::hanketunnus).isEqualTo(hanke.hankeTunnus)
+                prop(HankeAttachmentMetadata::contentType).isEqualTo(APPLICATION_PDF_VALUE)
+                prop(HankeAttachmentMetadata::size).isEqualTo(DEFAULT_SIZE)
             }
             assertThat(hankeAttachmentRepository.findAll()).single().all {
                 prop(HankeAttachmentEntity::createdByUserId).isEqualTo(USERNAME)
@@ -140,7 +140,7 @@ class HankeAttachmentMetadataServiceITests(
                         name = FILE_NAME_PDF,
                         type = APPLICATION_PDF_VALUE,
                         size = DEFAULT_SIZE,
-                        blobPath = blobPath(123)
+                        blobPath = blobPath(123),
                     )
                 }
                 .hasClass(HankeNotFoundException::class)

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentServiceITest.kt
@@ -49,7 +49,7 @@ class HankeAttachmentServiceITest(
     @Autowired private val attachmentRepository: HankeAttachmentRepository,
     @Autowired private val hankeFactory: HankeFactory,
     @Autowired private val hankeAttachmentFactory: HankeAttachmentFactory,
-    @Autowired private val fileClient: MockFileClient
+    @Autowired private val fileClient: MockFileClient,
 ) : IntegrationTest() {
 
     private lateinit var mockClamAv: MockWebServer
@@ -85,7 +85,7 @@ class HankeAttachmentServiceITest(
             assertThat(result).each { d ->
                 d.transform { it.id }.isNotNull()
                 d.transform { it.fileName }.endsWith(FILE_NAME_PDF)
-                d.transform { it.hankeTunnus }.isEqualTo(hanke.hankeTunnus)
+                d.transform { it.hanketunnus }.isEqualTo(hanke.hankeTunnus)
                 d.transform { it.contentType }.isEqualTo(APPLICATION_PDF_VALUE)
                 d.transform { it.size }.isEqualTo(DEFAULT_SIZE)
             }
@@ -103,7 +103,7 @@ class HankeAttachmentServiceITest(
             val result =
                 hankeAttachmentService.uploadHankeAttachment(
                     hankeTunnus = hanke.hankeTunnus,
-                    attachment = testFile()
+                    attachment = testFile(),
                 )
 
             assertThat(result).all {
@@ -127,7 +127,7 @@ class HankeAttachmentServiceITest(
             assertFailure {
                     hankeAttachmentService.uploadHankeAttachment(
                         hankeTunnus = hanke.hankeTunnus,
-                        attachment = testFile()
+                        attachment = testFile(),
                     )
                 }
                 .all {

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/taydennys/TaydennysAttachmentServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/taydennys/TaydennysAttachmentServiceITest.kt
@@ -203,9 +203,9 @@ class TaydennysAttachmentServiceITest(
 
             failure.all {
                 hasClass(AttachmentLimitReachedException::class)
-                hasMessage(
-                    "Attachment amount limit reached, limit=${ALLOWED_ATTACHMENT_COUNT}, taydennysId=${taydennys.id}"
-                )
+                messageContains("Attachment amount limit reached")
+                messageContains("limit=$ALLOWED_ATTACHMENT_COUNT")
+                messageContains("Täydennys: (id=${taydennys.id}")
             }
         }
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentMetadataService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentMetadataService.kt
@@ -20,7 +20,7 @@ private val logger = KotlinLogging.logger {}
 
 @Service
 class ApplicationAttachmentMetadataService(
-    private val attachmentRepository: ApplicationAttachmentRepository,
+    private val attachmentRepository: ApplicationAttachmentRepository
 ) {
     @Transactional(readOnly = true)
     fun getMetadataList(applicationId: Long): List<ApplicationAttachmentMetadata> =
@@ -41,7 +41,7 @@ class ApplicationAttachmentMetadataService(
         size: Long,
         blobLocation: String,
         attachmentType: ApplicationAttachmentType,
-        applicationId: Long
+        applicationId: Long,
     ): ApplicationAttachmentMetadata {
         val entity =
             ApplicationAttachmentEntity(
@@ -78,7 +78,7 @@ class ApplicationAttachmentMetadataService(
             logger.warn {
                 "Application $applicationId has reached the allowed amount of attachments."
             }
-            throw AttachmentLimitReachedException(applicationId, ALLOWED_ATTACHMENT_COUNT)
+            throw AttachmentLimitReachedException(applicationId)
         }
     }
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/common/AttachmentEntity.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/common/AttachmentEntity.kt
@@ -86,7 +86,7 @@ class HankeAttachmentEntity(
             createdByUserId,
             createdAt,
             blobLocation,
-            hanke.id,
+            hanke.hankeTunnus,
         )
 
     override fun equals(other: Any?): Boolean {

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/common/AttachmentService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/common/AttachmentService.kt
@@ -1,0 +1,67 @@
+package fi.hel.haitaton.hanke.attachment.common
+
+import fi.hel.haitaton.hanke.domain.Loggable
+import mu.KotlinLogging
+import org.springframework.http.MediaType
+
+private val logger = KotlinLogging.logger {}
+
+interface AttachmentService<E : Loggable, M : AttachmentMetadata> {
+
+    fun upload(filename: String, contentType: MediaType, content: ByteArray, entity: E): String
+
+    fun createMetadata(
+        filename: String,
+        contentType: String,
+        size: Long,
+        blobPath: String,
+        entity: E,
+        attachmentType: ApplicationAttachmentType? = null,
+    ): M
+
+    fun delete(blobPath: String): Boolean
+
+    /**
+     * Saves the attachment.
+     *
+     * It first tries to upload the attachment. If the upload fails, an exception is thrown.
+     *
+     * Then it saves the metadata to DB, including the path the file was uploaded to. If the DB-save
+     * fails for some reason, the uploaded file is deleted.
+     *
+     * If the deletion fails as well, we log the errors and return an error. The file will be
+     * deleted when the hanke / hakemus is deleted and all files with the same prefix are removed.
+     */
+    fun saveAttachment(
+        entity: E,
+        content: ByteArray,
+        filename: String,
+        contentType: MediaType,
+        attachmentType: ApplicationAttachmentType? = null,
+    ): M {
+        logger.info { "Saving attachment content for ${entity.logString()}" }
+        val blobPath = upload(filename, contentType, content, entity)
+        logger.info { "Saving attachment metadata for ${entity.logString()}" }
+        val newAttachment =
+            try {
+                createMetadata(
+                    filename,
+                    contentType.toString(),
+                    content.size.toLong(),
+                    blobPath,
+                    entity,
+                    attachmentType,
+                )
+            } catch (e: Exception) {
+                logger.error(e) {
+                    "Attachment metadata save failed, deleting attachment content $blobPath"
+                }
+                delete(blobPath)
+                throw e
+            }
+        logger.info {
+            "Added attachment metadata ${newAttachment.id} and content $blobPath for ${entity.logString()}"
+        }
+        return newAttachment
+    }
+}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/common/Domain.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/common/Domain.kt
@@ -5,7 +5,7 @@ import fi.hel.haitaton.hanke.allu.AttachmentMetadata as AlluAttachmentMetadata
 import java.time.OffsetDateTime
 import java.util.UUID
 
-sealed interface AttachmentMetadata {
+interface AttachmentMetadata {
     val id: UUID
     val fileName: String
     val contentType: String
@@ -15,7 +15,7 @@ sealed interface AttachmentMetadata {
     val blobLocation: String?
 }
 
-sealed interface AttachmentMetadataWithType : AttachmentMetadata {
+interface AttachmentMetadataWithType : AttachmentMetadata {
     val attachmentType: ApplicationAttachmentType
 
     fun toAlluAttachment(content: ByteArray): AlluAttachment {
@@ -40,8 +40,19 @@ data class HankeAttachmentMetadata(
     override val createdByUserId: String,
     override val createdAt: OffsetDateTime,
     override val blobLocation: String,
-    val hankeId: Int,
-) : AttachmentMetadata
+    val hanketunnus: String,
+) : AttachmentMetadata {
+    fun toDto(): HankeAttachmentMetadataDto =
+        HankeAttachmentMetadataDto(
+            id = id,
+            fileName = fileName,
+            contentType = contentType,
+            size = size,
+            createdAt = createdAt,
+            hankeTunnus = hanketunnus,
+            createdByUserId = createdByUserId,
+        )
+}
 
 data class ApplicationAttachmentMetadata(
     override val id: UUID,

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/common/Exceptions.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/common/Exceptions.kt
@@ -1,17 +1,21 @@
 package fi.hel.haitaton.hanke.attachment.common
 
+import fi.hel.haitaton.hanke.ALLOWED_ATTACHMENT_COUNT
+import fi.hel.haitaton.hanke.domain.Loggable
 import java.util.UUID
 
 class AttachmentLimitReachedException : RuntimeException {
     constructor(
-        applicationId: Long,
-        limit: Int,
-    ) : super("Attachment amount limit reached, limit=$limit, applicationId=$applicationId")
+        applicationId: Long
+    ) : super(
+        "Attachment amount limit reached, limit=$ALLOWED_ATTACHMENT_COUNT, applicationId=$applicationId"
+    )
 
     constructor(
-        taydennysId: UUID,
-        limit: Int,
-    ) : super("Attachment amount limit reached, limit=$limit, taydennysId=$taydennysId")
+        entity: Loggable
+    ) : super(
+        "Attachment amount limit reached, limit=$ALLOWED_ATTACHMENT_COUNT, ${entity.logString()}"
+    )
 }
 
 class AttachmentInvalidException(str: String) :

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/common/FileScanClient.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/common/FileScanClient.kt
@@ -29,6 +29,13 @@ class FileScanClient(
             logger.info { "Initialized file scan client with base-url: $clamAvUrl" }
         }
 
+    fun scanAttachment(filename: String, content: ByteArray) {
+        val scanResult = scan(listOf(FileScanInput(filename, content)))
+        if (scanResult.hasInfected()) {
+            throw AttachmentInvalidException("Infected file detected, see previous logs.")
+        }
+    }
+
     fun scan(files: List<FileScanInput>): List<FileResult> {
         logger.info { "Scanning ${files.size} files." }
 
@@ -87,7 +94,7 @@ data class FileScanData(val result: List<FileResult>)
 data class FileResult(
     val name: String,
     @JsonProperty("is_infected") val isInfected: Boolean?,
-    val viruses: List<String>
+    val viruses: List<String>,
 )
 
 class FileScanException(message: String) : RuntimeException(message)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentContentService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentContentService.kt
@@ -13,9 +13,7 @@ import org.springframework.stereotype.Service
 private val logger = KotlinLogging.logger {}
 
 @Service
-class HankeAttachmentContentService(
-    private val fileClient: FileClient,
-) {
+class HankeAttachmentContentService(private val fileClient: FileClient) {
     /** Uploads and returns the location of the created blob. */
     fun upload(fileName: String, contentType: MediaType, content: ByteArray, hankeId: Int): String {
         val blobPath = generateBlobPath(hankeId)
@@ -33,6 +31,15 @@ class HankeAttachmentContentService(
         logger.info { "Deleting attachment content from hanke attachment ${attachment.id}..." }
         fileClient.delete(Container.HANKE_LIITTEET, attachment.blobLocation)
     }
+
+    fun delete(blobPath: String) =
+        fileClient.delete(Container.HANKE_LIITTEET, blobPath).also {
+            if (it) {
+                logger.info { "Attachment content at $blobPath deleted" }
+            } else {
+                logger.warn { "Attachment content at $blobPath not found" }
+            }
+        }
 
     fun deleteAllForHanke(hankeId: Int) {
         fileClient.deleteAllByPrefix(Container.HANKE_LIITTEET, prefix(hankeId))

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentController.kt
@@ -28,9 +28,7 @@ private val logger = KotlinLogging.logger {}
 @RestController
 @RequestMapping("/hankkeet/{hankeTunnus}/liitteet")
 @SecurityRequirement(name = "bearerAuth")
-class HankeAttachmentController(
-    private val hankeAttachmentService: HankeAttachmentService,
-) {
+class HankeAttachmentController(private val hankeAttachmentService: HankeAttachmentService) {
 
     @GetMapping
     @Operation(summary = "Get metadata from hanke attachments")
@@ -41,13 +39,13 @@ class HankeAttachmentController(
                 ApiResponse(
                     description = "Hanke not found",
                     responseCode = "404",
-                    content = [Content(schema = Schema(implementation = HankeError::class))]
+                    content = [Content(schema = Schema(implementation = HankeError::class))],
                 ),
             ]
     )
     @PreAuthorize("@hankeAttachmentAuthorizer.authorizeHankeTunnus(#hankeTunnus,'VIEW')")
     fun getMetadataList(@PathVariable hankeTunnus: String): List<HankeAttachmentMetadataDto> {
-        return hankeAttachmentService.getMetadataList(hankeTunnus)
+        return hankeAttachmentService.getMetadataList(hankeTunnus).map { it.toDto() }
     }
 
     @GetMapping("/{attachmentId}/content")
@@ -59,7 +57,7 @@ class HankeAttachmentController(
                 ApiResponse(
                     description = "Attachment not found.",
                     responseCode = "404",
-                    content = [Content(schema = Schema(implementation = HankeError::class))]
+                    content = [Content(schema = Schema(implementation = HankeError::class))],
                 ),
             ]
     )
@@ -86,12 +84,12 @@ class HankeAttachmentController(
                 ApiResponse(
                     description = "Hanke not found",
                     responseCode = "404",
-                    content = [Content(schema = Schema(implementation = HankeError::class))]
+                    content = [Content(schema = Schema(implementation = HankeError::class))],
                 ),
                 ApiResponse(
                     description = "Invalid attachment",
                     responseCode = "400",
-                    content = [Content(schema = Schema(implementation = HankeError::class))]
+                    content = [Content(schema = Schema(implementation = HankeError::class))],
                 ),
             ]
     )
@@ -121,8 +119,8 @@ class HankeAttachmentController(
                 ApiResponse(
                     description = "Attachment not found",
                     responseCode = "404",
-                    content = [Content(schema = Schema(implementation = HankeError::class))]
-                )
+                    content = [Content(schema = Schema(implementation = HankeError::class))],
+                ),
             ]
     )
     @PreAuthorize(

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentMetadataService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentMetadataService.kt
@@ -7,7 +7,7 @@ import fi.hel.haitaton.hanke.HankeRepository
 import fi.hel.haitaton.hanke.attachment.common.AttachmentInvalidException
 import fi.hel.haitaton.hanke.attachment.common.AttachmentNotFoundException
 import fi.hel.haitaton.hanke.attachment.common.HankeAttachmentEntity
-import fi.hel.haitaton.hanke.attachment.common.HankeAttachmentMetadataDto
+import fi.hel.haitaton.hanke.attachment.common.HankeAttachmentMetadata
 import fi.hel.haitaton.hanke.attachment.common.HankeAttachmentRepository
 import fi.hel.haitaton.hanke.currentUserId
 import java.time.OffsetDateTime
@@ -26,8 +26,8 @@ class HankeAttachmentMetadataService(
 ) {
 
     @Transactional(readOnly = true)
-    fun getMetadataList(hankeTunnus: String): List<HankeAttachmentMetadataDto> =
-        findHanke(hankeTunnus).liitteet.map { it.toDto() }
+    fun getMetadataList(hankeTunnus: String): List<HankeAttachmentMetadata> =
+        findHanke(hankeTunnus).liitteet.map { it.toDomain() }
 
     @Transactional(readOnly = true)
     fun findAttachment(attachmentId: UUID) = findAttachmentEntity(attachmentId).toDomain()
@@ -39,7 +39,7 @@ class HankeAttachmentMetadataService(
         type: String,
         size: Long,
         blobPath: String,
-    ): HankeAttachmentMetadataDto {
+    ): HankeAttachmentMetadata {
         val hanke = findHanke(hankeTunnus).also { checkRoomForAttachment(it.id) }
 
         return attachmentRepository
@@ -55,7 +55,7 @@ class HankeAttachmentMetadataService(
                     hanke = hanke,
                 )
             )
-            .toDto()
+            .toDomain()
     }
 
     @Transactional

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentService.kt
@@ -1,16 +1,17 @@
 package fi.hel.haitaton.hanke.attachment.hanke
 
 import fi.hel.haitaton.hanke.HankeIdentifier
+import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType
 import fi.hel.haitaton.hanke.attachment.common.AttachmentContent
-import fi.hel.haitaton.hanke.attachment.common.AttachmentInvalidException
+import fi.hel.haitaton.hanke.attachment.common.AttachmentService
 import fi.hel.haitaton.hanke.attachment.common.AttachmentValidator
 import fi.hel.haitaton.hanke.attachment.common.FileScanClient
-import fi.hel.haitaton.hanke.attachment.common.FileScanInput
+import fi.hel.haitaton.hanke.attachment.common.HankeAttachmentMetadata
 import fi.hel.haitaton.hanke.attachment.common.HankeAttachmentMetadataDto
-import fi.hel.haitaton.hanke.attachment.common.hasInfected
 import fi.hel.haitaton.hanke.attachment.common.validNameAndType
 import java.util.UUID
 import mu.KotlinLogging
+import org.springframework.http.MediaType
 import org.springframework.stereotype.Service
 import org.springframework.web.multipart.MultipartFile
 
@@ -21,7 +22,8 @@ class HankeAttachmentService(
     private val metadataService: HankeAttachmentMetadataService,
     private val contentService: HankeAttachmentContentService,
     private val scanClient: FileScanClient,
-) {
+) : AttachmentService<HankeIdentifier, HankeAttachmentMetadata> {
+
     fun getMetadataList(hankeTunnus: String) = metadataService.getMetadataList(hankeTunnus)
 
     fun getContent(attachmentId: UUID): AttachmentContent {
@@ -39,25 +41,9 @@ class HankeAttachmentService(
         AttachmentValidator.validateSize(attachment.bytes.size)
         val (filename, mediatype) = attachment.validNameAndType()
 
-        scanAttachment(filename, attachment.bytes)
+        scanClient.scanAttachment(filename, attachment.bytes)
 
-        val blobPath =
-            contentService.upload(
-                fileName = filename,
-                contentType = mediatype,
-                content = attachment.bytes,
-                hankeId = hanke.id,
-            )
-
-        return metadataService
-            .saveAttachment(
-                hankeTunnus = hanke.hankeTunnus,
-                name = filename,
-                type = mediatype.toString(),
-                size = attachment.size,
-                blobPath = blobPath,
-            )
-            .also { logger.info { "Added attachment ${it.id} to hanke ${hanke.hankeTunnus}" } }
+        return saveAttachment(hanke, attachment.bytes, filename, mediatype).toDto()
     }
 
     fun deleteAttachment(attachmentId: UUID) {
@@ -74,10 +60,28 @@ class HankeAttachmentService(
         logger.info { "Deleted all attachments from hanke ${hanke.logString()}" }
     }
 
-    private fun scanAttachment(filename: String, content: ByteArray) {
-        val scanResult = scanClient.scan(listOf(FileScanInput(filename, content)))
-        if (scanResult.hasInfected()) {
-            throw AttachmentInvalidException("Infected file detected, see previous logs.")
-        }
-    }
+    override fun upload(
+        filename: String,
+        contentType: MediaType,
+        content: ByteArray,
+        entity: HankeIdentifier,
+    ): String =
+        contentService.upload(
+            fileName = filename,
+            contentType = contentType,
+            content = content,
+            hankeId = entity.id,
+        )
+
+    override fun createMetadata(
+        filename: String,
+        contentType: String,
+        size: Long,
+        blobPath: String,
+        entity: HankeIdentifier,
+        attachmentType: ApplicationAttachmentType?,
+    ): HankeAttachmentMetadata =
+        metadataService.saveAttachment(entity.hankeTunnus, filename, contentType, size, blobPath)
+
+    override fun delete(blobPath: String) = contentService.delete(blobPath)
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/taydennys/TaydennysAttachmentMetadataService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/taydennys/TaydennysAttachmentMetadataService.kt
@@ -68,7 +68,7 @@ class TaydennysAttachmentMetadataService(
             logger.warn {
                 "Täydennys ${taydennys.id} has reached the allowed total amount of attachments for it and its hakemus."
             }
-            throw AttachmentLimitReachedException(taydennys.id, ALLOWED_ATTACHMENT_COUNT)
+            throw AttachmentLimitReachedException(taydennys)
         }
     }
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/taydennys/TaydennysAttachmentService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/taydennys/TaydennysAttachmentService.kt
@@ -3,14 +3,12 @@ package fi.hel.haitaton.hanke.attachment.taydennys
 import fi.hel.haitaton.hanke.attachment.application.ApplicationAttachmentContentService
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType
 import fi.hel.haitaton.hanke.attachment.common.AttachmentContent
-import fi.hel.haitaton.hanke.attachment.common.AttachmentInvalidException
+import fi.hel.haitaton.hanke.attachment.common.AttachmentService
 import fi.hel.haitaton.hanke.attachment.common.AttachmentValidator
 import fi.hel.haitaton.hanke.attachment.common.FileScanClient
-import fi.hel.haitaton.hanke.attachment.common.FileScanInput
 import fi.hel.haitaton.hanke.attachment.common.TaydennysAttachmentMetadata
 import fi.hel.haitaton.hanke.attachment.common.TaydennysAttachmentMetadataDto
 import fi.hel.haitaton.hanke.attachment.common.ValtakirjaForbiddenException
-import fi.hel.haitaton.hanke.attachment.common.hasInfected
 import fi.hel.haitaton.hanke.taydennys.TaydennysIdentifier
 import fi.hel.haitaton.hanke.taydennys.TaydennysNotFoundException
 import fi.hel.haitaton.hanke.taydennys.TaydennysRepository
@@ -29,7 +27,7 @@ class TaydennysAttachmentService(
     private val taydennysRepository: TaydennysRepository,
     private val attachmentContentService: ApplicationAttachmentContentService,
     private val scanClient: FileScanClient,
-) {
+) : AttachmentService<TaydennysIdentifier, TaydennysAttachmentMetadata> {
     fun getMetadataList(taydennysId: UUID): List<TaydennysAttachmentMetadata> =
         metadataService.getMetadataList(taydennysId)
 
@@ -61,7 +59,7 @@ class TaydennysAttachmentService(
         val taydennys = findTaydennys(taydennysId)
 
         val contentType = AttachmentValidator.ensureMediaType(attachment.contentType)
-        scanAttachment(filename, attachment.bytes)
+        scanClient.scanAttachment(filename, attachment.bytes)
         metadataService.ensureRoomForAttachment(taydennys)
 
         val newAttachment =
@@ -73,47 +71,6 @@ class TaydennysAttachmentService(
     private fun findTaydennys(taydennysId: UUID): TaydennysIdentifier =
         taydennysRepository.findByIdOrNull(taydennysId)
             ?: throw TaydennysNotFoundException(taydennysId)
-
-    private fun scanAttachment(filename: String, content: ByteArray) {
-        val scanResult = scanClient.scan(listOf(FileScanInput(filename, content)))
-        if (scanResult.hasInfected()) {
-            throw AttachmentInvalidException("Infected file detected, see previous logs.")
-        }
-    }
-
-    private fun saveAttachment(
-        taydennys: TaydennysIdentifier,
-        content: ByteArray,
-        filename: String,
-        contentType: MediaType,
-        attachmentType: ApplicationAttachmentType,
-    ): TaydennysAttachmentMetadata {
-        logger.info { "Saving attachment content for täydennys. ${taydennys.logString()}" }
-        val blobPath =
-            attachmentContentService.upload(filename, contentType, content, taydennys.hakemusId())
-        logger.info { "Saving attachment metadata for täydennys. ${taydennys.logString()}" }
-        val newAttachment =
-            try {
-                metadataService.create(
-                    filename,
-                    contentType.toString(),
-                    content.size.toLong(),
-                    blobPath,
-                    attachmentType,
-                    taydennys.id,
-                )
-            } catch (e: Exception) {
-                logger.error(e) {
-                    "Attachment metadata save failed, deleting attachment content $blobPath"
-                }
-                attachmentContentService.delete(blobPath)
-                throw e
-            }
-        logger.info {
-            "Added attachment metadata ${newAttachment.id} and content $blobPath for täydennys. ${taydennys.logString()}"
-        }
-        return newAttachment
-    }
 
     fun deleteAttachment(attachmentId: UUID) {
         val attachment = metadataService.findAttachment(attachmentId)
@@ -136,4 +93,23 @@ class TaydennysAttachmentService(
         }
         logger.info { "Deleted all attachments from täydennys. ${taydennys.logString()}" }
     }
+
+    override fun upload(
+        filename: String,
+        contentType: MediaType,
+        content: ByteArray,
+        entity: TaydennysIdentifier,
+    ): String = attachmentContentService.upload(filename, contentType, content, entity.hakemusId())
+
+    override fun createMetadata(
+        filename: String,
+        contentType: String,
+        size: Long,
+        blobPath: String,
+        entity: TaydennysIdentifier,
+        attachmentType: ApplicationAttachmentType?,
+    ): TaydennysAttachmentMetadata =
+        metadataService.create(filename, contentType, size, blobPath, attachmentType!!, entity.id)
+
+    override fun delete(blobPath: String): Boolean = attachmentContentService.delete(blobPath)
 }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeAttachmentFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeAttachmentFactory.kt
@@ -31,7 +31,7 @@ class HankeAttachmentFactory(
         size: Long = SIZE,
         createdByUser: String = USERNAME,
         createdAt: OffsetDateTime = CREATED_AT,
-        hanke: HankeEntity = hankeFactory.builder(USERNAME).saveEntity()
+        hanke: HankeEntity = hankeFactory.builder(USERNAME).saveEntity(),
     ): HankeAttachmentBuilder {
         val entity =
             attachmentRepository.save(
@@ -44,7 +44,7 @@ class HankeAttachmentFactory(
         path: String,
         filename: String = FILE_NAME_PDF,
         mediaType: MediaType = MEDIA_TYPE,
-        bytes: ByteArray = PDF_BYTES
+        bytes: ByteArray = PDF_BYTES,
     ) {
         fileClient.upload(HANKE_LIITTEET, path, filename, mediaType, bytes)
     }
@@ -64,7 +64,7 @@ class HankeAttachmentFactory(
             blobLocation: String = HankeAttachmentContentService.generateBlobPath(42),
             createdByUser: String = currentUserId(),
             createdAt: OffsetDateTime = OffsetDateTime.now(),
-            hankeId: Int = 42,
+            hanketunnus: String = "HAI24-42",
         ): HankeAttachmentMetadata =
             HankeAttachmentMetadata(
                 id = attachmentId,
@@ -74,7 +74,7 @@ class HankeAttachmentFactory(
                 blobLocation = blobLocation,
                 createdByUserId = createdByUser,
                 createdAt = createdAt,
-                hankeId = hankeId,
+                hanketunnus = hanketunnus,
             )
 
         fun createDto(
@@ -103,7 +103,7 @@ class HankeAttachmentFactory(
             size: Long = SIZE,
             createdByUser: String = USERNAME,
             createdAt: OffsetDateTime = CREATED_AT,
-            hanke: HankeEntity = HankeFactory.createMinimalEntity()
+            hanke: HankeEntity = HankeFactory.createMinimalEntity(),
         ) =
             HankeAttachmentEntity(
                 id = id,


### PR DESCRIPTION
# Description

Attachment creation has some logic to it that needs to happen in a specific way every way. I.e. the uploaded file needs to be deleted if saving the attachment info to the database fails for some reason. This wasn't done with hanke attachments.

Extract this logic to an interface. Wrap the service calls to abstract interface methods, so the interface doesn't have to know anything about which services are involved. Use the proper logic also for hanke attachments.

Make hanke attachment services return domain objects instead of DTOs. To make the conversion of domain to DTO possible, add hanketunnus to the domain object. The hankeId from the domain object can be removed since it's not used anywhere and the hanketunnus serves the same purpose.

Also, move the `scanAttachment` method to `FileScanClient`, since it was literally identical in every service.

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [X] Other

# Instructions for testing
Attachments should still work the same way for hanke, hakemus and täydennyspyyntö.

# Checklist:

- [X] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 