### PR TITLE
HAI-3412 Add attachment API for muutosilmoitus

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/IntegrationTestConfiguration.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/IntegrationTestConfiguration.kt
@@ -5,6 +5,7 @@ import fi.hel.haitaton.hanke.attachment.application.ApplicationAttachmentService
 import fi.hel.haitaton.hanke.attachment.hanke.HankeAttachmentAuthorizer
 import fi.hel.haitaton.hanke.attachment.hanke.HankeAttachmentMetadataService
 import fi.hel.haitaton.hanke.attachment.hanke.HankeAttachmentService
+import fi.hel.haitaton.hanke.attachment.muutosilmoitus.MuutosilmoitusAttachmentService
 import fi.hel.haitaton.hanke.attachment.taydennys.TaydennysAttachmentService
 import fi.hel.haitaton.hanke.banners.BannerService
 import fi.hel.haitaton.hanke.configuration.FeatureFlags
@@ -99,6 +100,8 @@ class IntegrationTestConfiguration {
     @Bean fun hanketunnusService(): HanketunnusService = mockk()
 
     @Bean fun jdbcOperations(): JdbcOperations = mockk()
+
+    @Bean fun muutosilmoitusAttachmentService(): MuutosilmoitusAttachmentService = mockk()
 
     @Bean fun muutosilmoitusAuthorizer(): MuutosilmoitusAuthorizer = mockk()
 

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/muutosilmoitus/MuutosilmoitusAttachmentControllerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/muutosilmoitus/MuutosilmoitusAttachmentControllerITest.kt
@@ -1,0 +1,168 @@
+package fi.hel.haitaton.hanke.attachment.muutosilmoitus
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotNull
+import fi.hel.haitaton.hanke.ControllerTest
+import fi.hel.haitaton.hanke.HankeError
+import fi.hel.haitaton.hanke.HankeError.HAI0001
+import fi.hel.haitaton.hanke.HankeError.HAI1001
+import fi.hel.haitaton.hanke.HankeError.HAI2001
+import fi.hel.haitaton.hanke.HankeError.HAI7001
+import fi.hel.haitaton.hanke.HankeNotFoundException
+import fi.hel.haitaton.hanke.IntegrationTestConfiguration
+import fi.hel.haitaton.hanke.andReturnBody
+import fi.hel.haitaton.hanke.attachment.APPLICATION_ID
+import fi.hel.haitaton.hanke.attachment.FILE_NAME_PDF
+import fi.hel.haitaton.hanke.attachment.andExpectError
+import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType
+import fi.hel.haitaton.hanke.attachment.testFile
+import fi.hel.haitaton.hanke.factory.MuutosilmoitusAttachmentFactory
+import fi.hel.haitaton.hanke.factory.MuutosilmoitusFactory
+import fi.hel.haitaton.hanke.factory.MuutosilmoitusFactory.Companion.DEFAULT_ID
+import fi.hel.haitaton.hanke.hakemus.HakemusNotFoundException
+import fi.hel.haitaton.hanke.hankeError
+import fi.hel.haitaton.hanke.muutosilmoitus.MuutosilmoitusAlreadySentException
+import fi.hel.haitaton.hanke.muutosilmoitus.MuutosilmoitusAuthorizer
+import fi.hel.haitaton.hanke.muutosilmoitus.MuutosilmoitusNotFoundException
+import fi.hel.haitaton.hanke.permissions.PermissionCode.EDIT_APPLICATIONS
+import fi.hel.haitaton.hanke.test.USERNAME
+import io.mockk.checkUnnecessaryStub
+import io.mockk.clearAllMocks
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.verifyOrder
+import java.util.UUID
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.context.annotation.Import
+import org.springframework.mock.web.MockMultipartFile
+import org.springframework.security.test.context.support.WithAnonymousUser
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.ResultActions
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+@WebMvcTest(MuutosilmoitusAttachmentController::class)
+@Import(IntegrationTestConfiguration::class)
+@ActiveProfiles("test")
+@WithMockUser(USERNAME)
+class MuutosilmoitusAttachmentControllerITest(@Autowired override val mockMvc: MockMvc) :
+    ControllerTest {
+    @Autowired private lateinit var attachmentService: MuutosilmoitusAttachmentService
+    @Autowired private lateinit var authorizer: MuutosilmoitusAuthorizer
+
+    @BeforeEach
+    fun clearMocks() {
+        clearAllMocks()
+    }
+
+    @AfterEach
+    fun checkMocks() {
+        checkUnnecessaryStub()
+        confirmVerified(attachmentService, authorizer)
+    }
+
+    @Nested
+    inner class PostAttachment {
+        @Test
+        fun `returns 200 and metadata when request is valid`() {
+            val file = testFile()
+            every { authorizer.authorize(DEFAULT_ID, EDIT_APPLICATIONS.name) } returns true
+            every {
+                attachmentService.addAttachment(DEFAULT_ID, ApplicationAttachmentType.MUU, file)
+            } returns MuutosilmoitusAttachmentFactory.create()
+
+            val result: MuutosilmoitusAttachmentMetadataDto =
+                postAttachment(file = file).andExpect(status().isOk).andReturnBody()
+
+            with(result) {
+                assertThat(id).isNotNull()
+                assertThat(fileName).isEqualTo(FILE_NAME_PDF)
+                assertThat(createdByUserId).isEqualTo(USERNAME)
+                assertThat(createdAt).isNotNull()
+                assertThat(muutosilmoitusId).isEqualTo(DEFAULT_ID)
+                assertThat(attachmentType).isEqualTo(ApplicationAttachmentType.MUU)
+            }
+            verifyOrder {
+                authorizer.authorize(DEFAULT_ID, EDIT_APPLICATIONS.name)
+                attachmentService.addAttachment(DEFAULT_ID, ApplicationAttachmentType.MUU, file)
+            }
+        }
+
+        @Test
+        fun `returns 409 when muutosilmoitus has been sent already`() {
+            val file = testFile()
+            every { authorizer.authorize(DEFAULT_ID, EDIT_APPLICATIONS.name) } returns true
+            every {
+                attachmentService.addAttachment(DEFAULT_ID, ApplicationAttachmentType.MUU, file)
+            } throws
+                MuutosilmoitusAlreadySentException(MuutosilmoitusFactory.create(id = DEFAULT_ID))
+
+            postAttachment(file = file)
+                .andExpect(status().isConflict)
+                .andExpect(hankeError(HankeError.HAI7002))
+
+            verifyOrder {
+                authorizer.authorize(DEFAULT_ID, EDIT_APPLICATIONS.name)
+                attachmentService.addAttachment(DEFAULT_ID, ApplicationAttachmentType.MUU, file)
+            }
+        }
+
+        @Test
+        fun `returns 404 and error when user has no rights for hanke`() {
+            every { authorizer.authorize(DEFAULT_ID, EDIT_APPLICATIONS.name) } throws
+                HankeNotFoundException("HAI24-1")
+
+            postAttachment().andExpect(status().isNotFound).andExpect(hankeError(HAI1001))
+
+            verifyOrder { authorizer.authorize(DEFAULT_ID, EDIT_APPLICATIONS.name) }
+        }
+
+        @Test
+        fun `returns 404 and error when application is not found`() {
+            every { authorizer.authorize(DEFAULT_ID, EDIT_APPLICATIONS.name) } throws
+                HakemusNotFoundException(APPLICATION_ID)
+
+            postAttachment().andExpect(status().isNotFound).andExpect(hankeError(HAI2001))
+
+            verifyOrder { authorizer.authorize(DEFAULT_ID, EDIT_APPLICATIONS.name) }
+        }
+
+        @Test
+        fun `returns 404 and error when muutosilmoitus is not found`() {
+            every { authorizer.authorize(DEFAULT_ID, EDIT_APPLICATIONS.name) } throws
+                MuutosilmoitusNotFoundException(DEFAULT_ID)
+
+            postAttachment().andExpect(status().isNotFound).andExpect(hankeError(HAI7001))
+
+            verifyOrder { authorizer.authorize(DEFAULT_ID, EDIT_APPLICATIONS.name) }
+        }
+
+        @Test
+        @WithAnonymousUser
+        fun `returns 401 and error when user is unauthorized`() {
+            postAttachment().andExpectError(HAI0001)
+        }
+
+        private fun postAttachment(
+            muutosilmoitusId: UUID = DEFAULT_ID,
+            attachmentType: ApplicationAttachmentType = ApplicationAttachmentType.MUU,
+            file: MockMultipartFile = testFile(),
+        ): ResultActions {
+            return mockMvc.perform(
+                multipart("/muutosilmoitukset/$muutosilmoitusId/liitteet")
+                    .file(file)
+                    .param("tyyppi", attachmentType.toString())
+                    .with(csrf())
+            )
+        }
+    }
+}

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/muutosilmoitus/MuutosilmoitusAttachmentServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/muutosilmoitus/MuutosilmoitusAttachmentServiceITest.kt
@@ -1,0 +1,300 @@
+package fi.hel.haitaton.hanke.attachment.muutosilmoitus
+
+import assertk.all
+import assertk.assertFailure
+import assertk.assertThat
+import assertk.assertions.hasClass
+import assertk.assertions.hasMessage
+import assertk.assertions.isEmpty
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotNull
+import assertk.assertions.messageContains
+import assertk.assertions.prop
+import assertk.assertions.single
+import assertk.assertions.startsWith
+import fi.hel.haitaton.hanke.ALLOWED_ATTACHMENT_COUNT
+import fi.hel.haitaton.hanke.IntegrationTest
+import fi.hel.haitaton.hanke.attachment.DEFAULT_SIZE
+import fi.hel.haitaton.hanke.attachment.FILE_NAME_PDF
+import fi.hel.haitaton.hanke.attachment.PDF_BYTES
+import fi.hel.haitaton.hanke.attachment.azure.Container.HAKEMUS_LIITTEET
+import fi.hel.haitaton.hanke.attachment.body
+import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType
+import fi.hel.haitaton.hanke.attachment.common.AttachmentInvalidException
+import fi.hel.haitaton.hanke.attachment.common.AttachmentLimitReachedException
+import fi.hel.haitaton.hanke.attachment.common.DownloadResponse
+import fi.hel.haitaton.hanke.attachment.common.MockFileClient
+import fi.hel.haitaton.hanke.attachment.failResult
+import fi.hel.haitaton.hanke.attachment.response
+import fi.hel.haitaton.hanke.attachment.successResult
+import fi.hel.haitaton.hanke.attachment.testFile
+import fi.hel.haitaton.hanke.factory.MuutosilmoitusAttachmentFactory
+import fi.hel.haitaton.hanke.factory.MuutosilmoitusFactory
+import fi.hel.haitaton.hanke.muutosilmoitus.MuutosilmoitusAlreadySentException
+import fi.hel.haitaton.hanke.muutosilmoitus.MuutosilmoitusNotFoundException
+import fi.hel.haitaton.hanke.test.Asserts.isRecent
+import fi.hel.haitaton.hanke.test.USERNAME
+import io.mockk.checkUnnecessaryStub
+import io.mockk.clearAllMocks
+import java.util.UUID
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.MediaType.APPLICATION_PDF_VALUE
+
+class MuutosilmoitusAttachmentServiceITest(
+    @Autowired private val attachmentService: MuutosilmoitusAttachmentService,
+    @Autowired private val attachmentRepository: MuutosilmoitusAttachmentRepository,
+    @Autowired private val muutosilmoitusFactory: MuutosilmoitusFactory,
+    @Autowired private val fileClient: MockFileClient,
+) : IntegrationTest() {
+    private lateinit var mockClamAv: MockWebServer
+
+    @BeforeEach
+    fun setup() {
+        clearAllMocks()
+        mockClamAv = MockWebServer()
+        mockClamAv.start(6789)
+        fileClient.recreateContainers()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        mockClamAv.shutdown()
+        checkUnnecessaryStub()
+    }
+
+    @Nested
+    inner class AddAttachment {
+        @EnumSource(ApplicationAttachmentType::class)
+        @ParameterizedTest
+        fun `saves attachment metadata to DB and content to blob storage`(
+            typeInput: ApplicationAttachmentType
+        ) {
+            mockClamAv.enqueue(response(body(results = successResult())))
+            val muutosilmoitus = muutosilmoitusFactory.builder().save()
+
+            val result =
+                attachmentService.addAttachment(
+                    muutosilmoitusId = muutosilmoitus.id,
+                    attachmentType = typeInput,
+                    attachment = testFile(),
+                )
+
+            assertThat(result.id).isNotNull()
+            assertThat(result.createdByUserId).isEqualTo(USERNAME)
+            assertThat(result.fileName).isEqualTo(FILE_NAME_PDF)
+            assertThat(result.contentType).isEqualTo(APPLICATION_PDF_VALUE)
+            assertThat(result.size).isEqualTo(DEFAULT_SIZE)
+            assertThat(result.createdAt).isRecent()
+            assertThat(result.muutosilmoitusId).isEqualTo(muutosilmoitus.id)
+            assertThat(result.attachmentType).isEqualTo(typeInput)
+
+            val attachments = attachmentRepository.findAll()
+            assertThat(attachments).single().all {
+                prop(MuutosilmoitusAttachmentEntity::id).isEqualTo(result.id)
+                prop(MuutosilmoitusAttachmentEntity::createdByUserId).isEqualTo(USERNAME)
+                prop(MuutosilmoitusAttachmentEntity::fileName).isEqualTo(FILE_NAME_PDF)
+                prop(MuutosilmoitusAttachmentEntity::contentType).isEqualTo(APPLICATION_PDF_VALUE)
+                prop(MuutosilmoitusAttachmentEntity::size).isEqualTo(DEFAULT_SIZE)
+                prop(MuutosilmoitusAttachmentEntity::createdAt).isRecent()
+                prop(MuutosilmoitusAttachmentEntity::muutosilmoitusId).isEqualTo(muutosilmoitus.id)
+                prop(MuutosilmoitusAttachmentEntity::attachmentType).isEqualTo(typeInput)
+                prop(MuutosilmoitusAttachmentEntity::blobLocation)
+                    .isNotNull()
+                    .startsWith("${muutosilmoitus.hakemusId}/")
+            }
+
+            val content = fileClient.download(HAKEMUS_LIITTEET, attachments.first().blobLocation)
+            assertThat(content)
+                .isNotNull()
+                .prop(DownloadResponse::content)
+                .transform { it.toBytes() }
+                .isEqualTo(PDF_BYTES)
+        }
+
+        @Test
+        fun `sanitizes filenames with special characters`() {
+            mockClamAv.enqueue(response(body(results = successResult())))
+            val muutosilmoitus = muutosilmoitusFactory.builder().save()
+
+            val result =
+                attachmentService.addAttachment(
+                    muutosilmoitusId = muutosilmoitus.id,
+                    attachmentType = ApplicationAttachmentType.MUU,
+                    attachment = testFile(fileName = "exa*mple.pdf"),
+                )
+
+            assertThat(result.fileName).isEqualTo("exa_mple.pdf")
+            val attachmentInDb = attachmentRepository.getReferenceById(result.id)
+            assertThat(attachmentInDb.fileName).isEqualTo("exa_mple.pdf")
+        }
+
+        @Test
+        fun `throws exception when allowed attachment amount is reached`() {
+            val muutosilmoitus = muutosilmoitusFactory.builder().save()
+            val attachments =
+                (1..ALLOWED_ATTACHMENT_COUNT).map {
+                    MuutosilmoitusAttachmentFactory.createEntity(
+                        muutosilmoitusId = muutosilmoitus.id
+                    )
+                }
+            attachmentRepository.saveAll(attachments)
+            mockClamAv.enqueue(response(body(results = successResult())))
+
+            val failure = assertFailure {
+                attachmentService.addAttachment(
+                    muutosilmoitusId = muutosilmoitus.id,
+                    attachmentType = ApplicationAttachmentType.VALTAKIRJA,
+                    attachment = testFile(),
+                )
+            }
+
+            failure.all {
+                hasClass(AttachmentLimitReachedException::class)
+                messageContains("Attachment amount limit reached")
+                messageContains("limit=$ALLOWED_ATTACHMENT_COUNT")
+                messageContains("Muutosilmoitus: (id=${muutosilmoitus.id}")
+            }
+        }
+
+        @Test
+        fun `throws exception without content`() {
+            val muutosilmoitus = muutosilmoitusFactory.builder().save()
+
+            val failure = assertFailure {
+                attachmentService.addAttachment(
+                    muutosilmoitusId = muutosilmoitus.id,
+                    attachmentType = ApplicationAttachmentType.VALTAKIRJA,
+                    attachment = testFile(data = byteArrayOf()),
+                )
+            }
+
+            failure.all {
+                hasClass(AttachmentInvalidException::class)
+                messageContains("Attachment has no content")
+            }
+        }
+
+        @Test
+        fun `throws exception without content type`() {
+            val muutosilmoitus = muutosilmoitusFactory.builder().save()
+
+            val failure = assertFailure {
+                attachmentService.addAttachment(
+                    muutosilmoitusId = muutosilmoitus.id,
+                    attachmentType = ApplicationAttachmentType.VALTAKIRJA,
+                    attachment = testFile(contentType = null),
+                )
+            }
+
+            failure.all {
+                hasClass(AttachmentInvalidException::class)
+                hasMessage("Attachment upload exception: Content-Type null")
+            }
+        }
+
+        @Test
+        fun `throws exception when there is no existing muutosilmoitus`() {
+            val failure = assertFailure {
+                attachmentService.addAttachment(
+                    muutosilmoitusId = UUID.randomUUID(),
+                    attachmentType = ApplicationAttachmentType.MUU,
+                    attachment = testFile(),
+                )
+            }
+
+            failure.hasClass(MuutosilmoitusNotFoundException::class)
+            assertThat(attachmentRepository.findAll()).isEmpty()
+        }
+
+        @Test
+        fun `throws exception when file type is not supported`() {
+            val muutosilmoitus = muutosilmoitusFactory.builder().save()
+            val invalidFilename = "hello.html"
+
+            val failure = assertFailure {
+                attachmentService.addAttachment(
+                    muutosilmoitusId = muutosilmoitus.id,
+                    attachmentType = ApplicationAttachmentType.VALTAKIRJA,
+                    attachment = testFile(fileName = invalidFilename),
+                )
+            }
+
+            failure.all {
+                hasClass(AttachmentInvalidException::class)
+                hasMessage("Attachment upload exception: File 'hello.html' not supported")
+            }
+            assertThat(attachmentRepository.findAll()).isEmpty()
+        }
+
+        @Test
+        fun `throws exception when file type is not supported for attachment type`() {
+            val muutosilmoitus = muutosilmoitusFactory.builder().save()
+            val invalidFilename = "hello.jpeg"
+
+            val failure = assertFailure {
+                attachmentService.addAttachment(
+                    muutosilmoitusId = muutosilmoitus.id,
+                    attachmentType = ApplicationAttachmentType.VALTAKIRJA,
+                    attachment = testFile(fileName = invalidFilename),
+                )
+            }
+
+            failure.all {
+                hasClass(AttachmentInvalidException::class)
+                messageContains("File extension is not valid for attachment type")
+                messageContains("filename=$invalidFilename")
+                messageContains("attachmentType=${ApplicationAttachmentType.VALTAKIRJA}")
+            }
+            assertThat(attachmentRepository.findAll()).isEmpty()
+        }
+
+        @Test
+        fun `throws exception when virus scan fails`() {
+            mockClamAv.enqueue(response(body(results = failResult())))
+            val muutosilmoitus = muutosilmoitusFactory.builder().save()
+
+            val failure = assertFailure {
+                attachmentService.addAttachment(
+                    muutosilmoitusId = muutosilmoitus.id,
+                    attachmentType = ApplicationAttachmentType.VALTAKIRJA,
+                    attachment = testFile(),
+                )
+            }
+
+            failure.all {
+                hasClass(AttachmentInvalidException::class)
+                hasMessage(
+                    "Attachment upload exception: Infected file detected, see previous logs."
+                )
+            }
+            assertThat(attachmentRepository.findAll()).isEmpty()
+        }
+
+        @Test
+        fun `throws exception when muutosilmoitus has been already sent`() {
+            val muutosilmoitus = muutosilmoitusFactory.builder().withSent().save()
+
+            val failure = assertFailure {
+                attachmentService.addAttachment(
+                    muutosilmoitusId = muutosilmoitus.id,
+                    attachmentType = ApplicationAttachmentType.MUU,
+                    attachment = testFile(),
+                )
+            }
+
+            failure.all {
+                hasClass(MuutosilmoitusAlreadySentException::class)
+                messageContains("id=${muutosilmoitus.id}")
+                messageContains("Muutosilmoitus is already sent to Allu")
+            }
+            assertThat(attachmentRepository.findAll()).isEmpty()
+        }
+    }
+}

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/taydennys/TaydennysAttachmentControllerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/taydennys/TaydennysAttachmentControllerITest.kt
@@ -209,6 +209,16 @@ class TaydennysAttachmentControllerITest(@Autowired override val mockMvc: MockMv
         }
 
         @Test
+        fun `returns 404 and error when taydennys is not found`() {
+            every { authorizer.authorize(DEFAULT_ID, EDIT_APPLICATIONS.name) } throws
+                TaydennysNotFoundException(DEFAULT_ID)
+
+            postAttachment().andExpect(status().isNotFound).andExpect(hankeError(HAI6001))
+
+            verifyOrder { authorizer.authorize(DEFAULT_ID, EDIT_APPLICATIONS.name) }
+        }
+
+        @Test
         @WithAnonymousUser
         fun `returns 401 and error when user is unauthorized`() {
             postAttachment().andExpectError(HAI0001)

--- a/services/hanke-service/src/integrationTest/resources/clear-db.sql
+++ b/services/hanke-service/src/integrationTest/resources/clear-db.sql
@@ -18,6 +18,7 @@ TRUNCATE TABLE
     kayttajakutsu,
     muutosilmoituksen_yhteyshenkilo,
     muutosilmoituksen_yhteystieto,
+    muutosilmoituksen_liite,
     muutosilmoitus,
     paatos,
     permissions,

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/ControllerExceptionHandler.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/ControllerExceptionHandler.kt
@@ -15,6 +15,7 @@ import fi.hel.haitaton.hanke.hakemus.InvalidHakemusyhteyshenkiloException
 import fi.hel.haitaton.hanke.hakemus.InvalidHakemusyhteystietoException
 import fi.hel.haitaton.hanke.hakemus.InvalidHiddenRegistryKey
 import fi.hel.haitaton.hanke.hakemus.WrongHakemusTypeException
+import fi.hel.haitaton.hanke.muutosilmoitus.MuutosilmoitusAlreadySentException
 import io.sentry.Sentry
 import io.swagger.v3.oas.annotations.Hidden
 import io.swagger.v3.oas.annotations.responses.ApiResponse
@@ -230,6 +231,14 @@ class ControllerExceptionHandler {
         logger.warn { ex.message }
         Sentry.captureException(ex)
         return HankeError.HAI3003
+    }
+
+    @ExceptionHandler(MuutosilmoitusAlreadySentException::class)
+    @ResponseStatus(HttpStatus.CONFLICT)
+    @Hidden
+    fun muutosilmoitusAlreadySentException(ex: MuutosilmoitusAlreadySentException): HankeError {
+        logger.warn(ex) { ex.message }
+        return HankeError.HAI7002
     }
 
     @ExceptionHandler(MethodArgumentNotValidException::class)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/muutosilmoitus/MuutosilmoitusAttachmentController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/muutosilmoitus/MuutosilmoitusAttachmentController.kt
@@ -1,0 +1,70 @@
+package fi.hel.haitaton.hanke.attachment.muutosilmoitus
+
+import fi.hel.haitaton.hanke.HankeError
+import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType
+import fi.hel.haitaton.hanke.muutosilmoitus.MuutosilmoitusNotFoundException
+import io.swagger.v3.oas.annotations.Hidden
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
+import java.util.UUID
+import mu.KotlinLogging
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.multipart.MultipartFile
+
+private val logger = KotlinLogging.logger {}
+
+@RestController
+@RequestMapping("/muutosilmoitukset/{muutosilmoitusId}/liitteet")
+@SecurityRequirement(name = "bearerAuth")
+class MuutosilmoitusAttachmentController(
+    private val attachmentService: MuutosilmoitusAttachmentService
+) {
+
+    @PostMapping(consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
+    @Operation(summary = "Upload attachment for muutosilmoitus", description = "Upload attachment.")
+    @ApiResponses(
+        value =
+            [
+                ApiResponse(description = "Success", responseCode = "200"),
+                ApiResponse(
+                    description = "Muutosilmoitus not found",
+                    responseCode = "404",
+                    content = [Content(schema = Schema(implementation = HankeError::class))],
+                ),
+                ApiResponse(
+                    description = "Attachment invalid",
+                    responseCode = "400",
+                    content = [Content(schema = Schema(implementation = HankeError::class))],
+                ),
+            ]
+    )
+    @PreAuthorize("@muutosilmoitusAuthorizer.authorize(#muutosilmoitusId, 'EDIT_APPLICATIONS')")
+    fun postAttachment(
+        @PathVariable muutosilmoitusId: UUID,
+        @RequestParam("tyyppi") tyyppi: ApplicationAttachmentType,
+        @RequestParam("liite") attachment: MultipartFile,
+    ): MuutosilmoitusAttachmentMetadataDto {
+        return attachmentService.addAttachment(muutosilmoitusId, tyyppi, attachment).toDto()
+    }
+
+    @ExceptionHandler(MuutosilmoitusNotFoundException::class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    @Hidden
+    fun muutosilmoitusNotFoundException(ex: MuutosilmoitusNotFoundException): HankeError {
+        logger.warn(ex) { ex.message }
+        return HankeError.HAI7001
+    }
+}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/muutosilmoitus/MuutosilmoitusAttachmentEntity.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/muutosilmoitus/MuutosilmoitusAttachmentEntity.kt
@@ -1,0 +1,57 @@
+package fi.hel.haitaton.hanke.attachment.muutosilmoitus
+
+import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType
+import fi.hel.haitaton.hanke.attachment.common.AttachmentEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.Table
+import java.time.OffsetDateTime
+import java.util.UUID
+
+@Entity
+@Table(name = "muutosilmoituksen_liite")
+class MuutosilmoitusAttachmentEntity(
+    id: UUID?,
+    fileName: String,
+    contentType: String,
+    size: Long,
+    blobLocation: String,
+    createdByUserId: String,
+    createdAt: OffsetDateTime,
+    @Column(name = "muutosilmoitus_id") var muutosilmoitusId: UUID,
+    @Enumerated(EnumType.STRING)
+    @Column(name = "attachment_type")
+    var attachmentType: ApplicationAttachmentType,
+) : AttachmentEntity(id, fileName, contentType, size, blobLocation, createdByUserId, createdAt) {
+
+    fun toDomain(): MuutosilmoitusAttachmentMetadata =
+        MuutosilmoitusAttachmentMetadata(
+            id = id!!,
+            fileName = fileName,
+            contentType = contentType,
+            size = size,
+            attachmentType = attachmentType,
+            createdByUserId = createdByUserId,
+            createdAt = createdAt,
+            blobLocation = blobLocation,
+            muutosilmoitusId = muutosilmoitusId,
+        )
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+        if (!super.equals(other)) return false
+
+        other as MuutosilmoitusAttachmentEntity
+
+        return id == other.id
+    }
+
+    override fun hashCode(): Int {
+        var result = super.hashCode()
+        result = 31 * result + id.hashCode()
+        return result
+    }
+}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/muutosilmoitus/MuutosilmoitusAttachmentMetadata.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/muutosilmoitus/MuutosilmoitusAttachmentMetadata.kt
@@ -1,0 +1,31 @@
+package fi.hel.haitaton.hanke.attachment.muutosilmoitus
+
+import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType
+import fi.hel.haitaton.hanke.attachment.common.AttachmentMetadataWithType
+import java.time.OffsetDateTime
+import java.util.UUID
+
+data class MuutosilmoitusAttachmentMetadata(
+    override val id: UUID,
+    override val fileName: String,
+    override val contentType: String,
+    override val size: Long,
+    override val createdByUserId: String,
+    override val createdAt: OffsetDateTime,
+    override val blobLocation: String,
+    val muutosilmoitusId: UUID,
+    override val attachmentType: ApplicationAttachmentType,
+) : AttachmentMetadataWithType {
+    fun toDto(): MuutosilmoitusAttachmentMetadataDto {
+        return MuutosilmoitusAttachmentMetadataDto(
+            id = id,
+            fileName = fileName,
+            contentType = contentType,
+            size = size,
+            attachmentType = attachmentType,
+            createdAt = createdAt,
+            createdByUserId = createdByUserId,
+            muutosilmoitusId = muutosilmoitusId,
+        )
+    }
+}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/muutosilmoitus/MuutosilmoitusAttachmentMetadataDto.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/muutosilmoitus/MuutosilmoitusAttachmentMetadataDto.kt
@@ -1,0 +1,16 @@
+package fi.hel.haitaton.hanke.attachment.muutosilmoitus
+
+import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType
+import java.time.OffsetDateTime
+import java.util.UUID
+
+data class MuutosilmoitusAttachmentMetadataDto(
+    val id: UUID,
+    val fileName: String,
+    val contentType: String,
+    val size: Long,
+    val attachmentType: ApplicationAttachmentType,
+    val createdByUserId: String,
+    val createdAt: OffsetDateTime,
+    val muutosilmoitusId: UUID,
+)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/muutosilmoitus/MuutosilmoitusAttachmentMetadataService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/muutosilmoitus/MuutosilmoitusAttachmentMetadataService.kt
@@ -1,0 +1,70 @@
+package fi.hel.haitaton.hanke.attachment.muutosilmoitus
+
+import fi.hel.haitaton.hanke.ALLOWED_ATTACHMENT_COUNT
+import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentRepository
+import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType
+import fi.hel.haitaton.hanke.attachment.common.AttachmentLimitReachedException
+import fi.hel.haitaton.hanke.currentUserId
+import fi.hel.haitaton.hanke.muutosilmoitus.MuutosilmoitusIdentifier
+import java.time.OffsetDateTime
+import java.util.UUID
+import mu.KotlinLogging
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+private val logger = KotlinLogging.logger {}
+
+@Service
+class MuutosilmoitusAttachmentMetadataService(
+    private val attachmentRepository: MuutosilmoitusAttachmentRepository,
+    private val hakemusAttachmentRepository: ApplicationAttachmentRepository,
+) {
+    @Transactional
+    fun create(
+        filename: String,
+        contentType: String,
+        size: Long,
+        blobLocation: String,
+        attachmentType: ApplicationAttachmentType,
+        muutosilmoitusId: UUID,
+    ): MuutosilmoitusAttachmentMetadata {
+        val entity =
+            MuutosilmoitusAttachmentEntity(
+                id = null,
+                fileName = filename,
+                contentType = contentType,
+                size = size,
+                blobLocation = blobLocation,
+                createdByUserId = currentUserId(),
+                createdAt = OffsetDateTime.now(),
+                attachmentType = attachmentType,
+                muutosilmoitusId = muutosilmoitusId,
+            )
+        return attachmentRepository.save(entity).toDomain().also {
+            logger.info {
+                "Saved attachment metadata ${it.id} for muutosilmoitus $muutosilmoitusId"
+            }
+        }
+    }
+
+    @Transactional(readOnly = true)
+    fun ensureRoomForAttachment(muutosilmoitus: MuutosilmoitusIdentifier) {
+        if (attachmentAmountReached(muutosilmoitus)) {
+            logger.warn {
+                "Muutosilmoitus ${muutosilmoitus.id} has reached the allowed total amount of attachments for it and its hakemus."
+            }
+            throw AttachmentLimitReachedException(muutosilmoitus)
+        }
+    }
+
+    private fun attachmentAmountReached(entity: MuutosilmoitusIdentifier): Boolean {
+        val hakemusAttachmentCount =
+            hakemusAttachmentRepository.countByApplicationId(entity.hakemusId)
+        val muutosilmoitusAttachmentCount = attachmentRepository.countByMuutosilmoitusId(entity.id)
+        val totalAttachmentCount = muutosilmoitusAttachmentCount + hakemusAttachmentCount
+        logger.info {
+            "Muutosilmoitus ${entity.id} and application ${entity.hakemusId} contain total of $totalAttachmentCount attachments beforehand."
+        }
+        return totalAttachmentCount >= ALLOWED_ATTACHMENT_COUNT
+    }
+}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/muutosilmoitus/MuutosilmoitusAttachmentRepository.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/muutosilmoitus/MuutosilmoitusAttachmentRepository.kt
@@ -1,0 +1,10 @@
+package fi.hel.haitaton.hanke.attachment.muutosilmoitus
+
+import java.util.UUID
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface MuutosilmoitusAttachmentRepository : JpaRepository<MuutosilmoitusAttachmentEntity, UUID> {
+    fun countByMuutosilmoitusId(muutosilmoitusId: UUID): Int
+}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/muutosilmoitus/MuutosilmoitusAttachmentService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/muutosilmoitus/MuutosilmoitusAttachmentService.kt
@@ -1,0 +1,81 @@
+package fi.hel.haitaton.hanke.attachment.muutosilmoitus
+
+import fi.hel.haitaton.hanke.attachment.application.ApplicationAttachmentContentService
+import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType
+import fi.hel.haitaton.hanke.attachment.common.AttachmentService
+import fi.hel.haitaton.hanke.attachment.common.AttachmentValidator
+import fi.hel.haitaton.hanke.attachment.common.FileScanClient
+import fi.hel.haitaton.hanke.muutosilmoitus.MuutosilmoitusAlreadySentException
+import fi.hel.haitaton.hanke.muutosilmoitus.MuutosilmoitusEntity
+import fi.hel.haitaton.hanke.muutosilmoitus.MuutosilmoitusIdentifier
+import fi.hel.haitaton.hanke.muutosilmoitus.MuutosilmoitusNotFoundException
+import fi.hel.haitaton.hanke.muutosilmoitus.MuutosilmoitusRepository
+import java.util.UUID
+import mu.KotlinLogging
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Service
+import org.springframework.web.multipart.MultipartFile
+
+private val logger = KotlinLogging.logger {}
+
+@Service
+class MuutosilmoitusAttachmentService(
+    private val metadataService: MuutosilmoitusAttachmentMetadataService,
+    private val muutosilmoitusRepository: MuutosilmoitusRepository,
+    private val contentService: ApplicationAttachmentContentService,
+    private val scanClient: FileScanClient,
+) : AttachmentService<MuutosilmoitusIdentifier, MuutosilmoitusAttachmentMetadata> {
+
+    fun addAttachment(
+        muutosilmoitusId: UUID,
+        attachmentType: ApplicationAttachmentType,
+        attachment: MultipartFile,
+    ): MuutosilmoitusAttachmentMetadata {
+        logger.info {
+            "Adding attachment to muutosilmoitus, id = $muutosilmoitusId, " +
+                "attachment name = ${attachment.originalFilename}, size = ${attachment.bytes.size}, " +
+                "content type = ${attachment.contentType}"
+        }
+        AttachmentValidator.validateSize(attachment.bytes.size)
+        val filename = AttachmentValidator.validFilename(attachment.originalFilename)
+        AttachmentValidator.validateExtensionForType(filename, attachmentType)
+        val muutosilmoitus = findMuutosilmoitus(muutosilmoitusId)
+
+        if (muutosilmoitus.sent != null) {
+            throw MuutosilmoitusAlreadySentException(muutosilmoitus)
+        }
+
+        val contentType = AttachmentValidator.ensureMediaType(attachment.contentType)
+        scanClient.scanAttachment(filename, attachment.bytes)
+        metadataService.ensureRoomForAttachment(muutosilmoitus)
+
+        val newAttachment =
+            saveAttachment(muutosilmoitus, attachment.bytes, filename, contentType, attachmentType)
+
+        return newAttachment
+    }
+
+    private fun findMuutosilmoitus(muutosilmoitusId: UUID): MuutosilmoitusEntity =
+        muutosilmoitusRepository.findByIdOrNull(muutosilmoitusId)
+            ?: throw MuutosilmoitusNotFoundException(muutosilmoitusId)
+
+    override fun upload(
+        filename: String,
+        contentType: MediaType,
+        content: ByteArray,
+        entity: MuutosilmoitusIdentifier,
+    ): String = contentService.upload(filename, contentType, content, entity.hakemusId)
+
+    override fun createMetadata(
+        filename: String,
+        contentType: String,
+        size: Long,
+        blobPath: String,
+        entity: MuutosilmoitusIdentifier,
+        attachmentType: ApplicationAttachmentType?,
+    ): MuutosilmoitusAttachmentMetadata =
+        metadataService.create(filename, contentType, size, blobPath, attachmentType!!, entity.id)
+
+    override fun delete(blobPath: String): Boolean = contentService.delete(blobPath)
+}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/DisclosureLoggingAspect.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/DisclosureLoggingAspect.kt
@@ -3,6 +3,7 @@ package fi.hel.haitaton.hanke.logging
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentMetadataDto
 import fi.hel.haitaton.hanke.attachment.common.HankeAttachmentMetadataDto
 import fi.hel.haitaton.hanke.attachment.common.TaydennysAttachmentMetadataDto
+import fi.hel.haitaton.hanke.attachment.muutosilmoitus.MuutosilmoitusAttachmentMetadataDto
 import fi.hel.haitaton.hanke.banners.BannerResponse
 import fi.hel.haitaton.hanke.currentUserId
 import fi.hel.haitaton.hanke.domain.Hanke
@@ -69,6 +70,7 @@ class DisclosureLoggingAspect(private val disclosureLogService: DisclosureLogSer
             // Some classes cannot hold personal information, so they are skipped
             is ApplicationAttachmentMetadataDto -> return
             is TaydennysAttachmentMetadataDto -> return
+            is MuutosilmoitusAttachmentMetadataDto -> return
             is HakemusDeletionResultDto -> return
             is HankeAttachmentMetadataDto -> return
             is HankeKayttajaController.TunnistautuminenResponse -> return

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/muutosilmoitus/MuutosilmoitusController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/muutosilmoitus/MuutosilmoitusController.kt
@@ -202,14 +202,6 @@ class MuutosilmoitusController(private val muutosilmoitusService: Muutosilmoitus
         return HankeErrorDetail(hankeError = HankeError.HAI2008, errorPaths = ex.errorPaths)
     }
 
-    @ExceptionHandler(MuutosilmoitusAlreadySentException::class)
-    @ResponseStatus(HttpStatus.CONFLICT)
-    @Hidden
-    fun muutosilmoitusAlreadySentException(ex: MuutosilmoitusAlreadySentException): HankeError {
-        logger.warn(ex) { ex.message }
-        return HankeError.HAI7002
-    }
-
     @ExceptionHandler(IncompatibleMuutosilmoitusUpdateException::class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     @Hidden

--- a/services/hanke-service/src/main/resources/db/changelog/changesets/106-create-table-for-muutosilmoitus-attachment.sql
+++ b/services/hanke-service/src/main/resources/db/changelog/changesets/106-create-table-for-muutosilmoitus-attachment.sql
@@ -1,0 +1,29 @@
+--liquibase formatted sql
+--changeset Topias Heinonen:106-create-table-for-muutosilmoitus-attachment
+--comment: Create table for muutosilmoitus attachment
+
+CREATE TABLE muutosilmoituksen_liite
+(
+    id                 uuid                     NOT NULL PRIMARY KEY,
+    muutosilmoitus_id  uuid                     NOT NULL,
+    file_name          varchar                  NOT NULL,
+    attachment_type    varchar                  NOT NULL,
+    content_type       varchar                  NOT NULL,
+    size               bigint                   NOT NULL,
+    blob_location      varchar                  NOT NULL,
+    created_by_user_id varchar                  NOT NULL,
+    created_at         timestamp with time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT fk_liite_muutosilmoitus FOREIGN KEY (muutosilmoitus_id) REFERENCES muutosilmoitus (id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_liite_muutosilmoitus_id ON muutosilmoituksen_liite (muutosilmoitus_id);
+
+COMMENT ON TABLE muutosilmoituksen_liite is 'Attachment metadata for muutosilmoitus.';
+COMMENT ON COLUMN muutosilmoituksen_liite.muutosilmoitus_id is 'The muutosilmoitus this attachment belongs to.';
+COMMENT ON COLUMN muutosilmoituksen_liite.file_name is 'The name of the attachment file.';
+COMMENT ON COLUMN muutosilmoituksen_liite.attachment_type is 'The type of the attachment.';
+COMMENT ON COLUMN muutosilmoituksen_liite.content_type is 'The content type of the attachment.';
+COMMENT ON COLUMN muutosilmoituksen_liite.size is 'Size of the attachment in bytes.';
+COMMENT ON COLUMN muutosilmoituksen_liite.blob_location is 'The location of the attachment in the blob storage.';
+COMMENT ON COLUMN muutosilmoituksen_liite.created_by_user_id is 'The user who created this attachment.';
+COMMENT ON COLUMN muutosilmoituksen_liite.created_at is 'Timestamp of when this row was initially created.';

--- a/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -239,3 +239,5 @@ databaseChangeLog:
       file: db/changelog/changesets/104-create-table-kaivuilmoitusalueet-historia.yml
   - include:
       file: db/changelog/changesets/105-add-trigger-adding-kaivuilmoitusalueet-historia-lines-for-applications.sql
+  - include:
+      file: db/changelog/changesets/106-create-table-for-muutosilmoitus-attachment.sql

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/MuutosilmoitusAttachmentFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/MuutosilmoitusAttachmentFactory.kt
@@ -10,7 +10,6 @@ import fi.hel.haitaton.hanke.factory.MuutosilmoitusFactory.Companion.DEFAULT_ID
 import fi.hel.haitaton.hanke.test.USERNAME
 import java.time.OffsetDateTime
 import java.util.UUID
-import org.springframework.http.MediaType
 import org.springframework.http.MediaType.APPLICATION_PDF_VALUE
 import org.springframework.stereotype.Component
 
@@ -19,8 +18,6 @@ class MuutosilmoitusAttachmentFactory {
 
     companion object {
         val DEFAULT_ATTACHMENT_ID: UUID = UUID.fromString("5cba3a76-28ad-42aa-b7e6-b5c1775be81a")
-        val MEDIA_TYPE = MediaType.APPLICATION_PDF
-        val CONTENT_TYPE = MEDIA_TYPE.toString()
         val CREATED_AT: OffsetDateTime = OffsetDateTime.parse("2023-11-09T08:03:55Z")
 
         const val FILE_NAME = "file.pdf"

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/MuutosilmoitusAttachmentFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/MuutosilmoitusAttachmentFactory.kt
@@ -1,0 +1,74 @@
+package fi.hel.haitaton.hanke.factory
+
+import fi.hel.haitaton.hanke.attachment.DEFAULT_SIZE
+import fi.hel.haitaton.hanke.attachment.application.ApplicationAttachmentContentService.Companion.generateBlobPath
+import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType
+import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType.MUU
+import fi.hel.haitaton.hanke.attachment.muutosilmoitus.MuutosilmoitusAttachmentEntity
+import fi.hel.haitaton.hanke.attachment.muutosilmoitus.MuutosilmoitusAttachmentMetadata
+import fi.hel.haitaton.hanke.factory.MuutosilmoitusFactory.Companion.DEFAULT_ID
+import fi.hel.haitaton.hanke.test.USERNAME
+import java.time.OffsetDateTime
+import java.util.UUID
+import org.springframework.http.MediaType
+import org.springframework.http.MediaType.APPLICATION_PDF_VALUE
+import org.springframework.stereotype.Component
+
+@Component
+class MuutosilmoitusAttachmentFactory {
+
+    companion object {
+        val DEFAULT_ATTACHMENT_ID: UUID = UUID.fromString("5cba3a76-28ad-42aa-b7e6-b5c1775be81a")
+        val MEDIA_TYPE = MediaType.APPLICATION_PDF
+        val CONTENT_TYPE = MEDIA_TYPE.toString()
+        val CREATED_AT: OffsetDateTime = OffsetDateTime.parse("2023-11-09T08:03:55Z")
+
+        const val FILE_NAME = "file.pdf"
+
+        fun create(
+            id: UUID = DEFAULT_ATTACHMENT_ID,
+            fileName: String = FILE_NAME,
+            contentType: String = APPLICATION_PDF_VALUE,
+            size: Long = DEFAULT_SIZE,
+            blobLocation: String = generateBlobPath(1L),
+            createdByUserId: String = USERNAME,
+            createdAt: OffsetDateTime = CREATED_AT,
+            attachmentType: ApplicationAttachmentType = MUU,
+            muutosilmoitusId: UUID = DEFAULT_ID,
+        ): MuutosilmoitusAttachmentMetadata =
+            MuutosilmoitusAttachmentMetadata(
+                id = id,
+                fileName = fileName,
+                contentType = contentType,
+                size = size,
+                blobLocation = blobLocation,
+                createdByUserId = createdByUserId,
+                createdAt = createdAt,
+                attachmentType = attachmentType,
+                muutosilmoitusId = muutosilmoitusId,
+            )
+
+        fun createEntity(
+            id: UUID? = DEFAULT_ATTACHMENT_ID,
+            fileName: String = FILE_NAME,
+            contentType: String = APPLICATION_PDF_VALUE,
+            size: Long = DEFAULT_SIZE,
+            createdByUserId: String = USERNAME,
+            createdAt: OffsetDateTime = CREATED_AT,
+            attachmentType: ApplicationAttachmentType = MUU,
+            applicationId: Long = 1L,
+            muutosilmoitusId: UUID = DEFAULT_ID,
+        ): MuutosilmoitusAttachmentEntity =
+            MuutosilmoitusAttachmentEntity(
+                id = id,
+                fileName = fileName,
+                contentType = contentType,
+                size = size,
+                blobLocation = generateBlobPath(applicationId),
+                createdByUserId = createdByUserId,
+                createdAt = createdAt,
+                attachmentType = attachmentType,
+                muutosilmoitusId = muutosilmoitusId,
+            )
+    }
+}


### PR DESCRIPTION
# Description

Add an API for adding attachments to muutosilmoitus. The attachments are uploaded to Blob Storage using the same prefix as the attachments for the hakemus. If any attachments are left orphaned by the muutosilmoitus, they will be deleted when the hakemus is deleted.

An attachment cannot be added if the muutosilmoitus has been sent to Allu.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-3412

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
1. Create a muutosilmoitus for a kaivuilmoitus.
2. Use [Swagger UI](http://localhost:3001/api/swagger-ui/index.html#/muutosilmoitus-attachment-controller/postAttachment_1) to add an attachment to it.
3. Check from DB (`muutosilmoituksen_liite` table) that the attachment was added and with Azure Storage Explorer that the attachment in the hakemusliitteet container.
4. Send the muutosilmoitus to Allu. (The attachment is not sent yet)
5. Try to add a new attachment to the muutosilmoitus. This should fail.

# Checklist:

- [X I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 