### PR TITLE
HAI-3413 Download API for muutosilmoitus attachment

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/muutosilmoitus/MuutosilmoitusAuthorizerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/muutosilmoitus/MuutosilmoitusAuthorizerITest.kt
@@ -7,12 +7,16 @@ import assertk.assertions.hasClass
 import assertk.assertions.isTrue
 import assertk.assertions.messageContains
 import fi.hel.haitaton.hanke.IntegrationTest
+import fi.hel.haitaton.hanke.attachment.common.AttachmentNotFoundException
 import fi.hel.haitaton.hanke.factory.HakemusFactory
 import fi.hel.haitaton.hanke.factory.HankeFactory
+import fi.hel.haitaton.hanke.factory.MuutosilmoitusAttachmentFactory
 import fi.hel.haitaton.hanke.factory.MuutosilmoitusFactory
 import fi.hel.haitaton.hanke.hakemus.HakemusNotFoundException
 import fi.hel.haitaton.hanke.permissions.Kayttooikeustaso
 import fi.hel.haitaton.hanke.permissions.PermissionCode
+import fi.hel.haitaton.hanke.permissions.PermissionCode.EDIT
+import fi.hel.haitaton.hanke.permissions.PermissionCode.VIEW
 import fi.hel.haitaton.hanke.permissions.PermissionService
 import fi.hel.haitaton.hanke.test.USERNAME
 import java.util.UUID
@@ -22,10 +26,11 @@ import org.springframework.beans.factory.annotation.Autowired
 
 class MuutosilmoitusAuthorizerITest(
     @Autowired private val authorizer: MuutosilmoitusAuthorizer,
+    @Autowired private val permissionService: PermissionService,
     @Autowired private val muutosilmoitusFactory: MuutosilmoitusFactory,
     @Autowired private val hakemusFactory: HakemusFactory,
     @Autowired private val hankeFactory: HankeFactory,
-    @Autowired private val permissionService: PermissionService,
+    @Autowired private val attachmentFactory: MuutosilmoitusAttachmentFactory,
 ) : IntegrationTest() {
     @Nested
     inner class Authorize {
@@ -91,6 +96,95 @@ class MuutosilmoitusAuthorizerITest(
                 authorizer.authorize(muutosilmoitus.id, PermissionCode.EDIT_APPLICATIONS.name)
 
             assertThat(result).isTrue()
+        }
+    }
+
+    @Nested
+    inner class AuthorizeAttachment {
+        private val muutosilmoitusId: UUID = UUID.fromString("1f163338-93ed-409c-8230-ab7041565c70")
+        private val attachmentId = UUID.fromString("2f163338-93ed-409c-8230-ab7041565c70")
+
+        @Test
+        fun `throws exception if muutosilmoitus is not found`() {
+            assertFailure {
+                    authorizer.authorizeAttachment(muutosilmoitusId, attachmentId, VIEW.name)
+                }
+                .all {
+                    hasClass(MuutosilmoitusNotFoundException::class)
+                    messageContains(muutosilmoitusId.toString())
+                }
+        }
+
+        @Test
+        fun `throws exception if user doesn't have the required permission for the hanke`() {
+            val hanke = hankeFactory.saveMinimal()
+            permissionService.create(hanke.id, USERNAME, Kayttooikeustaso.KATSELUOIKEUS)
+            val hakemus = hakemusFactory.builder(hanke).saveEntity()
+            val muutosilmoitus = muutosilmoitusFactory.builder(hakemus).saveEntity()
+
+            assertFailure {
+                    authorizer.authorizeAttachment(muutosilmoitus.id, attachmentId, EDIT.name)
+                }
+                .all {
+                    hasClass(HakemusNotFoundException::class)
+                    messageContains(hakemus.id.toString())
+                }
+        }
+
+        @Test
+        fun `throws exception if the attachment is not found`() {
+            val muutosilmoitus = muutosilmoitusFactory.builder().saveEntity()
+
+            assertFailure {
+                    authorizer.authorizeAttachment(muutosilmoitus.id, attachmentId, VIEW.name)
+                }
+                .all {
+                    hasClass(AttachmentNotFoundException::class)
+                    messageContains(attachmentId.toString())
+                }
+        }
+
+        @Test
+        fun `throws exception if the attachment belongs to another muutosilmoitus`() {
+            val muutosilmoitus = muutosilmoitusFactory.builder().saveEntity()
+            val muutosilmoitus2 = muutosilmoitusFactory.builder(alluId = 2).saveEntity()
+            val attachment = attachmentFactory.save(muutosilmoitus = muutosilmoitus2.toDomain())
+
+            assertFailure {
+                    authorizer.authorizeAttachment(muutosilmoitus.id, attachment.id!!, VIEW.name)
+                }
+                .all {
+                    hasClass(AttachmentNotFoundException::class)
+                    messageContains(attachment.id.toString())
+                }
+        }
+
+        @Test
+        fun `returns true if the attachment is found, it belongs to the muutosilmoitus and the user has the correct permission`() {
+            val attachment = attachmentFactory.save()
+
+            assertThat(
+                    authorizer.authorizeAttachment(
+                        attachment.muutosilmoitusId,
+                        attachment.id!!,
+                        VIEW.name,
+                    )
+                )
+                .isTrue()
+        }
+
+        @Test
+        fun `throws error if enum value not found`() {
+            val muutosilmoitus = muutosilmoitusFactory.builder().saveEntity()
+            assertFailure {
+                    authorizer.authorizeAttachment(muutosilmoitus.id, attachmentId, "Not real")
+                }
+                .all {
+                    hasClass(IllegalArgumentException::class)
+                    messageContains(
+                        "No enum constant fi.hel.haitaton.hanke.permissions.PermissionCode.Not real"
+                    )
+                }
         }
     }
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/ControllerExceptionHandler.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/ControllerExceptionHandler.kt
@@ -4,6 +4,7 @@ import fi.hel.haitaton.hanke.attachment.application.ApplicationInAlluException
 import fi.hel.haitaton.hanke.attachment.common.AttachmentInvalidException
 import fi.hel.haitaton.hanke.attachment.common.AttachmentLimitReachedException
 import fi.hel.haitaton.hanke.attachment.common.AttachmentNotFoundException
+import fi.hel.haitaton.hanke.attachment.common.ValtakirjaForbiddenException
 import fi.hel.haitaton.hanke.geometria.GeometriaValidationException
 import fi.hel.haitaton.hanke.geometria.UnsupportedCoordinateSystemException
 import fi.hel.haitaton.hanke.hakemus.HakemusAlreadyProcessingException
@@ -231,6 +232,14 @@ class ControllerExceptionHandler {
         logger.warn { ex.message }
         Sentry.captureException(ex)
         return HankeError.HAI3003
+    }
+
+    @ExceptionHandler(ValtakirjaForbiddenException::class)
+    @ResponseStatus(HttpStatus.FORBIDDEN)
+    @Hidden
+    fun valtakirjaForbiddenException(ex: ValtakirjaForbiddenException): HankeError {
+        logger.warn(ex) { ex.message }
+        return HankeError.HAI3004
     }
 
     @ExceptionHandler(MuutosilmoitusAlreadySentException::class)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentService.kt
@@ -2,7 +2,6 @@ package fi.hel.haitaton.hanke.attachment.hanke
 
 import fi.hel.haitaton.hanke.HankeIdentifier
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType
-import fi.hel.haitaton.hanke.attachment.common.AttachmentContent
 import fi.hel.haitaton.hanke.attachment.common.AttachmentService
 import fi.hel.haitaton.hanke.attachment.common.AttachmentValidator
 import fi.hel.haitaton.hanke.attachment.common.FileScanClient
@@ -25,12 +24,6 @@ class HankeAttachmentService(
 ) : AttachmentService<HankeIdentifier, HankeAttachmentMetadata> {
 
     fun getMetadataList(hankeTunnus: String) = metadataService.getMetadataList(hankeTunnus)
-
-    fun getContent(attachmentId: UUID): AttachmentContent {
-        val attachment = metadataService.findAttachment(attachmentId)
-        val content = contentService.find(attachment)
-        return AttachmentContent(attachment.fileName, attachment.contentType, content)
-    }
 
     fun uploadHankeAttachment(
         hankeTunnus: String,
@@ -59,6 +52,12 @@ class HankeAttachmentService(
         metadataService.deleteAllByHanke(hanke.id)
         logger.info { "Deleted all attachments from hanke ${hanke.logString()}" }
     }
+
+    override fun findMetadata(attachmentId: UUID): HankeAttachmentMetadata =
+        metadataService.findAttachment(attachmentId)
+
+    override fun findContent(attachment: HankeAttachmentMetadata): ByteArray =
+        contentService.find(attachment)
 
     override fun upload(
         filename: String,

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/muutosilmoitus/MuutosilmoitusAttachmentController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/muutosilmoitus/MuutosilmoitusAttachmentController.kt
@@ -2,6 +2,7 @@ package fi.hel.haitaton.hanke.attachment.muutosilmoitus
 
 import fi.hel.haitaton.hanke.HankeError
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType
+import fi.hel.haitaton.hanke.attachment.common.HeadersBuilder.buildHeaders
 import fi.hel.haitaton.hanke.muutosilmoitus.MuutosilmoitusNotFoundException
 import io.swagger.v3.oas.annotations.Hidden
 import io.swagger.v3.oas.annotations.Operation
@@ -14,8 +15,10 @@ import java.util.UUID
 import mu.KotlinLogging
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
@@ -32,6 +35,46 @@ private val logger = KotlinLogging.logger {}
 class MuutosilmoitusAttachmentController(
     private val attachmentService: MuutosilmoitusAttachmentService
 ) {
+    @GetMapping("/{attachmentId}/content")
+    @Operation(
+        summary = "Download attachment file",
+        description =
+            """
+               Download the content for the given attachment.
+
+               If the attachment is a power of attorney (valtakirja), it can't
+               be downloaded because of privacy concerns.
+            """,
+    )
+    @ApiResponses(
+        value =
+            [
+                ApiResponse(description = "Attachment file", responseCode = "200"),
+                ApiResponse(
+                    description = "Attachment not found",
+                    responseCode = "404",
+                    content = [Content(schema = Schema(implementation = HankeError::class))],
+                ),
+                ApiResponse(
+                    description = "Attachment is valtakirja",
+                    responseCode = "403",
+                    content = [Content(schema = Schema(implementation = HankeError::class))],
+                ),
+            ]
+    )
+    @PreAuthorize(
+        "@muutosilmoitusAuthorizer.authorizeAttachment(#muutosilmoitusId, #attachmentId, 'VIEW')"
+    )
+    fun getApplicationAttachmentContent(
+        @PathVariable muutosilmoitusId: UUID,
+        @PathVariable attachmentId: UUID,
+    ): ResponseEntity<ByteArray> {
+        val content = attachmentService.getContent(attachmentId)
+
+        return ResponseEntity.ok()
+            .headers(buildHeaders(content.fileName, content.contentType))
+            .body(content.bytes)
+    }
 
     @PostMapping(consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
     @Operation(summary = "Upload attachment for muutosilmoitus", description = "Upload attachment.")
@@ -47,6 +90,11 @@ class MuutosilmoitusAttachmentController(
                 ApiResponse(
                     description = "Attachment invalid",
                     responseCode = "400",
+                    content = [Content(schema = Schema(implementation = HankeError::class))],
+                ),
+                ApiResponse(
+                    description = "Muutosilmoitus has been sent",
+                    responseCode = "409",
                     content = [Content(schema = Schema(implementation = HankeError::class))],
                 ),
             ]

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/muutosilmoitus/MuutosilmoitusAttachmentMetadataService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/muutosilmoitus/MuutosilmoitusAttachmentMetadataService.kt
@@ -4,11 +4,13 @@ import fi.hel.haitaton.hanke.ALLOWED_ATTACHMENT_COUNT
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentRepository
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType
 import fi.hel.haitaton.hanke.attachment.common.AttachmentLimitReachedException
+import fi.hel.haitaton.hanke.attachment.common.AttachmentNotFoundException
 import fi.hel.haitaton.hanke.currentUserId
 import fi.hel.haitaton.hanke.muutosilmoitus.MuutosilmoitusIdentifier
 import java.time.OffsetDateTime
 import java.util.UUID
 import mu.KotlinLogging
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -19,6 +21,12 @@ class MuutosilmoitusAttachmentMetadataService(
     private val attachmentRepository: MuutosilmoitusAttachmentRepository,
     private val hakemusAttachmentRepository: ApplicationAttachmentRepository,
 ) {
+
+    @Transactional(readOnly = true)
+    fun findAttachment(attachmentId: UUID): MuutosilmoitusAttachmentMetadata =
+        attachmentRepository.findByIdOrNull(attachmentId)?.toDomain()
+            ?: throw AttachmentNotFoundException(attachmentId)
+
     @Transactional
     fun create(
         filename: String,

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/muutosilmoitus/MuutosilmoitusAttachmentService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/muutosilmoitus/MuutosilmoitusAttachmentService.kt
@@ -60,6 +60,12 @@ class MuutosilmoitusAttachmentService(
         muutosilmoitusRepository.findByIdOrNull(muutosilmoitusId)
             ?: throw MuutosilmoitusNotFoundException(muutosilmoitusId)
 
+    override fun findMetadata(attachmentId: UUID): MuutosilmoitusAttachmentMetadata =
+        metadataService.findAttachment(attachmentId)
+
+    override fun findContent(attachment: MuutosilmoitusAttachmentMetadata): ByteArray =
+        contentService.find(attachment.blobLocation, attachment.id)
+
     override fun upload(
         filename: String,
         contentType: MediaType,

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/MuutosilmoitusAttachmentFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/MuutosilmoitusAttachmentFactory.kt
@@ -1,23 +1,75 @@
 package fi.hel.haitaton.hanke.factory
 
 import fi.hel.haitaton.hanke.attachment.DEFAULT_SIZE
+import fi.hel.haitaton.hanke.attachment.FILE_NAME_PDF
+import fi.hel.haitaton.hanke.attachment.PDF_BYTES
 import fi.hel.haitaton.hanke.attachment.application.ApplicationAttachmentContentService.Companion.generateBlobPath
+import fi.hel.haitaton.hanke.attachment.azure.Container
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType.MUU
+import fi.hel.haitaton.hanke.attachment.common.FileClient
 import fi.hel.haitaton.hanke.attachment.muutosilmoitus.MuutosilmoitusAttachmentEntity
 import fi.hel.haitaton.hanke.attachment.muutosilmoitus.MuutosilmoitusAttachmentMetadata
+import fi.hel.haitaton.hanke.attachment.muutosilmoitus.MuutosilmoitusAttachmentRepository
 import fi.hel.haitaton.hanke.factory.MuutosilmoitusFactory.Companion.DEFAULT_ID
+import fi.hel.haitaton.hanke.muutosilmoitus.Muutosilmoitus
 import fi.hel.haitaton.hanke.test.USERNAME
 import java.time.OffsetDateTime
 import java.util.UUID
+import org.springframework.http.MediaType
 import org.springframework.http.MediaType.APPLICATION_PDF_VALUE
 import org.springframework.stereotype.Component
 
 @Component
-class MuutosilmoitusAttachmentFactory {
+class MuutosilmoitusAttachmentFactory(
+    private val attachmentRepository: MuutosilmoitusAttachmentRepository,
+    private val muutosilmoitusFactory: MuutosilmoitusFactory,
+    private val fileClient: FileClient,
+) {
+    fun save(
+        id: UUID? = null,
+        fileName: String = FILE_NAME_PDF,
+        contentType: MediaType = MEDIA_TYPE,
+        size: Long = DEFAULT_SIZE,
+        createdByUser: String = USERNAME,
+        createdAt: OffsetDateTime = CREATED_AT,
+        attachmentType: ApplicationAttachmentType = MUU,
+        muutosilmoitus: Muutosilmoitus = muutosilmoitusFactory.builder().saveEntity().toDomain(),
+        content: ByteArray? = PDF_BYTES,
+    ): MuutosilmoitusAttachmentEntity {
+        val entity =
+            createEntity(
+                id,
+                fileName,
+                contentType.toString(),
+                size,
+                createdByUser,
+                createdAt,
+                attachmentType,
+                muutosilmoitus.hakemusId,
+                muutosilmoitus.id,
+            )
+
+        if (content != null) {
+            entity.size = content.size.toLong()
+            saveContentToCloud(entity.blobLocation, fileName, contentType, content)
+        }
+
+        return attachmentRepository.save(entity)
+    }
+
+    fun saveContentToCloud(
+        path: String,
+        filename: String = FILE_NAME_PDF,
+        mediaType: MediaType = HankeAttachmentFactory.MEDIA_TYPE,
+        bytes: ByteArray = PDF_BYTES,
+    ) {
+        fileClient.upload(Container.HAKEMUS_LIITTEET, path, filename, mediaType, bytes)
+    }
 
     companion object {
         val DEFAULT_ATTACHMENT_ID: UUID = UUID.fromString("5cba3a76-28ad-42aa-b7e6-b5c1775be81a")
+        val MEDIA_TYPE = MediaType.APPLICATION_PDF
         val CREATED_AT: OffsetDateTime = OffsetDateTime.parse("2023-11-09T08:03:55Z")
 
         const val FILE_NAME = "file.pdf"


### PR DESCRIPTION
# Description

Add an API for downloading muutosilmoitus attachments. The download is refused if the attachment is a power of attorney (valtakirja).

Add missing descriptions about the valtakirja case also to application and täydennys attachment API documentations.

Also, merge the `getContent` methods for all attachment services. They were all identical, except hanke was missing the valtakirja check.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-3413

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
With a muutosilmoitus that has an attachment:
1. Check the database `muutosilmoituksen_liite` table to see the attachment ID and muutosilmoitus ID.
2. Call the [Swagger UI](http://localhost:3001/api/swagger-ui/index.html#/muutosilmoitus-attachment-controller/getApplicationAttachmentContent_1) to download the attachment.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 