### PR TITLE
HAI-3414 Delete attachment API for muutosilmoitus

### DIFF
--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/common/Domain.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/common/Domain.kt
@@ -12,7 +12,7 @@ interface AttachmentMetadata {
     val size: Long
     val createdByUserId: String
     val createdAt: OffsetDateTime
-    val blobLocation: String?
+    val blobLocation: String
 }
 
 interface AttachmentMetadataWithType : AttachmentMetadata {

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentController.kt
@@ -128,6 +128,7 @@ class HankeAttachmentController(private val hankeAttachmentService: HankeAttachm
             "@hankeAttachmentAuthorizer.authorizeAttachment(#hankeTunnus,#attachmentId,'EDIT')"
     )
     fun deleteAttachment(@PathVariable hankeTunnus: String, @PathVariable attachmentId: UUID) {
+        logger.info { "Deleting attachment $attachmentId from hanke $hankeTunnus." }
         hankeAttachmentService.deleteAttachment(attachmentId)
         logger.info { "Deleted hanke attachment $attachmentId" }
     }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/hanke/HankeAttachmentService.kt
@@ -39,13 +39,6 @@ class HankeAttachmentService(
         return saveAttachment(hanke, attachment.bytes, filename, mediatype).toDto()
     }
 
-    fun deleteAttachment(attachmentId: UUID) {
-        logger.info { "Deleting hanke attachment $attachmentId..." }
-        val attachmentToDelete = metadataService.findAttachment(attachmentId)
-        contentService.delete(attachmentToDelete)
-        metadataService.delete(attachmentId)
-    }
-
     fun deleteAllAttachments(hanke: HankeIdentifier) {
         logger.info { "Deleting all attachments from hanke ${hanke.logString()}" }
         contentService.deleteAllForHanke(hanke.id)
@@ -82,5 +75,7 @@ class HankeAttachmentService(
     ): HankeAttachmentMetadata =
         metadataService.saveAttachment(entity.hankeTunnus, filename, contentType, size, blobPath)
 
-    override fun delete(blobPath: String) = contentService.delete(blobPath)
+    override fun deleteMetadata(attachmentId: UUID) = metadataService.delete(attachmentId)
+
+    override fun deleteContent(blobPath: String) = contentService.delete(blobPath)
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/muutosilmoitus/MuutosilmoitusAttachmentMetadataService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/muutosilmoitus/MuutosilmoitusAttachmentMetadataService.kt
@@ -65,6 +65,12 @@ class MuutosilmoitusAttachmentMetadataService(
         }
     }
 
+    @Transactional
+    fun deleteAttachmentById(attachmentId: UUID) {
+        attachmentRepository.deleteById(attachmentId)
+        logger.info { "Deleted attachment metadata $attachmentId" }
+    }
+
     private fun attachmentAmountReached(entity: MuutosilmoitusIdentifier): Boolean {
         val hakemusAttachmentCount =
             hakemusAttachmentRepository.countByApplicationId(entity.hakemusId)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/taydennys/TaydennysAttachmentService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/taydennys/TaydennysAttachmentService.kt
@@ -58,15 +58,6 @@ class TaydennysAttachmentService(
         taydennysRepository.findByIdOrNull(taydennysId)
             ?: throw TaydennysNotFoundException(taydennysId)
 
-    fun deleteAttachment(attachmentId: UUID) {
-        val attachment = metadataService.findAttachment(attachmentId)
-        logger.info { "Deleting attachment metadata ${attachment.id}" }
-        metadataService.deleteAttachmentById(attachment.id)
-        logger.info { "Deleting attachment content at ${attachment.blobLocation}" }
-        contentService.delete(attachment.blobLocation)
-        logger.info { "Deleted attachment $attachmentId from täydennys ${attachment.taydennysId}" }
-    }
-
     fun deleteAllAttachments(taydennys: TaydennysIdentifier) {
         logger.info { "Deleting all attachments from täydennys. ${taydennys.logString()}" }
         val paths = metadataService.deleteAllAttachments(taydennys)
@@ -103,5 +94,8 @@ class TaydennysAttachmentService(
     ): TaydennysAttachmentMetadata =
         metadataService.create(filename, contentType, size, blobPath, attachmentType!!, entity.id)
 
-    override fun delete(blobPath: String): Boolean = contentService.delete(blobPath)
+    override fun deleteMetadata(attachmentId: UUID) =
+        metadataService.deleteAttachmentById(attachmentId)
+
+    override fun deleteContent(blobPath: String): Boolean = contentService.delete(blobPath)
 }


### PR DESCRIPTION
# Description

Add an API for deleting attachments from muutosilmoitus.

Also, combine the delete methods of the attachment services, there's not much shared code, but the wrapper methods were mostly already there, so it didn't require much. Having the same amount of logging between different types of attachments is good, at least.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-3414

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
With an unsent muutosilmoitus that has an attachment:
1. Check the database muutosilmoituksen_liite table to see the attachment ID and muutosilmoitus ID.
2. Call the [Swagger UI](http://localhost:3001/api/swagger-ui/index.html#/muutosilmoitus-attachment-controller/removeAttachment).
3. The attachment should no longer be in the DB or Azure Storage Manager.

With a sent muutosilmoitus that has an attachment (add the attachment before sending it):
1. Check the database muutosilmoituksen_liite table to see the attachment ID and muutosilmoitus ID.
2. Call the [Swagger UI](http://localhost:3001/api/swagger-ui/index.html#/muutosilmoitus-attachment-controller/removeAttachment).
3. You should get a 409 error.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 