### PR TITLE
HAI-3415 Add attachments for muutosilmoitus to hakemus response

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusControllerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusControllerITest.kt
@@ -34,6 +34,7 @@ import fi.hel.haitaton.hanke.factory.HakemusUpdateRequestFactory.withRegistryKey
 import fi.hel.haitaton.hanke.factory.HakemusUpdateRequestFactory.withTimes
 import fi.hel.haitaton.hanke.factory.HakemusUpdateRequestFactory.withWorkDescription
 import fi.hel.haitaton.hanke.factory.HankeFactory
+import fi.hel.haitaton.hanke.factory.MuutosilmoitusAttachmentFactory
 import fi.hel.haitaton.hanke.factory.MuutosilmoitusFactory
 import fi.hel.haitaton.hanke.factory.MuutosilmoitusFactory.Companion.withExtras
 import fi.hel.haitaton.hanke.factory.PaatosFactory
@@ -46,6 +47,7 @@ import fi.hel.haitaton.hanke.geometria.GeometriatDao
 import fi.hel.haitaton.hanke.getResourceAsBytes
 import fi.hel.haitaton.hanke.hankeError
 import fi.hel.haitaton.hanke.logging.DisclosureLogService
+import fi.hel.haitaton.hanke.muutosilmoitus.MuutosilmoitusWithExtras
 import fi.hel.haitaton.hanke.paatos.PaatosTila.KORVATTU
 import fi.hel.haitaton.hanke.paatos.PaatosTila.NYKYINEN
 import fi.hel.haitaton.hanke.paatos.PaatosTyyppi.PAATOS
@@ -459,6 +461,47 @@ class HakemusControllerITest(@Autowired override val mockMvc: MockMvc) : Control
                 .andExpect(jsonPath("muutosilmoitus").exists())
                 .andExpect(jsonPath("muutosilmoitus.muutokset[0]").value(muutokset[0]))
                 .andExpect(jsonPath("muutosilmoitus.muutokset[1]").value(muutokset[1]))
+
+            verifySequence {
+                authorizer.authorizeHakemusId(id, PermissionCode.VIEW.name)
+                hakemusService.getWithExtras(id)
+                disclosureLogService.saveForHakemusResponse(any(), USERNAME)
+                disclosureLogService.saveForMuutosilmoitus(
+                    muutosilmoitus.toResponse().muutosilmoitus,
+                    USERNAME,
+                )
+            }
+        }
+
+        @ParameterizedTest
+        @EnumSource(ApplicationType::class)
+        fun `returns muutosilmoitus liitteet with hakemus`(applicationType: ApplicationType) {
+            val hakemus =
+                HakemusFactory.create(
+                    id = id,
+                    applicationType = applicationType,
+                    hankeTunnus = HANKE_TUNNUS,
+                )
+            val liitteet =
+                listOf(
+                    MuutosilmoitusAttachmentFactory.create(fileName = "First"),
+                    MuutosilmoitusAttachmentFactory.create(fileName = "Second"),
+                )
+            val muutosilmoitus: MuutosilmoitusWithExtras =
+                MuutosilmoitusFactory.create(
+                        hakemusId = hakemus.id,
+                        hakemusData = hakemus.applicationData,
+                    )
+                    .withExtras(liitteet = liitteet)
+            every { hakemusService.getWithExtras(id) } returns
+                hakemus.withExtras(muutosilmoitus = muutosilmoitus)
+            every { authorizer.authorizeHakemusId(id, PermissionCode.VIEW.name) } returns true
+
+            get(url)
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("muutosilmoitus").exists())
+                .andExpect(jsonPath("muutosilmoitus.liitteet[0].fileName").value("First"))
+                .andExpect(jsonPath("muutosilmoitus.liitteet[1].fileName").value("Second"))
 
             verifySequence {
                 authorizer.authorizeHakemusId(id, PermissionCode.VIEW.name)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/muutosilmoitus/MuutosilmoitusAttachmentMetadataService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/muutosilmoitus/MuutosilmoitusAttachmentMetadataService.kt
@@ -21,6 +21,9 @@ class MuutosilmoitusAttachmentMetadataService(
     private val attachmentRepository: MuutosilmoitusAttachmentRepository,
     private val hakemusAttachmentRepository: ApplicationAttachmentRepository,
 ) {
+    @Transactional(readOnly = true)
+    fun getMetadataList(muutosilmoitusId: UUID): List<MuutosilmoitusAttachmentMetadata> =
+        attachmentRepository.findByMuutosilmoitusId(muutosilmoitusId).map { it.toDomain() }
 
     @Transactional(readOnly = true)
     fun findAttachment(attachmentId: UUID): MuutosilmoitusAttachmentMetadata =

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/muutosilmoitus/MuutosilmoitusAttachmentRepository.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/muutosilmoitus/MuutosilmoitusAttachmentRepository.kt
@@ -7,4 +7,6 @@ import org.springframework.stereotype.Repository
 @Repository
 interface MuutosilmoitusAttachmentRepository : JpaRepository<MuutosilmoitusAttachmentEntity, UUID> {
     fun countByMuutosilmoitusId(muutosilmoitusId: UUID): Int
+
+    fun findByMuutosilmoitusId(muutosilmoitusId: UUID): List<MuutosilmoitusAttachmentEntity>
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
@@ -14,6 +14,7 @@ import fi.hel.haitaton.hanke.allu.CustomerType
 import fi.hel.haitaton.hanke.attachment.application.ApplicationAttachmentService
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentMetadata
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType
+import fi.hel.haitaton.hanke.attachment.muutosilmoitus.MuutosilmoitusAttachmentMetadataService
 import fi.hel.haitaton.hanke.attachment.taydennys.TaydennysAttachmentMetadataService
 import fi.hel.haitaton.hanke.daysBetween
 import fi.hel.haitaton.hanke.domain.Hankevaihe
@@ -79,6 +80,7 @@ class HakemusService(
     private val disclosureLogService: DisclosureLogService,
     private val hankeKayttajaService: HankeKayttajaService,
     private val attachmentService: ApplicationAttachmentService,
+    private val muutosilmoitusAttachmentService: MuutosilmoitusAttachmentMetadataService,
     private val taydennysAttachmentService: TaydennysAttachmentMetadataService,
     private val alluClient: AlluClient,
     private val paatosService: PaatosService,
@@ -101,10 +103,10 @@ class HakemusService(
                 it.toDomain().withExtras(hakemus.applicationData, liitteet)
             }
         val muutosilmoitus =
-            muutosilmoitusRepository
-                .findByHakemusId(hakemusId)
-                ?.toDomain()
-                ?.withExtras(hakemus.applicationData)
+            muutosilmoitusRepository.findByHakemusId(hakemusId)?.let {
+                val liitteet = muutosilmoitusAttachmentService.getMetadataList(it.id)
+                it.toDomain().withExtras(hakemus.applicationData, liitteet)
+            }
 
         return HakemusWithExtras(hakemus, paatokset, taydennyspyynto, taydennys, muutosilmoitus)
     }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/muutosilmoitus/Muutosilmoitus.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/muutosilmoitus/Muutosilmoitus.kt
@@ -1,5 +1,6 @@
 package fi.hel.haitaton.hanke.muutosilmoitus
 
+import fi.hel.haitaton.hanke.attachment.muutosilmoitus.MuutosilmoitusAttachmentMetadata
 import fi.hel.haitaton.hanke.hakemus.HakemusData
 import java.time.OffsetDateTime
 import java.util.UUID
@@ -12,13 +13,17 @@ data class Muutosilmoitus(
 ) : MuutosilmoitusIdentifier {
     fun toResponse() = MuutosilmoitusResponse(id, sent, hakemusData.toResponse())
 
-    fun withExtras(otherData: HakemusData): MuutosilmoitusWithExtras {
+    fun withExtras(
+        otherData: HakemusData,
+        liitteet: List<MuutosilmoitusAttachmentMetadata>,
+    ): MuutosilmoitusWithExtras {
         return MuutosilmoitusWithExtras(
             id = id,
             hakemusId = hakemusId,
             sent = sent,
             hakemusData = hakemusData,
             muutokset = hakemusData.listChanges(otherData),
+            liitteet = liitteet,
         )
     }
 }
@@ -29,7 +34,8 @@ data class MuutosilmoitusWithExtras(
     val sent: OffsetDateTime?,
     val hakemusData: HakemusData,
     val muutokset: List<String>,
+    val liitteet: List<MuutosilmoitusAttachmentMetadata>,
 ) : MuutosilmoitusIdentifier {
     fun toResponse() =
-        MuutosilmoitusResponse(id, sent, hakemusData.toResponse()).withExtras(muutokset)
+        MuutosilmoitusResponse(id, sent, hakemusData.toResponse()).withExtras(muutokset, liitteet)
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/muutosilmoitus/MuutosilmoitusResponse.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/muutosilmoitus/MuutosilmoitusResponse.kt
@@ -2,6 +2,8 @@ package fi.hel.haitaton.hanke.muutosilmoitus
 
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonUnwrapped
+import fi.hel.haitaton.hanke.attachment.muutosilmoitus.MuutosilmoitusAttachmentMetadata
+import fi.hel.haitaton.hanke.attachment.muutosilmoitus.MuutosilmoitusAttachmentMetadataDto
 import fi.hel.haitaton.hanke.domain.HasId
 import fi.hel.haitaton.hanke.hakemus.HakemusDataResponse
 import java.time.OffsetDateTime
@@ -12,11 +14,15 @@ data class MuutosilmoitusResponse(
     val sent: OffsetDateTime?,
     val applicationData: HakemusDataResponse,
 ) : HasId<UUID> {
-    fun withExtras(muutokset: List<String>): MuutosilmoitusWithExtrasResponse =
-        MuutosilmoitusWithExtrasResponse(this, muutokset)
+    fun withExtras(
+        muutokset: List<String>,
+        liitteet: List<MuutosilmoitusAttachmentMetadata>,
+    ): MuutosilmoitusWithExtrasResponse =
+        MuutosilmoitusWithExtrasResponse(this, muutokset, liitteet.map { it.toDto() })
 }
 
 data class MuutosilmoitusWithExtrasResponse(
     @JsonUnwrapped val muutosilmoitus: MuutosilmoitusResponse,
     @JsonInclude(JsonInclude.Include.NON_NULL) val muutokset: List<String>?,
+    val liitteet: List<MuutosilmoitusAttachmentMetadataDto>,
 )

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/MuutosilmoitusFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/MuutosilmoitusFactory.kt
@@ -2,6 +2,7 @@ package fi.hel.haitaton.hanke.factory
 
 import fi.hel.haitaton.hanke.allu.ApplicationStatus
 import fi.hel.haitaton.hanke.allu.CustomerType
+import fi.hel.haitaton.hanke.attachment.muutosilmoitus.MuutosilmoitusAttachmentMetadata
 import fi.hel.haitaton.hanke.hakemus.ApplicationContactType
 import fi.hel.haitaton.hanke.hakemus.ApplicationType
 import fi.hel.haitaton.hanke.hakemus.HakemusData
@@ -141,8 +142,10 @@ class MuutosilmoitusFactory(
         fun Muutosilmoitus.toUpdateRequest(): HakemusUpdateRequest =
             this.toResponse().applicationData.toJsonString().parseJson()
 
-        fun Muutosilmoitus.withExtras(muutokset: List<String> = listOf()) =
-            MuutosilmoitusWithExtras(id, hakemusId, sent, hakemusData, muutokset)
+        fun Muutosilmoitus.withExtras(
+            muutokset: List<String> = listOf(),
+            liitteet: List<MuutosilmoitusAttachmentMetadata> = listOf(),
+        ) = MuutosilmoitusWithExtras(id, hakemusId, sent, hakemusData, muutokset, liitteet)
 
         fun createYhteyshenkiloEntity(
             hankeId: Int,

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceTest.kt
@@ -22,6 +22,7 @@ import fi.hel.haitaton.hanke.allu.Contact
 import fi.hel.haitaton.hanke.allu.Customer
 import fi.hel.haitaton.hanke.allu.CustomerWithContacts
 import fi.hel.haitaton.hanke.attachment.application.ApplicationAttachmentService
+import fi.hel.haitaton.hanke.attachment.muutosilmoitus.MuutosilmoitusAttachmentMetadataService
 import fi.hel.haitaton.hanke.attachment.taydennys.TaydennysAttachmentMetadataService
 import fi.hel.haitaton.hanke.factory.AlluFactory
 import fi.hel.haitaton.hanke.factory.ApplicationFactory
@@ -84,6 +85,7 @@ class HakemusServiceTest {
     private val disclosureLogService: DisclosureLogService = mockk(relaxUnitFun = true)
     private val hankeKayttajaService: HankeKayttajaService = mockk(relaxUnitFun = true)
     private val attachmentService: ApplicationAttachmentService = mockk()
+    private val muutosilmoitusAttachmentService: MuutosilmoitusAttachmentMetadataService = mockk()
     private val taydennysAttachmentService: TaydennysAttachmentMetadataService = mockk()
     private val alluClient: AlluClient = mockk()
     private val paatosService: PaatosService = mockk()
@@ -106,6 +108,7 @@ class HakemusServiceTest {
             disclosureLogService,
             hankeKayttajaService,
             attachmentService,
+            muutosilmoitusAttachmentService,
             taydennysAttachmentService,
             alluClient,
             paatosService,


### PR DESCRIPTION
# Description

Add attachments for muutosilmoitus to hakemus response. 

### Jira Issue: 

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [ ] Other

# Instructions for testing
With a muutosilmoitus that has attachments, see the response from the network tab when opening the hakemus page. There should be `liitteet` under `muutosilmoitus`.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 