### PR TITLE
HAI-3416 Delete attachments when muutosilmoitus is cancelled

### DIFF
--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/muutosilmoitus/MuutosilmoitusAttachmentMetadataService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/muutosilmoitus/MuutosilmoitusAttachmentMetadataService.kt
@@ -74,6 +74,22 @@ class MuutosilmoitusAttachmentMetadataService(
         logger.info { "Deleted attachment metadata $attachmentId" }
     }
 
+    /**
+     * Delete all attachments for muutosilmoitus and return the blob locations of the deleted
+     * attachments.
+     */
+    @Transactional
+    fun deleteAllAttachments(muutosilmoitus: MuutosilmoitusIdentifier): List<String> {
+        return attachmentRepository
+            .deleteByMuutosilmoitusId(muutosilmoitus.id)
+            .map(MuutosilmoitusAttachmentEntity::blobLocation)
+            .also {
+                logger.info {
+                    "Deleted all attachment metadata for muutosilmoitus ${muutosilmoitus.logString()}"
+                }
+            }
+    }
+
     private fun attachmentAmountReached(entity: MuutosilmoitusIdentifier): Boolean {
         val hakemusAttachmentCount =
             hakemusAttachmentRepository.countByApplicationId(entity.hakemusId)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/muutosilmoitus/MuutosilmoitusAttachmentRepository.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/muutosilmoitus/MuutosilmoitusAttachmentRepository.kt
@@ -8,5 +8,7 @@ import org.springframework.stereotype.Repository
 interface MuutosilmoitusAttachmentRepository : JpaRepository<MuutosilmoitusAttachmentEntity, UUID> {
     fun countByMuutosilmoitusId(muutosilmoitusId: UUID): Int
 
+    fun deleteByMuutosilmoitusId(muutosilmoitusId: UUID): List<MuutosilmoitusAttachmentEntity>
+
     fun findByMuutosilmoitusId(muutosilmoitusId: UUID): List<MuutosilmoitusAttachmentEntity>
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/muutosilmoitus/MuutosilmoitusAttachmentService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/muutosilmoitus/MuutosilmoitusAttachmentService.kt
@@ -56,6 +56,21 @@ class MuutosilmoitusAttachmentService(
         return newAttachment
     }
 
+    fun deleteAllAttachments(muutosilmoitus: MuutosilmoitusIdentifier) {
+        logger.info {
+            "Deleting all attachments from muutosilmoitus. ${muutosilmoitus.logString()}"
+        }
+        val paths = metadataService.deleteAllAttachments(muutosilmoitus)
+        try {
+            paths.forEach(contentService::delete)
+        } catch (e: Exception) {
+            logger.error(e) {
+                "Failed to delete all attachment content for muutosilmoitus. Continuing with muutosilmoitus deletion regardless of error. ${muutosilmoitus.logString()}"
+            }
+        }
+        logger.info { "Deleted all attachments from muutosilmoitus. ${muutosilmoitus.logString()}" }
+    }
+
     private fun findMuutosilmoitus(muutosilmoitusId: UUID): MuutosilmoitusEntity =
         muutosilmoitusRepository.findByIdOrNull(muutosilmoitusId)
             ?: throw MuutosilmoitusNotFoundException(muutosilmoitusId)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/muutosilmoitus/MuutosilmoitusService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/muutosilmoitus/MuutosilmoitusService.kt
@@ -5,6 +5,7 @@ import fi.hel.haitaton.hanke.allu.AlluClient
 import fi.hel.haitaton.hanke.allu.ApplicationStatus
 import fi.hel.haitaton.hanke.allu.InformationRequestFieldKey
 import fi.hel.haitaton.hanke.attachment.application.ApplicationAttachmentService
+import fi.hel.haitaton.hanke.attachment.muutosilmoitus.MuutosilmoitusAttachmentService
 import fi.hel.haitaton.hanke.hakemus.ApplicationContactType
 import fi.hel.haitaton.hanke.hakemus.ApplicationType
 import fi.hel.haitaton.hanke.hakemus.CustomerWithContactsRequest
@@ -49,6 +50,7 @@ class MuutosilmoitusService(
     private val hakemusRepository: HakemusRepository,
     private val loggingService: MuutosilmoitusLoggingService,
     override val hakemusService: HakemusService,
+    private val attachmentService: MuutosilmoitusAttachmentService,
     override val hakemusAttachmentService: ApplicationAttachmentService,
     private val hankeKayttajaService: HankeKayttajaService,
     private val disclosureLogService: DisclosureLogService,
@@ -146,6 +148,7 @@ class MuutosilmoitusService(
             muutosilmoitusEntity,
         )
 
+        attachmentService.deleteAllAttachments(muutosilmoitusEntity)
         val muutosilmoitus = muutosilmoitusEntity.toDomain()
         muutosilmoitusRepository.delete(muutosilmoitusEntity)
         loggingService.logDelete(muutosilmoitus, currentUserId)


### PR DESCRIPTION
# Description

Delete all attachments added to a muutosilmoitus if it is cancelled (deleted). Don't stop if deleting the file from Blob Storage fails, the file will be deleted when the hakemus is eventually deleted.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-3416

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
1. Add an attachment to a muutosilmoitus.
2. Cancel the muutosilmoitus.
3. The attachment should be removed from DB and Azure Storage Manager.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 