### PR TITLE
HAI-3418 Move attachments to hakemus when muutosilmoitus is merged

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/muutosilmoitus/MuutosilmoitusAttachmentMetadataServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/muutosilmoitus/MuutosilmoitusAttachmentMetadataServiceITest.kt
@@ -1,0 +1,90 @@
+package fi.hel.haitaton.hanke.attachment.muutosilmoitus
+
+import assertk.all
+import assertk.assertThat
+import assertk.assertions.containsExactly
+import assertk.assertions.extracting
+import assertk.assertions.hasSize
+import assertk.assertions.isEmpty
+import assertk.assertions.isEqualTo
+import assertk.assertions.prop
+import assertk.assertions.single
+import fi.hel.haitaton.hanke.IntegrationTest
+import fi.hel.haitaton.hanke.attachment.PDF_BYTES
+import fi.hel.haitaton.hanke.attachment.application.ApplicationAttachmentContentService
+import fi.hel.haitaton.hanke.attachment.application.ApplicationAttachmentService
+import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentMetadata
+import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentRepository
+import fi.hel.haitaton.hanke.factory.MuutosilmoitusAttachmentFactory
+import fi.hel.haitaton.hanke.factory.MuutosilmoitusFactory
+import fi.hel.haitaton.hanke.hakemus.HakemusRepository
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+
+class MuutosilmoitusAttachmentMetadataServiceITest(
+    @Autowired
+    private val muutosilmoitusAttachmentMetadataService: MuutosilmoitusAttachmentMetadataService,
+    @Autowired private val muutosilmoitusAttachmentFactory: MuutosilmoitusAttachmentFactory,
+    @Autowired private val muutosilmoitusFactory: MuutosilmoitusFactory,
+    @Autowired private val muutosilmoitusAttachmentRepository: MuutosilmoitusAttachmentRepository,
+    @Autowired private val hakemusRepository: HakemusRepository,
+    @Autowired private val hakemusAttachmentRepository: ApplicationAttachmentRepository,
+    @Autowired private val hakemusAttachmentService: ApplicationAttachmentService,
+    @Autowired private val hakemusAttachmentContentService: ApplicationAttachmentContentService,
+) : IntegrationTest() {
+
+    @Test
+    fun `transfers attachment metadata from muutosilmoitus to hakemus`() {
+        val muutosilmoitus = muutosilmoitusFactory.builder().saveEntity()
+        val muutosilmoitusAttachments =
+            listOf(
+                muutosilmoitusAttachmentFactory
+                    .save(muutosilmoitus, fileName = "first.pdf")
+                    .toDomain(),
+                muutosilmoitusAttachmentFactory
+                    .save(muutosilmoitus, fileName = "second.pdf")
+                    .toDomain(),
+            )
+        val otherMuutosilmoitus = muutosilmoitusFactory.builder(alluId = 4144).save()
+        val otherAttachment =
+            muutosilmoitusAttachmentFactory.save(muutosilmoitus = otherMuutosilmoitus)
+        val hakemusEntity = hakemusRepository.getReferenceById(muutosilmoitus.hakemusId)
+        assertThat(hakemusAttachmentRepository.findAll()).isEmpty()
+        assertThat(muutosilmoitusAttachments)
+            .extracting { hakemusAttachmentContentService.find(it.blobLocation, it.id) }
+            .containsExactly(PDF_BYTES, PDF_BYTES)
+
+        muutosilmoitusAttachmentMetadataService.transferAttachmentsToHakemus(
+            muutosilmoitus,
+            hakemusEntity,
+        )
+
+        assertThat(muutosilmoitusAttachmentRepository.findAll())
+            .single()
+            .prop(MuutosilmoitusAttachmentEntity::id)
+            .isEqualTo(otherAttachment.id)
+        val hakemusAttachments = hakemusAttachmentService.getMetadataList(muutosilmoitus.hakemusId)
+        assertThat(hakemusAttachments).hasSize(muutosilmoitusAttachments.size)
+        muutosilmoitusAttachments.forEach { muutosilmoitusAttachment ->
+            val hakemusAttachment =
+                hakemusAttachments.single { it.fileName == muutosilmoitusAttachment.fileName }
+            assertThat(hakemusAttachment).all {
+                prop(ApplicationAttachmentMetadata::contentType)
+                    .isEqualTo(muutosilmoitusAttachment.contentType)
+                prop(ApplicationAttachmentMetadata::size).isEqualTo(muutosilmoitusAttachment.size)
+                prop(ApplicationAttachmentMetadata::blobLocation)
+                    .isEqualTo(muutosilmoitusAttachment.blobLocation)
+                prop(ApplicationAttachmentMetadata::createdByUserId)
+                    .isEqualTo(muutosilmoitusAttachment.createdByUserId)
+                prop(ApplicationAttachmentMetadata::createdAt)
+                    .isEqualTo(muutosilmoitusAttachment.createdAt)
+                prop(ApplicationAttachmentMetadata::applicationId).isEqualTo(hakemusEntity.id)
+                prop(ApplicationAttachmentMetadata::attachmentType)
+                    .isEqualTo(muutosilmoitusAttachment.attachmentType)
+            }
+        }
+        assertThat(muutosilmoitusAttachments)
+            .extracting { hakemusAttachmentContentService.find(it.blobLocation, it.id) }
+            .containsExactly(PDF_BYTES, PDF_BYTES)
+    }
+}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/muutosilmoitus/MuutosilmoitusAttachmentService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/muutosilmoitus/MuutosilmoitusAttachmentService.kt
@@ -5,6 +5,7 @@ import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType
 import fi.hel.haitaton.hanke.attachment.common.AttachmentService
 import fi.hel.haitaton.hanke.attachment.common.AttachmentValidator
 import fi.hel.haitaton.hanke.attachment.common.FileScanClient
+import fi.hel.haitaton.hanke.hakemus.HakemusEntity
 import fi.hel.haitaton.hanke.muutosilmoitus.MuutosilmoitusAlreadySentException
 import fi.hel.haitaton.hanke.muutosilmoitus.MuutosilmoitusEntity
 import fi.hel.haitaton.hanke.muutosilmoitus.MuutosilmoitusIdentifier
@@ -113,5 +114,9 @@ class MuutosilmoitusAttachmentService(
             }
             throw MuutosilmoitusAlreadySentException(muutosilmoitus)
         }
+    }
+
+    fun transferAttachmentsToHakemus(muutosilmoitus: MuutosilmoitusEntity, hakemus: HakemusEntity) {
+        metadataService.transferAttachmentsToHakemus(muutosilmoitus, hakemus)
     }
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/muutosilmoitus/MuutosilmoitusService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/muutosilmoitus/MuutosilmoitusService.kt
@@ -209,6 +209,7 @@ class MuutosilmoitusService(
         }
 
         mergeMuutosilmoitusToHakemus(muutosilmoitus, hakemus)
+        attachmentService.transferAttachmentsToHakemus(muutosilmoitus, hakemus)
 
         muutosilmoitusRepository.delete(muutosilmoitus)
         loggingService.logDeleteFromAllu(muutosilmoitus.toDomain())

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/MuutosilmoitusAttachmentFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/MuutosilmoitusAttachmentFactory.kt
@@ -13,6 +13,7 @@ import fi.hel.haitaton.hanke.attachment.muutosilmoitus.MuutosilmoitusAttachmentM
 import fi.hel.haitaton.hanke.attachment.muutosilmoitus.MuutosilmoitusAttachmentRepository
 import fi.hel.haitaton.hanke.factory.MuutosilmoitusFactory.Companion.DEFAULT_ID
 import fi.hel.haitaton.hanke.muutosilmoitus.Muutosilmoitus
+import fi.hel.haitaton.hanke.muutosilmoitus.MuutosilmoitusEntity
 import fi.hel.haitaton.hanke.test.USERNAME
 import java.time.OffsetDateTime
 import java.util.UUID
@@ -26,6 +27,29 @@ class MuutosilmoitusAttachmentFactory(
     private val muutosilmoitusFactory: MuutosilmoitusFactory,
     private val fileClient: FileClient,
 ) {
+    fun save(
+        muutosilmoitus: MuutosilmoitusEntity,
+        id: UUID? = null,
+        fileName: String = FILE_NAME_PDF,
+        contentType: MediaType = MEDIA_TYPE,
+        size: Long = DEFAULT_SIZE,
+        createdByUser: String = USERNAME,
+        createdAt: OffsetDateTime = CREATED_AT,
+        attachmentType: ApplicationAttachmentType = MUU,
+        content: ByteArray? = PDF_BYTES,
+    ) =
+        save(
+            id = id,
+            fileName = fileName,
+            contentType = contentType,
+            size = size,
+            createdByUser = createdByUser,
+            createdAt = createdAt,
+            attachmentType = attachmentType,
+            muutosilmoitus = muutosilmoitus.toDomain(),
+            content = content,
+        )
+
     fun save(
         id: UUID? = null,
         fileName: String = FILE_NAME_PDF,


### PR DESCRIPTION
# Description

Move attachments to hakemus when muutosilmoitus is merged.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-3418

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
1. Create a muutosilmoitus with some attachments.
2. Send it to Allu.
3. In Allu, create a decision or a täydennyspyyntö.
4. In Haitaton, the attachments should now be under the hakemus.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 