### PR TITLE
HAI-3419 Send muutosilmoitus attachments to Allu

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennysServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennysServiceITest.kt
@@ -29,6 +29,7 @@ import fi.hel.haitaton.hanke.attachment.application.ApplicationAttachmentContent
 import fi.hel.haitaton.hanke.attachment.azure.Container
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentMetadata
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentRepository
+import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType
 import fi.hel.haitaton.hanke.attachment.common.MockFileClient
 import fi.hel.haitaton.hanke.attachment.common.TaydennysAttachmentRepository
 import fi.hel.haitaton.hanke.domain.Haittojenhallintatyyppi
@@ -713,6 +714,26 @@ class TaydennysServiceITest(
             val taydennys = taydennysFactory.builder().save()
             val attachment =
                 attachmentFactory.save(taydennys = taydennys).withContent().value.toDomain()
+            val liikennejarjestely =
+                attachmentFactory
+                    .save(
+                        fileName = "liikennejärjestely.pdf",
+                        taydennys = taydennys,
+                        attachmentType = ApplicationAttachmentType.LIIKENNEJARJESTELY,
+                    )
+                    .withContent()
+                    .value
+                    .toDomain()
+            val valtakirja =
+                attachmentFactory
+                    .save(
+                        fileName = "valtakirja.pdf",
+                        taydennys = taydennys,
+                        attachmentType = ApplicationAttachmentType.VALTAKIRJA,
+                    )
+                    .withContent()
+                    .value
+                    .toDomain()
             val taydennyspyynto = taydennyspyyntoRepository.findAll().single()
             val hakemus = hakemusService.getById(taydennyspyynto.applicationId)
             val updatedTaydennysData = taydennysService.findTaydennys(hakemus.id)!!.hakemusData
@@ -725,6 +746,8 @@ class TaydennysServiceITest(
 
             verifySequence {
                 alluClient.addAttachment(any(), eq(attachment.toAlluAttachment(PDF_BYTES)))
+                alluClient.addAttachment(any(), eq(liikennejarjestely.toAlluAttachment(PDF_BYTES)))
+                alluClient.addAttachment(any(), eq(valtakirja.toAlluAttachment(PDF_BYTES)))
                 alluClient.respondToInformationRequest(
                     hakemus.alluid!!,
                     taydennyspyynto.alluId,

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentMetadataService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentMetadataService.kt
@@ -6,6 +6,7 @@ import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentMetadata
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentRepository
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType
 import fi.hel.haitaton.hanke.attachment.common.AttachmentLimitReachedException
+import fi.hel.haitaton.hanke.attachment.common.AttachmentMetadataWithType
 import fi.hel.haitaton.hanke.attachment.common.AttachmentNotFoundException
 import fi.hel.haitaton.hanke.currentUserId
 import fi.hel.haitaton.hanke.hakemus.HakemusIdentifier
@@ -58,6 +59,26 @@ class ApplicationAttachmentMetadataService(
         return attachmentRepository.save(entity).toDomain().also {
             logger.info { "Saved attachment metadata ${it.id} for application $applicationId" }
         }
+    }
+
+    @Transactional
+    fun create(
+        attachment: AttachmentMetadataWithType,
+        hakemusId: Long,
+    ): ApplicationAttachmentMetadata {
+        val hakemusAttachmentEntity =
+            ApplicationAttachmentEntity(
+                id = null,
+                fileName = attachment.fileName,
+                contentType = attachment.contentType,
+                size = attachment.size,
+                createdByUserId = attachment.createdByUserId,
+                createdAt = attachment.createdAt,
+                blobLocation = attachment.blobLocation,
+                applicationId = hakemusId,
+                attachmentType = attachment.attachmentType,
+            )
+        return attachmentRepository.save(hakemusAttachmentEntity).toDomain()
     }
 
     @Transactional

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/common/AttachmentService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/common/AttachmentService.kt
@@ -36,6 +36,10 @@ interface AttachmentService<E : Loggable, M : AttachmentMetadata> {
         // Do nothing by default.
     }
 
+    /**
+     * Download the content for serving it to the user. Downloading VALTAKIRJA attachments is
+     * forbidden.
+     */
     fun getContent(attachmentId: UUID): AttachmentContent {
         val attachment = findMetadata(attachmentId)
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/muutosilmoitus/MuutosilmoitusAttachmentService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/muutosilmoitus/MuutosilmoitusAttachmentService.kt
@@ -27,6 +27,8 @@ class MuutosilmoitusAttachmentService(
     private val contentService: ApplicationAttachmentContentService,
     private val scanClient: FileScanClient,
 ) : AttachmentService<MuutosilmoitusIdentifier, MuutosilmoitusAttachmentMetadata> {
+    fun getMetadataList(muutosilmoitusId: UUID): List<MuutosilmoitusAttachmentMetadata> =
+        metadataService.getMetadataList(muutosilmoitusId)
 
     fun addAttachment(
         muutosilmoitusId: UUID,
@@ -72,6 +74,10 @@ class MuutosilmoitusAttachmentService(
         logger.info { "Deleted all attachments from muutosilmoitus. ${muutosilmoitus.logString()}" }
     }
 
+    fun transferAttachmentsToHakemus(muutosilmoitus: MuutosilmoitusEntity, hakemus: HakemusEntity) {
+        metadataService.transferAttachmentsToHakemus(muutosilmoitus, hakemus)
+    }
+
     private fun findMuutosilmoitus(muutosilmoitusId: UUID): MuutosilmoitusEntity =
         muutosilmoitusRepository.findByIdOrNull(muutosilmoitusId)
             ?: throw MuutosilmoitusNotFoundException(muutosilmoitusId)
@@ -114,9 +120,5 @@ class MuutosilmoitusAttachmentService(
             }
             throw MuutosilmoitusAlreadySentException(muutosilmoitus)
         }
-    }
-
-    fun transferAttachmentsToHakemus(muutosilmoitus: MuutosilmoitusEntity, hakemus: HakemusEntity) {
-        metadataService.transferAttachmentsToHakemus(muutosilmoitus, hakemus)
     }
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/taydennys/TaydennysAttachmentMetadataService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/attachment/taydennys/TaydennysAttachmentMetadataService.kt
@@ -1,7 +1,7 @@
 package fi.hel.haitaton.hanke.attachment.taydennys
 
 import fi.hel.haitaton.hanke.ALLOWED_ATTACHMENT_COUNT
-import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentEntity
+import fi.hel.haitaton.hanke.attachment.application.ApplicationAttachmentMetadataService
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentRepository
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType
 import fi.hel.haitaton.hanke.attachment.common.AttachmentLimitReachedException
@@ -26,6 +26,7 @@ private val logger = KotlinLogging.logger {}
 class TaydennysAttachmentMetadataService(
     private val attachmentRepository: TaydennysAttachmentRepository,
     private val hakemusAttachmentRepository: ApplicationAttachmentRepository,
+    private val hakemusAttachmentService: ApplicationAttachmentMetadataService,
 ) {
     @Transactional(readOnly = true)
     fun getMetadataList(taydennysId: UUID): List<TaydennysAttachmentMetadata> =
@@ -111,19 +112,7 @@ class TaydennysAttachmentMetadataService(
         attachment: TaydennysAttachmentMetadata,
         hakemusEntity: HakemusEntity,
     ) {
-        val hakemusAttachmentEntity =
-            ApplicationAttachmentEntity(
-                id = null,
-                fileName = attachment.fileName,
-                contentType = attachment.contentType,
-                size = attachment.size,
-                createdByUserId = attachment.createdByUserId,
-                createdAt = attachment.createdAt,
-                blobLocation = attachment.blobLocation,
-                applicationId = hakemusEntity.id,
-                attachmentType = attachment.attachmentType,
-            )
-        hakemusAttachmentRepository.save(hakemusAttachmentEntity)
+        hakemusAttachmentService.create(attachment, hakemusEntity.id)
         attachmentRepository.deleteById(attachment.id)
     }
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
@@ -382,10 +382,10 @@ class HakemusService(
             .getMetadataList(kaivuilmoitus.id)
             .filter { it.attachmentType == ApplicationAttachmentType.MUU }
             .forEach { metadata ->
-                val content = attachmentService.getContent(metadata.id)
+                val content = attachmentService.findContent(metadata)
                 attachmentService.saveAttachment(
                     johtoselvityshakemusMetadata,
-                    content.bytes,
+                    content,
                     metadata.fileName,
                     MediaType.parseMediaType(metadata.contentType),
                     ApplicationAttachmentType.MUU,

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
@@ -12,8 +12,8 @@ import fi.hel.haitaton.hanke.allu.Attachment
 import fi.hel.haitaton.hanke.allu.AttachmentMetadata
 import fi.hel.haitaton.hanke.allu.CustomerType
 import fi.hel.haitaton.hanke.attachment.application.ApplicationAttachmentService
-import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentMetadata
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType
+import fi.hel.haitaton.hanke.attachment.common.AttachmentMetadataWithType
 import fi.hel.haitaton.hanke.attachment.muutosilmoitus.MuutosilmoitusAttachmentMetadataService
 import fi.hel.haitaton.hanke.attachment.taydennys.TaydennysAttachmentMetadataService
 import fi.hel.haitaton.hanke.daysBetween
@@ -701,7 +701,7 @@ class HakemusService(
 
     fun getApplicationDataAsPdf(
         hankeTunnus: String,
-        attachments: List<ApplicationAttachmentMetadata>,
+        attachments: List<AttachmentMetadataWithType>,
         data: HakemusData,
         filename: String,
         description: String,

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/muutosilmoitus/HasUploadFormDataPdf.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/muutosilmoitus/HasUploadFormDataPdf.kt
@@ -3,6 +3,7 @@ package fi.hel.haitaton.hanke.muutosilmoitus
 import fi.hel.haitaton.hanke.allu.AlluClient
 import fi.hel.haitaton.hanke.allu.Attachment
 import fi.hel.haitaton.hanke.attachment.application.ApplicationAttachmentService
+import fi.hel.haitaton.hanke.attachment.common.AttachmentMetadataWithType
 import fi.hel.haitaton.hanke.hakemus.HakemusData
 import fi.hel.haitaton.hanke.hakemus.HakemusIdentifier
 import fi.hel.haitaton.hanke.hakemus.HakemusService
@@ -25,8 +26,13 @@ interface HasUploadFormDataPdf {
 
     fun formDataDescription(now: LocalDateTime): String
 
-    fun uploadFormDataPdf(hakemus: HakemusIdentifier, hankeTunnus: String, data: HakemusData) {
-        val formAttachment = createPdfFromHakemusData(hakemus, hankeTunnus, data)
+    fun uploadFormDataPdf(
+        hakemus: HakemusIdentifier,
+        hankeTunnus: String,
+        data: HakemusData,
+        extraAttachments: List<AttachmentMetadataWithType> = listOf(),
+    ) {
+        val formAttachment = createPdfFromHakemusData(hakemus, hankeTunnus, data, extraAttachments)
         try {
             alluClient.addAttachment(hakemus.alluid!!, formAttachment)
         } catch (e: Exception) {
@@ -40,9 +46,10 @@ interface HasUploadFormDataPdf {
         hakemus: HakemusIdentifier,
         hankeTunnus: String,
         data: HakemusData,
+        extraAttachments: List<AttachmentMetadataWithType>,
     ): Attachment {
         logger.info { "Creating a PDF from the hakemus data for data attachment." }
-        val attachments = hakemusAttachmentService.getMetadataList(hakemus.id)
+        val attachments = hakemusAttachmentService.getMetadataList(hakemus.id) + extraAttachments
         return hakemusService.getApplicationDataAsPdf(
             hankeTunnus,
             attachments,

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/muutosilmoitus/MuutosilmoitusService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/muutosilmoitus/MuutosilmoitusService.kt
@@ -347,8 +347,8 @@ class MuutosilmoitusService(
         hakemus: HakemusIdentifier,
     ) {
         attachments.forEach { attachment ->
-            val content = attachmentService.getContent(attachment.id)
-            alluClient.addAttachment(hakemus.alluid!!, attachment.toAlluAttachment(content.bytes))
+            val content = attachmentService.findContent(attachment)
+            alluClient.addAttachment(hakemus.alluid!!, attachment.toAlluAttachment(content))
         }
     }
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/pdf/JohtoselvityshakemusPdfEncoder.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/pdf/JohtoselvityshakemusPdfEncoder.kt
@@ -1,7 +1,7 @@
 package fi.hel.haitaton.hanke.pdf
 
 import com.lowagie.text.Document
-import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentMetadata
+import fi.hel.haitaton.hanke.attachment.common.AttachmentMetadata
 import fi.hel.haitaton.hanke.hakemus.Hakemusyhteyshenkilo
 import fi.hel.haitaton.hanke.hakemus.JohtoselvityshakemusData
 
@@ -16,7 +16,7 @@ object JohtoselvityshakemusPdfEncoder {
         data: JohtoselvityshakemusData,
         totalArea: Float?,
         areas: List<Float?>,
-        attachments: List<ApplicationAttachmentMetadata>,
+        attachments: List<AttachmentMetadata>,
     ): ByteArray = createDocument { document, _ ->
         formatJohtoselvitysPdf(document, data, totalArea, areas, attachments)
     }
@@ -26,7 +26,7 @@ object JohtoselvityshakemusPdfEncoder {
         data: JohtoselvityshakemusData,
         totalArea: Float?,
         areas: List<Float?>,
-        attachments: List<ApplicationAttachmentMetadata>,
+        attachments: List<AttachmentMetadata>,
     ) {
 
         document.title("Johtoselvityshakemus")

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/pdf/KaivuilmoitusPdfEncoder.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/pdf/KaivuilmoitusPdfEncoder.kt
@@ -1,8 +1,8 @@
 package fi.hel.haitaton.hanke.pdf
 
 import com.lowagie.text.Document
-import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentMetadata
 import fi.hel.haitaton.hanke.attachment.common.ApplicationAttachmentType
+import fi.hel.haitaton.hanke.attachment.common.AttachmentMetadataWithType
 import fi.hel.haitaton.hanke.hakemus.Hakemusyhteyshenkilo
 import fi.hel.haitaton.hanke.hakemus.KaivuilmoitusData
 
@@ -11,7 +11,7 @@ object KaivuilmoitusPdfEncoder {
     fun createPdf(
         data: KaivuilmoitusData,
         totalArea: Float?,
-        attachments: List<ApplicationAttachmentMetadata>,
+        attachments: List<AttachmentMetadataWithType>,
         areas: List<EnrichedKaivuilmoitusalue>?,
     ): ByteArray = createDocument { document, _ ->
         formatKaivuilmoitusPdf(document, data, totalArea, attachments, areas)
@@ -21,7 +21,7 @@ object KaivuilmoitusPdfEncoder {
         document: Document,
         data: KaivuilmoitusData,
         totalArea: Float?,
-        attachments: List<ApplicationAttachmentMetadata>,
+        attachments: List<AttachmentMetadataWithType>,
         areas: List<EnrichedKaivuilmoitusalue>?,
     ) {
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennysService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennysService.kt
@@ -256,8 +256,8 @@ class TaydennysService(
         hakemus: HakemusEntity,
     ) {
         attachments.forEach { attachment ->
-            val content = attachmentService.getContent(attachment.id)
-            alluClient.addAttachment(hakemus.alluid!!, attachment.toAlluAttachment(content.bytes))
+            val content = attachmentService.findContent(attachment)
+            alluClient.addAttachment(hakemus.alluid!!, attachment.toAlluAttachment(content))
             attachmentMetadataService.transferAttachmentToHakemus(attachment, hakemus)
         }
     }


### PR DESCRIPTION
# Description

When there are attachments added to the muutosilmoitus, send them to Allu. Add the `ATTACHMENT` field key to changed fields, if attachments are sent. Update the form data PDF to include attachments from the muutosilmoitus as well as the attachments from the hakemus.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-3419

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
1. With a muutosilmoitus that has attachments, send it to Allu. (The muutosilmoitus shouldn't have changes in haittojenhallinta, since that will add the ATTACHMENT field key to the changes regardless of actual attachments).
3. Check that the attachments are visible in Allu when processing the muutosilmoitus.
4. Check the uploaded form data PDF. It should mention all the attachments for the hakemus and the muutosilmoitus.

# Checklist:

- [X] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [X] I have made necessary changes to the documentation, link to confluence
 or other location: 