### PR TITLE
HAI-3420 Update public hankkeet API

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeControllerITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeControllerITests.kt
@@ -13,7 +13,6 @@ import fi.hel.haitaton.hanke.factory.HankeFactory.Companion.withHankealue
 import fi.hel.haitaton.hanke.factory.HankeFactory.Companion.withMuuYhteystieto
 import fi.hel.haitaton.hanke.factory.HankeFactory.Companion.withOmistaja
 import fi.hel.haitaton.hanke.factory.HankeFactory.Companion.withRakennuttaja
-import fi.hel.haitaton.hanke.factory.HankeFactory.Companion.withTormaystarkasteluTulos
 import fi.hel.haitaton.hanke.factory.HankeFactory.Companion.withToteuttaja
 import fi.hel.haitaton.hanke.factory.HankeYhteyshenkiloFactory
 import fi.hel.haitaton.hanke.geometria.Geometriat
@@ -26,6 +25,7 @@ import fi.hel.haitaton.hanke.tormaystarkastelu.IndeksiType
 import fi.hel.haitaton.hanke.tormaystarkastelu.Meluhaitta
 import fi.hel.haitaton.hanke.tormaystarkastelu.Polyhaitta
 import fi.hel.haitaton.hanke.tormaystarkastelu.Tarinahaitta
+import fi.hel.haitaton.hanke.tormaystarkastelu.TormaystarkasteluTulos
 import fi.hel.haitaton.hanke.tormaystarkastelu.VaikutusAutoliikenteenKaistamaariin
 import io.mockk.Called
 import io.mockk.checkUnnecessaryStub
@@ -137,11 +137,14 @@ class HankeControllerITests(@Autowired override val mockMvc: MockMvc) : Controll
             val raitioliikenneindeksi = 3f
             val hanke =
                 HankeFactory.create(hankeTunnus = HANKE_TUNNUS)
-                    .withTormaystarkasteluTulos(
-                        autoliikenne = autoliikenne,
-                        pyoraliikenneindeksi = pyoraliikenneindeksi,
-                        linjaautoliikenneindeksi = linjaautoliikenneindeksi,
-                        raitioliikenneindeksi = raitioliikenneindeksi,
+                    .withHankealue(
+                        tormaystarkasteluTulos =
+                            TormaystarkasteluTulos(
+                                autoliikenne = autoliikenne,
+                                pyoraliikenneindeksi = pyoraliikenneindeksi,
+                                linjaautoliikenneindeksi = linjaautoliikenneindeksi,
+                                raitioliikenneindeksi = raitioliikenneindeksi,
+                            )
                     )
             every { hankeService.loadHanke(HANKE_TUNNUS) }.returns(hanke)
             every {
@@ -151,48 +154,48 @@ class HankeControllerITests(@Autowired override val mockMvc: MockMvc) : Controll
             get(url)
                 .andExpect(status().isOk)
                 .andExpect(
-                    jsonPath("tormaystarkasteluTulos.autoliikenne.haitanKesto")
+                    jsonPath("alueet[0].tormaystarkasteluTulos.autoliikenne.haitanKesto")
                         .value(autoliikenne.haitanKesto)
                 )
                 .andExpect(
-                    jsonPath("tormaystarkasteluTulos.autoliikenne.katuluokka")
+                    jsonPath("alueet[0].tormaystarkasteluTulos.autoliikenne.katuluokka")
                         .value(autoliikenne.katuluokka)
                 )
                 .andExpect(
-                    jsonPath("tormaystarkasteluTulos.autoliikenne.liikennemaara")
+                    jsonPath("alueet[0].tormaystarkasteluTulos.autoliikenne.liikennemaara")
                         .value(autoliikenne.liikennemaara)
                 )
                 .andExpect(
-                    jsonPath("tormaystarkasteluTulos.autoliikenne.kaistahaitta")
+                    jsonPath("alueet[0].tormaystarkasteluTulos.autoliikenne.kaistahaitta")
                         .value(autoliikenne.kaistahaitta)
                 )
                 .andExpect(
-                    jsonPath("tormaystarkasteluTulos.autoliikenne.kaistapituushaitta")
+                    jsonPath("alueet[0].tormaystarkasteluTulos.autoliikenne.kaistapituushaitta")
                         .value(autoliikenne.kaistapituushaitta)
                 )
                 .andExpect(
-                    jsonPath("tormaystarkasteluTulos.autoliikenne.indeksi")
+                    jsonPath("alueet[0].tormaystarkasteluTulos.autoliikenne.indeksi")
                         .value(autoliikenne.indeksi)
                 )
                 .andExpect(
-                    jsonPath("tormaystarkasteluTulos.pyoraliikenneindeksi")
+                    jsonPath("alueet[0].tormaystarkasteluTulos.pyoraliikenneindeksi")
                         .value(pyoraliikenneindeksi)
                 )
                 .andExpect(
-                    jsonPath("tormaystarkasteluTulos.linjaautoliikenneindeksi")
+                    jsonPath("alueet[0].tormaystarkasteluTulos.linjaautoliikenneindeksi")
                         .value(linjaautoliikenneindeksi)
                 )
                 .andExpect(
-                    jsonPath("tormaystarkasteluTulos.raitioliikenneindeksi")
+                    jsonPath("alueet[0].tormaystarkasteluTulos.raitioliikenneindeksi")
                         .value(raitioliikenneindeksi)
                 )
                 // In this case, raitioliikenneindeksi has the highest value
                 .andExpect(
-                    jsonPath("tormaystarkasteluTulos.liikennehaittaindeksi.indeksi")
+                    jsonPath("alueet[0].tormaystarkasteluTulos.liikennehaittaindeksi.indeksi")
                         .value(raitioliikenneindeksi)
                 )
                 .andExpect(
-                    jsonPath("tormaystarkasteluTulos.liikennehaittaindeksi.tyyppi")
+                    jsonPath("alueet[0].tormaystarkasteluTulos.liikennehaittaindeksi.tyyppi")
                         .value(IndeksiType.RAITIOLIIKENNEINDEKSI.name)
                 )
 

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
@@ -264,7 +264,6 @@ class HankeServiceITests(
                 prop(Hanke::alkuPvm).isNull()
                 prop(Hanke::loppuPvm).isNull()
                 prop(Hanke::alueet).isEmpty()
-                prop(Hanke::tormaystarkasteluTulos).isNull()
             }
         }
 

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/domain/PublicHankeControllerITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/domain/PublicHankeControllerITests.kt
@@ -1,13 +1,25 @@
 package fi.hel.haitaton.hanke.domain
 
+import assertk.assertThat
+import assertk.assertions.containsExactlyInAnyOrder
 import fi.hel.haitaton.hanke.ControllerTest
+import fi.hel.haitaton.hanke.HANKEALUE_DEFAULT_NAME
 import fi.hel.haitaton.hanke.HankeService
 import fi.hel.haitaton.hanke.IntegrationTestConfiguration
 import fi.hel.haitaton.hanke.PublicHankeController
+import fi.hel.haitaton.hanke.andReturnBody
+import fi.hel.haitaton.hanke.factory.DateFactory
+import fi.hel.haitaton.hanke.factory.GeometriaFactory
+import fi.hel.haitaton.hanke.factory.HaittaFactory
 import fi.hel.haitaton.hanke.factory.HankeFactory
 import fi.hel.haitaton.hanke.factory.HankeFactory.Companion.withHankealue
-import fi.hel.haitaton.hanke.factory.HankeFactory.Companion.withTormaystarkasteluTulos
 import fi.hel.haitaton.hanke.factory.HankeFactory.Companion.withYhteystiedot
+import fi.hel.haitaton.hanke.factory.HankeYhteystietoFactory
+import fi.hel.haitaton.hanke.tormaystarkastelu.AutoliikenteenKaistavaikutustenPituus
+import fi.hel.haitaton.hanke.tormaystarkastelu.Meluhaitta
+import fi.hel.haitaton.hanke.tormaystarkastelu.Polyhaitta
+import fi.hel.haitaton.hanke.tormaystarkastelu.Tarinahaitta
+import fi.hel.haitaton.hanke.tormaystarkastelu.VaikutusAutoliikenteenKaistamaariin
 import io.mockk.checkUnnecessaryStub
 import io.mockk.clearAllMocks
 import io.mockk.confirmVerified
@@ -57,49 +69,83 @@ class PublicHankeControllerITests(@Autowired override val mockMvc: MockMvc) : Co
     fun `returns public hankkeet`() {
         val hankkeet =
             listOf(
-                HankeFactory.create(id = 1, nimi = "nimi")
-                    .withHankealue()
-                    .withYhteystiedot()
-                    .withTormaystarkasteluTulos(),
-                HankeFactory.create(id = 2, nimi = "null")
-                    .withHankealue()
-                    .withYhteystiedot()
-                    .withTormaystarkasteluTulos(),
+                HankeFactory.create(id = 1, nimi = "nimi").withHankealue().withYhteystiedot(),
+                HankeFactory.create(id = 2, nimi = "null").withHankealue().withYhteystiedot(),
             )
         every { hankeService.loadPublicHanke() }.returns(hankkeet)
 
-        get("/public-hankkeet")
-            .andExpect(MockMvcResultMatchers.status().isOk)
-            .andExpect(jsonPath("[0]").exists())
-            .andExpect(jsonPath("[1]").exists())
-            .andExpect(jsonPath("[0].id").value(1))
-            .andExpect(jsonPath("[0].nimi").value("nimi"))
-            .andExpect(jsonPath("[1].id").value(2))
-            .andExpect(jsonPath("[1].nimi").value("null"))
+        val response: List<PublicHanke> =
+            get("/public-hankkeet")
+                .andExpect(MockMvcResultMatchers.status().isOk)
+                .andExpect(jsonPath("[0]").exists())
+                .andExpect(jsonPath("[1]").exists())
+                .andExpect(jsonPath("[0].id").value(1))
+                .andExpect(jsonPath("[0].nimi").value("nimi"))
+                .andExpect(jsonPath("[1].id").value(2))
+                .andExpect(jsonPath("[1].nimi").value("null"))
+                .andReturnBody()
 
+        fun expectedAlue(hankeId: Int) =
+            PublicHankealue(
+                id = 1,
+                hankeId = hankeId,
+                haittaAlkuPvm = DateFactory.getStartDatetime(),
+                haittaLoppuPvm = DateFactory.getEndDatetime(),
+                geometriat = PublicGeometriat(GeometriaFactory.create(1).featureCollection),
+                kaistaHaitta = VaikutusAutoliikenteenKaistamaariin.YKSI_KAISTA_VAHENEE,
+                kaistaPituusHaitta = AutoliikenteenKaistavaikutustenPituus.PITUUS_ALLE_10_METRIA,
+                meluHaitta = Meluhaitta.SATUNNAINEN_MELUHAITTA,
+                polyHaitta = Polyhaitta.TOISTUVA_POLYHAITTA,
+                tarinaHaitta = Tarinahaitta.JATKUVA_TARINAHAITTA,
+                nimi = "$HANKEALUE_DEFAULT_NAME 1",
+                tormaystarkastelu = HaittaFactory.tormaystarkasteluTulos(),
+            )
+        fun expectedHanke(id: Int, nimi: String) =
+            PublicHanke(
+                id = id,
+                hankeTunnus = HankeFactory.defaultHankeTunnus,
+                nimi = nimi,
+                kuvaus = HankeFactory.defaultKuvaus,
+                alkuPvm = DateFactory.getStartDatetime(),
+                loppuPvm = DateFactory.getEndDatetime(),
+                vaihe = Hankevaihe.OHJELMOINTI,
+                tyomaaTyyppi = setOf(TyomaaTyyppi.VESI, TyomaaTyyppi.MUU),
+                omistajat = listOf(PublicHankeYhteystieto("etu1 suku1")),
+                alueet = listOf(expectedAlue(id)),
+            )
+        assertThat(response)
+            .containsExactlyInAnyOrder(expectedHanke(1, "nimi"), expectedHanke(2, "null"))
         verify { hankeService.loadPublicHanke() }
     }
 
     @Test
     // Without mock user, i.e. anonymous
     fun `doesn't return personal information from yhteystiedot`() {
-        val hankkeet =
-            listOf(
-                HankeFactory.create()
-                    .withHankealue()
-                    .withYhteystiedot()
-                    .withTormaystarkasteluTulos()
+        val hanke = HankeFactory.create().withHankealue().withYhteystiedot()
+        hanke.omistajat =
+            mutableListOf(
+                HankeYhteystietoFactory.create(
+                    nimi = "Yritys Oy",
+                    tyyppi = YhteystietoTyyppi.YRITYS,
+                ),
+                HankeYhteystietoFactory.create(
+                    nimi = "Ykä Yksityishenkilö",
+                    tyyppi = YhteystietoTyyppi.YKSITYISHENKILO,
+                ),
+                HankeYhteystietoFactory.create(
+                    nimi = "Yhdistys Ry",
+                    tyyppi = YhteystietoTyyppi.YHTEISO,
+                ),
             )
-        every { hankeService.loadPublicHanke() }.returns(hankkeet)
+        every { hankeService.loadPublicHanke() }.returns(listOf(hanke))
 
         get("/public-hankkeet")
             .andExpect(MockMvcResultMatchers.status().isOk)
-            .andExpect(jsonPath("[0]").exists())
-            .andExpect(jsonPath("[0].omistajat[0]").exists())
-            .andExpect(jsonPath("[0].omistajat[0].sukunimi").doesNotExist())
-            .andExpect(jsonPath("[0].omistajat[0].etunimi").doesNotExist())
+            .andExpect(jsonPath("[0].omistajat[0].organisaatioNimi").value("Yritys Oy"))
             .andExpect(jsonPath("[0].omistajat[0].email").doesNotExist())
             .andExpect(jsonPath("[0].omistajat[0].puhelinnumero").doesNotExist())
+            .andExpect(jsonPath("[0].omistajat[1].organisaatioNimi").value(null))
+            .andExpect(jsonPath("[0].omistajat[2].organisaatioNimi").value("Yhdistys Ry"))
             .andExpect(jsonPath("[0].toteuttajat").doesNotExist())
             .andExpect(jsonPath("[0].rakennuttajat").doesNotExist())
             .andExpect(jsonPath("[0].muut").doesNotExist())

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeMapper.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeMapper.kt
@@ -34,7 +34,7 @@ object HankeMapper {
                     modifiedBy = modifiedByUserId,
                     modifiedAt = modifiedAt?.zonedDateTime(),
                     status = status,
-                    generated = generated
+                    generated = generated,
                 )
             }
             .apply {
@@ -46,7 +46,6 @@ object HankeMapper {
                 tyomaaKatuosoite = entity.tyomaaKatuosoite
                 tyomaaTyyppi = entity.tyomaaTyyppi
                 alueet = alueList(entity.hankeTunnus, entity.alueet, geometriaData)
-                tormaystarkasteluTulos = tormaystarkasteluTulos(entity)
             }
 
     private fun contacts(entity: HankeEntity): Map<ContactType, List<HankeYhteystieto>> =
@@ -55,7 +54,7 @@ object HankeMapper {
     private fun alueList(
         hankeTunnus: String?,
         alueet: List<HankealueEntity>,
-        geometriaData: Map<Int, Geometriat?>
+        geometriaData: Map<Int, Geometriat?>,
     ): MutableList<SavedHankealue> =
         alueet.map { alue(hankeTunnus, it, geometriaData[it.geometriat]) }.toMutableList()
 
@@ -94,7 +93,7 @@ object HankeMapper {
                                 it.katuluokka,
                                 it.autoliikennemaara,
                                 it.kaistahaitta,
-                                it.kaistapituushaitta
+                                it.kaistapituushaitta,
                             )
                         },
                 pyoraliikenneindeksi = tulokset.maxOf { it.pyoraliikenne },

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/PublicHankeController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/PublicHankeController.kt
@@ -1,7 +1,7 @@
 package fi.hel.haitaton.hanke
 
 import fi.hel.haitaton.hanke.domain.PublicHanke
-import fi.hel.haitaton.hanke.domain.hankeToPublic
+import fi.hel.haitaton.hanke.domain.toPublic
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Content
@@ -20,7 +20,13 @@ class PublicHankeController(private val hankeService: HankeService) {
     @Operation(
         summary = "Get list of public hanke",
         description =
-            "A public hanke contains data that is visible to everyone. It does not contain private information."
+            """
+              A public hanke contains data that is visible to everyone.
+              It does not contain private information.
+
+              If a hanke has a private person as an owner (in `omistajat`),
+              the name under `organisaatioNimi` will be null.
+           """,
     )
     @ApiResponses(
         value =
@@ -36,9 +42,9 @@ class PublicHankeController(private val hankeService: HankeService) {
                                         schema = Schema(implementation = PublicHanke::class)
                                     )
                             )
-                        ]
+                        ],
                 )
             ]
     )
-    fun getAll(): List<PublicHanke> = hankeService.loadPublicHanke().map { hankeToPublic(it) }
+    fun getAll(): List<PublicHanke> = hankeService.loadPublicHanke().map { it.toPublic() }
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/Hanke.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/Hanke.kt
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonView
 import fi.hel.haitaton.hanke.ChangeLogView
 import fi.hel.haitaton.hanke.HankeIdentifier
 import fi.hel.haitaton.hanke.NotInChangeLogView
-import fi.hel.haitaton.hanke.tormaystarkastelu.TormaystarkasteluTulos
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.ZonedDateTime
 
@@ -17,7 +16,7 @@ data class Hanke(
     @JsonView(ChangeLogView::class)
     @field:Schema(
         description = "Hanke identity for external purposes, set by the service.",
-        example = "HAI24-123"
+        example = "HAI24-123",
     )
     override val hankeTunnus: String,
     //
@@ -100,7 +99,7 @@ data class Hanke(
     @JsonView(ChangeLogView::class)
     @field:Schema(
         description = "Work site street address. Required for the hanke to be published.",
-        maxLength = 2000
+        maxLength = 2000,
     )
     var tyomaaKatuosoite: String? = null
 
@@ -120,10 +119,6 @@ data class Hanke(
             "Hanke areas data. At least one alue is required for the hanke to be published."
     )
     var alueet = mutableListOf<SavedHankealue>()
-
-    @JsonView(NotInChangeLogView::class)
-    @field:Schema(description = "Collision review result, set by the service.")
-    var tormaystarkasteluTulos: TormaystarkasteluTulos? = null
 
     override fun extractYhteystiedot(): List<HankeYhteystieto> =
         listOfNotNull(omistajat, rakennuttajat, toteuttajat, muut).flatten()
@@ -150,7 +145,7 @@ enum class HankeStatus {
 enum class Hankevaihe {
     OHJELMOINTI,
     SUUNNITTELU,
-    RAKENTAMINEN
+    RAKENTAMINEN,
 }
 
 enum class TyomaaTyyppi {
@@ -184,5 +179,5 @@ enum class TyomaaTyyppi {
     KUVAUKSET,
     LUMENPUDOTUS,
     YLEISOTILAISUUS,
-    VAIHTOLAVA
+    VAIHTOLAVA,
 }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeFactory.kt
@@ -24,7 +24,6 @@ import fi.hel.haitaton.hanke.factory.HankealueFactory.createHankeAlueEntity
 import fi.hel.haitaton.hanke.factory.ProfiiliFactory.DEFAULT_NAMES
 import fi.hel.haitaton.hanke.profiili.ProfiiliClient
 import fi.hel.haitaton.hanke.test.USERNAME
-import fi.hel.haitaton.hanke.tormaystarkastelu.Autoliikenneluokittelu
 import fi.hel.haitaton.hanke.tormaystarkastelu.TormaystarkasteluTulos
 import java.time.ZonedDateTime
 import org.springframework.stereotype.Component
@@ -215,6 +214,7 @@ class HankeFactory(
             haittaLoppuPvm: ZonedDateTime? = DateFactory.getEndDatetime(),
             haittojenhallintasuunnitelma: Haittojenhallintasuunnitelma? =
                 HaittaFactory.createHaittojenhallintasuunnitelma(),
+            tormaystarkasteluTulos: TormaystarkasteluTulos? = HaittaFactory.tormaystarkasteluTulos(),
         ): Hanke {
             this.tyomaaKatuosoite = "Testikatu 1"
             this.tyomaaTyyppi.add(TyomaaTyyppi.VESI)
@@ -227,26 +227,10 @@ class HankeFactory(
                     haittaAlkuPvm = haittaAlkuPvm,
                     haittaLoppuPvm = haittaLoppuPvm,
                     haittojenhallintasuunnitelma = haittojenhallintasuunnitelma,
+                    tormaystarkasteluTulos = tormaystarkasteluTulos,
                 )
             this.alueet.add(alue)
 
-            return this
-        }
-
-        fun Hanke.withTormaystarkasteluTulos(
-            autoliikenne: Autoliikenneluokittelu =
-                HaittaFactory.TORMAYSTARKASTELU_DEFAULT_AUTOLIIKENNELUOKITTELU,
-            pyoraliikenneindeksi: Float = 1f,
-            linjaautoliikenneindeksi: Float = 1f,
-            raitioliikenneindeksi: Float = 1f,
-        ): Hanke {
-            this.tormaystarkasteluTulos =
-                TormaystarkasteluTulos(
-                    autoliikenne,
-                    pyoraliikenneindeksi,
-                    linjaautoliikenneindeksi,
-                    raitioliikenneindeksi,
-                )
             return this
         }
 

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/validation/HankePublicValidatorTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/validation/HankePublicValidatorTest.kt
@@ -11,7 +11,6 @@ import fi.hel.haitaton.hanke.factory.HaittaFactory.TORMAYSTARKASTELU_DEFAULT_AUT
 import fi.hel.haitaton.hanke.factory.HaittaFactory.TORMAYSTARKASTELU_ZERO_AUTOLIIKENNELUOKITTELU
 import fi.hel.haitaton.hanke.factory.HankeFactory
 import fi.hel.haitaton.hanke.factory.HankeFactory.Companion.withHankealue
-import fi.hel.haitaton.hanke.factory.HankeFactory.Companion.withTormaystarkasteluTulos
 import fi.hel.haitaton.hanke.factory.HankeFactory.Companion.withYhteystiedot
 import fi.hel.haitaton.hanke.factory.modify
 import fi.hel.haitaton.hanke.test.Asserts.failedWith
@@ -35,8 +34,7 @@ private const val BLANK = "   \t\n\t   "
 class HankePublicValidatorTest {
 
     companion object {
-        private fun completeHanke() =
-            HankeFactory.create().withHankealue().withYhteystiedot().withTormaystarkasteluTulos()
+        private fun completeHanke() = HankeFactory.create().withHankealue().withYhteystiedot()
 
         @JvmStatic
         private fun draftHankkeet(): Stream<Arguments> =


### PR DESCRIPTION
# Description

- Add all omistajat, but only add their names when they are businesses or organisations. A private person will have null in `organisaatioNimi`.
- Remove `osasto` from public customers, since it's always null for omistajat, the only customer added to public hanke.
- Use the common pattern for the PublicHanke conversion methods.
- Remove the unused audit fields from PublicGeometriat, leaving only the feature collection.
- Remove `tormaystarkasteluTulos` from PublicHanke.
- Add `tormaystarkasteluTulos` to PublicHankeAlue.

Also, remove `tormaystarkasteluTulos` from Hanke. The public hanke was the last using it in backend. It shouldn't be used anymore on frontend side.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-3420

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [X] Other

# Instructions for testing
Open the public hanke map and look at the response from the network tab of developer tools.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: