### PR TITLE
HAI-167 Send reminders when a hanke is ending

### DIFF
--- a/email/hanke-paattyy.mjml
+++ b/email/hanke-paattyy.mjml
@@ -1,0 +1,44 @@
+<mjml>
+    <mj-head>
+        <mj-include path="common/attributes.partial"/>
+    </mj-head>
+    <mj-body>
+        <mj-include path="common/header-content.partial"/>
+        <mj-section>
+            <mj-column>
+                <mj-text mj-class="header-txt">
+                    Hankkeesi {{hanketunnus}} ilmoitettu päättymispäivä lähenee / Hankkeesi {{hanketunnus}} ilmoitettu
+                    päättymispäivä lähenee / Hankkeesi {{hanketunnus}} ilmoitettu päättymispäivä lähenee
+                </mj-text>
+                <mj-text mj-class="basic-txt">
+                    Hankkeesi <b>{{hankeNimi}} ({{hanketunnus}})</b> ilmoitettu päättymispäivä {{endingDate}} lähenee.
+                    Varmistathan, että hankkeen ja sen töiden aikataulut ovat ajan tasalla. Päivitä tiedot tarvittaessa
+                    Haitattomaan tai ota tarvitsemasi tiedot talteen. Huomaathan, että hankkeen päättyminen lukitsee
+                    hankkeen ja estää sen näkymisen hankkeen ulkopuolisille.
+                </mj-text>
+                <mj-include path="common/signature-fi.partial"/>
+
+                <mj-divider mj-class="language-separator"/>
+
+                <mj-text mj-class="basic-txt">
+                    Hankkeesi <b>{{hankeNimi}} ({{hanketunnus}})</b> ilmoitettu päättymispäivä {{endingDate}} lähenee.
+                    Varmistathan, että hankkeen ja sen töiden aikataulut ovat ajan tasalla. Päivitä tiedot tarvittaessa
+                    Haitattomaan tai ota tarvitsemasi tiedot talteen. Huomaathan, että hankkeen päättyminen lukitsee
+                    hankkeen ja estää sen näkymisen hankkeen ulkopuolisille.
+                </mj-text>
+                <mj-include path="common/signature-sv.partial"/>
+
+                <mj-divider mj-class="language-separator"/>
+
+                <mj-text mj-class="basic-txt">
+                    Hankkeesi <b>{{hankeNimi}} ({{hanketunnus}})</b> ilmoitettu päättymispäivä {{endingDate}} lähenee.
+                    Varmistathan, että hankkeen ja sen töiden aikataulut ovat ajan tasalla. Päivitä tiedot tarvittaessa
+                    Haitattomaan tai ota tarvitsemasi tiedot talteen. Huomaathan, että hankkeen päättyminen lukitsee
+                    hankkeen ja estää sen näkymisen hankkeen ulkopuolisille.
+                </mj-text>
+                <mj-include path="common/signature-en.partial"/>
+            </mj-column>
+        </mj-section>
+        <mj-include path="common/footer-content.partial"/>
+    </mj-body>
+</mjml>

--- a/services/hanke-service/build.gradle.kts
+++ b/services/hanke-service/build.gradle.kts
@@ -55,7 +55,7 @@ spotless {
 
 plugins {
     val kotlinVersion = "2.1.20"
-    id("org.springframework.boot") version "3.3.5"
+    id("org.springframework.boot") version "3.3.10"
     id("io.spring.dependency-management") version "1.1.7"
     id("com.diffplug.spotless") version "7.0.2"
     kotlin("jvm") version kotlinVersion

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeCompletionServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeCompletionServiceITest.kt
@@ -2,22 +2,34 @@ package fi.hel.haitaton.hanke
 
 import assertk.assertFailure
 import assertk.assertThat
+import assertk.assertions.contains
 import assertk.assertions.containsExactly
 import assertk.assertions.containsExactlyInAnyOrder
 import assertk.assertions.hasClass
+import assertk.assertions.hasSize
 import assertk.assertions.isEmpty
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNull
+import com.icegreen.greenmail.configuration.GreenMailConfiguration
+import com.icegreen.greenmail.junit5.GreenMailExtension
+import com.icegreen.greenmail.util.ServerSetupTest
 import fi.hel.haitaton.hanke.allu.ApplicationStatus
+import fi.hel.haitaton.hanke.domain.HankeReminder
 import fi.hel.haitaton.hanke.domain.HankeStatus
+import fi.hel.haitaton.hanke.email.textBody
 import fi.hel.haitaton.hanke.factory.HakemusFactory
 import fi.hel.haitaton.hanke.factory.HankeFactory
 import fi.hel.haitaton.hanke.factory.HankealueFactory
+import fi.hel.haitaton.hanke.permissions.Kayttooikeustaso
 import fi.hel.haitaton.hanke.test.Asserts.isRecent
 import java.time.LocalDateTime
 import java.time.ZonedDateTime
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+import org.junit.jupiter.params.provider.ValueSource
 import org.springframework.beans.factory.annotation.Autowired
 
 class HankeCompletionServiceITest(
@@ -41,13 +53,7 @@ class HankeCompletionServiceITest(
         fun `returns only public hanke`() {
             hankeFactory.builder().saveEntity(HankeStatus.DRAFT)
             hankeFactory.builder().saveEntity(HankeStatus.COMPLETED)
-            val publicHanke =
-                hankeFactory
-                    .builder()
-                    .withHankealue(
-                        HankealueFactory.create(haittaLoppuPvm = ZonedDateTime.now().minusDays(1))
-                    )
-                    .saveEntity(HankeStatus.PUBLIC)
+            val publicHanke = hankeFactory.builder().saveEntity(HankeStatus.PUBLIC)
 
             val result = hankeCompletionService.getPublicIds()
 
@@ -97,19 +103,122 @@ class HankeCompletionServiceITest(
 
         @Test
         fun `returns only the the first n ids, ordered by modifiedAt`() {
-            val hankkeet = (1..6).map { hankeFactory.builder().saveEntity(HankeStatus.PUBLIC) }
-            val dates = listOf(30, 2, 25, null, 15, 4)
             val baseDate = LocalDateTime.parse("2025-03-01T09:54:05")
-            dates.zip(hankkeet).forEach { (date, hanke) ->
-                hanke.modifiedAt = date?.let { baseDate.withDayOfMonth(it) }
-                hankeRepository.save(hanke)
-            }
+            val hankkeet =
+                listOf(30, 2, 25, null, 15, 4).map { date ->
+                    val hanke = hankeFactory.builder().saveEntity(HankeStatus.PUBLIC)
+                    hanke.modifiedAt = date?.let { baseDate.withDayOfMonth(it) }
+                    hankeRepository.save(hanke)
+                }
 
             val result = hankeCompletionService.getPublicIds()
 
             // max-per-run is set to 3 in application-test.yml
+            assertThat(result).containsExactly(hankkeet[1].id, hankkeet[5].id, hankkeet[4].id)
+        }
+    }
+
+    @Nested
+    inner class IdsForReminders {
+        @Test
+        fun `with no hanke returns empty list`() {
+            val result = hankeCompletionService.idsForReminders(HankeReminder.COMPLETION_5)
+
+            assertThat(result).isEmpty()
+        }
+
+        @Test
+        fun `returns only public hanke`() {
+            hankeFactory.builder().saveEntity(HankeStatus.DRAFT)
+            hankeFactory.builder().saveEntity(HankeStatus.COMPLETED)
+            val publicHanke = hankeFactory.builder().saveEntity(HankeStatus.PUBLIC)
+
+            val result = hankeCompletionService.idsForReminders(HankeReminder.COMPLETION_14)
+
+            assertThat(result).containsExactly(publicHanke.id)
+        }
+
+        @Test
+        fun `returns ids for hanke with no areas without an end date`() {
+            val hankeWithoutArea =
+                hankeFactory.builder().withNoAreas().saveEntity(HankeStatus.PUBLIC)
+            val hankeWithoutEndDate =
+                hankeFactory
+                    .builder()
+                    .withHankealue(HankealueFactory.create(haittaLoppuPvm = null))
+                    .saveEntity(HankeStatus.PUBLIC)
+
+            val result = hankeCompletionService.idsForReminders(HankeReminder.COMPLETION_14)
+
             assertThat(result)
-                .containsExactlyInAnyOrder(hankkeet[1].id, hankkeet[5].id, hankkeet[4].id)
+                .containsExactlyInAnyOrder(hankeWithoutArea.id, hankeWithoutEndDate.id)
+        }
+
+        @Test
+        fun `returns only the the first n ids, ordered by modifiedAt`() {
+            val baseDate = LocalDateTime.parse("2025-03-01T09:54:05")
+            val hankkeet =
+                listOf(30, 2, 25, null, 15, 4).map { date ->
+                    val hanke = hankeFactory.builder().saveEntity(HankeStatus.PUBLIC)
+                    hanke.modifiedAt = date?.let { baseDate.withDayOfMonth(it) }
+                    hankeRepository.save(hanke)
+                }
+
+            val result = hankeCompletionService.idsForReminders(HankeReminder.COMPLETION_14)
+
+            // max-per-run is set to 3 in application-test.yml
+            assertThat(result).containsExactly(hankkeet[1].id, hankkeet[5].id, hankkeet[4].id)
+        }
+
+        @Test
+        fun `only returns hanke where the reminder is due`() {
+            val justBeforeHanke =
+                hankeFactory
+                    .builder()
+                    .withHankealue(
+                        HankealueFactory.create(haittaLoppuPvm = ZonedDateTime.now().plusDays(4))
+                    )
+                    .saveEntity(HankeStatus.PUBLIC)
+            val onTheDayHanke =
+                hankeFactory
+                    .builder()
+                    .withHankealue(
+                        HankealueFactory.create(haittaLoppuPvm = ZonedDateTime.now().plusDays(5))
+                    )
+                    .saveEntity(HankeStatus.PUBLIC)
+            hankeFactory
+                .builder()
+                .withHankealue(
+                    HankealueFactory.create(haittaLoppuPvm = ZonedDateTime.now().plusDays(6))
+                )
+                .saveEntity(HankeStatus.PUBLIC)
+
+            val result = hankeCompletionService.idsForReminders(HankeReminder.COMPLETION_5)
+
+            assertThat(result).containsExactly(justBeforeHanke.id, onTheDayHanke.id)
+        }
+
+        @Test
+        fun `returns only hanke where the reminder hasn't been sent already`() {
+            val unsentHanke =
+                hankeFactory
+                    .builder()
+                    .withHankealue(
+                        HankealueFactory.create(haittaLoppuPvm = ZonedDateTime.now().plusDays(5))
+                    )
+                    .saveEntity(HankeStatus.PUBLIC) { it.sentReminders = arrayOf() }
+            hankeFactory
+                .builder()
+                .withHankealue(
+                    HankealueFactory.create(haittaLoppuPvm = ZonedDateTime.now().plusDays(5))
+                )
+                .saveEntity(HankeStatus.PUBLIC) {
+                    it.sentReminders = arrayOf(HankeReminder.COMPLETION_5)
+                }
+
+            val result = hankeCompletionService.idsForReminders(HankeReminder.COMPLETION_5)
+
+            assertThat(result).containsExactly(unsentHanke.id)
         }
     }
 
@@ -199,5 +308,280 @@ class HankeCompletionServiceITest(
             assertThat(result.status).isEqualTo(HankeStatus.COMPLETED)
             assertThat(result.completedAt).isRecent()
         }
+    }
+
+    @Nested
+    inner class SendReminderIfNecessary {
+        @Test
+        fun `throws exception when the hanke is not public`() {
+            val hanke = hankeFactory.builder().saveEntity(HankeStatus.COMPLETED)
+
+            val failure = assertFailure {
+                hankeCompletionService.sendReminderIfNecessary(hanke.id, HankeReminder.COMPLETION_5)
+            }
+
+            failure.hasClass(HankeNotPublicException::class)
+        }
+
+        @Test
+        fun `throws exception when the hanke has no areas`() {
+            val hanke = hankeFactory.builder().withNoAreas().saveEntity(HankeStatus.PUBLIC)
+
+            val failure = assertFailure {
+                hankeCompletionService.sendReminderIfNecessary(hanke.id, HankeReminder.COMPLETION_5)
+            }
+
+            failure.hasClass(PublicHankeHasNoAreasException::class)
+        }
+
+        @Test
+        fun `throws exception when the hanke has only empty end dates`() {
+            val hanke =
+                hankeFactory
+                    .builder()
+                    .withHankealue(HankealueFactory.create(haittaLoppuPvm = null))
+                    .saveEntity(HankeStatus.PUBLIC)
+
+            val failure = assertFailure {
+                hankeCompletionService.sendReminderIfNecessary(
+                    hanke.id,
+                    HankeReminder.COMPLETION_14,
+                )
+            }
+
+            failure.hasClass(HankealueWithoutEndDateException::class)
+        }
+
+        @ParameterizedTest
+        @EnumSource(HankeReminder::class, names = ["COMPLETION_5", "COMPLETION_14"])
+        fun `marks the reminder sent but doesn't send anything when the hanke is due to be completed`(
+            reminder: HankeReminder
+        ) {
+            val hanke =
+                hankeFactory
+                    .builder()
+                    .withHankealue(HankealueFactory.create(haittaLoppuPvm = ZonedDateTime.now()))
+                    .saveEntity(HankeStatus.PUBLIC)
+
+            hankeCompletionService.sendReminderIfNecessary(hanke.id, reminder)
+
+            val updatedHanke = hankeRepository.getReferenceById(hanke.id)
+            assertThat(updatedHanke.sentReminders).containsExactly(reminder)
+            assertThat(greenMail.receivedMessages).isEmpty()
+        }
+
+        @Test
+        fun `sends the reminder to everyone with EDIT permissions`() {
+            val hanke =
+                hankeFactory
+                    .builder()
+                    .withHankealue(
+                        HankealueFactory.create(haittaLoppuPvm = ZonedDateTime.now().plusDays(5))
+                    )
+                    .saveWithYhteystiedot {
+                        omistaja(
+                            kayttaja("omistaja@test", "omistaja", Kayttooikeustaso.HANKEMUOKKAUS)
+                        )
+                        rakennuttaja(
+                            kayttaja(
+                                "rakennuttaja@test",
+                                "rakennuttaja",
+                                Kayttooikeustaso.HAKEMUSASIOINTI,
+                            )
+                        )
+                        toteuttaja(
+                            kayttaja(
+                                "toteuttaja@test",
+                                "toteuttaja",
+                                Kayttooikeustaso.KAIKKIEN_MUOKKAUS,
+                            )
+                        )
+                    }
+            hanke.status = HankeStatus.PUBLIC
+            hankeRepository.save(hanke)
+
+            hankeCompletionService.sendReminderIfNecessary(hanke.id, HankeReminder.COMPLETION_5)
+
+            assertThat(greenMail.receivedMessages).hasSize(3)
+            val recipients = greenMail.receivedMessages.map { it.allRecipients.single().toString() }
+            assertThat(recipients).hasSize(3)
+            assertThat(recipients)
+                .containsExactlyInAnyOrder(
+                    "pertti@perustaja.test",
+                    "omistaja@test",
+                    "toteuttaja@test",
+                )
+        }
+
+        @Test
+        fun `uses the last end date of the hankealue when determining the hanke end date`() {
+            val hanke =
+                hankeFactory
+                    .builder()
+                    .withHankealue(HankealueFactory.create(haittaLoppuPvm = null))
+                    .withHankealue(
+                        HankealueFactory.create(haittaLoppuPvm = ZonedDateTime.now().plusDays(5))
+                    )
+                    .withHankealue(
+                        HankealueFactory.create(haittaLoppuPvm = ZonedDateTime.now().plusDays(6))
+                    )
+                    .saveEntity(HankeStatus.PUBLIC)
+
+            hankeCompletionService.sendReminderIfNecessary(hanke.id, HankeReminder.COMPLETION_5)
+
+            val updatedHanke = hankeRepository.getReferenceById(hanke.id)
+            assertThat(updatedHanke.sentReminders).isEmpty()
+            assertThat(greenMail.receivedMessages).isEmpty()
+        }
+
+        @Nested
+        inner class Completion5 {
+            @Test
+            fun `doesn't do anything if the reminder is not yet due`() {
+                val hanke =
+                    hankeFactory
+                        .builder()
+                        .withHankealue(
+                            HankealueFactory.create(
+                                haittaLoppuPvm = ZonedDateTime.now().plusDays(6)
+                            )
+                        )
+                        .saveEntity(HankeStatus.PUBLIC)
+
+                hankeCompletionService.sendReminderIfNecessary(hanke.id, HankeReminder.COMPLETION_5)
+
+                val updatedHanke = hankeRepository.getReferenceById(hanke.id)
+                assertThat(updatedHanke.sentReminders).isEmpty()
+                assertThat(greenMail.receivedMessages).isEmpty()
+            }
+
+            @ParameterizedTest
+            @ValueSource(ints = [1, 4, 5])
+            fun `marks the reminder sent and sends the reminder when the hanke is ending soon`(
+                date: Long
+            ) {
+                val endDate = ZonedDateTime.now().plusDays(date)
+                val hanke =
+                    hankeFactory
+                        .builder()
+                        .withHankealue(HankealueFactory.create(haittaLoppuPvm = endDate))
+                        .saveEntity(HankeStatus.PUBLIC)
+
+                hankeCompletionService.sendReminderIfNecessary(hanke.id, HankeReminder.COMPLETION_5)
+
+                val updatedHanke = hankeRepository.getReferenceById(hanke.id)
+                assertThat(updatedHanke.sentReminders).containsExactly(HankeReminder.COMPLETION_5)
+                assertThat(greenMail.receivedMessages).hasSize(1)
+                val email = greenMail.firstReceivedMessage()
+                assertThat(email.allRecipients).hasSize(1)
+                assertThat(email.allRecipients[0].toString()).isEqualTo("pertti@perustaja.test")
+                assertThat(email.subject)
+                    .isEqualTo(
+                        "Haitaton: Hankkeesi ${hanke.hankeTunnus} päättymispäivä lähenee " +
+                            "/ Hankkeesi ${hanke.hankeTunnus} päättymispäivä lähenee " +
+                            "/ Hankkeesi ${hanke.hankeTunnus} päättymispäivä lähenee"
+                    )
+                val day = endDate.dayOfMonth
+                val month = endDate.monthValue
+                val year = endDate.year
+                assertThat(email.textBody())
+                    .contains(
+                        "Hankkeesi ${hanke.nimi} (${hanke.hankeTunnus}) ilmoitettu päättymispäivä $day.$month.$year lähenee"
+                    )
+            }
+        }
+
+        @Nested
+        inner class Completion14 {
+            @Test
+            fun `doesn't do anything if the reminder is not yet due`() {
+                val hanke =
+                    hankeFactory
+                        .builder()
+                        .withHankealue(
+                            HankealueFactory.create(
+                                haittaLoppuPvm = ZonedDateTime.now().plusDays(15)
+                            )
+                        )
+                        .saveEntity(HankeStatus.PUBLIC)
+
+                hankeCompletionService.sendReminderIfNecessary(
+                    hanke.id,
+                    HankeReminder.COMPLETION_14,
+                )
+
+                val updatedHanke = hankeRepository.getReferenceById(hanke.id)
+                assertThat(updatedHanke.sentReminders).isEmpty()
+                assertThat(greenMail.receivedMessages).isEmpty()
+            }
+
+            @Test
+            fun `marks the reminder sent but doesn't send anything when the hanke is due to be sent the next reminder`() {
+                val hanke =
+                    hankeFactory
+                        .builder()
+                        .withHankealue(
+                            HankealueFactory.create(
+                                haittaLoppuPvm = ZonedDateTime.now().plusDays(5)
+                            )
+                        )
+                        .saveEntity(HankeStatus.PUBLIC)
+
+                hankeCompletionService.sendReminderIfNecessary(
+                    hanke.id,
+                    HankeReminder.COMPLETION_14,
+                )
+
+                val updatedHanke = hankeRepository.getReferenceById(hanke.id)
+                assertThat(updatedHanke.sentReminders).containsExactly(HankeReminder.COMPLETION_14)
+                assertThat(greenMail.receivedMessages).isEmpty()
+            }
+
+            @ParameterizedTest
+            @ValueSource(ints = [6, 13, 14])
+            fun `marks the 14-day reminder sent and sends the reminder when the hanke is ending soon`(
+                date: Long
+            ) {
+                val endDate = ZonedDateTime.now().plusDays(date)
+                val hanke =
+                    hankeFactory
+                        .builder()
+                        .withHankealue(HankealueFactory.create(haittaLoppuPvm = endDate))
+                        .saveEntity(HankeStatus.PUBLIC)
+
+                hankeCompletionService.sendReminderIfNecessary(
+                    hanke.id,
+                    HankeReminder.COMPLETION_14,
+                )
+
+                val updatedHanke = hankeRepository.getReferenceById(hanke.id)
+                assertThat(updatedHanke.sentReminders).containsExactly(HankeReminder.COMPLETION_14)
+                assertThat(greenMail.receivedMessages).hasSize(1)
+                val email = greenMail.firstReceivedMessage()
+                assertThat(email.allRecipients).hasSize(1)
+                assertThat(email.allRecipients[0].toString()).isEqualTo("pertti@perustaja.test")
+                assertThat(email.subject)
+                    .isEqualTo(
+                        "Haitaton: Hankkeesi ${hanke.hankeTunnus} päättymispäivä lähenee " +
+                            "/ Hankkeesi ${hanke.hankeTunnus} päättymispäivä lähenee " +
+                            "/ Hankkeesi ${hanke.hankeTunnus} päättymispäivä lähenee"
+                    )
+                val day = endDate.dayOfMonth
+                val month = endDate.monthValue
+                val year = endDate.year
+                assertThat(email.textBody())
+                    .contains(
+                        "Hankkeesi ${hanke.nimi} (${hanke.hankeTunnus}) ilmoitettu päättymispäivä $day.$month.$year lähenee"
+                    )
+            }
+        }
+    }
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val greenMail: GreenMailExtension =
+            GreenMailExtension(ServerSetupTest.SMTP)
+                .withConfiguration(GreenMailConfiguration.aConfig().withDisabledAuthentication())
     }
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeCompletionScheduler.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeCompletionScheduler.kt
@@ -3,11 +3,10 @@ package fi.hel.haitaton.hanke
 import fi.hel.haitaton.hanke.configuration.Feature
 import fi.hel.haitaton.hanke.configuration.FeatureFlags
 import fi.hel.haitaton.hanke.configuration.LockService
+import fi.hel.haitaton.hanke.domain.HankeReminder
 import java.util.concurrent.TimeUnit
 import mu.KotlinLogging
-import org.springframework.boot.context.event.ApplicationReadyEvent
 import org.springframework.context.annotation.Profile
-import org.springframework.context.event.EventListener
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
 
@@ -21,7 +20,6 @@ class HankeCompletionScheduler(
     private val featureFlags: FeatureFlags,
 ) {
     @Scheduled(cron = "\${haitaton.hanke.completions.cron}", zone = "Europe/Helsinki")
-    @EventListener(ApplicationReadyEvent::class)
     fun completeHankkeet() {
         if (featureFlags.isDisabled(Feature.HANKE_COMPLETION)) {
             logger.info { "Hanke completion is disabled, not running daily completion job." }
@@ -33,15 +31,44 @@ class HankeCompletionScheduler(
         )
         lockService.withLock(LOCK_NAME, 10, TimeUnit.MINUTES) {
             val ids = completionService.getPublicIds()
-            logger.info("Got ${ids.size} hanke to try to complete.")
+            logger.info { "Got ${ids.size} hanke to try to complete." }
 
-            ids.forEach { id ->
-                try {
-                    completionService.completeHankeIfPossible(id)
-                } catch (e: HankeValidityException) {
-                    // Don't fail on hanke validation issues, log the error and continue.
-                    logger.error(e) { e.message }
-                }
+            doForEachId(ids) { id -> completionService.completeHankeIfPossible(id) }
+        }
+    }
+
+    @Scheduled(cron = "\${haitaton.hanke.completions.reminderCron}", zone = "Europe/Helsinki")
+    fun sendCompletionReminders() {
+        if (featureFlags.isDisabled(Feature.HANKE_COMPLETION)) {
+            logger.info { "Hanke completion is disabled, not checking for reminders to send." }
+            return
+        }
+
+        logger.info {
+            "Trying to obtain lock $LOCK_NAME to start checking for hanke completion reminders"
+        }
+
+        lockService.withLock(LOCK_NAME, 10, TimeUnit.MINUTES) {
+            sendReminders(HankeReminder.COMPLETION_14)
+            sendReminders(HankeReminder.COMPLETION_5)
+        }
+    }
+
+    private fun sendReminders(reminder: HankeReminder) {
+        val ids = completionService.idsForReminders(reminder)
+
+        logger.info { "Got ${ids.size} hanke for sending reminder $reminder." }
+
+        doForEachId(ids) { id -> completionService.sendReminderIfNecessary(id, reminder) }
+    }
+
+    private fun doForEachId(ids: List<Int>, f: (Int) -> Unit) {
+        ids.forEach { id ->
+            try {
+                f(id)
+            } catch (e: HankeValidityException) {
+                // Don't fail on hanke validation issues, log the error and continue.
+                logger.error(e) { e.message }
             }
         }
     }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeCompletionService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeCompletionService.kt
@@ -1,13 +1,18 @@
 package fi.hel.haitaton.hanke
 
 import fi.hel.haitaton.hanke.allu.ApplicationStatus
+import fi.hel.haitaton.hanke.domain.HankeReminder
 import fi.hel.haitaton.hanke.domain.HankeStatus
+import fi.hel.haitaton.hanke.email.HankeEndingReminder
 import fi.hel.haitaton.hanke.hakemus.ApplicationType
 import fi.hel.haitaton.hanke.hakemus.HakemusEntity
+import fi.hel.haitaton.hanke.permissions.HankeKayttajaService
+import fi.hel.haitaton.hanke.permissions.PermissionCode
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import mu.KotlinLogging
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -16,13 +21,17 @@ private val logger = KotlinLogging.logger {}
 @Service
 class HankeCompletionService(
     private val hankeRepository: HankeRepository,
+    private val hankeKayttajaService: HankeKayttajaService,
+    private val applicationEventPublisher: ApplicationEventPublisher,
     @Value("\${haitaton.hanke.completions.max-per-run}") private val completionsPerDay: Int,
 ) {
 
     @Transactional(readOnly = true)
-    fun getPublicIds(): List<Int> {
-        return hankeRepository.findHankeToComplete(completionsPerDay)
-    }
+    fun getPublicIds(): List<Int> = hankeRepository.findHankeToComplete(completionsPerDay)
+
+    @Transactional(readOnly = true)
+    fun idsForReminders(reminder: HankeReminder): List<Int> =
+        hankeRepository.findHankeToRemind(completionsPerDay, reminderDate(reminder), reminder)
 
     @Transactional
     fun completeHankeIfPossible(id: Int) {
@@ -49,6 +58,66 @@ class HankeCompletionService(
         logger.info { "Hanke has been completed, marking it completed. ${hanke.logString()}" }
         hanke.status = HankeStatus.COMPLETED
         hanke.completedAt = OffsetDateTime.now()
+    }
+
+    @Transactional
+    fun sendReminderIfNecessary(id: Int, reminder: HankeReminder) {
+        logger.info { "Checking if a reminder needs to be sent to hanke $id" }
+        val hanke = hankeRepository.getReferenceById(id)
+
+        assertHankePublic(hanke)
+        assertHankeHasAreas(hanke)
+
+        if (hanke.sentReminders.contains(reminder)) {
+            logger.info {
+                "Hanke has been sent this reminder already, so not sending it again. " +
+                    "reminder=$reminder, ${hanke.logString()}"
+            }
+            return
+        }
+
+        val endDate = hanke.endDate() ?: throw HankealueWithoutEndDateException(hanke)
+
+        if (endDate.isAfter(reminderDate(reminder))) {
+            return
+        }
+
+        if (!endDate.isAfter(LocalDate.now())) {
+            logger.info {
+                "Hanke is due to be completed, not sending reminders anymore. ${hanke.logString()}"
+            }
+            // Mark this reminder as sent so it doesn't come up again unless the hanke end date
+            // changes.
+            hanke.sentReminders += reminder
+            return
+        }
+
+        if (
+            reminder == HankeReminder.COMPLETION_14 &&
+                !endDate.isAfter(reminderDate(HankeReminder.COMPLETION_5))
+        ) {
+            logger.info {
+                "Hanke is due to be sent the next reminder, so not sending this one. " +
+                    "reminder = $reminder, ${hanke.logString()}"
+            }
+            hanke.sentReminders += reminder
+            // Mark this reminder as sent so it doesn't come up again unless the hanke end date
+            // changes.
+            return
+        }
+
+        hanke.sentReminders += reminder
+        sendReminders(hanke, endDate)
+    }
+
+    private fun sendReminders(hanke: HankeEntity, endingDate: LocalDate) {
+        hankeKayttajaService
+            .getHankeKayttajatWithPermission(hanke.id, PermissionCode.EDIT)
+            .forEach {
+                applicationEventPublisher.publishEvent(
+                    HankeEndingReminder(it.sahkoposti, hanke.nimi, hanke.hankeTunnus, endingDate)
+                )
+            }
     }
 
     companion object {
@@ -86,6 +155,12 @@ class HankeCompletionService(
 
             return activeApplications.isNotEmpty()
         }
+
+        fun reminderDate(reminder: HankeReminder): LocalDate =
+            when (reminder) {
+                HankeReminder.COMPLETION_14 -> LocalDate.now().plusDays(14)
+                HankeReminder.COMPLETION_5 -> LocalDate.now().plusDays(5)
+            }
 
         private fun hasCompletedStatus(hakemus: HakemusEntity): Boolean =
             hakemus.alluStatus in

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeService.kt
@@ -107,6 +107,7 @@ class HankeService(
             hankeRepository.findByHankeTunnus(hankeTunnus)
                 ?: throw HankeNotFoundException(hankeTunnus)
 
+        val originalEndDate = entity.endDate()
         val hankeBeforeUpdate = createHankeDomainObjectFromEntity(entity)
 
         val existingYTs = prepareMapOfExistingYhteystietos(entity)
@@ -127,6 +128,10 @@ class HankeService(
 
         updateTormaystarkastelut(entity.alueet)
         entity.status = decideNewHankeStatus(entity)
+
+        if (entity.endDate() != originalEndDate) {
+            entity.sentReminders = arrayOf()
+        }
 
         logger.debug { "Saving Hanke ${entity.logString()}." }
         val savedHankeEntity = hankeRepository.saveAndFlush(entity)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/Hanke.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/Hanke.kt
@@ -182,3 +182,8 @@ enum class TyomaaTyyppi {
     YLEISOTILAISUUS,
     VAIHTOLAVA,
 }
+
+enum class HankeReminder {
+    COMPLETION_5,
+    COMPLETION_14,
+}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/email/EmailEvent.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/email/EmailEvent.kt
@@ -2,6 +2,7 @@ package fi.hel.haitaton.hanke.email
 
 import fi.hel.haitaton.hanke.hakemus.ApplicationType
 import fi.hel.haitaton.hanke.permissions.Kayttooikeustaso
+import java.time.LocalDate
 
 sealed interface EmailEvent {
     val to: String
@@ -66,4 +67,11 @@ data class InformationRequestCanceledEmail(
     val hakemusNimi: String,
     val hakemustunnus: String,
     val hakemusId: Long,
+) : EmailEvent
+
+data class HankeEndingReminder(
+    override val to: String,
+    val hankeNimi: String,
+    val hanketunnus: String,
+    val endingDate: LocalDate,
 ) : EmailEvent

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaService.kt
@@ -45,6 +45,16 @@ class HankeKayttajaService(
     fun getKayttajatByHankeId(hankeId: Int): List<HankeKayttajaDto> =
         hankekayttajaRepository.findByHankeId(hankeId).map { it.toDto() }
 
+    @Transactional
+    fun getHankeKayttajatWithPermission(
+        hankeId: Int,
+        permission: PermissionCode,
+    ): List<HankeKayttaja> =
+        hankekayttajaRepository
+            .findByHankeId(hankeId)
+            .filter { hasPermission(it, permission) }
+            .map { it.toDomain() }
+
     @Transactional(readOnly = true)
     fun getKayttajaForHanke(kayttajaId: UUID, hankeId: Int): HankekayttajaEntity {
         val kayttaja =

--- a/services/hanke-service/src/main/resources/application.yml
+++ b/services/hanke-service/src/main/resources/application.yml
@@ -56,6 +56,8 @@ haitaton:
       max-per-run: ${HAITATON_COMPLETIONS_PER_RUN:250}
       # By default, run every day at 18:26:41 (Helsinki time).
       cron: ${HAITATON_COMPLETIONS_CRON:41 26 18 * * *}
+      # By default, run every day at 19:17:21 (Helsinki time).
+      reminderCron: ${HAITATON_COMPLETIONS_REMINDER_CRON:21 17 19 * * *}
   map-service:
     capability-url: https://kartta.hel.fi/ws/geoserver/avoindata/wms?REQUEST=GetCapabilities&SERVICE=WMS
   profiili-api:

--- a/services/hanke-service/src/main/resources/db/changelog/changesets/108-add-sent-reminders-to-hanke.sql
+++ b/services/hanke-service/src/main/resources/db/changelog/changesets/108-add-sent-reminders-to-hanke.sql
@@ -1,0 +1,6 @@
+--liquibase formatted sql
+--changeset Topias Heinonen:108-add-sent-reminders-to-hanke
+--comment: Add sent_reminders to Hanke
+
+ALTER TABLE hanke
+    ADD COLUMN sent_reminders character varying[] NOT NULL DEFAULT '{}';

--- a/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -243,3 +243,5 @@ databaseChangeLog:
       file: db/changelog/changesets/106-create-table-for-muutosilmoitus-attachment.sql
   - include:
       file: db/changelog/changesets/107-add-completion-date-to-hanke.sql
+  - include:
+      file: db/changelog/changesets/108-add-sent-reminders-to-hanke.sql

--- a/services/hanke-service/src/main/resources/email/template/hanke-paattyy.subject.mustache
+++ b/services/hanke-service/src/main/resources/email/template/hanke-paattyy.subject.mustache
@@ -1,0 +1,1 @@
+Haitaton: Hankkeesi {{hanketunnus}} päättymispäivä lähenee / Hankkeesi {{hanketunnus}} päättymispäivä lähenee / Hankkeesi {{hanketunnus}} päättymispäivä lähenee

--- a/services/hanke-service/src/main/resources/email/template/hanke-paattyy.text.mustache
+++ b/services/hanke-service/src/main/resources/email/template/hanke-paattyy.text.mustache
@@ -1,0 +1,15 @@
+Hankkeesi {{hanketunnus}} päättymispäivä lähenee / Hankkeesi {{hanketunnus}} päättymispäivä lähenee Hankkeesi {{hanketunnus}} päättymispäivä lähenee
+
+Hankkeesi {{{hankeNimi}}} ({{hanketunnus}}) ilmoitettu päättymispäivä {{endingDate}} lähenee. Varmistathan, että hankkeen ja sen töiden aikataulut ovat ajan tasalla. Päivitä tiedot tarvittaessa Haitattomaan tai ota tarvitsemasi tiedot talteen. Huomaathan, että hankkeen päättyminen lukitsee hankkeen ja estää sen näkymisen hankkeen ulkopuolisille.
+
+{{{signatures.fi}}}
+
+
+Hankkeesi {{{hankeNimi}}} ({{hanketunnus}}) ilmoitettu päättymispäivä {{endingDate}} lähenee. Varmistathan, että hankkeen ja sen töiden aikataulut ovat ajan tasalla. Päivitä tiedot tarvittaessa Haitattomaan tai ota tarvitsemasi tiedot talteen. Huomaathan, että hankkeen päättyminen lukitsee hankkeen ja estää sen näkymisen hankkeen ulkopuolisille.
+
+{{{signatures.sv}}}
+
+
+Hankkeesi {{{hankeNimi}}} ({{hanketunnus}}) ilmoitettu päättymispäivä {{endingDate}} lähenee. Varmistathan, että hankkeen ja sen töiden aikataulut ovat ajan tasalla. Päivitä tiedot tarvittaessa Haitattomaan tai ota tarvitsemasi tiedot talteen. Huomaathan, että hankkeen päättyminen lukitsee hankkeen ja estää sen näkymisen hankkeen ulkopuolisille.
+
+{{{signatures.en}}}

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeBuilder.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeBuilder.kt
@@ -71,9 +71,10 @@ data class HankeBuilder(
     fun saveEntity(): HankeEntity = hankeRepository.getReferenceById(save().id)
 
     /** Create the hanke and save it with an overridden status. */
-    fun saveEntity(status: HankeStatus): HankeEntity {
+    fun saveEntity(status: HankeStatus, modifier: (HankeEntity) -> Unit = {}): HankeEntity {
         val entity = hankeRepository.getReferenceById(save().id)
         entity.status = status
+        modifier(entity)
         return hankeRepository.save(entity)
     }
 


### PR DESCRIPTION
# Description

Send reminder emails when a hanke is about to end, 5 and 14 days before the hanke end date. The reminders are sent so the user has a chance to extend the hanke period if the work is still continuing.

The reminders are not sent if the hanke if the end date has already passed. The 14-day won't be sent if the 5-day reminder instead.

The reminders are sent to all hanke users with EDIT permissions to the hanke, i.e. the people who can change the hanke end date.

If a reminder is sent, it's marked as sent on the hanke, so it's not sent again.

Also, update Spring Boot to the latest batch version.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-167

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
- Create some hankkeet:
  - One with the end date 6-14 days in the future.
  - One with the end date 1-5 days in the future.
- Add some users with different permissions to those hanke.
- Run the by changing the `reminderCron` value or adding `@EventListener(ApplicationReadyEvent::class)` in front of `sendCompletionReminders`.
- Check [smtp4dev](http://localhost:3003) that the correct emails have been sent. For both hanke, there should be emails to users with edit permissions.
- Check from the DB, that the hanke have their `sent_reminders` set. The hanke with its end date 6-14 days in the future, the column should contain only `COMPLETION_14` and for the other one, it should contain both `COMPLETION_14` and `COMPLETION_5`.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 