### PR TITLE
HAI-156 Delete hanke after being completed for 6 months

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeCompletionServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeCompletionServiceITest.kt
@@ -721,6 +721,10 @@ class HankeCompletionServiceITest(
                 .save()
             hakemusFactory
                 .builder(hanke, ApplicationType.EXCAVATION_NOTIFICATION)
+                .withNoAlluFields()
+                .save()
+            hakemusFactory
+                .builder(hanke, ApplicationType.EXCAVATION_NOTIFICATION)
                 .withStatus(ApplicationStatus.ARCHIVED, alluId = 53)
                 .save()
             hankeAttachmentFactory.save(hanke = hanke).withContent()

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeCompletionServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeCompletionServiceITest.kt
@@ -1,5 +1,6 @@
 package fi.hel.haitaton.hanke
 
+import assertk.all
 import assertk.assertFailure
 import assertk.assertThat
 import assertk.assertions.contains
@@ -9,20 +10,40 @@ import assertk.assertions.hasClass
 import assertk.assertions.hasSize
 import assertk.assertions.isEmpty
 import assertk.assertions.isEqualTo
+import assertk.assertions.isNotNull
 import assertk.assertions.isNull
+import assertk.assertions.messageContains
+import assertk.assertions.prop
+import assertk.assertions.single
 import com.icegreen.greenmail.configuration.GreenMailConfiguration
 import com.icegreen.greenmail.junit5.GreenMailExtension
 import com.icegreen.greenmail.util.ServerSetupTest
 import fi.hel.haitaton.hanke.allu.ApplicationStatus
+import fi.hel.haitaton.hanke.attachment.azure.Container
+import fi.hel.haitaton.hanke.attachment.common.MockFileClient
 import fi.hel.haitaton.hanke.domain.HankeReminder
 import fi.hel.haitaton.hanke.domain.HankeStatus
 import fi.hel.haitaton.hanke.email.textBody
 import fi.hel.haitaton.hanke.factory.HakemusFactory
+import fi.hel.haitaton.hanke.factory.HankeAttachmentFactory
 import fi.hel.haitaton.hanke.factory.HankeFactory
 import fi.hel.haitaton.hanke.factory.HankealueFactory
+import fi.hel.haitaton.hanke.hakemus.ApplicationType
+import fi.hel.haitaton.hanke.hakemus.HakemusRepository
+import fi.hel.haitaton.hanke.logging.AuditLogRepository
+import fi.hel.haitaton.hanke.logging.AuditLogTarget
+import fi.hel.haitaton.hanke.logging.HAITATON_AUDIT_LOG_USERID
+import fi.hel.haitaton.hanke.logging.ObjectType
+import fi.hel.haitaton.hanke.logging.Operation
 import fi.hel.haitaton.hanke.permissions.Kayttooikeustaso
 import fi.hel.haitaton.hanke.test.Asserts.isRecent
+import fi.hel.haitaton.hanke.test.AuditLogEntryEntityAsserts.hasId
+import fi.hel.haitaton.hanke.test.AuditLogEntryEntityAsserts.hasNoObjectAfter
+import fi.hel.haitaton.hanke.test.AuditLogEntryEntityAsserts.hasServiceActor
+import fi.hel.haitaton.hanke.test.AuditLogEntryEntityAsserts.isSuccess
+import fi.hel.haitaton.hanke.test.AuditLogEntryEntityAsserts.withTarget
 import java.time.LocalDateTime
+import java.time.OffsetDateTime
 import java.time.ZonedDateTime
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -34,9 +55,13 @@ import org.springframework.beans.factory.annotation.Autowired
 
 class HankeCompletionServiceITest(
     @Autowired private val hankeCompletionService: HankeCompletionService,
-    @Autowired private val hankeFactory: HankeFactory,
     @Autowired private val hakemusFactory: HakemusFactory,
+    @Autowired private val hankeAttachmentFactory: HankeAttachmentFactory,
+    @Autowired private val auditLogRepository: AuditLogRepository,
+    @Autowired private val hankeFactory: HankeFactory,
+    @Autowired private val hakemusRepository: HakemusRepository,
     @Autowired private val hankeRepository: HankeRepository,
+    @Autowired private val fileClient: MockFileClient,
 ) : IntegrationTest() {
 
     @Nested
@@ -618,6 +643,113 @@ class HankeCompletionServiceITest(
                     .contains(
                         "Hankkeesi ${hanke.nimi} (${hanke.hankeTunnus}) ilmoitettu päättymispäivä $day.$month.$year lähenee"
                     )
+            }
+        }
+    }
+
+    @Nested
+    inner class DeleteHanke {
+        @ParameterizedTest
+        @EnumSource(HankeStatus::class, names = ["COMPLETED"], mode = EnumSource.Mode.EXCLUDE)
+        fun `throws exception when hanke is not completed`(status: HankeStatus) {
+            val hanke = hankeFactory.builder().saveEntity(status)
+
+            val failure = assertFailure { hankeCompletionService.deleteHanke(hanke.id) }
+
+            failure.all {
+                hasClass(HankeNotCompletedException::class)
+                messageContains("Hanke is not completed")
+                messageContains("id=${hanke.id}")
+            }
+        }
+
+        @Test
+        fun `throws exception when hanke has no completion date`() {
+            val hanke =
+                hankeFactory.builder().saveEntity(HankeStatus.COMPLETED) { it.completedAt = null }
+
+            val failure = assertFailure { hankeCompletionService.deleteHanke(hanke.id) }
+
+            failure.all {
+                hasClass(HankeHasNoCompletionDateException::class)
+                messageContains("Hanke has no completion date")
+                messageContains("id=${hanke.id}")
+            }
+        }
+
+        @Test
+        fun `throws exception when hanke completion date is too recently`() {
+            val hanke =
+                hankeFactory.builder().withNoAreas().saveEntity(HankeStatus.COMPLETED) {
+                    it.completedAt = OffsetDateTime.now().minusMonths(6).plusDays(1)
+                }
+
+            val failure = assertFailure { hankeCompletionService.deleteHanke(hanke.id) }
+
+            failure.all {
+                hasClass(HankeCompletedRecently::class)
+                messageContains("Hanke has been completed too recently")
+                messageContains("id=${hanke.id}")
+            }
+        }
+
+        @Test
+        fun `does nothing when hanke has active applications`() {
+            val hanke =
+                hankeFactory.builder().withNoAreas().saveEntity(HankeStatus.COMPLETED) {
+                    it.completedAt = OffsetDateTime.now().minusMonths(6)
+                }
+            hakemusFactory.builder(hanke).withStatus(ApplicationStatus.DECISIONMAKING).save()
+
+            hankeCompletionService.deleteHanke(hanke.id)
+
+            assertThat(hankeRepository.findOneById(hanke.id)).isNotNull().all {
+                prop(HankeIdentifier::id).isEqualTo(hanke.id)
+                prop(HankeIdentifier::hankeTunnus).isEqualTo(hanke.hankeTunnus)
+            }
+        }
+
+        @Test
+        fun `deletes the hanke with attachments and applications`() {
+            val hanke =
+                hankeFactory.builder().withNoAreas().saveEntity(HankeStatus.COMPLETED) {
+                    it.completedAt = OffsetDateTime.now().minusMonths(6)
+                }
+            hakemusFactory
+                .builder(hanke, ApplicationType.CABLE_REPORT)
+                .withStatus(ApplicationStatus.FINISHED, alluId = 41)
+                .save()
+            hakemusFactory
+                .builder(hanke, ApplicationType.EXCAVATION_NOTIFICATION)
+                .withStatus(ApplicationStatus.ARCHIVED, alluId = 53)
+                .save()
+            hankeAttachmentFactory.save(hanke = hanke).withContent()
+            hankeAttachmentFactory.save(hanke = hanke).withContent()
+
+            hankeCompletionService.deleteHanke(hanke.id)
+
+            assertThat(hankeRepository.findAll()).isEmpty()
+            assertThat(hakemusRepository.findAll()).isEmpty()
+            assertThat(fileClient.listBlobs(Container.HANKE_LIITTEET)).isEmpty()
+        }
+
+        @Test
+        fun `logs the deletion to audit logs`() {
+            val hanke =
+                hankeFactory.builder().withNoAreas().saveEntity(HankeStatus.COMPLETED) {
+                    it.completedAt = OffsetDateTime.now().minusMonths(6)
+                }
+            auditLogRepository.deleteAll()
+
+            hankeCompletionService.deleteHanke(hanke.id)
+
+            assertThat(auditLogRepository.findAll()).single().isSuccess(Operation.DELETE) {
+                hasServiceActor(HAITATON_AUDIT_LOG_USERID)
+                withTarget {
+                    hasId(hanke.id)
+                    prop(AuditLogTarget::type).isEqualTo(ObjectType.HANKE)
+                    hasNoObjectAfter()
+                }
             }
         }
     }

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceITest.kt
@@ -2165,7 +2165,7 @@ class HakemusServiceITest(
     }
 
     @Nested
-    inner class DeleteCompleted {
+    inner class DeleteFromCompletedHanke {
         private val alluId = 570
 
         @Test
@@ -2173,7 +2173,7 @@ class HakemusServiceITest(
             val hakemus =
                 hakemusFactory.builder().withStatus(ApplicationStatus.PENDING, alluId).save()
 
-            val failure = assertFailure { hakemusService.deleteCompleted(hakemus.id) }
+            val failure = assertFailure { hakemusService.deleteFromCompletedHanke(hakemus.id) }
 
             failure.all {
                 hasClass(HakemusInWrongStatusException::class)
@@ -2193,10 +2193,19 @@ class HakemusServiceITest(
             attachmentFactory.save(application = application).withContent()
             attachmentFactory.save(application = application).withContent()
 
-            hakemusService.deleteCompleted(application.id)
+            hakemusService.deleteFromCompletedHanke(application.id)
 
             assertThat(hakemusRepository.findAll()).isEmpty()
             assertThat(fileClient.listBlobs(Container.HAKEMUS_LIITTEET)).isEmpty()
+        }
+
+        @Test
+        fun `also deletes a draft application`() {
+            val application = hakemusFactory.builder().withNoAlluFields().saveEntity()
+
+            hakemusService.deleteFromCompletedHanke(application.id)
+
+            assertThat(hakemusRepository.findAll()).isEmpty()
         }
 
         @Test
@@ -2207,7 +2216,7 @@ class HakemusServiceITest(
             attachmentFactory.save(application = application).withContent()
             fileClient.connected = false
 
-            hakemusService.deleteCompleted(application.id)
+            hakemusService.deleteFromCompletedHanke(application.id)
 
             assertThat(hakemusRepository.findAll()).isEmpty()
             assertThat(applicationAttachmentRepository.findAll()).isEmpty()
@@ -2220,7 +2229,7 @@ class HakemusServiceITest(
             val hakemus = hakemusFactory.builder().withStatus(ApplicationStatus.FINISHED).save()
             auditLogRepository.deleteAll()
 
-            hakemusService.deleteCompleted(hakemus.id)
+            hakemusService.deleteFromCompletedHanke(hakemus.id)
 
             assertThat(auditLogRepository.findAll()).single().isSuccess(Operation.DELETE) {
                 hasServiceActor(HAITATON_AUDIT_LOG_USERID)
@@ -2245,7 +2254,7 @@ class HakemusServiceITest(
                     .asianhoitaja()
                     .save()
 
-            hakemusService.deleteCompleted(hakemus.id)
+            hakemusService.deleteFromCompletedHanke(hakemus.id)
 
             assertThat(hakemusRepository.findAll()).isEmpty()
             assertThat(hakemusyhteystietoRepository.findAll()).isEmpty()

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeCompletionService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeCompletionService.kt
@@ -138,7 +138,7 @@ class HankeCompletionService(
             return
         }
 
-        hanke.hakemukset.forEach { hakemus -> hakemusService.deleteCompleted(hakemus.id) }
+        hanke.hakemukset.forEach { hakemus -> hakemusService.deleteFromCompletedHanke(hakemus.id) }
 
         hankeAttachmentService.deleteAllAttachments(hanke)
         val domain = hankeService.loadHanke(hanke.hankeTunnus)!!

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Persistence.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Persistence.kt
@@ -105,6 +105,8 @@ class HankeEntity(
 
     fun endDate(): LocalDate? = alueet.mapNotNull { it.haittaLoppuPvm }.maxOrNull()
 
+    fun deletionDate(): LocalDate? = completedAt?.plusMonths(6)?.toLocalDate()
+
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other !is HankeEntity) return false
@@ -154,6 +156,9 @@ interface HankeRepository : JpaRepository<HankeEntity, Int> {
             "order by h.modifiedAt asc limit :limit"
     )
     fun findHankeToRemind(limit: Int, reminderDate: LocalDate, reminder: HankeReminder): List<Int>
+
+    @Query("select h.id from HankeEntity h where h.completedAt <= :date")
+    fun findHankeToDelete(date: OffsetDateTime): List<Int>
 }
 
 interface HankeIdentifier : HasId<Int>, Loggable {

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusEntity.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusEntity.kt
@@ -27,7 +27,7 @@ import org.hibernate.annotations.Type
 data class HakemusEntity(
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY) override val id: Long,
     override var alluid: Int?,
-    @Enumerated(EnumType.STRING) var alluStatus: ApplicationStatus?,
+    @Enumerated(EnumType.STRING) override var alluStatus: ApplicationStatus?,
     override var applicationIdentifier: String?,
     var userId: String?,
     @Enumerated(EnumType.STRING) override val applicationType: ApplicationType,
@@ -53,7 +53,7 @@ data class HakemusEntity(
     )
     @BatchSize(size = 100)
     val valmistumisilmoitukset: MutableList<ValmistumisilmoitusEntity> = mutableListOf(),
-) : HakemusIdentifier, HasYhteystietoEntities<HakemusyhteyshenkiloEntity> {
+) : HakemusIdentifier, HasAlluStatus, HasYhteystietoEntities<HakemusyhteyshenkiloEntity> {
     fun toMetadata(): HakemusMetaData =
         HakemusMetaData(
             id = id,

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
@@ -1116,22 +1116,22 @@ class HakemusService(
     }
 
     @Transactional
-    fun deleteCompleted(hakemusId: Long) {
+    fun deleteFromCompletedHanke(hakemusId: Long) {
         val hakemus = getById(hakemusId)
-        assertCompleted(hakemus)
-        logger.info { "Deleting completed hakemus, ${hakemus.logString()}" }
+        assertDraftOrCompleted(hakemus)
+        logger.info { "Deleting hakemus for completed hanke, ${hakemus.logString()}" }
         attachmentService.deleteAllAttachments(hakemus)
         hakemusRepository.deleteById(hakemus.id)
         hakemusLoggingService.logDeleteFromHaitaton(hakemus)
         logger.info { "Hakemus deleted, ${hakemus.logString()}" }
     }
 
-    private fun assertCompleted(hakemus: Hakemus) {
-        if (!hakemus.hasCompletedStatus()) {
+    private fun assertDraftOrCompleted(hakemus: Hakemus) {
+        if (hakemus.alluStatus != null && !hakemus.hasCompletedStatus()) {
             throw HakemusInWrongStatusException(
                 hakemus,
                 hakemus.alluStatus,
-                hakemus.completedStatuses().toList(),
+                hakemus.completedStatuses().toList() + null,
             )
         }
     }
@@ -1298,7 +1298,7 @@ class WrongHakemusTypeException(
 class HakemusInWrongStatusException(
     hakemus: HakemusIdentifier,
     status: ApplicationStatus?,
-    allowed: Collection<ApplicationStatus>,
+    allowed: Collection<ApplicationStatus?>,
 ) :
     RuntimeException(
         "Hakemus is in the wrong status for this operation. status=$status, " +

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
@@ -398,8 +398,9 @@ class HakemusService(
      * delete, if the application is in Allu, and it's beyond the pending status.
      */
     @Transactional
-    fun delete(applicationId: Long, userId: String) =
-        with(getById(applicationId)) { cancelAndDelete(this, userId) }
+    fun delete(applicationId: Long, userId: String) {
+        cancelAndDelete(getById(applicationId), userId)
+    }
 
     /**
      * Deletes an application. Cancels the application in Allu if it's still pending. Refuses to
@@ -1114,6 +1115,27 @@ class HakemusService(
         logger.info { "Hakemus deleted, ${hakemus.logString()}" }
     }
 
+    @Transactional
+    fun deleteCompleted(hakemusId: Long) {
+        val hakemus = getById(hakemusId)
+        assertCompleted(hakemus)
+        logger.info { "Deleting completed hakemus, ${hakemus.logString()}" }
+        attachmentService.deleteAllAttachments(hakemus)
+        hakemusRepository.deleteById(hakemus.id)
+        hakemusLoggingService.logDeleteFromHaitaton(hakemus)
+        logger.info { "Hakemus deleted, ${hakemus.logString()}" }
+    }
+
+    private fun assertCompleted(hakemus: Hakemus) {
+        if (!hakemus.hasCompletedStatus()) {
+            throw HakemusInWrongStatusException(
+                hakemus,
+                hakemus.alluStatus,
+                hakemus.completedStatuses().toList(),
+            )
+        }
+    }
+
     /** Cancel a hakemus that's been sent to Allu. */
     private fun cancelHakemus(id: Long?, alluId: Int, alluStatus: ApplicationStatus?) {
         if (isStillPending(alluId, alluStatus)) {
@@ -1276,7 +1298,7 @@ class WrongHakemusTypeException(
 class HakemusInWrongStatusException(
     hakemus: HakemusIdentifier,
     status: ApplicationStatus?,
-    allowed: List<ApplicationStatus>,
+    allowed: Collection<ApplicationStatus>,
 ) :
     RuntimeException(
         "Hakemus is in the wrong status for this operation. status=$status, " +

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/AuditLogService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/AuditLogService.kt
@@ -75,16 +75,10 @@ class AuditLogService(private val auditLogRepository: AuditLogRepository) {
             )
 
         fun <ID, T : HasId<ID>> deleteEntryForAllu(type: ObjectType, deletedObject: T) =
-            AuditLogEntry(
-                operation = Operation.DELETE,
-                status = Status.SUCCESS,
-                userId = ALLU_AUDIT_LOG_USERID,
-                userRole = UserRole.SERVICE,
-                objectId = deletedObject.id!!.toString(),
-                objectType = type,
-                objectBefore = deletedObject.toChangeLogJsonString(),
-                objectAfter = null,
-            )
+            deleteEntryForService(type, deletedObject, ALLU_AUDIT_LOG_USERID)
+
+        fun <ID, T : HasId<ID>> deleteEntryForHaitaton(type: ObjectType, deletedObject: T) =
+            deleteEntryForService(type, deletedObject, HAITATON_AUDIT_LOG_USERID)
 
         fun <ID, T : HasId<ID>> createEntry(userId: String, type: ObjectType, createdObject: T) =
             AuditLogEntry(
@@ -127,5 +121,21 @@ class AuditLogService(private val auditLogRepository: AuditLogRepository) {
                 )
             }
         }
+
+        private fun <ID, T : HasId<ID>> deleteEntryForService(
+            type: ObjectType,
+            deletedObject: T,
+            userId: String,
+        ) =
+            AuditLogEntry(
+                operation = Operation.DELETE,
+                status = Status.SUCCESS,
+                userId = userId,
+                userRole = UserRole.SERVICE,
+                objectId = deletedObject.id!!.toString(),
+                objectType = type,
+                objectBefore = deletedObject.toChangeLogJsonString(),
+                objectAfter = null,
+            )
     }
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/ChangeLoggingService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/ChangeLoggingService.kt
@@ -30,4 +30,9 @@ abstract class ChangeLoggingService<ID, T : HasId<ID>>(
     open fun logDeleteFromAllu(before: T) {
         auditLogService.create(AuditLogService.deleteEntryForAllu(objectType, before))
     }
+
+    @Transactional(propagation = Propagation.MANDATORY)
+    open fun logDeleteFromHaitaton(before: T) {
+        auditLogService.create(AuditLogService.deleteEntryForHaitaton(objectType, before))
+    }
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/DisclosureLogService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/DisclosureLogService.kt
@@ -30,6 +30,9 @@ import org.springframework.stereotype.Service
 /** Special username for Allu service. */
 const val ALLU_AUDIT_LOG_USERID = "Allu"
 
+/** Special username for Haitaton itself. */
+const val HAITATON_AUDIT_LOG_USERID = "Haitaton"
+
 /** Special username for Helsinki Profiili. */
 const val PROFIILI_AUDIT_LOG_USERID = "Helsinki Profiili"
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/HankeLoggingService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/logging/HankeLoggingService.kt
@@ -28,5 +28,22 @@ class HankeLoggingService(private val auditLogService: AuditLogService) :
         auditLogService.createAll(yhteystietoEntries + auditLogEntry)
     }
 
+    /**
+     * Create audit log entry for a hanke deleted by Haitaton.
+     *
+     * This also creates entries for sub-entities (yhteystiedot), since they will be deleted with
+     * the hanke, and they are not handled anywhere else.
+     */
+    @Transactional(propagation = Propagation.MANDATORY)
+    override fun logDeleteFromHaitaton(before: Hanke) {
+        val auditLogEntry = AuditLogService.deleteEntryForHaitaton(ObjectType.HANKE, before)
+        val yhteystietoEntries =
+            before.extractYhteystiedot().map {
+                AuditLogService.deleteEntryForHaitaton(ObjectType.YHTEYSTIETO, it)
+            }
+
+        auditLogService.createAll(yhteystietoEntries + auditLogEntry)
+    }
+
     fun createAll(auditLogEntries: List<AuditLogEntry>) = auditLogService.createAll(auditLogEntries)
 }

--- a/services/hanke-service/src/main/resources/application.yml
+++ b/services/hanke-service/src/main/resources/application.yml
@@ -56,6 +56,8 @@ haitaton:
       max-per-run: ${HAITATON_COMPLETIONS_PER_RUN:250}
       # By default, run every day at 18:26:41 (Helsinki time).
       cron: ${HAITATON_COMPLETIONS_CRON:41 26 18 * * *}
+      # By default, run every day at 20:32:38 (Helsinki time).
+      deletionCron: ${HAITATON_COMPLETIONS_DELETE_CRON:38 32 20 * * *}
       # By default, run every day at 19:17:21 (Helsinki time).
       reminderCron: ${HAITATON_COMPLETIONS_REMINDER_CRON:21 17 19 * * *}
   map-service:


### PR DESCRIPTION
# Description

Once per day, delete all hanke that were completed 6 months ago. The hanke is not deleted if it has an active application for some unexpected reason.

All information related to the hanke is deleted, like users, applications and attachments.

Haitaton is not an archive, so we need to delete old hanke after they are no longer useful. Six months after completion was decided to be a enough time for users to download any decisions and other information that the hanke and its applications might still have.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-156

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
1. Complete some hanke like in #1013.
2. Change their `completedAt` value in the database to be in the past.
3. Change the `deletionCron` value or add `@EventListener(ApplicationReadyEvent::class)` to `deleteCompletedHanke`.
4. Check that the hanke were deleted and the `audit_logs` table has rows about the deletion.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 