### PR TITLE
HAI-1150 Deny most modifying API calls for completed hanke

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ out/
 
 ### Azurite debug log ###
 azurite-debug.log
+
+# Kotlin 2 cache directory
+/.kotlin

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeControllerITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeControllerITests.kt
@@ -488,6 +488,19 @@ class HankeControllerITests(@Autowired override val mockMvc: MockMvc) : Controll
         }
 
         @Test
+        fun `returns 409 when hanke has been completed`() {
+            val hanke = HankeFactory.create(version = null)
+            every { authorizer.authorizeHankeTunnus(HANKE_TUNNUS, PermissionCode.EDIT.name) } throws
+                HankeAlreadyCompletedException(hanke.id)
+
+            put(url, hanke).andExpect(status().isConflict).andExpect(hankeError(HankeError.HAI1034))
+
+            verifySequence {
+                authorizer.authorizeHankeTunnus(HANKE_TUNNUS, PermissionCode.EDIT.name)
+            }
+        }
+
+        @Test
         fun `Update Hanke with data and return it (PUT)`() {
             val hankeToBeUpdated = HankeFactory.create(version = null)
             val updatedHanke =

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusAuthorizerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusAuthorizerITest.kt
@@ -6,9 +6,11 @@ import assertk.assertThat
 import assertk.assertions.hasClass
 import assertk.assertions.isTrue
 import assertk.assertions.messageContains
+import fi.hel.haitaton.hanke.HankeAlreadyCompletedException
 import fi.hel.haitaton.hanke.HankeNotFoundException
 import fi.hel.haitaton.hanke.IntegrationTest
 import fi.hel.haitaton.hanke.attachment.common.AttachmentNotFoundException
+import fi.hel.haitaton.hanke.domain.HankeStatus
 import fi.hel.haitaton.hanke.factory.ApplicationAttachmentFactory
 import fi.hel.haitaton.hanke.factory.ApplicationFactory
 import fi.hel.haitaton.hanke.factory.CreateHakemusRequestFactory
@@ -38,11 +40,12 @@ class HakemusAuthorizerITest(
     inner class AuthorizeHakemusId {
         @Test
         fun `throws exception if application doesn't exist`() {
-            assertFailure { authorizer.authorizeHakemusId(applicationId, VIEW.name) }
-                .all {
-                    hasClass(HakemusNotFoundException::class)
-                    messageContains(applicationId.toString())
-                }
+            val failure = assertFailure { authorizer.authorizeHakemusId(applicationId, VIEW.name) }
+
+            failure.all {
+                hasClass(HakemusNotFoundException::class)
+                messageContains(applicationId.toString())
+            }
         }
 
         @Test
@@ -50,11 +53,12 @@ class HakemusAuthorizerITest(
             val hanke = hankeFactory.saveMinimal()
             val application = applicationFactory.saveApplicationEntity(USERNAME, hanke)
 
-            assertFailure { authorizer.authorizeHakemusId(application.id, VIEW.name) }
-                .all {
-                    hasClass(HakemusNotFoundException::class)
-                    messageContains(application.id.toString())
-                }
+            val failure = assertFailure { authorizer.authorizeHakemusId(application.id, VIEW.name) }
+
+            failure.all {
+                hasClass(HakemusNotFoundException::class)
+                messageContains(application.id.toString())
+            }
         }
 
         @Test
@@ -63,13 +67,14 @@ class HakemusAuthorizerITest(
             val application = applicationFactory.saveApplicationEntity(USERNAME, hanke)
             permissionService.create(hanke.id, USERNAME, Kayttooikeustaso.HANKEMUOKKAUS)
 
-            assertFailure {
-                    authorizer.authorizeHakemusId(application.id, PermissionCode.DELETE.name)
-                }
-                .all {
-                    hasClass(HakemusNotFoundException::class)
-                    messageContains(application.id.toString())
-                }
+            val failure = assertFailure {
+                authorizer.authorizeHakemusId(application.id, PermissionCode.DELETE.name)
+            }
+
+            failure.all {
+                hasClass(HakemusNotFoundException::class)
+                messageContains(application.id.toString())
+            }
         }
 
         @Test
@@ -78,7 +83,37 @@ class HakemusAuthorizerITest(
             val application = applicationFactory.saveApplicationEntity(USERNAME, hanke)
             permissionService.create(hanke.id, USERNAME, Kayttooikeustaso.HANKEMUOKKAUS)
 
-            assertThat(authorizer.authorizeHakemusId(application.id, VIEW.name)).isTrue()
+            val result = authorizer.authorizeHakemusId(application.id, VIEW.name)
+
+            assertThat(result).isTrue()
+        }
+
+        @Test
+        fun `throws exception when editing a hakemus from a completed hanke`() {
+            val hanke = hankeFactory.saveMinimal(status = HankeStatus.COMPLETED)
+            val application = applicationFactory.saveApplicationEntity(USERNAME, hanke)
+            permissionService.create(hanke.id, USERNAME, Kayttooikeustaso.HAKEMUSASIOINTI)
+
+            val failure = assertFailure {
+                authorizer.authorizeHakemusId(application.id, PermissionCode.EDIT_APPLICATIONS.name)
+            }
+
+            failure.all {
+                hasClass(HankeAlreadyCompletedException::class)
+                messageContains("Hanke has already been completed, so the operation is not allowed")
+                messageContains("hankeId=${hanke.id}")
+            }
+        }
+
+        @Test
+        fun `returns true when viewing a hakemus from a completed hanke`() {
+            val hanke = hankeFactory.saveMinimal(status = HankeStatus.COMPLETED)
+            val application = applicationFactory.saveApplicationEntity(USERNAME, hanke)
+            permissionService.create(hanke.id, USERNAME, Kayttooikeustaso.HANKEMUOKKAUS)
+
+            val result = authorizer.authorizeHakemusId(application.id, VIEW.name)
+
+            assertThat(result).isTrue()
         }
     }
 
@@ -91,11 +126,12 @@ class HakemusAuthorizerITest(
             val request =
                 CreateHakemusRequestFactory.johtoselvitysRequest(hankeTunnus = hankeTunnus)
 
-            assertFailure { authorizer.authorizeCreate(request) }
-                .all {
-                    hasClass(HankeNotFoundException::class)
-                    messageContains("hankeTunnus $hankeTunnus")
-                }
+            val failure = assertFailure { authorizer.authorizeCreate(request) }
+
+            failure.all {
+                hasClass(HankeNotFoundException::class)
+                messageContains("hankeTunnus $hankeTunnus")
+            }
         }
 
         @Test
@@ -105,11 +141,12 @@ class HakemusAuthorizerITest(
                 CreateHakemusRequestFactory.johtoselvitysRequest(hankeTunnus = hankeTunnus)
             permissionService.create(hanke.id, USERNAME, Kayttooikeustaso.HANKEMUOKKAUS)
 
-            assertFailure { authorizer.authorizeCreate(request) }
-                .all {
-                    hasClass(HankeNotFoundException::class)
-                    messageContains("hankeTunnus $hankeTunnus")
-                }
+            val failure = assertFailure { authorizer.authorizeCreate(request) }
+
+            failure.all {
+                hasClass(HankeNotFoundException::class)
+                messageContains("hankeTunnus $hankeTunnus")
+            }
         }
 
         @Test
@@ -121,6 +158,23 @@ class HakemusAuthorizerITest(
 
             assertThat(authorizer.authorizeCreate(request)).isTrue()
         }
+
+        @Test
+        fun `throws exception when creating a hakemus to a completed hanke`() {
+            val hanke =
+                hankeFactory.saveMinimal(hankeTunnus = hankeTunnus, status = HankeStatus.COMPLETED)
+            val request =
+                CreateHakemusRequestFactory.johtoselvitysRequest(hankeTunnus = hankeTunnus)
+            permissionService.create(hanke.id, USERNAME, Kayttooikeustaso.HAKEMUSASIOINTI)
+
+            val failure = assertFailure { authorizer.authorizeCreate(request) }
+
+            failure.all {
+                hasClass(HankeAlreadyCompletedException::class)
+                messageContains("Hanke has already been completed, so the operation is not allowed")
+                messageContains("hankeId=${hanke.id}")
+            }
+        }
     }
 
     @Nested
@@ -129,11 +183,14 @@ class HakemusAuthorizerITest(
 
         @Test
         fun `throws exception if applicationId is not found`() {
-            assertFailure { authorizer.authorizeAttachment(applicationId, attachmentId, VIEW.name) }
-                .all {
-                    hasClass(HakemusNotFoundException::class)
-                    messageContains(applicationId.toString())
-                }
+            val failure = assertFailure {
+                authorizer.authorizeAttachment(applicationId, attachmentId, VIEW.name)
+            }
+
+            failure.all {
+                hasClass(HakemusNotFoundException::class)
+                messageContains(applicationId.toString())
+            }
         }
 
         @Test
@@ -141,13 +198,14 @@ class HakemusAuthorizerITest(
             val hanke = hankeFactory.saveMinimal()
             val application = applicationFactory.saveApplicationEntity(USERNAME, hanke)
 
-            assertFailure {
-                    authorizer.authorizeAttachment(application.id, attachmentId, VIEW.name)
-                }
-                .all {
-                    hasClass(HakemusNotFoundException::class)
-                    messageContains(application.id.toString())
-                }
+            val failure = assertFailure {
+                authorizer.authorizeAttachment(application.id, attachmentId, VIEW.name)
+            }
+
+            failure.all {
+                hasClass(HakemusNotFoundException::class)
+                messageContains(application.id.toString())
+            }
         }
 
         @Test
@@ -156,13 +214,14 @@ class HakemusAuthorizerITest(
             permissionService.create(hanke.id, USERNAME, Kayttooikeustaso.KATSELUOIKEUS)
             val application = applicationFactory.saveApplicationEntity(USERNAME, hanke)
 
-            assertFailure {
-                    authorizer.authorizeAttachment(application.id, attachmentId, EDIT.name)
-                }
-                .all {
-                    hasClass(HakemusNotFoundException::class)
-                    messageContains(application.id.toString())
-                }
+            val failure = assertFailure {
+                authorizer.authorizeAttachment(application.id, attachmentId, EDIT.name)
+            }
+
+            failure.all {
+                hasClass(HakemusNotFoundException::class)
+                messageContains(application.id.toString())
+            }
         }
 
         @Test
@@ -171,13 +230,14 @@ class HakemusAuthorizerITest(
             permissionService.create(hanke.id, USERNAME, Kayttooikeustaso.KATSELUOIKEUS)
             val application = applicationFactory.saveApplicationEntity(USERNAME, hanke)
 
-            assertFailure {
-                    authorizer.authorizeAttachment(application.id, attachmentId, VIEW.name)
-                }
-                .all {
-                    hasClass(AttachmentNotFoundException::class)
-                    messageContains(attachmentId.toString())
-                }
+            val failure = assertFailure {
+                authorizer.authorizeAttachment(application.id, attachmentId, VIEW.name)
+            }
+
+            failure.all {
+                hasClass(AttachmentNotFoundException::class)
+                messageContains(attachmentId.toString())
+            }
         }
 
         @Test
@@ -190,13 +250,14 @@ class HakemusAuthorizerITest(
                 applicationAttachmentFactory.save(application = application2).withContent().value
             permissionService.create(hanke.id, USERNAME, Kayttooikeustaso.KATSELUOIKEUS)
 
-            assertFailure {
-                    authorizer.authorizeAttachment(application.id, attachment.id!!, VIEW.name)
-                }
-                .all {
-                    hasClass(AttachmentNotFoundException::class)
-                    messageContains(attachment.id.toString())
-                }
+            val failure = assertFailure {
+                authorizer.authorizeAttachment(application.id, attachment.id!!, VIEW.name)
+            }
+
+            failure.all {
+                hasClass(AttachmentNotFoundException::class)
+                messageContains(attachment.id.toString())
+            }
         }
 
         @Test
@@ -207,21 +268,59 @@ class HakemusAuthorizerITest(
                 applicationAttachmentFactory.save(application = application).withContent().value
             permissionService.create(hanke.id, USERNAME, Kayttooikeustaso.KATSELUOIKEUS)
 
-            assertThat(authorizer.authorizeAttachment(application.id, attachment.id!!, VIEW.name))
-                .isTrue()
+            val result = authorizer.authorizeAttachment(application.id, attachment.id!!, VIEW.name)
+
+            assertThat(result).isTrue()
+        }
+
+        @Test
+        fun `throws exception when editing a hakemus attachment from a completed hanke`() {
+            val hanke = hankeFactory.saveMinimal(status = HankeStatus.COMPLETED)
+            val application = applicationFactory.saveApplicationEntity(USERNAME, hanke)
+            val attachment =
+                applicationAttachmentFactory.save(application = application).withContent().value
+            permissionService.create(hanke.id, USERNAME, Kayttooikeustaso.KAIKKI_OIKEUDET)
+
+            val failure = assertFailure {
+                authorizer.authorizeAttachment(
+                    application.id,
+                    attachment.id!!,
+                    PermissionCode.EDIT_APPLICATIONS.name,
+                )
+            }
+
+            failure.all {
+                hasClass(HankeAlreadyCompletedException::class)
+                messageContains("Hanke has already been completed, so the operation is not allowed")
+                messageContains("hankeId=${hanke.id}")
+            }
+        }
+
+        @Test
+        fun `returns true when viewing a hakemus attachment from a completed hanke`() {
+            val hanke = hankeFactory.saveMinimal(status = HankeStatus.COMPLETED)
+            val application = applicationFactory.saveApplicationEntity(USERNAME, hanke)
+            val attachment =
+                applicationAttachmentFactory.save(application = application).withContent().value
+            permissionService.create(hanke.id, USERNAME, Kayttooikeustaso.KATSELUOIKEUS)
+
+            val result = authorizer.authorizeAttachment(application.id, attachment.id!!, VIEW.name)
+
+            assertThat(result).isTrue()
         }
 
         @Test
         fun `throws error if enum value not found`() {
-            assertFailure {
-                    authorizer.authorizeAttachment(applicationId, attachmentId, "Not real")
-                }
-                .all {
-                    hasClass(IllegalArgumentException::class)
-                    messageContains(
-                        "No enum constant fi.hel.haitaton.hanke.permissions.PermissionCode.Not real"
-                    )
-                }
+            val failure = assertFailure {
+                authorizer.authorizeAttachment(applicationId, attachmentId, "Not real")
+            }
+
+            failure.all {
+                hasClass(IllegalArgumentException::class)
+                messageContains(
+                    "No enum constant fi.hel.haitaton.hanke.permissions.PermissionCode.Not real"
+                )
+            }
         }
     }
 }

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaAuthorizerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaAuthorizerITest.kt
@@ -6,7 +6,9 @@ import assertk.assertThat
 import assertk.assertions.hasClass
 import assertk.assertions.isTrue
 import assertk.assertions.messageContains
+import fi.hel.haitaton.hanke.HankeAlreadyCompletedException
 import fi.hel.haitaton.hanke.IntegrationTest
+import fi.hel.haitaton.hanke.domain.HankeStatus
 import fi.hel.haitaton.hanke.factory.HankeFactory
 import fi.hel.haitaton.hanke.factory.HankeKayttajaFactory
 import fi.hel.haitaton.hanke.test.USERNAME
@@ -28,11 +30,14 @@ class HankeKayttajaAuthorizerITest(
         fun `throws exception if kayttajaId is not found`() {
             val kayttajaId = UUID.fromString("bb201bf3-58b7-48d5-a7e4-e358370f74e1")
 
-            assertFailure { authorizer.authorizeKayttajaId(kayttajaId, PermissionCode.VIEW.name) }
-                .all {
-                    hasClass(HankeKayttajaNotFoundException::class)
-                    messageContains(kayttajaId.toString())
-                }
+            val failure = assertFailure {
+                authorizer.authorizeKayttajaId(kayttajaId, PermissionCode.VIEW.name)
+            }
+
+            failure.all {
+                hasClass(HankeKayttajaNotFoundException::class)
+                messageContains(kayttajaId.toString())
+            }
         }
 
         @Test
@@ -40,11 +45,14 @@ class HankeKayttajaAuthorizerITest(
             val hankeId = hankeFactory.saveMinimal().id
             val kayttajaId = hankeKayttajaFactory.saveUser(hankeId).id
 
-            assertFailure { authorizer.authorizeKayttajaId(kayttajaId, PermissionCode.VIEW.name) }
-                .all {
-                    hasClass(HankeKayttajaNotFoundException::class)
-                    messageContains(kayttajaId.toString())
-                }
+            val failure = assertFailure {
+                authorizer.authorizeKayttajaId(kayttajaId, PermissionCode.VIEW.name)
+            }
+
+            failure.all {
+                hasClass(HankeKayttajaNotFoundException::class)
+                messageContains(kayttajaId.toString())
+            }
         }
 
         @Test
@@ -53,11 +61,14 @@ class HankeKayttajaAuthorizerITest(
             val kayttajaId = hankeKayttajaFactory.saveIdentifiedUser(hankeId).id
             permissionService.create(hankeId, USERNAME, Kayttooikeustaso.KATSELUOIKEUS)
 
-            assertFailure { authorizer.authorizeKayttajaId(kayttajaId, PermissionCode.EDIT.name) }
-                .all {
-                    hasClass(HankeKayttajaNotFoundException::class)
-                    messageContains(kayttajaId.toString())
-                }
+            val failure = assertFailure {
+                authorizer.authorizeKayttajaId(kayttajaId, PermissionCode.EDIT.name)
+            }
+
+            failure.all {
+                hasClass(HankeKayttajaNotFoundException::class)
+                messageContains(kayttajaId.toString())
+            }
         }
 
         @Test
@@ -66,21 +77,146 @@ class HankeKayttajaAuthorizerITest(
             val kayttajaId = hankeKayttajaFactory.saveIdentifiedUser(hankeId).id
             permissionService.create(hankeId, USERNAME, Kayttooikeustaso.HANKEMUOKKAUS)
 
-            assertThat(authorizer.authorizeKayttajaId(kayttajaId, PermissionCode.EDIT.name))
-                .isTrue()
+            val result = authorizer.authorizeKayttajaId(kayttajaId, PermissionCode.EDIT.name)
+
+            assertThat(result).isTrue()
         }
 
         @Test
         fun `throws error if enum value not found`() {
             val kayttajaId = UUID.fromString("bb201bf3-58b7-48d5-a7e4-e358370f74e1")
 
-            assertFailure { authorizer.authorizeKayttajaId(kayttajaId, "Not real") }
-                .all {
-                    hasClass(IllegalArgumentException::class)
-                    messageContains(
-                        "No enum constant fi.hel.haitaton.hanke.permissions.PermissionCode.Not real"
-                    )
-                }
+            val failure = assertFailure { authorizer.authorizeKayttajaId(kayttajaId, "Not real") }
+
+            failure.all {
+                hasClass(IllegalArgumentException::class)
+                messageContains(
+                    "No enum constant fi.hel.haitaton.hanke.permissions.PermissionCode.Not real"
+                )
+            }
+        }
+
+        @Test
+        fun `throws exception when modifying a hankekayttaja from a completed hanke`() {
+            val hankeId = hankeFactory.saveMinimal(status = HankeStatus.COMPLETED).id
+            val kayttajaId = hankeKayttajaFactory.saveIdentifiedUser(hankeId).id
+            permissionService.create(hankeId, USERNAME, Kayttooikeustaso.KAIKKI_OIKEUDET)
+
+            val failure = assertFailure {
+                authorizer.authorizeKayttajaId(kayttajaId, PermissionCode.EDIT.name)
+            }
+
+            failure.all {
+                hasClass(HankeAlreadyCompletedException::class)
+                messageContains("Hanke has already been completed, so the operation is not allowed")
+                messageContains("hankeId=${hankeId}")
+            }
+        }
+
+        @Test
+        fun `returns true when viewing a hankekayttaja from a completed hanke`() {
+            val hankeId = hankeFactory.saveMinimal(status = HankeStatus.COMPLETED).id
+            val kayttajaId = hankeKayttajaFactory.saveIdentifiedUser(hankeId).id
+            permissionService.create(hankeId, USERNAME, Kayttooikeustaso.KAIKKI_OIKEUDET)
+
+            val result = authorizer.authorizeKayttajaId(kayttajaId, PermissionCode.VIEW.name)
+
+            assertThat(result).isTrue()
+        }
+    }
+
+    @Nested
+    inner class AuthorizeResend {
+        @Test
+        fun `throws exception if kayttajaId is not found`() {
+            val kayttajaId = UUID.fromString("bb201bf3-58b7-48d5-a7e4-e358370f74e1")
+
+            val failure = assertFailure {
+                authorizer.authorizeResend(kayttajaId, PermissionCode.VIEW.name)
+            }
+
+            failure.all {
+                hasClass(HankeKayttajaNotFoundException::class)
+                messageContains(kayttajaId.toString())
+            }
+        }
+
+        @Test
+        fun `throws exception if user doesn't have any permission for the hanke`() {
+            val hankeId = hankeFactory.saveMinimal().id
+            val kayttajaId = hankeKayttajaFactory.saveUser(hankeId).id
+
+            val failure = assertFailure {
+                authorizer.authorizeResend(kayttajaId, PermissionCode.VIEW.name)
+            }
+
+            failure.all {
+                hasClass(HankeKayttajaNotFoundException::class)
+                messageContains(kayttajaId.toString())
+            }
+        }
+
+        @Test
+        fun `throws exception if user doesn't have the required permission for the hanke`() {
+            val hankeId = hankeFactory.saveMinimal().id
+            val kayttajaId = hankeKayttajaFactory.saveIdentifiedUser(hankeId).id
+            permissionService.create(hankeId, USERNAME, Kayttooikeustaso.KATSELUOIKEUS)
+
+            val failure = assertFailure {
+                authorizer.authorizeResend(kayttajaId, PermissionCode.EDIT.name)
+            }
+
+            failure.all {
+                hasClass(HankeKayttajaNotFoundException::class)
+                messageContains(kayttajaId.toString())
+            }
+        }
+
+        @Test
+        fun `return true if user has the required permission for the hanke`() {
+            val hankeId = hankeFactory.saveMinimal().id
+            val kayttajaId = hankeKayttajaFactory.saveIdentifiedUser(hankeId).id
+            permissionService.create(hankeId, USERNAME, Kayttooikeustaso.HANKEMUOKKAUS)
+
+            val result = authorizer.authorizeResend(kayttajaId, PermissionCode.EDIT.name)
+
+            assertThat(result).isTrue()
+        }
+
+        @Test
+        fun `throws error if enum value not found`() {
+            val kayttajaId = UUID.fromString("bb201bf3-58b7-48d5-a7e4-e358370f74e1")
+
+            val failure = assertFailure { authorizer.authorizeResend(kayttajaId, "Not real") }
+
+            failure.all {
+                hasClass(IllegalArgumentException::class)
+                messageContains(
+                    "No enum constant fi.hel.haitaton.hanke.permissions.PermissionCode.Not real"
+                )
+            }
+        }
+
+        @Test
+        fun `returns true when modifying a hankekayttaja from a completed hanke`() {
+            val hankeId = hankeFactory.saveMinimal(status = HankeStatus.COMPLETED).id
+            val kayttajaId = hankeKayttajaFactory.saveIdentifiedUser(hankeId).id
+            permissionService.create(hankeId, USERNAME, Kayttooikeustaso.KAIKKI_OIKEUDET)
+
+            val result = authorizer.authorizeResend(kayttajaId, PermissionCode.EDIT.name)
+
+            assertThat(result).isTrue()
+        }
+
+        @Test
+        fun `returns true when viewing a hankekayttaja from a completed hanke`() {
+            val hankeId = hankeFactory.saveMinimal(status = HankeStatus.COMPLETED).id
+            val kayttajaId = hankeKayttajaFactory.saveIdentifiedUser(hankeId).id
+            permissionService.create(hankeId, USERNAME, Kayttooikeustaso.KAIKKI_OIKEUDET)
+
+            val result = authorizer.authorizeResend(kayttajaId, PermissionCode.VIEW.name)
+
+            assertThat(result).isTrue()
         }
     }
 }

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaControllerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaControllerITest.kt
@@ -297,7 +297,10 @@ class HankeKayttajaControllerITest(
             val testData =
                 listOf(
                     HankeKayttajaFactory.createHankeKayttaja(
-                        1, ContactType.OMISTAJA, ContactType.MUU),
+                        1,
+                        ContactType.OMISTAJA,
+                        ContactType.MUU,
+                    ),
                     HankeKayttajaFactory.createHankeKayttaja(2),
                     HankeKayttajaFactory.createHankeKayttaja(3),
                 )
@@ -438,9 +441,8 @@ class HankeKayttajaControllerITest(
             every {
                 authorizer.authorizeHankeTunnus(HANKE_TUNNUS, MODIFY_EDIT_PERMISSIONS.name)
             } throws HankeNotFoundException(HANKE_TUNNUS)
-            val request =
-                PermissionUpdate(
-                    listOf(PermissionDto(hankeKayttajaId, Kayttooikeustaso.HANKEMUOKKAUS)))
+            val change = PermissionDto(hankeKayttajaId, Kayttooikeustaso.HANKEMUOKKAUS)
+            val request = PermissionUpdate(listOf(change))
 
             put(url, request).andExpect(status().isNotFound)
 
@@ -456,15 +458,17 @@ class HankeKayttajaControllerITest(
             every { hankeService.findIdentifier(HANKE_TUNNUS) } returns hankeIdentifier
             every {
                 permissionService.hasPermission(
-                    hankeIdentifier.id, USERNAME, PermissionCode.MODIFY_DELETE_PERMISSIONS)
+                    hankeIdentifier.id,
+                    USERNAME,
+                    PermissionCode.MODIFY_DELETE_PERMISSIONS,
+                )
             } returns false
             val updates = mapOf(hankeKayttajaId to Kayttooikeustaso.HANKEMUOKKAUS)
             justRun {
                 hankeKayttajaService.updatePermissions(hankeIdentifier, updates, false, USERNAME)
             }
-            val request =
-                PermissionUpdate(
-                    listOf(PermissionDto(hankeKayttajaId, Kayttooikeustaso.HANKEMUOKKAUS)))
+            val change = PermissionDto(hankeKayttajaId, Kayttooikeustaso.HANKEMUOKKAUS)
+            val request = PermissionUpdate(listOf(change))
 
             put(url, request).andExpect(status().isNoContent).andExpect(content().string(""))
 
@@ -479,15 +483,17 @@ class HankeKayttajaControllerITest(
             every { hankeService.findIdentifier(HANKE_TUNNUS) } returns hankeIdentifier
             every {
                 permissionService.hasPermission(
-                    hankeIdentifier.id, USERNAME, PermissionCode.MODIFY_DELETE_PERMISSIONS)
+                    hankeIdentifier.id,
+                    USERNAME,
+                    PermissionCode.MODIFY_DELETE_PERMISSIONS,
+                )
             } returns true
             val updates = mapOf(hankeKayttajaId to Kayttooikeustaso.HANKEMUOKKAUS)
             justRun {
                 hankeKayttajaService.updatePermissions(hankeIdentifier, updates, true, USERNAME)
             }
-            val request =
-                PermissionUpdate(
-                    listOf(PermissionDto(hankeKayttajaId, Kayttooikeustaso.HANKEMUOKKAUS)))
+            val change = PermissionDto(hankeKayttajaId, Kayttooikeustaso.HANKEMUOKKAUS)
+            val request = PermissionUpdate(listOf(change))
 
             put(url, request).andExpect(status().isNoContent)
 
@@ -497,9 +503,8 @@ class HankeKayttajaControllerITest(
         @Test
         fun `Returns forbidden when missing admin permissions`() {
             val updates = setupForException(MissingAdminPermissionException(USERNAME))
-            val request =
-                PermissionUpdate(
-                    listOf(PermissionDto(hankeKayttajaId, Kayttooikeustaso.HANKEMUOKKAUS)))
+            val change = PermissionDto(hankeKayttajaId, Kayttooikeustaso.HANKEMUOKKAUS)
+            val request = PermissionUpdate(listOf(change))
 
             put(url, request)
                 .andExpect(status().isForbidden)
@@ -511,9 +516,8 @@ class HankeKayttajaControllerITest(
         @Test
         fun `Returns forbidden when changing own permissions`() {
             val updates = setupForException(ChangingOwnPermissionException(USERNAME))
-            val request =
-                PermissionUpdate(
-                    listOf(PermissionDto(hankeKayttajaId, Kayttooikeustaso.HANKEMUOKKAUS)))
+            val change = PermissionDto(hankeKayttajaId, Kayttooikeustaso.HANKEMUOKKAUS)
+            val request = PermissionUpdate(listOf(change))
 
             put(url, request)
                 .andExpect(status().isForbidden)
@@ -524,12 +528,11 @@ class HankeKayttajaControllerITest(
 
         @Test
         fun `Returns internal server error if there are users without either permission or tunniste`() {
-            val updates =
-                setupForException(
-                    UsersWithoutKayttooikeustasoException(missingIds = listOf(hankeKayttajaId)))
-            val request =
-                PermissionUpdate(
-                    listOf(PermissionDto(hankeKayttajaId, Kayttooikeustaso.HANKEMUOKKAUS)))
+            val exception =
+                UsersWithoutKayttooikeustasoException(missingIds = listOf(hankeKayttajaId))
+            val updates = setupForException(exception)
+            val change = PermissionDto(hankeKayttajaId, Kayttooikeustaso.HANKEMUOKKAUS)
+            val request = PermissionUpdate(listOf(change))
 
             put(url, request)
                 .andExpect(status().isInternalServerError)
@@ -541,9 +544,8 @@ class HankeKayttajaControllerITest(
         @Test
         fun `Returns conflict if there would be no admins remaining`() {
             val updates = setupForException(NoAdminRemainingException(hankeIdentifier))
-            val request =
-                PermissionUpdate(
-                    listOf(PermissionDto(hankeKayttajaId, Kayttooikeustaso.HANKEMUOKKAUS)))
+            val change = PermissionDto(hankeKayttajaId, Kayttooikeustaso.HANKEMUOKKAUS)
+            val request = PermissionUpdate(listOf(change))
 
             put(url, request)
                 .andExpect(status().isConflict)
@@ -554,12 +556,11 @@ class HankeKayttajaControllerITest(
 
         @Test
         fun `Returns bad request if there would be no admins remaining`() {
-            val updates =
-                setupForException(
-                    HankeKayttajatNotFoundException(listOf(hankeKayttajaId), hankeIdentifier))
-            val request =
-                PermissionUpdate(
-                    listOf(PermissionDto(hankeKayttajaId, Kayttooikeustaso.HANKEMUOKKAUS)))
+            val exception =
+                HankeKayttajatNotFoundException(listOf(hankeKayttajaId), hankeIdentifier)
+            val updates = setupForException(exception)
+            val change = PermissionDto(hankeKayttajaId, Kayttooikeustaso.HANKEMUOKKAUS)
+            val request = PermissionUpdate(listOf(change))
 
             put(url, request)
                 .andExpect(status().isBadRequest)
@@ -595,7 +596,10 @@ class HankeKayttajaControllerITest(
             every { hankeService.findIdentifier(HANKE_TUNNUS) } returns hankeIdentifier
             every {
                 permissionService.hasPermission(
-                    hankeIdentifier.id, USERNAME, PermissionCode.MODIFY_DELETE_PERMISSIONS)
+                    hankeIdentifier.id,
+                    USERNAME,
+                    PermissionCode.MODIFY_DELETE_PERMISSIONS,
+                )
             } returns false
             val updates = mapOf(hankeKayttajaId to Kayttooikeustaso.HANKEMUOKKAUS)
             every {
@@ -701,48 +705,45 @@ class HankeKayttajaControllerITest(
 
         @Test
         fun `Returns 404 if current user doesn't have permission for hanke`() {
-            every { authorizer.authorizeKayttajaId(kayttajaId, RESEND_INVITATION.name) } throws
+            every { authorizer.authorizeResend(kayttajaId, RESEND_INVITATION.name) } throws
                 HankeKayttajaNotFoundException(kayttajaId)
 
             post(url).andExpect(status().isNotFound).andExpect(hankeError(HankeError.HAI4001))
 
-            verifySequence { authorizer.authorizeKayttajaId(kayttajaId, RESEND_INVITATION.name) }
+            verifySequence { authorizer.authorizeResend(kayttajaId, RESEND_INVITATION.name) }
         }
 
         @Test
         fun `Returns 409 if kayttaja already has permission`() {
-            every { authorizer.authorizeKayttajaId(kayttajaId, RESEND_INVITATION.name) } returns
-                true
+            every { authorizer.authorizeResend(kayttajaId, RESEND_INVITATION.name) } returns true
             every { hankeKayttajaService.resendInvitation(kayttajaId, USERNAME) } throws
                 UserAlreadyHasPermissionException(USERNAME, kayttajaId, 41)
 
             post(url).andExpect(status().isConflict).andExpect(hankeError(HankeError.HAI4003))
 
             verifySequence {
-                authorizer.authorizeKayttajaId(kayttajaId, RESEND_INVITATION.name)
+                authorizer.authorizeResend(kayttajaId, RESEND_INVITATION.name)
                 hankeKayttajaService.resendInvitation(kayttajaId, USERNAME)
             }
         }
 
         @Test
         fun `Returns 409 if current user doesn't have a kayttaja`() {
-            every { authorizer.authorizeKayttajaId(kayttajaId, RESEND_INVITATION.name) } returns
-                true
+            every { authorizer.authorizeResend(kayttajaId, RESEND_INVITATION.name) } returns true
             every { hankeKayttajaService.resendInvitation(kayttajaId, USERNAME) } throws
                 CurrentUserWithoutKayttajaException(USERNAME)
 
             post(url).andExpect(status().isConflict).andExpect(hankeError(HankeError.HAI4003))
 
             verifySequence {
-                authorizer.authorizeKayttajaId(kayttajaId, RESEND_INVITATION.name)
+                authorizer.authorizeResend(kayttajaId, RESEND_INVITATION.name)
                 hankeKayttajaService.resendInvitation(kayttajaId, USERNAME)
             }
         }
 
         @Test
         fun `Returns 200 if invitation resent`() {
-            every { authorizer.authorizeKayttajaId(kayttajaId, RESEND_INVITATION.name) } returns
-                true
+            every { authorizer.authorizeResend(kayttajaId, RESEND_INVITATION.name) } returns true
             val hankekayttaja = HankeKayttajaFactory.create()
             every { hankeKayttajaService.resendInvitation(kayttajaId, USERNAME) } returns
                 hankekayttaja
@@ -755,7 +756,7 @@ class HankeKayttajaControllerITest(
                 prop(HankeKayttajaDto::kutsuttu).isEqualTo(hankekayttaja.kutsuttu)
             }
             verifySequence {
-                authorizer.authorizeKayttajaId(kayttajaId, RESEND_INVITATION.name)
+                authorizer.authorizeResend(kayttajaId, RESEND_INVITATION.name)
                 hankeKayttajaService.resendInvitation(kayttajaId, USERNAME)
                 disclosureLogService.saveForHankeKayttaja(response, USERNAME)
             }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/ControllerExceptionHandler.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/ControllerExceptionHandler.kt
@@ -131,6 +131,15 @@ class ControllerExceptionHandler {
         return HankeError.HAI2001
     }
 
+    @ExceptionHandler(HankeAlreadyCompletedException::class)
+    @ResponseStatus(HttpStatus.CONFLICT)
+    @Hidden
+    fun hankeAlreadyCompleted(ex: HankeAlreadyCompletedException): HankeError {
+        logger.warn { ex.message }
+        Sentry.captureException(ex)
+        return HankeError.HAI1034
+    }
+
     @ExceptionHandler(ApplicationInAlluException::class)
     @ResponseStatus(HttpStatus.CONFLICT)
     @Hidden

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeError.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeError.kt
@@ -30,6 +30,7 @@ enum class HankeError(val errorMessage: String) {
     HAI1030("Problem with classification of geometries"),
     HAI1031("Invalid state: Missing needed data"),
     HAI1032("Invalid Hankealue data"),
+    HAI1034("Hanke has been completed, operation is forbidden"),
     HAI2001("Application not found"),
     HAI2002("Incompatible application data type"),
     HAI2003("Application is already processing in Allu and can no longer be updated."),
@@ -95,5 +96,10 @@ class HankeYhteystietoNotFoundException(val hanke: HankeIdentifier, ytId: Int) :
     )
 
 class HankeAlluConflictException(message: String) : RuntimeException(message)
+
+class HankeAlreadyCompletedException(hankeId: Int) :
+    RuntimeException(
+        "Hanke has already been completed, so the operation is not allowed. hankeId=$hankeId"
+    )
 
 class DatabaseStateException(message: String) : RuntimeException(message)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Persistence.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Persistence.kt
@@ -137,6 +137,9 @@ interface HankeRepository : JpaRepository<HankeEntity, Int> {
 
     fun findAllByStatus(status: HankeStatus): List<HankeEntity>
 
+    @Query("select h.status from HankeEntity h where h.id = :id")
+    fun findStatusById(id: Int): HankeStatus?
+
     @Query(
         "select h.id " +
             "from HankeEntity h " +

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/Authorizer.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/Authorizer.kt
@@ -1,25 +1,42 @@
 package fi.hel.haitaton.hanke.permissions
 
+import fi.hel.haitaton.hanke.HankeAlreadyCompletedException
 import fi.hel.haitaton.hanke.HankeNotFoundException
 import fi.hel.haitaton.hanke.HankeRepository
 import fi.hel.haitaton.hanke.currentUserId
+import fi.hel.haitaton.hanke.domain.HankeStatus
 import org.springframework.transaction.annotation.Transactional
 
 abstract class Authorizer(
     private val permissionService: PermissionService,
-    private val hankeRepository: HankeRepository? = null
+    private val hankeRepository: HankeRepository,
 ) {
-    fun authorize(hankeId: Int?, permissionCode: PermissionCode, ex: () -> Exception) {
-        hankeId
-            ?.let { permissionService.hasPermission(it, currentUserId(), permissionCode) }
-            .let { if (it != true) throw ex() }
+    fun authorize(
+        hankeId: Int?,
+        permissionCode: PermissionCode,
+        editDeniedForCompleted: Boolean = true,
+        ex: () -> Exception,
+    ) {
+        if (hankeId == null) throw ex()
+        if (!permissionService.hasPermission(hankeId, currentUserId(), permissionCode)) {
+            throw ex()
+        }
+
+        val hankeStatus = hankeRepository.findStatusById(hankeId)!!
+        if (
+            editDeniedForCompleted &&
+                hankeStatus == HankeStatus.COMPLETED &&
+                permissionCode != PermissionCode.VIEW
+        ) {
+            throw HankeAlreadyCompletedException(hankeId)
+        }
     }
 
     internal fun authorizeHankeTunnus(
         hankeTunnus: String,
-        permissionCode: PermissionCode
+        permissionCode: PermissionCode,
     ): Boolean {
-        val hankeIdentifier = hankeRepository!!.findOneByHankeTunnus(hankeTunnus)
+        val hankeIdentifier = hankeRepository.findOneByHankeTunnus(hankeTunnus)
         authorize(hankeIdentifier?.id, permissionCode) { HankeNotFoundException(hankeTunnus) }
         return true
     }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaAuthorizer.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaAuthorizer.kt
@@ -12,12 +12,29 @@ class HankeKayttajaAuthorizer(
     private val hankekayttajaRepository: HankekayttajaRepository,
 ) : Authorizer(permissionService, hankeRepository) {
 
-    fun authorizeKayttajaId(hankeKayttajaId: UUID, permissionCode: PermissionCode): Boolean {
+    private fun authorizeKayttajaId(
+        hankeKayttajaId: UUID,
+        permissionCode: PermissionCode,
+        editDeniedForCompleted: Boolean,
+    ): Boolean {
         val hankeId = hankekayttajaRepository.findByIdOrNull(hankeKayttajaId)?.hankeId
-        authorize(hankeId, permissionCode) { HankeKayttajaNotFoundException(hankeKayttajaId) }
+        authorize(hankeId, permissionCode, editDeniedForCompleted) {
+            HankeKayttajaNotFoundException(hankeKayttajaId)
+        }
         return true
     }
 
     fun authorizeKayttajaId(hankeKayttajaId: UUID, permissionCode: String): Boolean =
-        authorizeKayttajaId(hankeKayttajaId, PermissionCode.valueOf(permissionCode))
+        authorizeKayttajaId(
+            hankeKayttajaId,
+            PermissionCode.valueOf(permissionCode),
+            editDeniedForCompleted = true,
+        )
+
+    fun authorizeResend(hankeKayttajaId: UUID, permissionCode: String) =
+        authorizeKayttajaId(
+            hankeKayttajaId,
+            PermissionCode.valueOf(permissionCode),
+            editDeniedForCompleted = false,
+        )
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaController.kt
@@ -42,15 +42,12 @@ class HankeKayttajaController(
     @GetMapping("/my-permissions")
     @Operation(
         summary = "Get your permissions for your own projects",
-        description =
-            "Returns a map of current users Hanke identifiers and respective permissions.")
+        description = "Returns a map of current users Hanke identifiers and respective permissions.",
+    )
     @ApiResponses(
         value =
-            [
-                ApiResponse(
-                    description = "Permissions grouped by hankeTunnus.",
-                    responseCode = "200",
-                )])
+            [ApiResponse(description = "Permissions grouped by hankeTunnus.", responseCode = "200")]
+    )
     fun whoAmIByHanke(): Map<String, WhoamiResponse> {
         val permissions: List<HankePermission> =
             permissionService.permissionsByHanke(userId = currentUserId())
@@ -66,12 +63,15 @@ class HankeKayttajaController(
                 ApiResponse(
                     description = "Your permissions",
                     responseCode = "200",
-                    content = [Content(schema = Schema(implementation = WhoamiResponse::class))]),
+                    content = [Content(schema = Schema(implementation = WhoamiResponse::class))],
+                ),
                 ApiResponse(
                     description = "Hanke not found",
                     responseCode = "404",
-                    content = [Content(schema = Schema(implementation = HankeError::class))]),
-            ])
+                    content = [Content(schema = Schema(implementation = HankeError::class))],
+                ),
+            ]
+    )
     @PreAuthorize("@hankeKayttajaAuthorizer.authorizeHankeTunnus(#hankeTunnus, 'VIEW')")
     fun whoami(@PathVariable hankeTunnus: String): WhoamiResponse {
         val userId = currentUserId()
@@ -86,7 +86,8 @@ class HankeKayttajaController(
     @GetMapping("/kayttajat/{kayttajaId}")
     @Operation(
         summary = "Get a Hanke user",
-        description = "Returns a single user and their Hanke related information.")
+        description = "Returns a single user and their Hanke related information.",
+    )
     @ApiResponses(
         value =
             [
@@ -94,12 +95,15 @@ class HankeKayttajaController(
                 ApiResponse(
                     description = "Invalid UUID",
                     responseCode = "400",
-                    content = [Content(schema = Schema(implementation = HankeError::class))]),
+                    content = [Content(schema = Schema(implementation = HankeError::class))],
+                ),
                 ApiResponse(
                     description = "Hanke or user not found",
                     responseCode = "404",
-                    content = [Content(schema = Schema(implementation = HankeError::class))]),
-            ])
+                    content = [Content(schema = Schema(implementation = HankeError::class))],
+                ),
+            ]
+    )
     @PreAuthorize("@hankeKayttajaAuthorizer.authorizeKayttajaId(#kayttajaId, 'VIEW')")
     fun getHankeKayttaja(@PathVariable kayttajaId: UUID): HankeKayttajaDto =
         hankeKayttajaService.getKayttaja(kayttajaId).toDto()
@@ -107,7 +111,8 @@ class HankeKayttajaController(
     @GetMapping("/hankkeet/{hankeTunnus}/kayttajat")
     @Operation(
         summary = "Get Hanke users",
-        description = "Returns a list of users and their Hanke related information.")
+        description = "Returns a list of users and their Hanke related information.",
+    )
     @ApiResponses(
         value =
             [
@@ -115,12 +120,15 @@ class HankeKayttajaController(
                     description = "Users in Hanke",
                     responseCode = "200",
                     content =
-                        [Content(schema = Schema(implementation = HankeKayttajaResponse::class))]),
+                        [Content(schema = Schema(implementation = HankeKayttajaResponse::class))],
+                ),
                 ApiResponse(
                     description = "Hanke not found",
                     responseCode = "404",
-                    content = [Content(schema = Schema(implementation = HankeError::class))]),
-            ])
+                    content = [Content(schema = Schema(implementation = HankeError::class))],
+                ),
+            ]
+    )
     @PreAuthorize("@hankeKayttajaAuthorizer.authorizeHankeTunnus(#hankeTunnus, 'VIEW')")
     fun getHankeKayttajat(@PathVariable hankeTunnus: String): HankeKayttajaResponse {
         logger.info { "Finding kayttajat for hanke $hankeTunnus" }
@@ -140,10 +148,7 @@ class HankeKayttajaController(
         description =
             "Add a new user for the hanke. Adds an invitation with viewing permissions. Sends an invitation email to them.",
     )
-    @ApiResponse(
-        description = "The user that was added",
-        responseCode = "200",
-    )
+    @ApiResponse(description = "The user that was added", responseCode = "200")
     @ApiResponse(
         description = "Hanke not found",
         responseCode = "404",
@@ -157,7 +162,7 @@ class HankeKayttajaController(
     @PreAuthorize("@hankeKayttajaAuthorizer.authorizeHankeTunnus(#hankeTunnus, 'CREATE_USER')")
     fun createNewUser(
         @RequestBody request: NewUserRequest,
-        @PathVariable hankeTunnus: String
+        @PathVariable hankeTunnus: String,
     ): HankeKayttajaDto {
         val hanke = hankeService.loadHanke(hankeTunnus)!!
         return hankeKayttajaService.createNewUser(request, hanke, currentUserId())
@@ -182,7 +187,8 @@ permissions.
 
 If removing or adding KAIKKI_OIKEUDET kayttooikeustaso, the caller needs to
 have those same permissions.
-""")
+""",
+    )
     @ApiResponses(
         value =
             [
@@ -190,28 +196,34 @@ have those same permissions.
                 ApiResponse(
                     description = "The request body was invalid",
                     responseCode = "400",
-                    content = [Content(schema = Schema(implementation = HankeError::class))]),
+                    content = [Content(schema = Schema(implementation = HankeError::class))],
+                ),
                 ApiResponse(
                     description = "Not authorized to change admin permissions",
                     responseCode = "403",
-                    content = [Content(schema = Schema(implementation = HankeError::class))]),
+                    content = [Content(schema = Schema(implementation = HankeError::class))],
+                ),
                 ApiResponse(
                     description = "Hanke by requested tunnus not found",
                     responseCode = "404",
-                    content = [Content(schema = Schema(implementation = HankeError::class))]),
+                    content = [Content(schema = Schema(implementation = HankeError::class))],
+                ),
                 ApiResponse(
                     description =
                         "User tried editing their own permissions or there would " +
                             "be no users with KAIKKI_OIKEUDET left.",
                     responseCode = "409",
-                    content = [Content(schema = Schema(implementation = HankeError::class))]),
-            ])
+                    content = [Content(schema = Schema(implementation = HankeError::class))],
+                ),
+            ]
+    )
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @PreAuthorize(
-        "@hankeKayttajaAuthorizer.authorizeHankeTunnus(#hankeTunnus, 'MODIFY_EDIT_PERMISSIONS')")
+        "@hankeKayttajaAuthorizer.authorizeHankeTunnus(#hankeTunnus, 'MODIFY_EDIT_PERMISSIONS')"
+    )
     fun updatePermissions(
         @RequestBody permissions: PermissionUpdate,
-        @PathVariable hankeTunnus: String
+        @PathVariable hankeTunnus: String,
     ) {
         val hankeIdentifier = hankeService.findIdentifier(hankeTunnus)!!
 
@@ -219,13 +231,17 @@ have those same permissions.
 
         val deleteAdminPermission =
             permissionService.hasPermission(
-                hankeIdentifier.id, userId, PermissionCode.MODIFY_DELETE_PERMISSIONS)
+                hankeIdentifier.id,
+                userId,
+                PermissionCode.MODIFY_DELETE_PERMISSIONS,
+            )
 
         hankeKayttajaService.updatePermissions(
             hankeIdentifier,
             permissions.kayttajat.associate { it.id to it.kayttooikeustaso },
             deleteAdminPermission,
-            userId)
+            userId,
+        )
     }
 
     @PostMapping("/kayttajat")
@@ -240,7 +256,8 @@ the hanke the token was created for.
 Removes the token after a successful identification.
 
 Responds with information about the activated user and the hanke associated with it.
-""")
+""",
+    )
     @ApiResponses(
         value =
             [
@@ -251,24 +268,31 @@ Responds with information about the activated user and the hanke associated with
                 ApiResponse(
                     description = "Token not found or outdated",
                     responseCode = "404",
-                    content = [Content(schema = Schema(implementation = HankeError::class))]),
+                    content = [Content(schema = Schema(implementation = HankeError::class))],
+                ),
                 ApiResponse(
                     description =
                         "Token doesn't have a user associated with it or the verified name cannot be retrieved from Profiili",
                     responseCode = "500",
-                    content = [Content(schema = Schema(implementation = HankeError::class))]),
+                    content = [Content(schema = Schema(implementation = HankeError::class))],
+                ),
                 ApiResponse(
                     description = "Permission already exists",
                     responseCode = "409",
-                    content = [Content(schema = Schema(implementation = HankeError::class))]),
-            ])
+                    content = [Content(schema = Schema(implementation = HankeError::class))],
+                ),
+            ]
+    )
     fun identifyUser(
         @RequestBody tunnistautuminen: Tunnistautuminen,
-        @Parameter(hidden = true) @CurrentSecurityContext securityContext: SecurityContext
+        @Parameter(hidden = true) @CurrentSecurityContext securityContext: SecurityContext,
     ): TunnistautuminenResponse {
         val kayttaja =
             hankeKayttajaService.createPermissionFromToken(
-                currentUserId(), tunnistautuminen.tunniste, securityContext)
+                currentUserId(),
+                tunnistautuminen.tunniste,
+                securityContext,
+            )
 
         val hanke = hankeService.loadHankeById(kayttaja.hankeId)!!
         return TunnistautuminenResponse(kayttaja.id, hanke.hankeTunnus, hanke.nimi)
@@ -287,25 +311,22 @@ original email will not work anymore. It also means that the period of validity
 of the token and link will be reset.
 
 Returns the updated hankekayttaja.
-""")
+""",
+    )
     @ApiResponses(
         value =
             [
-                ApiResponse(
-                    description = "Invitation email resent",
-                    responseCode = "204",
-                ),
-                ApiResponse(
-                    description = "User not found",
-                    responseCode = "404",
-                ),
+                ApiResponse(description = "Invitation email resent", responseCode = "204"),
+                ApiResponse(description = "User not found", responseCode = "404"),
                 ApiResponse(
                     description =
                         "User has already been activated or the current user doesn't have name and email registered.",
                     responseCode = "409",
-                    content = [Content(schema = Schema(implementation = HankeError::class))]),
-            ])
-    @PreAuthorize("@hankeKayttajaAuthorizer.authorizeKayttajaId(#kayttajaId, 'RESEND_INVITATION')")
+                    content = [Content(schema = Schema(implementation = HankeError::class))],
+                ),
+            ]
+    )
+    @PreAuthorize("@hankeKayttajaAuthorizer.authorizeResend(#kayttajaId, 'RESEND_INVITATION')")
     fun resendInvitations(@PathVariable kayttajaId: UUID): HankeKayttajaDto =
         hankeKayttajaService.resendInvitation(kayttajaId, currentUserId()).toDto()
 
@@ -319,27 +340,23 @@ Updates the contact information of the hankekayttaja the user has in the hanke.
 The sahkoposti and puhelinnumero are mandatory and can't be empty or blank.
 
 Returns the updated hankekayttaja.
-""")
+""",
+    )
     @ApiResponses(
         value =
             [
-                ApiResponse(
-                    description = "Information updated",
-                    responseCode = "200",
-                ),
+                ApiResponse(description = "Information updated", responseCode = "200"),
                 ApiResponse(
                     description = "Email or telephone number is missing",
                     responseCode = "400",
                 ),
-                ApiResponse(
-                    description = "Hanke not found or not authorized",
-                    responseCode = "404",
-                ),
-            ])
+                ApiResponse(description = "Hanke not found or not authorized", responseCode = "404"),
+            ]
+    )
     @PreAuthorize("@hankeKayttajaAuthorizer.authorizeHankeTunnus(#hankeTunnus, 'VIEW')")
     fun updateOwnContactInfo(
         @Valid @RequestBody update: ContactUpdate,
-        @PathVariable hankeTunnus: String
+        @PathVariable hankeTunnus: String,
     ): HankeKayttajaDto {
         return hankeKayttajaService
             .updateOwnContactInfo(hankeTunnus, update, currentUserId())
@@ -354,14 +371,12 @@ Returns the updated hankekayttaja.
 Updates the contact and (optionally) name information of the hankekayttaja.
 
 Returns the updated hankekayttaja.
-""")
+""",
+    )
     @ApiResponses(
         value =
             [
-                ApiResponse(
-                    description = "Information updated",
-                    responseCode = "200",
-                ),
+                ApiResponse(description = "Information updated", responseCode = "200"),
                 ApiResponse(
                     description = "Email or telephone number is missing",
                     responseCode = "400",
@@ -375,12 +390,13 @@ Returns the updated hankekayttaja.
                         "User has already been activated and therefore cannot update name",
                     responseCode = "409",
                 ),
-            ])
+            ]
+    )
     @PreAuthorize("@hankeKayttajaAuthorizer.authorizeHankeTunnus(#hankeTunnus, 'MODIFY_USER')")
     fun updateKayttajaInfo(
         @RequestBody @Valid update: KayttajaUpdate,
         @PathVariable hankeTunnus: String,
-        @PathVariable kayttajaId: UUID
+        @PathVariable kayttajaId: UUID,
     ): HankeKayttajaDto {
         return hankeKayttajaService.updateKayttajaInfo(hankeTunnus, update, kayttajaId).toDto()
     }
@@ -399,23 +415,19 @@ needs to show them when asking for confirmation.
 
 Does not check if the caller needs KAIKKI_OIKEUDET to delete this particular
 user.
-""")
+""",
+    )
     @ApiResponses(
         value =
             [
-                ApiResponse(
-                    description = "Return the results",
-                    responseCode = "200",
-                ),
-                ApiResponse(
-                    description = "kayttajaId is not a proper UUID",
-                    responseCode = "400",
-                ),
+                ApiResponse(description = "Return the results", responseCode = "200"),
+                ApiResponse(description = "kayttajaId is not a proper UUID", responseCode = "400"),
                 ApiResponse(
                     description = "Hankekayttaja not found or not authorized",
                     responseCode = "404",
                 ),
-            ])
+            ]
+    )
     @PreAuthorize("@hankeKayttajaAuthorizer.authorizeKayttajaId(#kayttajaId, 'DELETE_USER')")
     fun checkForDelete(@PathVariable kayttajaId: UUID): HankekayttajaDeleteService.DeleteInfo =
         hankekayttajaDeleteService.checkForDelete(kayttajaId)
@@ -428,18 +440,13 @@ Deletes the given hankekayttaja (user) from the hanke.
 
 Check if there are active applications the user is a contact in or if the user is the only
 contact in the applicant customer role. If either is true, refuse to delete the kayttaja.
-""")
+""",
+    )
     @ApiResponses(
         value =
             [
-                ApiResponse(
-                    description = "User deleted. No body.",
-                    responseCode = "204",
-                ),
-                ApiResponse(
-                    description = "kayttajaId is not a proper UUID.",
-                    responseCode = "400",
-                ),
+                ApiResponse(description = "User deleted. No body.", responseCode = "204"),
+                ApiResponse(description = "kayttajaId is not a proper UUID.", responseCode = "400"),
                 ApiResponse(
                     description = "Hankekayttaja not found or not authorized.",
                     responseCode = "404",
@@ -451,7 +458,8 @@ contact in the applicant customer role. If either is true, refuse to delete the 
                             "there would be no admin users left.",
                     responseCode = "409",
                 ),
-            ])
+            ]
+    )
     @DeleteMapping("/kayttajat/{kayttajaId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @PreAuthorize("@hankeKayttajaAuthorizer.authorizeKayttajaId(#kayttajaId, 'DELETE_USER')")

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/HankeAuthorizerTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/HankeAuthorizerTest.kt
@@ -1,0 +1,102 @@
+package fi.hel.haitaton.hanke
+
+import assertk.all
+import assertk.assertFailure
+import assertk.assertThat
+import assertk.assertions.hasClass
+import assertk.assertions.isTrue
+import assertk.assertions.messageContains
+import fi.hel.haitaton.hanke.domain.HankeStatus
+import fi.hel.haitaton.hanke.factory.TestHankeIdentifier
+import fi.hel.haitaton.hanke.permissions.PermissionCode
+import fi.hel.haitaton.hanke.permissions.PermissionService
+import fi.hel.haitaton.hanke.test.USERNAME
+import io.mockk.checkUnnecessaryStub
+import io.mockk.clearAllMocks
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verifySequence
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+import org.springframework.security.core.Authentication
+import org.springframework.security.core.context.SecurityContext
+import org.springframework.security.core.context.SecurityContextHolder
+
+class HankeAuthorizerTest {
+
+    private val permissionService: PermissionService = mockk()
+    private val hankeRepository: HankeRepository = mockk()
+    private val authorizer: HankeAuthorizer = HankeAuthorizer(permissionService, hankeRepository)
+
+    @BeforeEach
+    fun clearMocks() {
+        clearAllMocks()
+        mockAuthentication()
+    }
+
+    @AfterEach
+    fun checkMocks() {
+        checkUnnecessaryStub()
+        confirmVerified(permissionService, hankeRepository)
+    }
+
+    private fun mockAuthentication() {
+        val authentication: Authentication = mockk()
+        every { authentication.name } returns USERNAME
+        val context: SecurityContext = mockk()
+        every { context.authentication } returns authentication
+        SecurityContextHolder.setContext(context)
+    }
+
+    @Nested
+    inner class AuthorizeHankeTunnus {
+        val hankeId = 6532
+        val hanketunnus = "HAI24-141"
+
+        @Test
+        fun `returns true when viewing a completed hanke`() {
+            every { hankeRepository.findOneByHankeTunnus(hanketunnus) } returns
+                TestHankeIdentifier(hankeId, hanketunnus)
+            every {
+                permissionService.hasPermission(hankeId, USERNAME, PermissionCode.VIEW)
+            } returns true
+            every { hankeRepository.findStatusById(hankeId) } returns HankeStatus.COMPLETED
+
+            val result = authorizer.authorizeHankeTunnus(hanketunnus, PermissionCode.VIEW)
+
+            assertThat(result).isTrue()
+            verifySequence {
+                hankeRepository.findOneByHankeTunnus(hanketunnus)
+                permissionService.hasPermission(hankeId, USERNAME, PermissionCode.VIEW)
+                hankeRepository.findStatusById(hankeId)
+            }
+        }
+
+        @ParameterizedTest
+        @EnumSource(PermissionCode::class, names = ["VIEW"], mode = EnumSource.Mode.EXCLUDE)
+        fun `throws exception when modifying a completed hanke`(permission: PermissionCode) {
+            every { hankeRepository.findOneByHankeTunnus(hanketunnus) } returns
+                TestHankeIdentifier(hankeId, hanketunnus)
+            every { permissionService.hasPermission(hankeId, USERNAME, permission) } returns true
+            every { hankeRepository.findStatusById(hankeId) } returns HankeStatus.COMPLETED
+
+            val failure = assertFailure { authorizer.authorizeHankeTunnus(hanketunnus, permission) }
+
+            failure.all {
+                hasClass(HankeAlreadyCompletedException::class.java)
+                messageContains("Hanke has already been completed, so the operation is not allowed")
+                messageContains("hankeId=$hankeId")
+            }
+            verifySequence {
+                hankeRepository.findOneByHankeTunnus(hanketunnus)
+                permissionService.hasPermission(hankeId, USERNAME, permission)
+                hankeRepository.findStatusById(hankeId)
+            }
+        }
+    }
+}

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeFactory.kt
@@ -43,9 +43,15 @@ class HankeFactory(
         hankeTunnus: String = hanketunnusService.newHanketunnus(),
         nimi: String = defaultNimi,
         generated: Boolean = false,
+        status: HankeStatus = HankeStatus.DRAFT,
     ): HankeEntity =
         hankeRepository.save(
-            HankeEntity(hankeTunnus = hankeTunnus, nimi = nimi, generated = generated)
+            HankeEntity(
+                hankeTunnus = hankeTunnus,
+                nimi = nimi,
+                generated = generated,
+                status = status,
+            )
         )
 
     fun saveSeveralMinimal(n: Int): List<HankeEntity> = (1..n).map { saveMinimal() }

--- a/services/hanke-service/src/test/resources/application-test.yml
+++ b/services/hanke-service/src/test/resources/application-test.yml
@@ -1,4 +1,8 @@
 haitaton:
+  allu:
+    # Allu update service is mocked in test, but the scheduling seems to be active.
+    # Set a ridiculously long initial delay, so it's never actually called.
+    updateInitialDelayMilliSeconds: 6000000000
   azure:
     blob:
       decisions: paatokset-test


### PR DESCRIPTION
# Description

The authorizer will by default deny any API calls where:
1. The permission asked for is not VIEW
2. The hanke has COMPLETED status.

This should stop any edits being done to completed hanke.

The exception is resending the invitation to join a hanke. That can be sent even after the hanke has been completed. It would've been possible to implement this by also allowing the `RESEND_INVITATION` permission for completed hanke, but it felt safer to allow editing completed hanke explicitly in the controller.

Tests were added to all authorizer methods to check that calling them for completed hanke works correctly.

I added unit tests for HankeAuthorizers to check that all permission codes except VIEW are blocked for completed hanke. I didn't see it necessary to repeat this for every other authorizer method.

I added only one controller test to check that the controller returns the correct error codes when the authorizer throws the hanke already completed exception. The controller methods are already tested for calling the authorizer, so it didn't felt necessary to add a bunch of tests to test the same exception handler.

Also, TaydennysAuthorizer was missing tests for one of it's methods so I added them. While adding new tests to authorizers, I enforced stricter AAA-pattern on the authorizer tests. Specifically, I seperated the Act and Assert phases to different blocks.

Automated formatting caused a bunch of changes to some files that haven't been touched in a while. I mitigated some changes by aliasing, especially in `HankeKayttajaControllerITest`.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1150

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
You can try to modify a completed hanke. I don't think it's feasible to test all possible APIs, though.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 