### PR TITLE
HAI-148 Remove rock excavation info when sending kaivuilmoitus

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceITest.kt
@@ -1556,6 +1556,7 @@ class HakemusServiceITest(
                             .copy(
                                 cableReports = listOf(DEFAULT_CABLE_REPORT_APPLICATION_IDENTIFIER),
                                 cableReportDone = true,
+                                rockExcavation = null,
                             )
                             .setOrdererForRepresentative(currentUser.id)
                     expectedCableReportAlluRequest =

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
@@ -362,9 +362,11 @@ class HakemusService(
     private fun updateCableReportDoneFlag(hakemus: HakemusEntity) {
         val hakemusData = hakemus.hakemusEntityData
         if (hakemusData is KaivuilmoitusEntityData && !hakemusData.cableReportDone) {
-            hakemus.hakemusEntityData = hakemusData.copy(cableReportDone = true)
+            hakemus.hakemusEntityData =
+                hakemusData.copy(cableReportDone = true, rockExcavation = null)
             logger.info(
-                "Set cablereportDone as 'true' after send for accompanying johtoselvityshakemus in kaivuilmoitus. ${hakemus.logString()}"
+                "Set cablereportDone as 'true' and rockExcavation as 'null' after " +
+                    "send for accompanying johtoselvityshakemus in kaivuilmoitus. ${hakemus.logString()}"
             )
         }
     }


### PR DESCRIPTION
# Description

The kaivuilmoitus has rock excavation information just because it's needed to create a johtoselvityshakemus when sending the kaivuilmoitus. The identifier of the created johtoselvityshakemus is added to the kaivuilmoitus and the flag that a new johtoselvityshakemus is needed is reset, so it makes sense that the rock excavation information is also removed, since it's no longer used in anything.

Having the rock excavation information set after sending can cause problems later when creating a muutosilmoitus for the kaivuilmoitus. Muutosilmoitus form doesn't have a field for the rock excavation info, so it's always removed. This causes the 'OTHER' change being set for the muutosilmoitus, even when no changes are made on the muutosilmoitus form.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-148

## Type of change

- [X] Bug fix 
- [ ] New feature 
- [ ] Other

# Instructions for testing
1. Create a kaivuilmoitus and ask for a johtoselvitys to be created as well.
2. Send the kaivuilmoitus to Allu and make a decision for it.
3. Create a muutosilmoitus. Don't change any values on the form and click to the last page.
4. On the summary page, there should be no changes visible and the send button should not be visible.
5. The send button should also not be visible on the hakemus page after save and suspend.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 

# Other relevant info
I'll merge this without review, the review can be done afterwards.