### PR TITLE
HAI-3444 Send reminder before a hanke is deleted

### DIFF
--- a/email/hanke-poistetaan.mjml
+++ b/email/hanke-poistetaan.mjml
@@ -1,0 +1,41 @@
+<mjml>
+    <mj-head>
+        <mj-include path="common/attributes.partial"/>
+    </mj-head>
+    <mj-body>
+        <mj-include path="common/header-content.partial"/>
+        <mj-section>
+            <mj-column>
+                <mj-text mj-class="header-txt">
+                    Hankkeesi {{hanketunnus}} poistetaan järjestelmästä / Hankkeesi {{hanketunnus}} poistetaan
+                    järjestelmästä / Hankkeesi {{hanketunnus}} poistetaan järjestelmästä
+                </mj-text>
+                <mj-text mj-class="basic-txt">
+                    Hankkeesi <b>{{hankeNimi}} ({{hanketunnus}})</b> poistuu Haitattomasta {{deletionDate}}. Ota
+                    tarvitsemasi tiedot talteen ennen hankkeen poistumista. Poistumisen jälkeen hankkeen ja sen
+                    hakemusten kaikki tiedot poistuvat, eikä niitä pääse enää palauttamaan.
+                </mj-text>
+                <mj-include path="common/signature-fi.partial"/>
+
+                <mj-divider mj-class="language-separator"/>
+
+                <mj-text mj-class="basic-txt">
+                    Hankkeesi <b>{{hankeNimi}} ({{hanketunnus}})</b> poistuu Haitattomasta {{deletionDate}}. Ota
+                    tarvitsemasi tiedot talteen ennen hankkeen poistumista. Poistumisen jälkeen hankkeen ja sen
+                    hakemusten kaikki tiedot poistuvat, eikä niitä pääse enää palauttamaan.
+                </mj-text>
+                <mj-include path="common/signature-sv.partial"/>
+
+                <mj-divider mj-class="language-separator"/>
+
+                <mj-text mj-class="basic-txt">
+                    Hankkeesi <b>{{hankeNimi}} ({{hanketunnus}})</b> poistuu Haitattomasta {{deletionDate}}. Ota
+                    tarvitsemasi tiedot talteen ennen hankkeen poistumista. Poistumisen jälkeen hankkeen ja sen
+                    hakemusten kaikki tiedot poistuvat, eikä niitä pääse enää palauttamaan.
+                </mj-text>
+                <mj-include path="common/signature-en.partial"/>
+            </mj-column>
+        </mj-section>
+        <mj-include path="common/footer-content.partial"/>
+    </mj-body>
+</mjml>

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Persistence.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Persistence.kt
@@ -162,8 +162,16 @@ interface HankeRepository : JpaRepository<HankeEntity, Int> {
     )
     fun findHankeToRemind(limit: Int, reminderDate: LocalDate, reminder: HankeReminder): List<Int>
 
-    @Query("select h.id from HankeEntity h where h.completedAt <= :date")
+    @Query("select h.id from HankeEntity h where h.completedAt <= :date order by h.completedAt asc")
     fun findHankeToDelete(date: OffsetDateTime): List<Int>
+
+    @Query(
+        "select h.id from HankeEntity h " +
+            "where date(h.completedAt) <= :reminderDate " +
+            "and not array_contains(h.sentReminders, :reminder) " +
+            "order by h.completedAt asc"
+    )
+    fun findIdsForDeletionReminders(reminderDate: LocalDate, reminder: HankeReminder): List<Int>
 }
 
 interface HankeIdentifier : HasId<Int>, Loggable {

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/Hanke.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/domain/Hanke.kt
@@ -191,4 +191,5 @@ enum class TyomaaTyyppi {
 enum class HankeReminder {
     COMPLETION_5,
     COMPLETION_14,
+    DELETION_5,
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/email/EmailEvent.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/email/EmailEvent.kt
@@ -76,6 +76,13 @@ data class HankeEndingReminder(
     val endingDate: LocalDate,
 ) : EmailEvent
 
+data class HankeDeletionReminder(
+    override val to: String,
+    val hankeNimi: String,
+    val hanketunnus: String,
+    val deletionDate: LocalDate,
+) : EmailEvent
+
 data class HankeCompletedNotification(
     override val to: String,
     val hankeNimi: String,

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/email/EmailSenderService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/email/EmailSenderService.kt
@@ -39,6 +39,7 @@ enum class EmailTemplate(val value: String) {
     CABLE_REPORT_DONE("johtoselvitys-valmis"),
     EXCAVATION_NOTIFICATION_DECISION("kaivuilmoitus-paatos"),
     HANKE_COMPLETED("hanke-valmistunut"),
+    HANKE_DELETION_REMINDER("hanke-poistetaan"),
     HANKE_ENDING("hanke-paattyy"),
     INFORMATION_REQUEST("taydennyspyynto"),
     INFORMATION_REQUEST_CANCELED("taydennyspyynto-peruttu"),
@@ -195,6 +196,19 @@ class EmailSenderService(
             )
 
         sendHybridEmail(data.to, EmailTemplate.HANKE_ENDING, templateData)
+    }
+
+    @TransactionalEventListener
+    fun sendHankeDeletionReminder(data: HankeDeletionReminder) {
+        logger.info { "Sending reminder email for hanke being deleted soon" }
+        val templateData =
+            mapOf(
+                "hanketunnus" to data.hanketunnus,
+                "hankeNimi" to data.hankeNimi,
+                "deletionDate" to data.deletionDate.format(FINNISH_DATE_FORMAT),
+            )
+
+        sendHybridEmail(data.to, EmailTemplate.HANKE_DELETION_REMINDER, templateData)
     }
 
     @TransactionalEventListener

--- a/services/hanke-service/src/main/resources/application.yml
+++ b/services/hanke-service/src/main/resources/application.yml
@@ -60,6 +60,8 @@ haitaton:
       deletionCron: ${HAITATON_COMPLETIONS_DELETE_CRON:38 32 20 * * *}
       # By default, run every day at 19:17:21 (Helsinki time).
       reminderCron: ${HAITATON_COMPLETIONS_REMINDER_CRON:21 17 19 * * *}
+      # By default, run every day at 20:03:53 (Helsinki time).
+      deletionReminderCron: ${HAITATON_COMPLETIONS_DELETE_CRON:53 03 20 * * *}
   map-service:
     capability-url: https://kartta.hel.fi/ws/geoserver/avoindata/wms?REQUEST=GetCapabilities&SERVICE=WMS
   profiili-api:

--- a/services/hanke-service/src/main/resources/email/template/hanke-poistetaan.html.mustache
+++ b/services/hanke-service/src/main/resources/email/template/hanke-poistetaan.html.mustache
@@ -1,0 +1,215 @@
+<!doctype html>
+<html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
+
+<head>
+  <title></title>
+  <!--[if !mso]><!-->
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <!--<![endif]-->
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <style type="text/css">#outlook a{padding:0}body{margin:0;padding:0;-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%}table,td{border-collapse:collapse;mso-table-lspace:0;mso-table-rspace:0}img{border:0;height:auto;line-height:100%;outline:0;text-decoration:none;-ms-interpolation-mode:bicubic}p{display:block;margin:13px 0}</style>
+  <!--[if mso]>
+    <noscript>
+    <xml>
+    <o:OfficeDocumentSettings>
+      <o:AllowPNG/>
+      <o:PixelsPerInch>96</o:PixelsPerInch>
+    </o:OfficeDocumentSettings>
+    </xml>
+    </noscript>
+    <![endif]-->
+  <!--[if lte mso 11]>
+    <style type="text/css">
+      .mj-outlook-group-fix { width:100% !important; }
+    </style>
+    <![endif]-->
+  <style type="text/css">@media only screen and (min-width:480px){.mj-column-per-100{width:100%!important;max-width:100%}}</style>
+  <style media="screen and (min-width:480px)">.moz-text-html .mj-column-per-100{width:100%!important;max-width:100%}</style>
+</head>
+
+<body style="word-spacing:normal">
+  <div lang="und" dir="auto">
+    <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    <div style="margin:0 auto;max-width:600px">
+      <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%">
+        <tbody>
+          <tr>
+            <td style="direction:ltr;font-size:0;padding:20px 0;text-align:center">
+              <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
+              <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%">
+                <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top" width="100%">
+                  <tbody>
+                    <div style="display:flex;align-items:center">
+                      <div style="padding-left:24px;padding-top:16px">
+                        <img src="{{baseUrl}}/helsinki.png" alt="Helsingin logo" width="131" height="65">
+                      </div>
+                      <div style="padding-left:16px;padding-top:12px;font-family:Arial;font-size:24px"> Haitaton </div>
+                    </div>
+                  </tbody>
+                </table>
+              </div>
+              <!--[if mso | IE]></td></tr></table><![endif]-->
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    <div style="margin:0 auto;max-width:600px">
+      <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%">
+        <tbody>
+          <tr>
+            <td style="direction:ltr;font-size:0;padding:20px 0;text-align:center">
+              <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
+              <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%">
+                <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top" width="100%">
+                  <tbody>
+                    <tr>
+                      <td align="left" style="font-size:0;padding:16px 24px 16px 24px;word-break:break-word">
+                        <div style="font-family:Arial;font-size:36px;line-height:43px;text-align:left;color:#000">Hankkeesi {{hanketunnus}} poistetaan järjestelmästä / Hankkeesi {{hanketunnus}} poistetaan järjestelmästä / Hankkeesi {{hanketunnus}} poistetaan järjestelmästä</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="left" style="font-size:0;padding:16px 24px 0 24px;word-break:break-word">
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">Hankkeesi <b>{{hankeNimi}} ({{hanketunnus}})</b> poistuu Haitattomasta {{deletionDate}}. Ota tarvitsemasi tiedot talteen ennen hankkeen poistumista. Poistumisen jälkeen hankkeen ja sen hakemusten kaikki tiedot poistuvat, eikä niitä pääse enää palauttamaan.</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="left" style="font-size:0;padding:16px 24px 0 24px;word-break:break-word">
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">Haitaton on Helsingin kaupungin asiointijärjestelmä yleisille alueille sijoittuvien hankkeiden edistämiseen ja haittojen hallintaan.</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="left" style="font-size:0;padding:16px 24px 0 24px;word-break:break-word">
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">Tämä on automaattinen sähköposti – älä vastaa tähän viestiin.</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="left" style="font-size:0;padding:16px 24px 0 24px;word-break:break-word">
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">Ystävällisin terveisin,</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="left" style="font-size:0;padding:16px 24px 16px 24px;word-break:break-word">
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">Helsingin kaupungin kaupunkiympäristön toimiala <br> Haitaton-asiointi <br> haitaton@hel.fi</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="center" style="font-size:0;padding:10px 25px;word-break:break-word">
+                        <p style="border-top:solid 1px #999898;font-size:1px;margin:0 auto;width:100%">
+                        </p>
+                        <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" style="border-top:solid 1px #999898;font-size:1px;margin:0px auto;width:550px;" role="presentation" width="550px" ><tr><td style="height:0;line-height:0;"> &nbsp;
+</td></tr></table><![endif]-->
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="left" style="font-size:0;padding:16px 24px 0 24px;word-break:break-word">
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">Hankkeesi <b>{{hankeNimi}} ({{hanketunnus}})</b> poistuu Haitattomasta {{deletionDate}}. Ota tarvitsemasi tiedot talteen ennen hankkeen poistumista. Poistumisen jälkeen hankkeen ja sen hakemusten kaikki tiedot poistuvat, eikä niitä pääse enää palauttamaan.</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="left" style="font-size:0;padding:16px 24px 0 24px;word-break:break-word">
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">Haitaton är Helsingfors stads hanteringssystem för att främja projekt i allmänna områden och att hantera olägenheter</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="left" style="font-size:0;padding:16px 24px 0 24px;word-break:break-word">
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">Det här är ett automatiskt e-postmeddelande – svara inte på det.</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="left" style="font-size:0;padding:16px 24px 0 24px;word-break:break-word">
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">Med vänlig hälsning,</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="left" style="font-size:0;padding:16px 24px 16px 24px;word-break:break-word">
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">Helsingfors stads stadsmiljösektor <br> Haitaton-ärenden <br> haitaton@hel.fi</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="center" style="font-size:0;padding:10px 25px;word-break:break-word">
+                        <p style="border-top:solid 1px #999898;font-size:1px;margin:0 auto;width:100%">
+                        </p>
+                        <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" style="border-top:solid 1px #999898;font-size:1px;margin:0px auto;width:550px;" role="presentation" width="550px" ><tr><td style="height:0;line-height:0;"> &nbsp;
+</td></tr></table><![endif]-->
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="left" style="font-size:0;padding:16px 24px 0 24px;word-break:break-word">
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">Hankkeesi <b>{{hankeNimi}} ({{hanketunnus}})</b> poistuu Haitattomasta {{deletionDate}}. Ota tarvitsemasi tiedot talteen ennen hankkeen poistumista. Poistumisen jälkeen hankkeen ja sen hakemusten kaikki tiedot poistuvat, eikä niitä pääse enää palauttamaan.</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="left" style="font-size:0;padding:16px 24px 0 24px;word-break:break-word">
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">Haitaton is the City of Helsinki’s service system intended for advancing projects taking place in public areas and managing the disturbances caused by them.</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="left" style="font-size:0;padding:16px 24px 0 24px;word-break:break-word">
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">This email was generated automatically – please do not reply to this message.</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="left" style="font-size:0;padding:16px 24px 0 24px;word-break:break-word">
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">Kind regards,</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="left" style="font-size:0;padding:16px 24px 16px 24px;word-break:break-word">
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">City of Helsinki Urban Environment Division <br> Haitaton services <br> haitaton@hel.fi</div>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+              <!--[if mso | IE]></td></tr></table><![endif]-->
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#FFC61E" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    <div style="background:#ffc61e;background-color:#ffc61e;margin:0 auto;max-width:600px">
+      <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#ffc61e;background-color:#ffc61e;width:100%">
+        <tbody>
+          <tr>
+            <td style="direction:ltr;font-size:0;padding:20px 0;text-align:center">
+              <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
+              <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%">
+                <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top" width="100%">
+                  <tbody>
+                    <div style="display:flex;align-items:center">
+                      <div style="padding-left:24px;padding-top:5px;padding-bottom:16px">
+                        <img src="{{baseUrl}}/helsinki.png" alt="Helsingin logo" width="87" height="43">
+                      </div>
+                      <div style="padding-left:16px;padding-top:12px;padding-bottom:26px;font-family:Arial;font-size:16px"> Haitaton </div>
+                    </div>
+                    <tr>
+                      <td align="center" style="font-size:0;padding:0 24px 16px 24px;word-break:break-word">
+                        <p style="border-top:solid 1px #999898;font-size:1px;margin:0 auto;width:100%">
+                        </p>
+                        <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" style="border-top:solid 1px #999898;font-size:1px;margin:0px auto;width:552px;" role="presentation" width="552px" ><tr><td style="height:0;line-height:0;"> &nbsp;
+</td></tr></table><![endif]-->
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="left" style="font-size:0;padding:0 24px 0 24px;word-break:break-word">
+                        <div style="font-family:Arial;font-size:16px;line-height:1;text-align:left;color:#000">© Helsingin kaupunki 2023</div>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+              <!--[if mso | IE]></td></tr></table><![endif]-->
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <!--[if mso | IE]></td></tr></table><![endif]-->
+  </div>
+</body>
+
+</html>

--- a/services/hanke-service/src/main/resources/email/template/hanke-poistetaan.subject.mustache
+++ b/services/hanke-service/src/main/resources/email/template/hanke-poistetaan.subject.mustache
@@ -1,0 +1,1 @@
+Haitaton: Hankkeesi {{hanketunnus}} poistetaan järjestelmästä / Hankkeesi {{hanketunnus}} poistetaan järjestelmästä / Hankkeesi {{hanketunnus}} poistetaan järjestelmästä

--- a/services/hanke-service/src/main/resources/email/template/hanke-poistetaan.text.mustache
+++ b/services/hanke-service/src/main/resources/email/template/hanke-poistetaan.text.mustache
@@ -1,0 +1,15 @@
+Hankkeesi {{hanketunnus}} poistetaan järjestelmästä / Hankkeesi {{hanketunnus}} poistetaan järjestelmästä / Hankkeesi {{hanketunnus}} poistetaan järjestelmästä
+
+Hankkeesi {{{hankeNimi}}} ({{hanketunnus}}) poistuu Haitattomasta {{deletionDate}}. Ota tarvitsemasi tiedot talteen ennen hankkeen poistumista. Poistumisen jälkeen hankkeen ja sen hakemusten kaikki tiedot poistuvat, eikä niitä pääse enää palauttamaan.
+
+{{{signatures.fi}}}
+
+
+Hankkeesi {{{hankeNimi}}} ({{hanketunnus}}) poistuu Haitattomasta {{deletionDate}}. Ota tarvitsemasi tiedot talteen ennen hankkeen poistumista. Poistumisen jälkeen hankkeen ja sen hakemusten kaikki tiedot poistuvat, eikä niitä pääse enää palauttamaan.
+
+{{{signatures.sv}}}
+
+
+Hankkeesi {{{hankeNimi}}} ({{hanketunnus}}) poistuu Haitattomasta {{deletionDate}}. Ota tarvitsemasi tiedot talteen ennen hankkeen poistumista. Poistumisen jälkeen hankkeen ja sen hakemusten kaikki tiedot poistuvat, eikä niitä pääse enää palauttamaan.
+
+{{{signatures.en}}}


### PR DESCRIPTION
# Description

A hanke will be deleted after it has been completed and locked for 6 months. Send a reminder that the users should save any data from the hanke 5 days before the deletion. The reminder is sent to everyone with EDIT permissions on the hanke.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-3444

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
1. Complete some hanke like in https://github.com/City-of-Helsinki/haitaton-backend/pull/1013.
2. Change their completedAt value in the database to between 6 months ago and 5 months 25 days ago.
3. Change the deletionCron value or add @EventListener(ApplicationReadyEvent::class) to sendDeletionReminders.
4. Check from http://localhost:3003 that the reminders were sent.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 