### PR TITLE
HAI-3447 Complete draft hanke with all end dates

### DIFF
--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankealueFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankealueFactory.kt
@@ -86,7 +86,7 @@ object HankealueFactory {
 
     fun createHankeAlueEntity(
         mockId: Int = 1,
-        hankeEntity: HankeEntity,
+        hankeEntity: HankeEntity = HankeFactory.createMinimalEntity(),
         haittaAlkuPvm: LocalDate? = DateFactory.getStartDatetime().toLocalDate(),
         haittaLoppuPvm: LocalDate? = DateFactory.getEndDatetime().toLocalDate(),
     ): HankealueEntity {


### PR DESCRIPTION
# Description

When a draft hanke has end dates in every hankealue, complete it like a public hanke. If a draft hanke has no areas or some areas don't have end dates, return without doing anything with it.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-3447

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
1. Create a new hanke.
2. On the form, fill out only the hankealue. Add it with dates from the past.
3. Change the `haitaton.hanke.completions.cron` value or add `@Eventlistener(ApplicationReadyEvent::class)` to completeHankkeet.
4. The hanke should be completed.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 

# Other relevant info
There will be another PR about completing drafts without end dates (based on the last time they were updated).