### PR TITLE
HAI Remove Apache Commons dependency

### DIFF
--- a/services/hanke-service/build.gradle.kts
+++ b/services/hanke-service/build.gradle.kts
@@ -86,7 +86,6 @@ dependencies {
     implementation("org.liquibase:liquibase-core")
     implementation("com.github.blagerweij:liquibase-sessionlock:1.6.9")
     implementation("io.hypersistence:hypersistence-utils-hibernate-63:3.9.9")
-    implementation("commons-io:commons-io:2.18.0")
     implementation("net.pwall.mustache:kotlin-mustache:0.12")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2")
     implementation("com.auth0:java-jwt:4.5.0")

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/attachment/AttachmentValidatorTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/attachment/AttachmentValidatorTest.kt
@@ -93,9 +93,18 @@ class AttachmentValidatorTest {
         }
 
         @ParameterizedTest
+        @CsvSource("exa/mple,mple", "../example,example", "/var/file/example,example")
+        fun `removes the path part from the filename`(given: String, expected: String) {
+            val filename = "$given.txt"
+
+            val result = AttachmentValidator.validFilename(filename)
+
+            assertThat(result).isEqualTo("$expected.txt")
+        }
+
+        @ParameterizedTest
         @CsvSource(
             "exa\\mple,exa_mple",
-            "exa/mple,exa_mple",
             "example:,example_",
             "exa*mple,exa_mple",
             "examp?le,examp_le",
@@ -106,8 +115,8 @@ class AttachmentValidatorTest {
             "exa%22mple,exa_mple",
             "exa*|%22:<>mple,exa______mple",
             "exa-mple,exa-mple",
-            "../example,___example",
             "example.,example_",
+            "example.tar,example_tar",
         )
         fun `Invalid characters should be sanitized`(given: String, expected: String) {
             val filename = "$given.txt"
@@ -178,7 +187,7 @@ class AttachmentValidatorTest {
         fun `accepts other extensions for MUU type attachments`(extension: String) {
             AttachmentValidator.validateExtensionForType(
                 "file.$extension",
-                ApplicationAttachmentType.MUU
+                ApplicationAttachmentType.MUU,
             )
         }
     }
@@ -189,7 +198,7 @@ class AttachmentValidatorTest {
         @ParameterizedTest
         fun `Should sanitize file name when it has special characters`(
             input: String,
-            expected: String
+            expected: String,
         ) {
             val file =
                 MockMultipartFile("file", input, MediaType.APPLICATION_PDF_VALUE, ByteArray(0))
@@ -206,7 +215,7 @@ class AttachmentValidatorTest {
                     "file",
                     "hello.html",
                     MediaType.APPLICATION_PDF_VALUE,
-                    ByteArray(0)
+                    ByteArray(0),
                 )
 
             assertFailure { file.validNameAndType() }
@@ -221,7 +230,7 @@ class AttachmentValidatorTest {
                 [
                     MediaType.APPLICATION_PDF_VALUE,
                     MediaType.APPLICATION_OCTET_STREAM_VALUE,
-                    MediaType.TEXT_PLAIN_VALUE
+                    MediaType.TEXT_PLAIN_VALUE,
                 ]
         )
         @ParameterizedTest


### PR DESCRIPTION
# Description

Apache Commons is only used to get and remove filename extensions. Kotlin has built-in extensions to do the same thing. Less dependencies are better, so it's better to use the Kotlin extensions if necessary.

The Kotlin extension uses `java.io.File.name` which cleans the path part from the filename. This means a file named '/etc/var/file.txt' will be cleaned to 'file.txt'. I think this is a positive change.

### Jira Issue: -

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [X] Other

# Instructions for testing
Please describe tests how this change or new feature can be tested.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 