### PR TITLE
HAI-3447 Complete draft hanke

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeCompletionServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeCompletionServiceITest.kt
@@ -371,14 +371,6 @@ class HankeCompletionServiceITest(
 
     @Nested
     inner class IdsForDraftsToComplete {
-        /*
-                fun saveHanke(modifier: HankeEntity.() -> Unit = {}) =
-                    hankeFactory.builder().saveEntity(HankeStatus.DRAFT) {
-                        it.modifiedAt = getCurrentTimeUTCAsLocalTime().minusMonths(6)
-                        it.modifier()
-                    }
-        */
-
         private fun saveHanke(
             status: HankeStatus = HankeStatus.DRAFT,
             modifiedDaysAgo: Long = DAYS_BEFORE_COMPLETING_DRAFT,

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Persistence.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Persistence.kt
@@ -179,6 +179,22 @@ interface HankeRepository : JpaRepository<HankeEntity, Int> {
             "order by h.completedAt asc"
     )
     fun findIdsForDeletionReminders(reminderDate: LocalDate, reminder: HankeReminder): List<Int>
+
+    /**
+     * Find drafts that don't have end dates for all their areas and that haven't been edited in
+     * some time.
+     */
+    @Query(
+        "select h.id " +
+            "from HankeEntity h " +
+            "left join HankealueEntity ha on ha.hanke = h " +
+            "where h.status = 'DRAFT' " +
+            "and h.modifiedAt < :date " +
+            "group by h.id " +
+            "having max(case when ha.haittaLoppuPvm is null then 1 else 0 end) > 0 " +
+            "order by h.modifiedAt asc limit :limit"
+    )
+    fun findDraftsToComplete(limit: Int, date: LocalDateTime): List<Int>
 }
 
 interface HankeIdentifier : HasId<Int>, Loggable {

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/testdata/TestDataService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/testdata/TestDataService.kt
@@ -4,6 +4,7 @@ import fi.hel.haitaton.hanke.attachment.application.ApplicationAttachmentContent
 import fi.hel.haitaton.hanke.attachment.azure.Container
 import fi.hel.haitaton.hanke.attachment.common.FileClient
 import fi.hel.haitaton.hanke.attachment.common.TaydennysAttachmentRepository
+import fi.hel.haitaton.hanke.attachment.muutosilmoitus.MuutosilmoitusAttachmentRepository
 import fi.hel.haitaton.hanke.hakemus.AlluUpdateService
 import fi.hel.haitaton.hanke.hakemus.HakemusRepository
 import fi.hel.haitaton.hanke.muutosilmoitus.MuutosilmoitusRepository
@@ -25,6 +26,7 @@ class TestDataService(
     private val taydennysAttachmentRepository: TaydennysAttachmentRepository,
     private val paatosRepository: PaatosRepository,
     private val muutosilmoitusRepository: MuutosilmoitusRepository,
+    private val muutosilmoitusAttachmentRepository: MuutosilmoitusAttachmentRepository,
     private val attachmentContentService: ApplicationAttachmentContentService,
     private val fileClient: FileClient,
     private val alluUpdateService: AlluUpdateService,
@@ -45,10 +47,13 @@ class TestDataService(
         }
         taydennyspyyntoRepository.deleteAll()
 
-        logger.warn { "Removing all päätökset and täydennykset." }
+        logger.warn { "Removing all päätökset." }
         paatosRepository.findAll().forEach { deletePaatosWithAttachments(it) }
 
         logger.warn { "Removing all muutosilmoitukset." }
+        muutosilmoitusAttachmentRepository.findAll().forEach {
+            attachmentContentService.delete(it.blobLocation)
+        }
         muutosilmoitusRepository.deleteAll()
     }
 

--- a/services/hanke-service/src/main/resources/application.yml
+++ b/services/hanke-service/src/main/resources/application.yml
@@ -62,6 +62,8 @@ haitaton:
       reminderCron: ${HAITATON_COMPLETIONS_REMINDER_CRON:21 17 19 * * *}
       # By default, run every day at 20:03:53 (Helsinki time).
       deletionReminderCron: ${HAITATON_COMPLETIONS_DELETE_CRON:53 03 20 * * *}
+      # By default, run every day at 17:53:27 (Helsinki time).
+      draftCompletionCron: ${HAITATON_COMPLETIONS_CRON:27 53 17 * * *}
   map-service:
     capability-url: https://kartta.hel.fi/ws/geoserver/avoindata/wms?REQUEST=GetCapabilities&SERVICE=WMS
   profiili-api:

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeBuilder.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/HankeBuilder.kt
@@ -28,6 +28,7 @@ import fi.hel.haitaton.hanke.permissions.Kayttooikeustaso
 import fi.hel.haitaton.hanke.profiili.Names
 import fi.hel.haitaton.hanke.profiili.ProfiiliClient
 import fi.hel.haitaton.hanke.test.AuthenticationMocks
+import java.time.ZonedDateTime
 
 data class HankeBuilder(
     private val hanke: Hanke,
@@ -134,6 +135,9 @@ data class HankeBuilder(
         tyomaaTyyppi = mutableSetOf(TyomaaTyyppi.VESI, TyomaaTyyppi.MUU)
         alue.haittojenhallintasuunnitelma = haittojenhallintasuunnitelma
     }
+
+    fun withHankealue(haittaLoppuPvm: ZonedDateTime?) =
+        withHankealue(alue = HankealueFactory.create(haittaLoppuPvm = haittaLoppuPvm))
 
     fun withNoAreas() = applyToHanke { alueet.clear() }
 


### PR DESCRIPTION
# Description

Complete draft hanke that don't have an end date and that have been unmodified for 180 days. The hanke should also have no active applications. Send a notification when the hanke is marked as completed.

If the draft has an end date, i.e. all its areas have end dates, it will be completed like a public hanke.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-3447

## Type of change

- [ ] Bug fix 
- [X] New feature 
- [ ] Other

# Instructions for testing
1. Create a new draft hanke.
2. Set its `modifiedBy` date to 180 days in the past.
3. Run the scheduled `completeDrafts` in one of the usual ways.

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 