### PR TITLE
HAI-3475 Add and update email translations

### DIFF
--- a/email/hanke-paattyy.mjml
+++ b/email/hanke-paattyy.mjml
@@ -7,11 +7,11 @@
         <mj-section>
             <mj-column>
                 <mj-text mj-class="header-txt">
-                    Hankkeesi {{hanketunnus}} ilmoitettu päättymispäivä lähenee / Hankkeesi {{hanketunnus}} ilmoitettu
-                    päättymispäivä lähenee / Hankkeesi {{hanketunnus}} ilmoitettu päättymispäivä lähenee
+                    Hankkeesi {{hanketunnus}} päättymispäivä lähenee / Avslutningsdatum för ditt projekt {{hanketunnus}}
+                    närmar sig / The end date of your project {{hanketunnus}} is approaching
                 </mj-text>
                 <mj-text mj-class="basic-txt">
-                    Hankkeesi <b>{{hankeNimi}} ({{hanketunnus}})</b> ilmoitettu päättymispäivä {{endingDate}} lähenee.
+                    Hankkeesi <b>{{hankeNimi}} ({{hanketunnus}})</b> ilmoitettu päättymispäivä {{finnishEndingDate}} lähenee.
                     Varmistathan, että hankkeen ja sen töiden aikataulut ovat ajan tasalla. Päivitä tiedot tarvittaessa
                     Haitattomaan tai ota tarvitsemasi tiedot talteen. Huomaathan, että hankkeen päättyminen lukitsee
                     hankkeen ja estää sen näkymisen hankkeen ulkopuolisille.
@@ -21,20 +21,20 @@
                 <mj-divider mj-class="language-separator"/>
 
                 <mj-text mj-class="basic-txt">
-                    Hankkeesi <b>{{hankeNimi}} ({{hanketunnus}})</b> ilmoitettu päättymispäivä {{endingDate}} lähenee.
-                    Varmistathan, että hankkeen ja sen töiden aikataulut ovat ajan tasalla. Päivitä tiedot tarvittaessa
-                    Haitattomaan tai ota tarvitsemasi tiedot talteen. Huomaathan, että hankkeen päättyminen lukitsee
-                    hankkeen ja estää sen näkymisen hankkeen ulkopuolisille.
+                    Ditt projekt <b>{{hankeNimi}} ({{hanketunnus}})</b> börjar närma sig sitt anmälda avslutningsdatum
+                    {{finnishEndingDate}}. Försäkra dig om att tidtabellerna för projektet och dess arbeten är uppdaterade.
+                    Uppdatera uppgifterna vid behov i Haitaton eller ta till vara de uppgifter du behöver. Observera att
+                    avslutning av projektet låser projektet och förhindrar att det syns för utomstående.
                 </mj-text>
                 <mj-include path="common/signature-sv.partial"/>
 
                 <mj-divider mj-class="language-separator"/>
 
                 <mj-text mj-class="basic-txt">
-                    Hankkeesi <b>{{hankeNimi}} ({{hanketunnus}})</b> ilmoitettu päättymispäivä {{endingDate}} lähenee.
-                    Varmistathan, että hankkeen ja sen töiden aikataulut ovat ajan tasalla. Päivitä tiedot tarvittaessa
-                    Haitattomaan tai ota tarvitsemasi tiedot talteen. Huomaathan, että hankkeen päättyminen lukitsee
-                    hankkeen ja estää sen näkymisen hankkeen ulkopuolisille.
+                    The reported end date {{britishEndingDate}} of your project <b>{{hankeNimi}} ({{hanketunnus}})</b> is
+                    approaching. Please make sure that the schedules of the project and its works are up-to-date. Update
+                    the information to Haitaton, if necessary, or save the information you need. Please note that when a
+                    project ends, the project will become locked, preventing it from being visible to outsiders.
                 </mj-text>
                 <mj-include path="common/signature-en.partial"/>
             </mj-column>

--- a/email/hanke-poistetaan.mjml
+++ b/email/hanke-poistetaan.mjml
@@ -7,11 +7,11 @@
         <mj-section>
             <mj-column>
                 <mj-text mj-class="header-txt">
-                    Hankkeesi {{hanketunnus}} poistetaan järjestelmästä / Hankkeesi {{hanketunnus}} poistetaan
-                    järjestelmästä / Hankkeesi {{hanketunnus}} poistetaan järjestelmästä
+                    Hankkeesi {{hanketunnus}} poistetaan järjestelmästä / Ditt projekt {{hanketunnus}} raderas ur
+                    systemet / Your project {{hanketunnus}} will be deleted from the system
                 </mj-text>
                 <mj-text mj-class="basic-txt">
-                    Hankkeesi <b>{{hankeNimi}} ({{hanketunnus}})</b> poistuu Haitattomasta {{deletionDate}}. Ota
+                    Hankkeesi <b>{{hankeNimi}} ({{hanketunnus}})</b> poistuu Haitattomasta {{finnishDeletionDate}}. Ota
                     tarvitsemasi tiedot talteen ennen hankkeen poistumista. Poistumisen jälkeen hankkeen ja sen
                     hakemusten kaikki tiedot poistuvat, eikä niitä pääse enää palauttamaan.
                 </mj-text>
@@ -20,18 +20,19 @@
                 <mj-divider mj-class="language-separator"/>
 
                 <mj-text mj-class="basic-txt">
-                    Hankkeesi <b>{{hankeNimi}} ({{hanketunnus}})</b> poistuu Haitattomasta {{deletionDate}}. Ota
-                    tarvitsemasi tiedot talteen ennen hankkeen poistumista. Poistumisen jälkeen hankkeen ja sen
-                    hakemusten kaikki tiedot poistuvat, eikä niitä pääse enää palauttamaan.
+                    Ditt projekt <b>{{hankeNimi}} ({{hanketunnus}})</b> raderas ur Haitaton {{finnishDeletionDate}}. Ta
+                    till vara de uppgifter du behöver innan projektet försvinner. Efter raderingen försvinner alla
+                    uppgifter om projektet och dess ansökningar, och de kan inte längre återställas.
                 </mj-text>
                 <mj-include path="common/signature-sv.partial"/>
 
                 <mj-divider mj-class="language-separator"/>
 
                 <mj-text mj-class="basic-txt">
-                    Hankkeesi <b>{{hankeNimi}} ({{hanketunnus}})</b> poistuu Haitattomasta {{deletionDate}}. Ota
-                    tarvitsemasi tiedot talteen ennen hankkeen poistumista. Poistumisen jälkeen hankkeen ja sen
-                    hakemusten kaikki tiedot poistuvat, eikä niitä pääse enää palauttamaan.
+                    Your project <b>{{hankeNimi}} ({{hanketunnus}})</b> will be deleted from Haitaton on
+                    {{britishDeletionDate}}. Save the information you need before the project is deleted. All
+                    information of the project and its applications will be removed after the project is deleted, and
+                    they cannot be recovered.
                 </mj-text>
                 <mj-include path="common/signature-en.partial"/>
             </mj-column>

--- a/email/hanke-valmistunut.mjml
+++ b/email/hanke-valmistunut.mjml
@@ -7,32 +7,31 @@
         <mj-section>
             <mj-column>
                 <mj-text mj-class="header-txt">
-                    Hankkeesi {{hanketunnus}} ilmoitettu päättymispäivä on ohitettu / Hankkeesi {{hanketunnus}}
-                    ilmoitettu päättymispäivä on ohitettu / Hankkeesi {{hanketunnus}} ilmoitettu päättymispäivä on
-                    ohitettu
+                    Hankkeesi {{hanketunnus}} ilmoitettu päättymispäivä on ohitettu / Avslutningsdatum för ditt projekt
+                    {{hanketunnus}} har passerats / The reported end date of your project {{hanketunnus}} has passed
                 </mj-text>
                 <mj-text mj-class="basic-txt">
                     Hankkeesi <b>{{hankeNimi}} ({{hanketunnus}})</b> ilmoitettu päättymispäivä on ohitettu. Hankkeesi ei
-                    enää näy muille Haitattoman käyttäjille eikä sitä pääse enää muokkamaan. Hanke säilyy Haitattomassa
-                    6 kk, jona aikana pääset tarkastelemaan sitä.
+                    enää näy muille Haitattoman käyttäjille, eikä sitä pääse enää muokkaamaan. Hanke säilyy
+                    Haitattomassa 6 kk, jona aikana pääset tarkastelemaan sitä.
                 </mj-text>
                 <mj-include path="common/signature-fi.partial"/>
 
                 <mj-divider mj-class="language-separator"/>
 
                 <mj-text mj-class="basic-txt">
-                    Hankkeesi <b>{{hankeNimi}} ({{hanketunnus}})</b> ilmoitettu päättymispäivä on ohitettu. Hankkeesi ei
-                    enää näy muille Haitattoman käyttäjille eikä sitä pääse enää muokkamaan. Hanke säilyy Haitattomassa
-                    6 kk, jona aikana pääset tarkastelemaan sitä.
+                    Avslutningsdatum för ditt projekt <b>{{hankeNimi}} ({{hanketunnus}})</b> har passerats. Ditt projekt
+                    syns inte längre för andra användare av Haitaton, och det kan inte längre redigeras. Projektet finns
+                    kvar i Haitaton i 6 mån under vilken tid du kan granska det.
                 </mj-text>
                 <mj-include path="common/signature-sv.partial"/>
 
                 <mj-divider mj-class="language-separator"/>
 
                 <mj-text mj-class="basic-txt">
-                    Hankkeesi <b>{{hankeNimi}} ({{hanketunnus}})</b> ilmoitettu päättymispäivä on ohitettu. Hankkeesi ei
-                    enää näy muille Haitattoman käyttäjille eikä sitä pääse enää muokkamaan. Hanke säilyy Haitattomassa
-                    6 kk, jona aikana pääset tarkastelemaan sitä.
+                    The reported end date of your project <b>{{hankeNimi}} ({{hanketunnus}})</b> has passed. Your
+                    project will no longer be visible to other Haitaton users, and it can no longer be edited. The
+                    project will be available for viewing in Haitaton for six months.
                 </mj-text>
                 <mj-include path="common/signature-en.partial"/>
             </mj-column>

--- a/email/johtoselvitys-valmis.mjml
+++ b/email/johtoselvitys-valmis.mjml
@@ -6,11 +6,17 @@
         <mj-include path="common/header-content.partial"/>
         <mj-section>
             <mj-column>
-                <mj-text mj-class="header-txt">Johtoselvitys {{applicationIdentifier}} / Ledningsutredning {{applicationIdentifier}} / Cable report {{applicationIdentifier}}</mj-text>
+                <mj-text mj-class="header-txt">Johtoselvitys {{applicationIdentifier}} / Ledningsutredning
+                    {{applicationIdentifier}} / Cable report {{applicationIdentifier}}
+                </mj-text>
                 <mj-text mj-class="basic-txt">
                     Hakemanne johtoselvitys {{applicationIdentifier}} on käsitelty. Lataa selvitys Haitattomasta <a
                         href="{{baseUrl}}/fi/hakemus/{{applicationId}}">{{baseUrl}}/fi/hakemus/{{applicationId}}
                 </a> ja tutustu sen sisältöön huolellisesti.
+                </mj-text>
+                <mj-text>
+                    Huomioithan, että johtoselvitys poistuu Haitattomasta 6 kuukauden päästä hakemuksen voimassaoloajan
+                    päätyttyä, joten tallennathan päätöksen itsellesi ennen sitä.
                 </mj-text>
                 <mj-text mj-class="basic-txt">
                     Miten onnistuimme? Kerro mielipiteesi <a href="https://ecv.microsoft.com/zepZlZSdnT">täällä</a>.
@@ -21,8 +27,8 @@
                 <mj-text mj-class="signature">
                     Helsingin kaupunki
                     <br/>
-					Kaupunkiympäristön asukas- ja yrityspalvelut
-					<br/>
+                    Kaupunkiympäristön asukas- ja yrityspalvelut
+                    <br/>
                     Alueiden käyttö ja valvonta
                     <br/>
                     Johtotietopalvelu
@@ -32,7 +38,7 @@
                     johtotietopalvelu@hel.fi
                 </mj-text>
 
-                <mj-divider mj-class="language-separator" />
+                <mj-divider mj-class="language-separator"/>
 
                 <mj-text mj-class="basic-txt">
                     Ledningsutredningen {{applicationIdentifier}} ni ansökt om har behandlats. Ladda ned utredningen
@@ -41,7 +47,11 @@
                         {{baseUrl}}/sv/ansokan/{{applicationId}}
                     </a>
                     och läs
-                    innehållet i den noggrannt.
+                    innehållet i den noggrann.
+                </mj-text>
+                <mj-text>
+                    Observera att ledningsutredningen avlägsnas från Haitaton 6 månader efter att giltighetstiden för
+                    ansökan gått ut, så spara beslutet själv före det.
                 </mj-text>
                 <mj-text mj-class="basic-txt">
                     Hur lyckades vi? Ge din åsikt <a
@@ -54,8 +64,8 @@
                 <mj-text mj-class="signature">
                     Helsingfors stad
                     <br/>
-					Stadsmiljös boende- och företagstjänster
-					<br/>
+                    Stadsmiljös boende- och företagstjänster
+                    <br/>
                     Användning och tillsyn av områden
                     <br/>
                     Ledningstjänsten
@@ -65,14 +75,18 @@
                     johtotietopalvelu@hel.fi
                 </mj-text>
 
-                <mj-divider mj-class="language-separator" />
+                <mj-divider mj-class="language-separator"/>
 
                 <mj-text mj-class="basic-txt">
-                    Cable report {{applicationIdentifier}} that you requested has been processed. Download the
+                    The cable report {{applicationIdentifier}} that you requested has been processed. Download the
                     report
                     via Haitaton <a href="{{baseUrl}}/en/application/{{applicationId}}">
                     {{baseUrl}}/en/application/{{applicationId}}
                 </a> and read it carefully.
+                </mj-text>
+                <mj-text>
+                    Please note that the cable report will be deleted from Haitaton six months after the application’s
+                    validity period has ended. Please download and save the decision before this.
                 </mj-text>
                 <mj-text mj-class="basic-txt">
                     How did we do? Please share your opinion <a
@@ -85,8 +99,8 @@
                 <mj-text mj-class="signature">
                     City of Helsinki
                     <br/>
-					Urban Environment Resident and Business Services
-					<br/>
+                    Urban Environment Resident and Business Services
+                    <br/>
                     Land Use and Monitoring
                     <br/>
                     Cable Location Service

--- a/email/kayttaja-poistettu-hanke.mjml
+++ b/email/kayttaja-poistettu-hanke.mjml
@@ -19,7 +19,7 @@
 
                 <mj-text mj-class="basic-txt">
                     {{deletedByName}} ({{deletedByEmail}}) har tagit bort dig från projektet <b>{{hankeNimi}} ({{hankeTunnus}})</b>
-                    och du har tagit bort dig från projektet.
+                    och du har inte längre tillträde till projektet.
                 </mj-text>
                 <mj-include path="common/signature-sv.partial"/>
 

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeCompletionServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeCompletionServiceITest.kt
@@ -569,12 +569,12 @@ class HankeCompletionServiceITest(
             assertThat(email.subject)
                 .isEqualTo(
                     "Haitaton: Hankkeesi ${hanke.hankeTunnus} ilmoitettu päättymispäivä on ohitettu " +
-                        "/ Hankkeesi ${hanke.hankeTunnus} ilmoitettu päättymispäivä on ohitettu " +
-                        "/ Hankkeesi ${hanke.hankeTunnus} ilmoitettu päättymispäivä on ohitettu"
+                        "/ Avslutningsdatum för ditt projekt ${hanke.hankeTunnus} har passerats " +
+                        "/ The reported end date of your project ${hanke.hankeTunnus} has passed"
                 )
             assertThat(email.textBody())
                 .contains(
-                    "Hankkeesi ${hanke.nimi} (${hanke.hankeTunnus}) ilmoitettu päättymispäivä on ohitettu. Hankkeesi ei enää näy muille Haitattoman käyttäjille eikä sitä pääse enää muokkamaan. Hanke säilyy Haitattomassa 6 kk, jona aikana pääset tarkastelemaan sitä."
+                    "Hankkeesi ${hanke.nimi} (${hanke.hankeTunnus}) ilmoitettu päättymispäivä on ohitettu. Hankkeesi ei enää näy muille Haitattoman käyttäjille, eikä sitä pääse enää muokkaamaan. Hanke säilyy Haitattomassa 6 kk, jona aikana pääset tarkastelemaan sitä."
                 )
         }
     }
@@ -803,8 +803,8 @@ class HankeCompletionServiceITest(
                 assertThat(email.subject)
                     .isEqualTo(
                         "Haitaton: Hankkeesi ${hanke.hankeTunnus} päättymispäivä lähenee " +
-                            "/ Hankkeesi ${hanke.hankeTunnus} päättymispäivä lähenee " +
-                            "/ Hankkeesi ${hanke.hankeTunnus} päättymispäivä lähenee"
+                            "/ Avslutningsdatum för ditt projekt ${hanke.hankeTunnus} närmar sig " +
+                            "/ The end date of your project ${hanke.hankeTunnus} is approaching"
                     )
                 val day = endDate.dayOfMonth
                 val month = endDate.monthValue
@@ -834,8 +834,8 @@ class HankeCompletionServiceITest(
                 assertThat(email.subject)
                     .isEqualTo(
                         "Haitaton: Hankkeesi ${hanke.hankeTunnus} päättymispäivä lähenee " +
-                            "/ Hankkeesi ${hanke.hankeTunnus} päättymispäivä lähenee " +
-                            "/ Hankkeesi ${hanke.hankeTunnus} päättymispäivä lähenee"
+                            "/ Avslutningsdatum för ditt projekt ${hanke.hankeTunnus} närmar sig " +
+                            "/ The end date of your project ${hanke.hankeTunnus} is approaching"
                     )
                 val day = endDate.dayOfMonth
                 val month = endDate.monthValue
@@ -971,8 +971,8 @@ class HankeCompletionServiceITest(
                 assertThat(email.subject)
                     .isEqualTo(
                         "Haitaton: Hankkeesi ${hanke.hankeTunnus} päättymispäivä lähenee " +
-                            "/ Hankkeesi ${hanke.hankeTunnus} päättymispäivä lähenee " +
-                            "/ Hankkeesi ${hanke.hankeTunnus} päättymispäivä lähenee"
+                            "/ Avslutningsdatum för ditt projekt ${hanke.hankeTunnus} närmar sig " +
+                            "/ The end date of your project ${hanke.hankeTunnus} is approaching"
                     )
                 val day = endDate.dayOfMonth
                 val month = endDate.monthValue
@@ -1005,8 +1005,8 @@ class HankeCompletionServiceITest(
                 assertThat(email.subject)
                     .isEqualTo(
                         "Haitaton: Hankkeesi ${hanke.hankeTunnus} päättymispäivä lähenee " +
-                            "/ Hankkeesi ${hanke.hankeTunnus} päättymispäivä lähenee " +
-                            "/ Hankkeesi ${hanke.hankeTunnus} päättymispäivä lähenee"
+                            "/ Avslutningsdatum för ditt projekt ${hanke.hankeTunnus} närmar sig " +
+                            "/ The end date of your project ${hanke.hankeTunnus} is approaching"
                     )
                 val day = endDate.dayOfMonth
                 val month = endDate.monthValue
@@ -1227,8 +1227,8 @@ class HankeCompletionServiceITest(
             assertThat(email.subject)
                 .isEqualTo(
                     "Haitaton: Hankkeesi ${hanke.hankeTunnus} poistetaan järjestelmästä " +
-                        "/ Hankkeesi ${hanke.hankeTunnus} poistetaan järjestelmästä " +
-                        "/ Hankkeesi ${hanke.hankeTunnus} poistetaan järjestelmästä"
+                        "/ Ditt projekt ${hanke.hankeTunnus} raderas ur systemet " +
+                        "/ Your project ${hanke.hankeTunnus} will be deleted from the system"
                 )
             val deletionDate = LocalDate.now().plusDays(date)
             val day = deletionDate.dayOfMonth
@@ -1408,12 +1408,12 @@ class HankeCompletionServiceITest(
             assertThat(email.subject)
                 .isEqualTo(
                     "Haitaton: Hankkeesi ${hanke.hankeTunnus} ilmoitettu päättymispäivä on ohitettu " +
-                        "/ Hankkeesi ${hanke.hankeTunnus} ilmoitettu päättymispäivä on ohitettu " +
-                        "/ Hankkeesi ${hanke.hankeTunnus} ilmoitettu päättymispäivä on ohitettu"
+                        "/ Avslutningsdatum för ditt projekt ${hanke.hankeTunnus} har passerats " +
+                        "/ The reported end date of your project ${hanke.hankeTunnus} has passed"
                 )
             assertThat(email.textBody())
                 .contains(
-                    "Hankkeesi ${hanke.nimi} (${hanke.hankeTunnus}) ilmoitettu päättymispäivä on ohitettu. Hankkeesi ei enää näy muille Haitattoman käyttäjille eikä sitä pääse enää muokkamaan. Hanke säilyy Haitattomassa 6 kk, jona aikana pääset tarkastelemaan sitä."
+                    "Hankkeesi ${hanke.nimi} (${hanke.hankeTunnus}) ilmoitettu päättymispäivä on ohitettu. Hankkeesi ei enää näy muille Haitattoman käyttäjille, eikä sitä pääse enää muokkaamaan. Hanke säilyy Haitattomassa 6 kk, jona aikana pääset tarkastelemaan sitä."
                 )
         }
     }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/email/EmailSenderService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/email/EmailSenderService.kt
@@ -17,6 +17,7 @@ import org.springframework.transaction.event.TransactionalEventListener
 
 private val logger = KotlinLogging.logger {}
 private val FINNISH_DATE_FORMAT: DateTimeFormatter = DateTimeFormatter.ofPattern("d.M.uuuu")
+private val BRITISH_DATE_FORMAT: DateTimeFormatter = DateTimeFormatter.ofPattern("d MMM uuuu")
 
 @ConfigurationProperties(prefix = "haitaton.email")
 data class EmailProperties(
@@ -192,7 +193,9 @@ class EmailSenderService(
             mapOf(
                 "hanketunnus" to data.hanketunnus,
                 "hankeNimi" to data.hankeNimi,
-                "endingDate" to data.endingDate.format(FINNISH_DATE_FORMAT),
+                "finnishEndingDate" to data.endingDate.format(FINNISH_DATE_FORMAT),
+                "britishEndingDate" to data.endingDate.format(BRITISH_DATE_FORMAT),
+                "signatures" to signatures(),
             )
 
         sendHybridEmail(data.to, EmailTemplate.HANKE_ENDING, templateData)
@@ -205,7 +208,9 @@ class EmailSenderService(
             mapOf(
                 "hanketunnus" to data.hanketunnus,
                 "hankeNimi" to data.hankeNimi,
-                "deletionDate" to data.deletionDate.format(FINNISH_DATE_FORMAT),
+                "finnishDeletionDate" to data.deletionDate.format(FINNISH_DATE_FORMAT),
+                "britishDeletionDate" to data.deletionDate.format(BRITISH_DATE_FORMAT),
+                "signatures" to signatures(),
             )
 
         sendHybridEmail(data.to, EmailTemplate.HANKE_DELETION_REMINDER, templateData)
@@ -214,7 +219,12 @@ class EmailSenderService(
     @TransactionalEventListener
     fun sendHankeCompletedNotification(data: HankeCompletedNotification) {
         logger.info { "Sending notification email for hanke completed" }
-        val templateData = mapOf("hanketunnus" to data.hanketunnus, "hankeNimi" to data.hankeNimi)
+        val templateData =
+            mapOf(
+                "hanketunnus" to data.hanketunnus,
+                "hankeNimi" to data.hankeNimi,
+                "signatures" to signatures(),
+            )
         sendHybridEmail(data.to, EmailTemplate.HANKE_COMPLETED, templateData)
     }
 

--- a/services/hanke-service/src/main/resources/email/template/hanke-paattyy.html.mustache
+++ b/services/hanke-service/src/main/resources/email/template/hanke-paattyy.html.mustache
@@ -67,12 +67,12 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0;padding:16px 24px 16px 24px;word-break:break-word">
-                        <div style="font-family:Arial;font-size:36px;line-height:43px;text-align:left;color:#000">Hankkeesi {{hanketunnus}} ilmoitettu päättymispäivä lähenee / Hankkeesi {{hanketunnus}} ilmoitettu päättymispäivä lähenee / Hankkeesi {{hanketunnus}} ilmoitettu päättymispäivä lähenee</div>
+                        <div style="font-family:Arial;font-size:36px;line-height:43px;text-align:left;color:#000">Hankkeesi {{hanketunnus}} päättymispäivä lähenee / Avslutningsdatum för ditt projekt {{hanketunnus}} närmar sig / The end date of your project {{hanketunnus}} is approaching</div>
                       </td>
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0;padding:16px 24px 0 24px;word-break:break-word">
-                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">Hankkeesi <b>{{hankeNimi}} ({{hanketunnus}})</b> ilmoitettu päättymispäivä {{endingDate}} lähenee. Varmistathan, että hankkeen ja sen töiden aikataulut ovat ajan tasalla. Päivitä tiedot tarvittaessa Haitattomaan tai ota tarvitsemasi tiedot talteen. Huomaathan, että hankkeen päättyminen lukitsee hankkeen ja estää sen näkymisen hankkeen ulkopuolisille.</div>
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">Hankkeesi <b>{{hankeNimi}} ({{hanketunnus}})</b> ilmoitettu päättymispäivä {{finnishEndingDate}} lähenee. Varmistathan, että hankkeen ja sen töiden aikataulut ovat ajan tasalla. Päivitä tiedot tarvittaessa Haitattomaan tai ota tarvitsemasi tiedot talteen. Huomaathan, että hankkeen päättyminen lukitsee hankkeen ja estää sen näkymisen hankkeen ulkopuolisille.</div>
                       </td>
                     </tr>
                     <tr>
@@ -105,7 +105,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0;padding:16px 24px 0 24px;word-break:break-word">
-                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">Hankkeesi <b>{{hankeNimi}} ({{hanketunnus}})</b> ilmoitettu päättymispäivä {{endingDate}} lähenee. Varmistathan, että hankkeen ja sen töiden aikataulut ovat ajan tasalla. Päivitä tiedot tarvittaessa Haitattomaan tai ota tarvitsemasi tiedot talteen. Huomaathan, että hankkeen päättyminen lukitsee hankkeen ja estää sen näkymisen hankkeen ulkopuolisille.</div>
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">Ditt projekt <b>{{hankeNimi}} ({{hanketunnus}})</b> börjar närma sig sitt anmälda avslutningsdatum {{finnishEndingDate}}. Försäkra dig om att tidtabellerna för projektet och dess arbeten är uppdaterade. Uppdatera uppgifterna vid behov i Haitaton eller ta till vara de uppgifter du behöver. Observera att avslutning av projektet låser projektet och förhindrar att det syns för utomstående.</div>
                       </td>
                     </tr>
                     <tr>
@@ -138,7 +138,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0;padding:16px 24px 0 24px;word-break:break-word">
-                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">Hankkeesi <b>{{hankeNimi}} ({{hanketunnus}})</b> ilmoitettu päättymispäivä {{endingDate}} lähenee. Varmistathan, että hankkeen ja sen töiden aikataulut ovat ajan tasalla. Päivitä tiedot tarvittaessa Haitattomaan tai ota tarvitsemasi tiedot talteen. Huomaathan, että hankkeen päättyminen lukitsee hankkeen ja estää sen näkymisen hankkeen ulkopuolisille.</div>
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">The reported end date {{britishEndingDate}} of your project <b>{{hankeNimi}} ({{hanketunnus}})</b> is approaching. Please make sure that the schedules of the project and its works are up-to-date. Update the information to Haitaton, if necessary, or save the information you need. Please note that when a project ends, the project will become locked, preventing it from being visible to outsiders.</div>
                       </td>
                     </tr>
                     <tr>

--- a/services/hanke-service/src/main/resources/email/template/hanke-paattyy.subject.mustache
+++ b/services/hanke-service/src/main/resources/email/template/hanke-paattyy.subject.mustache
@@ -1,1 +1,1 @@
-Haitaton: Hankkeesi {{hanketunnus}} päättymispäivä lähenee / Hankkeesi {{hanketunnus}} päättymispäivä lähenee / Hankkeesi {{hanketunnus}} päättymispäivä lähenee
+Haitaton: Hankkeesi {{hanketunnus}} päättymispäivä lähenee / Avslutningsdatum för ditt projekt {{hanketunnus}} närmar sig / The end date of your project {{hanketunnus}} is approaching

--- a/services/hanke-service/src/main/resources/email/template/hanke-paattyy.text.mustache
+++ b/services/hanke-service/src/main/resources/email/template/hanke-paattyy.text.mustache
@@ -1,15 +1,15 @@
-Hankkeesi {{hanketunnus}} päättymispäivä lähenee / Hankkeesi {{hanketunnus}} päättymispäivä lähenee Hankkeesi {{hanketunnus}} päättymispäivä lähenee
+Hankkeesi {{hanketunnus}} päättymispäivä lähenee / Avslutningsdatum för ditt projekt {{hanketunnus}} närmar sig / The end date of your project {{hanketunnus}} is approaching
 
-Hankkeesi {{{hankeNimi}}} ({{hanketunnus}}) ilmoitettu päättymispäivä {{endingDate}} lähenee. Varmistathan, että hankkeen ja sen töiden aikataulut ovat ajan tasalla. Päivitä tiedot tarvittaessa Haitattomaan tai ota tarvitsemasi tiedot talteen. Huomaathan, että hankkeen päättyminen lukitsee hankkeen ja estää sen näkymisen hankkeen ulkopuolisille.
+Hankkeesi {{{hankeNimi}}} ({{hanketunnus}}) ilmoitettu päättymispäivä {{finnishEndingDate}} lähenee. Varmistathan, että hankkeen ja sen töiden aikataulut ovat ajan tasalla. Päivitä tiedot tarvittaessa Haitattomaan tai ota tarvitsemasi tiedot talteen. Huomaathan, että hankkeen päättyminen lukitsee hankkeen ja estää sen näkymisen hankkeen ulkopuolisille.
 
 {{{signatures.fi}}}
 
 
-Hankkeesi {{{hankeNimi}}} ({{hanketunnus}}) ilmoitettu päättymispäivä {{endingDate}} lähenee. Varmistathan, että hankkeen ja sen töiden aikataulut ovat ajan tasalla. Päivitä tiedot tarvittaessa Haitattomaan tai ota tarvitsemasi tiedot talteen. Huomaathan, että hankkeen päättyminen lukitsee hankkeen ja estää sen näkymisen hankkeen ulkopuolisille.
+Ditt projekt {{{hankeNimi}}} ({{hanketunnus}}) börjar närma sig sitt anmälda avslutningsdatum {{finnishEndingDate}}. Försäkra dig om att tidtabellerna för projektet och dess arbeten är uppdaterade. Uppdatera uppgifterna vid behov i Haitaton eller ta till vara de uppgifter du behöver. Observera att avslutning av projektet låser projektet och förhindrar att det syns för utomstående.
 
 {{{signatures.sv}}}
 
 
-Hankkeesi {{{hankeNimi}}} ({{hanketunnus}}) ilmoitettu päättymispäivä {{endingDate}} lähenee. Varmistathan, että hankkeen ja sen töiden aikataulut ovat ajan tasalla. Päivitä tiedot tarvittaessa Haitattomaan tai ota tarvitsemasi tiedot talteen. Huomaathan, että hankkeen päättyminen lukitsee hankkeen ja estää sen näkymisen hankkeen ulkopuolisille.
+The reported end date {{britishEndingDate}} of your project {{{hankeNimi}}} ({{hanketunnus}}) is approaching. Please make sure that the schedules of the project and its works are up-to-date. Update the information to Haitaton, if necessary, or save the information you need. Please note that when a project ends, the project will become locked, preventing it from being visible to outsiders.
 
 {{{signatures.en}}}

--- a/services/hanke-service/src/main/resources/email/template/hanke-poistetaan.html.mustache
+++ b/services/hanke-service/src/main/resources/email/template/hanke-poistetaan.html.mustache
@@ -67,12 +67,12 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0;padding:16px 24px 16px 24px;word-break:break-word">
-                        <div style="font-family:Arial;font-size:36px;line-height:43px;text-align:left;color:#000">Hankkeesi {{hanketunnus}} poistetaan järjestelmästä / Hankkeesi {{hanketunnus}} poistetaan järjestelmästä / Hankkeesi {{hanketunnus}} poistetaan järjestelmästä</div>
+                        <div style="font-family:Arial;font-size:36px;line-height:43px;text-align:left;color:#000">Hankkeesi {{hanketunnus}} poistetaan järjestelmästä / Ditt projekt {{hanketunnus}} raderas ur systemet / Your project {{hanketunnus}} will be deleted from the system</div>
                       </td>
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0;padding:16px 24px 0 24px;word-break:break-word">
-                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">Hankkeesi <b>{{hankeNimi}} ({{hanketunnus}})</b> poistuu Haitattomasta {{deletionDate}}. Ota tarvitsemasi tiedot talteen ennen hankkeen poistumista. Poistumisen jälkeen hankkeen ja sen hakemusten kaikki tiedot poistuvat, eikä niitä pääse enää palauttamaan.</div>
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">Hankkeesi <b>{{hankeNimi}} ({{hanketunnus}})</b> poistuu Haitattomasta {{finnishDeletionDate}}. Ota tarvitsemasi tiedot talteen ennen hankkeen poistumista. Poistumisen jälkeen hankkeen ja sen hakemusten kaikki tiedot poistuvat, eikä niitä pääse enää palauttamaan.</div>
                       </td>
                     </tr>
                     <tr>
@@ -105,7 +105,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0;padding:16px 24px 0 24px;word-break:break-word">
-                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">Hankkeesi <b>{{hankeNimi}} ({{hanketunnus}})</b> poistuu Haitattomasta {{deletionDate}}. Ota tarvitsemasi tiedot talteen ennen hankkeen poistumista. Poistumisen jälkeen hankkeen ja sen hakemusten kaikki tiedot poistuvat, eikä niitä pääse enää palauttamaan.</div>
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">Ditt projekt <b>{{hankeNimi}} ({{hanketunnus}})</b> raderas ur Haitaton {{finnishDeletionDate}}. Ta till vara de uppgifter du behöver innan projektet försvinner. Efter raderingen försvinner alla uppgifter om projektet och dess ansökningar, och de kan inte längre återställas.</div>
                       </td>
                     </tr>
                     <tr>
@@ -138,7 +138,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0;padding:16px 24px 0 24px;word-break:break-word">
-                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">Hankkeesi <b>{{hankeNimi}} ({{hanketunnus}})</b> poistuu Haitattomasta {{deletionDate}}. Ota tarvitsemasi tiedot talteen ennen hankkeen poistumista. Poistumisen jälkeen hankkeen ja sen hakemusten kaikki tiedot poistuvat, eikä niitä pääse enää palauttamaan.</div>
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">Your project <b>{{hankeNimi}} ({{hanketunnus}})</b> will be deleted from Haitaton on {{britishDeletionDate}}. Save the information you need before the project is deleted. All information of the project and its applications will be removed after the project is deleted, and they cannot be recovered.</div>
                       </td>
                     </tr>
                     <tr>

--- a/services/hanke-service/src/main/resources/email/template/hanke-poistetaan.subject.mustache
+++ b/services/hanke-service/src/main/resources/email/template/hanke-poistetaan.subject.mustache
@@ -1,1 +1,1 @@
-Haitaton: Hankkeesi {{hanketunnus}} poistetaan järjestelmästä / Hankkeesi {{hanketunnus}} poistetaan järjestelmästä / Hankkeesi {{hanketunnus}} poistetaan järjestelmästä
+Haitaton: Hankkeesi {{hanketunnus}} poistetaan järjestelmästä / Ditt projekt {{hanketunnus}} raderas ur systemet / Your project {{hanketunnus}} will be deleted from the system

--- a/services/hanke-service/src/main/resources/email/template/hanke-poistetaan.text.mustache
+++ b/services/hanke-service/src/main/resources/email/template/hanke-poistetaan.text.mustache
@@ -1,15 +1,15 @@
-Hankkeesi {{hanketunnus}} poistetaan järjestelmästä / Hankkeesi {{hanketunnus}} poistetaan järjestelmästä / Hankkeesi {{hanketunnus}} poistetaan järjestelmästä
+Hankkeesi {{hanketunnus}} poistetaan järjestelmästä / Ditt projekt {{hanketunnus}} raderas ur systemet / Your project {{hanketunnus}} will be deleted from the system
 
-Hankkeesi {{{hankeNimi}}} ({{hanketunnus}}) poistuu Haitattomasta {{deletionDate}}. Ota tarvitsemasi tiedot talteen ennen hankkeen poistumista. Poistumisen jälkeen hankkeen ja sen hakemusten kaikki tiedot poistuvat, eikä niitä pääse enää palauttamaan.
+Hankkeesi {{{hankeNimi}}} ({{hanketunnus}}) poistuu Haitattomasta {{finnishDeletionDate}}. Ota tarvitsemasi tiedot talteen ennen hankkeen poistumista. Poistumisen jälkeen hankkeen ja sen hakemusten kaikki tiedot poistuvat, eikä niitä pääse enää palauttamaan.
 
 {{{signatures.fi}}}
 
 
-Hankkeesi {{{hankeNimi}}} ({{hanketunnus}}) poistuu Haitattomasta {{deletionDate}}. Ota tarvitsemasi tiedot talteen ennen hankkeen poistumista. Poistumisen jälkeen hankkeen ja sen hakemusten kaikki tiedot poistuvat, eikä niitä pääse enää palauttamaan.
+Ditt projekt {{{hankeNimi}}} ({{hanketunnus}}) raderas ur Haitaton {{finnishDeletionDate}}. Ta till vara de uppgifter du behöver innan projektet försvinner. Efter raderingen försvinner alla uppgifter om projektet och dess ansökningar, och de kan inte längre återställas.
 
 {{{signatures.sv}}}
 
 
-Hankkeesi {{{hankeNimi}}} ({{hanketunnus}}) poistuu Haitattomasta {{deletionDate}}. Ota tarvitsemasi tiedot talteen ennen hankkeen poistumista. Poistumisen jälkeen hankkeen ja sen hakemusten kaikki tiedot poistuvat, eikä niitä pääse enää palauttamaan.
+Your project {{{hankeNimi}}} ({{hanketunnus}}) will be deleted from Haitaton on {{britishDeletionDate}}. Save the information you need before the project is deleted. All information of the project and its applications will be removed after the project is deleted, and they cannot be recovered.
 
 {{{signatures.en}}}

--- a/services/hanke-service/src/main/resources/email/template/hanke-valmistunut.html.mustache
+++ b/services/hanke-service/src/main/resources/email/template/hanke-valmistunut.html.mustache
@@ -67,12 +67,12 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0;padding:16px 24px 16px 24px;word-break:break-word">
-                        <div style="font-family:Arial;font-size:36px;line-height:43px;text-align:left;color:#000">Hankkeesi {{hanketunnus}} ilmoitettu päättymispäivä on ohitettu / Hankkeesi {{hanketunnus}} ilmoitettu päättymispäivä on ohitettu / Hankkeesi {{hanketunnus}} ilmoitettu päättymispäivä on ohitettu</div>
+                        <div style="font-family:Arial;font-size:36px;line-height:43px;text-align:left;color:#000">Hankkeesi {{hanketunnus}} ilmoitettu päättymispäivä on ohitettu / Avslutningsdatum för ditt projekt {{hanketunnus}} har passerats / The reported end date of your project {{hanketunnus}} has passed</div>
                       </td>
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0;padding:16px 24px 0 24px;word-break:break-word">
-                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">Hankkeesi <b>{{hankeNimi}} ({{hanketunnus}})</b> ilmoitettu päättymispäivä on ohitettu. Hankkeesi ei enää näy muille Haitattoman käyttäjille eikä sitä pääse enää muokkamaan. Hanke säilyy Haitattomassa 6 kk, jona aikana pääset tarkastelemaan sitä.</div>
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">Hankkeesi <b>{{hankeNimi}} ({{hanketunnus}})</b> ilmoitettu päättymispäivä on ohitettu. Hankkeesi ei enää näy muille Haitattoman käyttäjille, eikä sitä pääse enää muokkaamaan. Hanke säilyy Haitattomassa 6 kk, jona aikana pääset tarkastelemaan sitä.</div>
                       </td>
                     </tr>
                     <tr>
@@ -105,7 +105,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0;padding:16px 24px 0 24px;word-break:break-word">
-                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">Hankkeesi <b>{{hankeNimi}} ({{hanketunnus}})</b> ilmoitettu päättymispäivä on ohitettu. Hankkeesi ei enää näy muille Haitattoman käyttäjille eikä sitä pääse enää muokkamaan. Hanke säilyy Haitattomassa 6 kk, jona aikana pääset tarkastelemaan sitä.</div>
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">Avslutningsdatum för ditt projekt <b>{{hankeNimi}} ({{hanketunnus}})</b> har passerats. Ditt projekt syns inte längre för andra användare av Haitaton, och det kan inte längre redigeras. Projektet finns kvar i Haitaton i 6 mån under vilken tid du kan granska det.</div>
                       </td>
                     </tr>
                     <tr>
@@ -138,7 +138,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0;padding:16px 24px 0 24px;word-break:break-word">
-                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">Hankkeesi <b>{{hankeNimi}} ({{hanketunnus}})</b> ilmoitettu päättymispäivä on ohitettu. Hankkeesi ei enää näy muille Haitattoman käyttäjille eikä sitä pääse enää muokkamaan. Hanke säilyy Haitattomassa 6 kk, jona aikana pääset tarkastelemaan sitä.</div>
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">The reported end date of your project <b>{{hankeNimi}} ({{hanketunnus}})</b> has passed. Your project will no longer be visible to other Haitaton users, and it can no longer be edited. The project will be available for viewing in Haitaton for six months.</div>
                       </td>
                     </tr>
                     <tr>

--- a/services/hanke-service/src/main/resources/email/template/hanke-valmistunut.subject.mustache
+++ b/services/hanke-service/src/main/resources/email/template/hanke-valmistunut.subject.mustache
@@ -1,1 +1,1 @@
-Haitaton: Hankkeesi {{hanketunnus}} ilmoitettu päättymispäivä on ohitettu / Hankkeesi {{hanketunnus}} ilmoitettu päättymispäivä on ohitettu / Hankkeesi {{hanketunnus}} ilmoitettu päättymispäivä on ohitettu
+Haitaton: Hankkeesi {{hanketunnus}} ilmoitettu päättymispäivä on ohitettu / Avslutningsdatum för ditt projekt {{hanketunnus}} har passerats / The reported end date of your project {{hanketunnus}} has passed

--- a/services/hanke-service/src/main/resources/email/template/hanke-valmistunut.text.mustache
+++ b/services/hanke-service/src/main/resources/email/template/hanke-valmistunut.text.mustache
@@ -1,15 +1,16 @@
-Hankkeesi {{hanketunnus}} ilmoitettu päättymispäivä on ohitettu / Hankkeesi {{hanketunnus}} ilmoitettu päättymispäivä on ohitettu / Hankkeesi {{hanketunnus}} ilmoitettu päättymispäivä on ohitettu
+Hankkeesi {{hanketunnus}} ilmoitettu päättymispäivä on ohitettu / Avslutningsdatum för ditt projekt {{hanketunnus}} har passerats / The reported end date of your project {{hanketunnus}} has passed
 
-Hankkeesi {{{hankeNimi}}} ({{hanketunnus}}) ilmoitettu päättymispäivä on ohitettu. Hankkeesi ei enää näy muille Haitattoman käyttäjille eikä sitä pääse enää muokkamaan. Hanke säilyy Haitattomassa 6 kk, jona aikana pääset tarkastelemaan sitä.
+
+Hankkeesi {{{hankeNimi}}} ({{hanketunnus}}) ilmoitettu päättymispäivä on ohitettu. Hankkeesi ei enää näy muille Haitattoman käyttäjille, eikä sitä pääse enää muokkaamaan. Hanke säilyy Haitattomassa 6 kk, jona aikana pääset tarkastelemaan sitä.
 
 {{{signatures.fi}}}
 
 
-Hankkeesi {{{hankeNimi}}} ({{hanketunnus}}) ilmoitettu päättymispäivä on ohitettu. Hankkeesi ei enää näy muille Haitattoman käyttäjille eikä sitä pääse enää muokkamaan. Hanke säilyy Haitattomassa 6 kk, jona aikana pääset tarkastelemaan sitä.
+Avslutningsdatum för ditt projekt {{{hankeNimi}}} ({{hanketunnus}}) har passerats. Ditt projekt syns inte längre för andra användare av Haitaton, och det kan inte längre redigeras. Projektet finns kvar i Haitaton i 6 mån under vilken tid du kan granska det.
 
 {{{signatures.sv}}}
 
 
-Hankkeesi {{{hankeNimi}}} ({{hanketunnus}}) ilmoitettu päättymispäivä on ohitettu. Hankkeesi ei enää näy muille Haitattoman käyttäjille eikä sitä pääse enää muokkamaan. Hanke säilyy Haitattomassa 6 kk, jona aikana pääset tarkastelemaan sitä.
+The reported end date of your project {{{hankeNimi}}} ({{hanketunnus}}) has passed. Your project will no longer be visible to other Haitaton users, and it can no longer be edited. The project will be available for viewing in Haitaton for six months.
 
 {{{signatures.en}}}

--- a/services/hanke-service/src/main/resources/email/template/johtoselvitys-valmis.html.mustache
+++ b/services/hanke-service/src/main/resources/email/template/johtoselvitys-valmis.html.mustache
@@ -77,6 +77,11 @@
                       </td>
                     </tr>
                     <tr>
+                      <td align="left" style="font-size:0;padding:10px 25px;word-break:break-word">
+                        <div style="font-family:Arial;font-size:13px;line-height:1;text-align:left;color:#000">Huomioithan, että johtoselvitys poistuu Haitattomasta 6 kuukauden päästä hakemuksen voimassaoloajan päätyttyä, joten tallennathan päätöksen itsellesi ennen sitä.</div>
+                      </td>
+                    </tr>
+                    <tr>
                       <td align="left" style="font-size:0;padding:16px 24px 0 24px;word-break:break-word">
                         <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">Miten onnistuimme? Kerro mielipiteesi <a href="https://ecv.microsoft.com/zepZlZSdnT">täällä</a>.</div>
                       </td>
@@ -103,7 +108,12 @@
                       <td align="left" style="font-size:0;padding:16px 24px 0 24px;word-break:break-word">
                         <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">Ledningsutredningen {{applicationIdentifier}} ni ansökt om har behandlats. Ladda ned utredningen från Haitaton <a href="{{baseUrl}}/sv/ansokan/{{applicationId}}">
                             {{baseUrl}}/sv/ansokan/{{applicationId}}
-                          </a> och läs innehållet i den noggrannt.</div>
+                          </a> och läs innehållet i den noggrann.</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="left" style="font-size:0;padding:10px 25px;word-break:break-word">
+                        <div style="font-family:Arial;font-size:13px;line-height:1;text-align:left;color:#000">Observera att ledningsutredningen avlägsnas från Haitaton 6 månader efter att giltighetstiden för ansökan gått ut, så spara beslutet själv före det.</div>
                       </td>
                     </tr>
                     <tr>
@@ -131,9 +141,14 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0;padding:16px 24px 0 24px;word-break:break-word">
-                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">Cable report {{applicationIdentifier}} that you requested has been processed. Download the report via Haitaton <a href="{{baseUrl}}/en/application/{{applicationId}}">
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">The cable report {{applicationIdentifier}} that you requested has been processed. Download the report via Haitaton <a href="{{baseUrl}}/en/application/{{applicationId}}">
                             {{baseUrl}}/en/application/{{applicationId}}
                           </a> and read it carefully.</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="left" style="font-size:0;padding:10px 25px;word-break:break-word">
+                        <div style="font-family:Arial;font-size:13px;line-height:1;text-align:left;color:#000">Please note that the cable report will be deleted from Haitaton six months after the application’s validity period has ended. Please download and save the decision before this.</div>
                       </td>
                     </tr>
                     <tr>

--- a/services/hanke-service/src/main/resources/email/template/johtoselvitys-valmis.text.mustache
+++ b/services/hanke-service/src/main/resources/email/template/johtoselvitys-valmis.text.mustache
@@ -1,5 +1,7 @@
 Hakemanne johtoselvitys {{applicationIdentifier}} on käsitelty. Lataa selvitys Haitattomasta ({{baseUrl}}/fi/hakemus/{{applicationId}}) ja tutustu sen sisältöön huolellisesti.
 
+Huomioithan, että johtoselvitys poistuu Haitattomasta 6 kuukauden päästä hakemuksen voimassaoloajan päätyttyä, joten tallennathan päätöksen itsellesi ennen sitä.
+
 Miten onnistuimme? Kerro mielipiteesi täällä: https://ecv.microsoft.com/zepZlZSdnT.
 
 Ystävällisin terveisin,
@@ -11,7 +13,9 @@ Puh. 09 310 31940
 johtotietopalvelu@hel.fi
 
 
-Ledningsutredningen {{applicationIdentifier}} ni ansökt om har behandlats. Ladda ned utredningen från Haitaton ({{baseUrl}}/sv/ansokan/{{applicationId}}) och läs innehållet i den noggrannt.
+Ledningsutredningen {{applicationIdentifier}} ni ansökt om har behandlats. Ladda ned utredningen från Haitaton ({{baseUrl}}/sv/ansokan/{{applicationId}}) och läs innehållet i den noggrann.
+
+Observera att ledningsutredningen avlägsnas från Haitaton 6 månader efter att giltighetstiden för ansökan gått ut, så spara beslutet själv före det.
 
 Hur lyckades vi? Ge din åsikt här: https://ecv.microsoft.com/zepZlZSdnT.
 
@@ -24,7 +28,9 @@ Tfn 09 310 31940
 johtotietopalvelu@hel.fi
 
 
-Cable report {{applicationIdentifier}} that you requested has been processed. Download the report via Haitaton ({{baseUrl}}/en/application/{{applicationId}}) and read it carefully.
+The cable report {{applicationIdentifier}} that you requested has been processed. Download the report via Haitaton ({{baseUrl}}/en/application/{{applicationId}}) and read it carefully.
+
+Please note that the cable report will be deleted from Haitaton six months after the application’s validity period has ended. Please download and save the decision before this.
 
 How did we do? Please share your opinion here: https://ecv.microsoft.com/zepZlZSdnT.
 

--- a/services/hanke-service/src/main/resources/email/template/kayttaja-poistettu-hanke.html.mustache
+++ b/services/hanke-service/src/main/resources/email/template/kayttaja-poistettu-hanke.html.mustache
@@ -105,7 +105,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0;padding:16px 24px 0 24px;word-break:break-word">
-                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">{{deletedByName}} ({{deletedByEmail}}) har tagit bort dig från projektet <b>{{hankeNimi}} ({{hankeTunnus}})</b> och du har tagit bort dig från projektet.</div>
+                        <div style="font-family:Arial;font-size:16px;line-height:24px;text-align:left;color:#000">{{deletedByName}} ({{deletedByEmail}}) har tagit bort dig från projektet <b>{{hankeNimi}} ({{hankeTunnus}})</b> och du har inte längre tillträde till projektet.</div>
                       </td>
                     </tr>
                     <tr>

--- a/services/hanke-service/src/main/resources/email/template/kayttaja-poistettu-hanke.text.mustache
+++ b/services/hanke-service/src/main/resources/email/template/kayttaja-poistettu-hanke.text.mustache
@@ -5,7 +5,7 @@ Sinut on poistettu hankkeelta ({{hankeTunnus}}) / Du har tagits bort från proje
 {{{signatures.fi}}}
 
 
-{{{deletedByName}}} ({{{deletedByEmail}}}) har tagit bort dig från projektet "{{{hankeNimi}}}" ({{hankeTunnus}}) och du har tagit bort dig från projektet.
+{{{deletedByName}}} ({{{deletedByEmail}}}) har tagit bort dig från projektet "{{{hankeNimi}}}" ({{hankeTunnus}}) och du har inte längre tillträde till projektet.
 
 {{{signatures.sv}}}
 


### PR DESCRIPTION
# Description

Add translations for recently added emails.
  - Hanke ending reminder
  - Hanke deletion reminder
  - Hanke completed notification

Add unit tests for those emails, mainly to make sure dates are formatted correctly for each language.

Johtoselvitys completed email was missing a paragraph. It's added to the Finnish version and translations. The swedish version also had a grammatical error.

Removal from hanke email had some errors in the translations.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-3475

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [X] Other

# Checklist:

- [X] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 