### PR TITLE
HAI-3549 Add cable reports and placement contracts as OTHER Allu fields in kaivuilmoitus täydennys and muutosilmoitus

### DIFF
--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/InformationRequest.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/InformationRequest.kt
@@ -53,6 +53,8 @@ enum class InformationRequestFieldKey {
                 "emergencyWork" -> OTHER
                 "rockExcavation" -> OTHER
                 "workDescription" -> OTHER
+                "cableReports" -> OTHER
+                "placementContracts" -> OTHER
                 "startTime" -> START_TIME
                 "endTime" -> END_TIME
                 "customerWithContacts" -> CUSTOMER

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/MuutosilmoitusBuilder.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/MuutosilmoitusBuilder.kt
@@ -74,6 +74,12 @@ class MuutosilmoitusBuilder(
             { copy(maintenanceWork = maintenanceWork) },
         )
 
+    fun withCableReports(identifiers: List<String>) =
+        updateApplicationData({ invalidHakemusType() }, { copy(cableReports = identifiers) })
+
+    fun withPlacementContracts(identifiers: List<String>) =
+        updateApplicationData({ invalidHakemusType() }, { copy(placementContracts = identifiers) })
+
     fun withCustomerReference(customerReference: String) =
         updateApplicationData(
             { invalidHakemusType() },

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/TaydennysBuilder.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/TaydennysBuilder.kt
@@ -62,6 +62,12 @@ data class TaydennysBuilder(
             { copy(emergencyWork = emergencyWork) },
         )
 
+    fun withCableReports(identifiers: List<String>): TaydennysBuilder =
+        updateApplicationData({ invalidHakemusType() }, { copy(cableReports = identifiers) })
+
+    fun withPlacementContracts(identifiers: List<String>): TaydennysBuilder =
+        updateApplicationData({ invalidHakemusType() }, { copy(placementContracts = identifiers) })
+
     fun withWorkDescription(description: String): TaydennysBuilder =
         updateApplicationData(
             { copy(workDescription = description) },


### PR DESCRIPTION
# Description

Add cable reports and placement contracts as OTHER Allu fields in kaivuilmoitus täydennys and muutosilmoitus.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-3549

## Type of change

- [x] Bug fix 
- [ ] New feature 
- [ ] Other

# Instructions for testing
1. Create a täydennys or muutosilmoitus for kaivuilmoitus that has johtoselvitys or sijoitussopimus identifiers
2. Change only johtoselvitys or sijoitussopimus
3. Send täydennys or muutosilmoitus - there should be no errors

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 

# Other relevant info
Please describe here if there is e.g. some requirements for this change or
 other info that the tester/user needs to know.