### PR TITLE
HAI-3549 Add missing changes to Allu messages for täydennys and muutosilmoitus

### DIFF
--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/InformationRequest.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/InformationRequest.kt
@@ -63,6 +63,7 @@ enum class InformationRequestFieldKey {
                 "representativeWithContacts" -> REPRESENTATIVE
                 "invoicingCustomer" -> INVOICING_CUSTOMER
                 "attachment" -> ATTACHMENT
+                "additionalInfo" -> OTHER
                 else -> {
                     when {
                         name.matches(Regex("areas\\[\\d+]")) &&
@@ -71,6 +72,14 @@ enum class InformationRequestFieldKey {
                         name.matches(
                             Regex("areas\\[\\d+]\\.haittojenhallintasuunnitelma\\[[A-Z]+]")
                         ) -> ATTACHMENT
+                        name.matches(Regex("areas\\[\\d+]\\.katuosoite")) -> POSTAL_ADDRESS
+                        name.matches(Regex("areas\\[\\d+]\\.tyonTarkoitukset")) -> ATTACHMENT
+                        name.matches(Regex("areas\\[\\d+]\\.meluhaitta")) -> ATTACHMENT
+                        name.matches(Regex("areas\\[\\d+]\\.polyhaitta")) -> ATTACHMENT
+                        name.matches(Regex("areas\\[\\d+]\\.tarinahaitta")) -> ATTACHMENT
+                        name.matches(Regex("areas\\[\\d+]\\.kaistahaitta")) -> ATTACHMENT
+                        name.matches(Regex("areas\\[\\d+]\\.kaistahaittojenPituus")) -> ATTACHMENT
+                        name.matches(Regex("areas\\[\\d+]\\.lisatiedot")) -> ATTACHMENT
                         else -> null
                     }
                 }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/allu/InformationRequestTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/allu/InformationRequestTest.kt
@@ -43,5 +43,27 @@ class InformationRequestTest {
 
             assertThat(result).isEqualTo(InformationRequestFieldKey.ATTACHMENT)
         }
+
+        @Test
+        fun `returns ATTACHMENT if name matches areas with lisatiedot`() {
+            val result =
+                InformationRequestFieldKey.fromHaitatonFieldName(
+                    "areas[0].lisatiedot",
+                    ApplicationType.EXCAVATION_NOTIFICATION,
+                )
+
+            assertThat(result).isEqualTo(InformationRequestFieldKey.ATTACHMENT)
+        }
+
+        @Test
+        fun `returns POSTAL_ADDRESS if name matches areas with katuosoite`() {
+            val result =
+                InformationRequestFieldKey.fromHaitatonFieldName(
+                    "areas[0].katuosoite",
+                    ApplicationType.EXCAVATION_NOTIFICATION,
+                )
+
+            assertThat(result).isEqualTo(InformationRequestFieldKey.POSTAL_ADDRESS)
+        }
     }
 }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/TaydennysBuilder.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/TaydennysBuilder.kt
@@ -258,6 +258,9 @@ data class TaydennysBuilder(
             tilaaja = tilaaja,
         )
 
+    fun withAdditionalInfo(additionalInfo: String): TaydennysBuilder =
+        updateApplicationData({ invalidHakemusType() }, { copy(additionalInfo = additionalInfo) })
+
     private fun updateApplicationData(
         onCableReport: JohtoselvityshakemusEntityData.() -> JohtoselvityshakemusEntityData,
         onExcavationNotification: KaivuilmoitusEntityData.() -> KaivuilmoitusEntityData,


### PR DESCRIPTION
# Description

Added these changes to kaivuilmoitus täydennys and muutosilmoitus Allu messages:
* additionalInfo --> OTHER
* alueet[n].katuosoite --> POSTAL_ADDRESS
* aluuet[n].tyonTarkoitukset --> ATTACHMENT
* aluuet[n].meluhaitta --> ATTACHMENT
* aluuet[n].polyhaitta --> ATTACHMENT
* aluuet[n].tarinahaitta --> ATTACHMENT
* aluuet[n].kaistahaitta --> ATTACHMENT
* aluuet[n].kaistahaittojenPituus --> ATTACHMENT
* aluuet[n].lisatiedot--> ATTACHMENT

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-3549

## Type of change

- [x] Bug fix 
- [ ] New feature 
- [ ] Other

# Instructions for testing
1. Create a kaivuilmoitus and a täydennys or muutosilmoitus for it
2. Change only some of those fields mentioned in description
3. Send to Allu - there should not be errors about sending without any changes

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [x] I have made necessary changes to the documentation, link to confluence
 or other location: https://helsinkisolutionoffice.atlassian.net/wiki/spaces/HAI/pages/9217376257/Kaivuilmoituksen+t+ydennyspyynt+ja+muutosilmoitus+kentt+kokonaisuudet+Allu+vs.+Haitaton+data

# Other relevant info
Please describe here if there is e.g. some requirements for this change or
 other info that the tester/user needs to know.