### PR TITLE
HAI-16 Fix date handling for deletion reminders

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeCompletionServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeCompletionServiceITest.kt
@@ -1053,8 +1053,9 @@ class HankeCompletionServiceITest(
         fun `throws exception when hanke completion date is too recently`() {
             val hanke =
                 hankeFactory.builder().withNoAreas().saveEntity(HankeStatus.COMPLETED) {
-                    it.completedAt = OffsetDateTime.now().minusMonths(6).plusDays(1)
+                    it.completedAt = OffsetDateTime.now().plusDays(1).minusMonths(6)
                 }
+            assertThat(hanke.deletionDate()).isEqualTo(LocalDate.now().plusDays(1))
 
             val failure = assertFailure { hankeCompletionService.deleteHanke(hanke.id) }
 
@@ -1183,8 +1184,9 @@ class HankeCompletionServiceITest(
         ) {
             val hanke =
                 hankeFactory.builder().saveEntity(HankeStatus.COMPLETED) {
-                    it.completedAt = OffsetDateTime.now().minusMonths(6).minusDays(daysAgo)
+                    it.completedAt = OffsetDateTime.now().minusDays(daysAgo).minusMonths(6)
                 }
+            assertThat(hanke.deletionDate()).isEqualTo(LocalDate.now().minusDays(daysAgo))
 
             hankeCompletionService.sendDeletionRemindersIfNecessary(hanke.id)
 
@@ -1197,8 +1199,9 @@ class HankeCompletionServiceITest(
         fun `does nothing when the reminder is not yet due`() {
             val hanke =
                 hankeFactory.builder().saveEntity(HankeStatus.COMPLETED) {
-                    it.completedAt = OffsetDateTime.now().minusMonths(6).plusDays(6)
+                    it.completedAt = OffsetDateTime.now().plusDays(6).minusMonths(6)
                 }
+            assertThat(hanke.deletionDate()).isEqualTo(LocalDate.now().plusDays(6))
 
             hankeCompletionService.sendDeletionRemindersIfNecessary(hanke.id)
 
@@ -1214,8 +1217,9 @@ class HankeCompletionServiceITest(
         ) {
             val hanke =
                 hankeFactory.builder().saveEntity(HankeStatus.COMPLETED) {
-                    it.completedAt = OffsetDateTime.now().minusMonths(6).plusDays(date)
+                    it.completedAt = OffsetDateTime.now().plusDays(date).minusMonths(6)
                 }
+            assertThat(hanke.deletionDate()).isEqualTo(LocalDate.now().plusDays(date))
 
             hankeCompletionService.sendDeletionRemindersIfNecessary(hanke.id)
 
@@ -1269,7 +1273,8 @@ class HankeCompletionServiceITest(
                         muuYhteystieto(kayttooikeustaso = Kayttooikeustaso.KATSELUOIKEUS)
                     }
             hanke.status = HankeStatus.COMPLETED
-            hanke.completedAt = OffsetDateTime.now().minusMonths(6).plusDays(3)
+            hanke.completedAt = OffsetDateTime.now().plusDays(3).minusMonths(6)
+            assertThat(hanke.deletionDate()).isEqualTo(LocalDate.now().plusDays(3))
             hankeRepository.save(hanke)
 
             hankeCompletionService.sendDeletionRemindersIfNecessary(hanke.id)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeCompletionService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeCompletionService.kt
@@ -192,7 +192,8 @@ class HankeCompletionService(
         }
         val deletionDate = hanke.deletionDate() ?: throw HankeHasNoCompletionDateException(hanke)
 
-        if (deletionDate.isAfter(LocalDate.now().plusDays(5))) {
+        if (deletionDate.minusDays(5).isAfter(LocalDate.now())) {
+            logger.info { "Deletion notification is not yet due. ${hanke.logString()}" }
             return
         }
 

--- a/services/hanke-service/src/main/resources/application.yml
+++ b/services/hanke-service/src/main/resources/application.yml
@@ -61,9 +61,9 @@ haitaton:
       # By default, run every day at 19:17:21 (Helsinki time).
       reminderCron: ${HAITATON_COMPLETIONS_REMINDER_CRON:21 17 19 * * *}
       # By default, run every day at 20:03:53 (Helsinki time).
-      deletionReminderCron: ${HAITATON_COMPLETIONS_DELETE_CRON:53 03 20 * * *}
+      deletionReminderCron: ${HAITATON_COMPLETIONS_DELETE_REMINDER_CRON:53 03 20 * * *}
       # By default, run every day at 17:53:27 (Helsinki time).
-      draftCompletionCron: ${HAITATON_COMPLETIONS_CRON:27 53 17 * * *}
+      draftCompletionCron: ${HAITATON_COMPLETIONS_DRAFT_CRON:27 53 17 * * *}
   map-service:
     capability-url: https://kartta.hel.fi/ws/geoserver/avoindata/wms?REQUEST=GetCapabilities&SERVICE=WMS
   profiili-api:


### PR DESCRIPTION
# Description

Fix a bug where the deletion reminder is sometimes sent too early on the 5th last day of the month.

This boils down to the fact that [25th Apr 2025 + 6 days - 6 months](https://www.wolframalpha.com/input?i=25th+Apr+2025+%2B+6+days++++-+6+months+++) is not the same day as [25th Apr 2025 - 6 months + 6 days](https://www.wolframalpha.com/input?i=25th+Apr+2025+-+6+months+%2B+6+days).

Fix by doing the calculation in the same order each time. Fix by doing the calculation in the same order each time. In tests, when constructing a specific deletion date, the order of operations needs to be the opposite. Add asserts to tests to make sure the deletion date is set correctly.

Also, change the env vars for some of the completion cron schedules. Some variables were reused unintentionally.

## Type of change

- [x] Bug fix 
- [ ] New feature 
- [ ] Other