### PR TITLE
HAI-3473 Spring Boot 3.4.5 update

### DIFF
--- a/services/hanke-service/build.gradle.kts
+++ b/services/hanke-service/build.gradle.kts
@@ -55,7 +55,7 @@ spotless {
 
 plugins {
     val kotlinVersion = "2.1.20"
-    id("org.springframework.boot") version "3.3.10"
+    id("org.springframework.boot") version "3.4.5"
     id("io.spring.dependency-management") version "1.1.7"
     id("com.diffplug.spotless") version "7.0.3"
     kotlin("jvm") version kotlinVersion
@@ -91,7 +91,7 @@ dependencies {
     implementation("com.auth0:java-jwt:4.5.0")
 
     implementation("org.postgresql:postgresql")
-    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0")
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test") {
         exclude(group = "org.junit.vintage", module = "junit-vintage-engine")
@@ -99,7 +99,7 @@ dependencies {
     testImplementation("io.mockk:mockk:1.14.0")
     testImplementation("com.ninja-squad:springmockk:4.0.2")
     testImplementation("com.willowtreeapps.assertk:assertk-jvm:0.28.1")
-    testImplementation("com.squareup.okhttp3:mockwebserver")
+    testImplementation("com.squareup.okhttp3:mockwebserver:4.12.0")
     testImplementation("com.icegreen:greenmail-junit5:2.1.3")
 
     // Pdf generation

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/application/ApplicationAttachmentServiceITest.kt
@@ -246,7 +246,10 @@ class ApplicationAttachmentServiceITest(
             val application = applicationFactory.saveApplicationEntity(USERNAME)
             val attachments =
                 (1..ALLOWED_ATTACHMENT_COUNT).map {
-                    ApplicationAttachmentFactory.createEntity(applicationId = application.id)
+                    ApplicationAttachmentFactory.createEntity(
+                        id = null,
+                        applicationId = application.id,
+                    )
                 }
             attachmentRepository.saveAll(attachments)
             mockClamAv.enqueue(response(body(results = successResult())))

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/muutosilmoitus/MuutosilmoitusAttachmentServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/muutosilmoitus/MuutosilmoitusAttachmentServiceITest.kt
@@ -200,7 +200,8 @@ class MuutosilmoitusAttachmentServiceITest(
             val attachments =
                 (1..ALLOWED_ATTACHMENT_COUNT).map {
                     MuutosilmoitusAttachmentFactory.createEntity(
-                        muutosilmoitusId = muutosilmoitus.id
+                        id = null,
+                        muutosilmoitusId = muutosilmoitus.id,
                     )
                 }
             attachmentRepository.saveAll(attachments)

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/taydennys/TaydennysAttachmentServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/taydennys/TaydennysAttachmentServiceITest.kt
@@ -188,7 +188,7 @@ class TaydennysAttachmentServiceITest(
             val taydennys = taydennysFactory.builder().save()
             val attachments =
                 (1..ALLOWED_ATTACHMENT_COUNT).map {
-                    TaydennysAttachmentFactory.Companion.createEntity(taydennysId = taydennys.id)
+                    TaydennysAttachmentFactory.createEntity(id = null, taydennysId = taydennys.id)
                 }
             attachmentRepository.saveAll(attachments)
             mockClamAv.enqueue(response(body(results = successResult())))

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/gdpr/GdprServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/gdpr/GdprServiceITest.kt
@@ -76,9 +76,11 @@ class GdprServiceITest(
             val hanke1 = hankeFactory.saveMinimal()
             val hanke2 = hankeFactory.saveMinimal()
             permissionRepository.save(
-                PermissionFactory.createEntity(userId = USERNAME, hankeId = hanke1.id))
+                PermissionFactory.createEntity(id = 0, userId = USERNAME, hankeId = hanke1.id)
+            )
             permissionRepository.save(
-                PermissionFactory.createEntity(userId = USERNAME, hankeId = hanke2.id))
+                PermissionFactory.createEntity(id = 0, userId = USERNAME, hankeId = hanke2.id)
+            )
 
             val result = gdprService.findGdprInfo(USERNAME)
 
@@ -173,15 +175,9 @@ class GdprServiceITest(
         @Test
         fun `returns organization info when user is hakemusyhteyshenkilo`() {
             val toteuttajaYhteystieto =
-                HakemusyhteystietoFactory.create(
-                    nimi = "Yritys Oy",
-                    registryKey = "4134328-8",
-                )
+                HakemusyhteystietoFactory.create(nimi = "Yritys Oy", registryKey = "4134328-8")
             val omistajaYhteystieto =
-                HakemusyhteystietoFactory.create(
-                    nimi = "Omistaja Oy",
-                    registryKey = "3213212-0",
-                )
+                HakemusyhteystietoFactory.create(nimi = "Omistaja Oy", registryKey = "3213212-0")
             val hanke = hankeFactory.saveMinimal(generated = true)
             val kayttaja = hankekayttajaFactory.saveIdentifiedUser(hanke.id, userId = USERNAME)
             hakemusFactory
@@ -636,7 +632,7 @@ fun Assert<CollectionNode>.hasCollectionWithChildren(key: String, vararg child: 
 
 fun Assert<CollectionNode>.hasCollectionChild(
     key: String,
-    body: Assert<CollectionNode>.() -> Unit
+    body: Assert<CollectionNode>.() -> Unit,
 ) {
     hasChild(key) { isInstanceOf(CollectionNode::class).all(body) }
 }
@@ -644,7 +640,7 @@ fun Assert<CollectionNode>.hasCollectionChild(
 fun Assert<CollectionNode>.hasOrganisaatio(
     nimi: String,
     ytunnus: String? = null,
-    osasto: String? = null
+    osasto: String? = null,
 ) {
     prop(CollectionNode::children)
         .transform { it.filter { child -> child.key == "organisaatio" } }

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/profiili/ProfiiliClientITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/profiili/ProfiiliClientITest.kt
@@ -177,7 +177,7 @@ class ProfiiliClientITest {
             assertThat(request.getHeader("Authorization")).isEqualTo("Bearer $ACCESS_TOKEN")
             assertThat(request.getHeader("Accept")).isEqualTo(MediaType.APPLICATION_JSON_VALUE)
             assertThat(request.getHeader("Content-Type"))
-                .isEqualTo(MediaType.APPLICATION_FORM_URLENCODED_VALUE + ";charset=UTF-8")
+                .isEqualTo(MediaType.APPLICATION_FORM_URLENCODED_VALUE)
         }
 
         @Test

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Persistence.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Persistence.kt
@@ -162,7 +162,7 @@ interface HankeRepository : JpaRepository<HankeEntity, Int> {
         "select h.id from HankeEntity h " +
             "left join HankealueEntity ha on ha.hanke = h " +
             "where h.status in ('PUBLIC', 'DRAFT') " +
-            "and not array_contains(h.sentReminders, :reminder) " +
+            "and not array_includes(h.sentReminders, :reminder) " +
             "group by h.id " +
             "having coalesce(max(ha.haittaLoppuPvm), '1990-01-01') <= :reminderDate " +
             "order by h.modifiedAt asc limit :limit"
@@ -175,7 +175,7 @@ interface HankeRepository : JpaRepository<HankeEntity, Int> {
     @Query(
         "select h.id from HankeEntity h " +
             "where date(h.completedAt) <= :reminderDate " +
-            "and not array_contains(h.sentReminders, :reminder) " +
+            "and not array_includes(h.sentReminders, :reminder) " +
             "order by h.completedAt asc"
     )
     fun findIdsForDeletionReminders(reminderDate: LocalDate, reminder: HankeReminder): List<Int>

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttaja.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttaja.kt
@@ -81,7 +81,8 @@ class HankekayttajaEntity(
     var permission: PermissionEntity?,
 
     /** Invitation data including e.g. the sign in token. */
-    @OneToOne(mappedBy = "hankekayttaja") var kayttajakutsu: KayttajakutsuEntity? = null,
+    @OneToOne(mappedBy = "hankekayttaja", cascade = [CascadeType.ALL])
+    var kayttajakutsu: KayttajakutsuEntity? = null,
 
     /** Identifier of the inviter. */
     @Column(name = "kutsuja_id") var kutsujaId: UUID? = null,
@@ -89,14 +90,14 @@ class HankekayttajaEntity(
         fetch = FetchType.LAZY,
         mappedBy = "hankeKayttaja",
         cascade = [CascadeType.ALL],
-        orphanRemoval = true
+        orphanRemoval = true,
     )
     var yhteyshenkilot: MutableList<HankeYhteyshenkiloEntity> = mutableListOf(),
     @OneToMany(
         fetch = FetchType.LAZY,
         mappedBy = "hankekayttaja",
         cascade = [CascadeType.ALL],
-        orphanRemoval = true
+        orphanRemoval = true,
     )
     var hakemusyhteyshenkilot: MutableList<HakemusyhteyshenkiloEntity> = mutableListOf(),
 ) {
@@ -183,7 +184,7 @@ interface HankekayttajaRepository : JpaRepository<HankekayttajaEntity, UUID> {
 
     fun findByHankeIdAndSahkopostiIn(
         hankeId: Int,
-        sahkopostit: List<String>
+        sahkopostit: List<String>,
     ): List<HankekayttajaEntity>
 
     fun findByPermissionId(permissionId: Int): HankekayttajaEntity?

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/permissions/HankeKayttajaService.kt
@@ -455,8 +455,6 @@ class HankeKayttajaService(
         kayttaja.kayttajakutsu?.let { tunniste ->
             logger.info { "Deleting old tunniste ${tunniste.id}" }
             kayttajakutsuRepository.delete(tunniste)
-            // Flush to avoid unique key collision on hanke_kayttaja_id
-            kayttajakutsuRepository.flush()
             logService.logDelete(tunniste.toDomain(), currentUserId)
         }
         kayttaja.kayttajakutsu = createKutsu(kayttaja, currentUserId)


### PR DESCRIPTION
# Description

Upgrade Spring Boot to 3.4.5. Some fixes are required to make the new version work. Most of the fixes are needed because the new version uses Hibernate 6.6, which has some changes to entity validation, even though it's not clearly documented.

- In some tests, we get a StaleObjectStateException unless we explicitly set the id to null or zero.
- `array_contains` no longer works for us. It complains about trying to find a number in an array of varchars. Changing it to `array_includes` fixes the problem, though I'm not sure why.
-  The relationship between Hankekayttaja and Kayttajakutsu cascade type set. I'm not quite sure how this has worked without one.
- Probably related to adding that, the explicit flush when recreating the Kayttajakutsu is no longer necessary. It now breaks the method.
- Deleting a hankekayttaja doesn't properly cascade to yhteystiedot in hanke and hakemukset if we have loaded the hanke and hakemukset to the Hibernate context. We need to remove all references to the hankekayttaja before deleting it.
- Mockwebserver is no longer in Spring dependency management, so the version needs to be set explicitly.
- Springdoc update needs this one, so it's updated at the same time.
- The charset is no longer automatically added to the Content-Type header when sending GraphQL requests. The Profiili API doesn't need them, so this only changes the test.

### Jira Issue: 

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [ ] Other

# Instructions for testing
The user management functionality should be tested. Most of the changes were done over there. At least:
- Inviting new users
- Re-sending the invitation
- Accepting an invitation
- Deleting users when they are contacts in the hanke, a hakemus and both.