### PR TITLE
HAI-3564 Use explicit current user id in GeometryService

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/geometria/GeometriatServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/geometria/GeometriatServiceITest.kt
@@ -83,7 +83,7 @@ internal class GeometriatServiceITest : IntegrationTest() {
         loadedGeometriat.featureCollection!!
             .features
             .add(loadedGeometriat.featureCollection!!.features[0])
-        geometriatService.saveGeometriat(loadedGeometriat, loadedGeometriat.id)
+        geometriatService.saveGeometriat(loadedGeometriat, loadedGeometriat.id, USERNAME)
 
         // load
         loadedGeometriat = geometriatService.getGeometriat(loadedGeometriat.id!!)
@@ -125,7 +125,7 @@ internal class GeometriatServiceITest : IntegrationTest() {
         geometriat.featureCollection?.crs?.properties = null
 
         assertThrows<GeometriaValidationException> {
-            geometriatService.saveGeometriat(geometriat, null)
+            geometriatService.saveGeometriat(geometriat, null, USERNAME)
         }
     }
 
@@ -135,7 +135,7 @@ internal class GeometriatServiceITest : IntegrationTest() {
         geometriat.featureCollection?.crs?.properties?.set("name", "urn:ogc:def:crs:EPSG::0000")
 
         assertThrows<UnsupportedCoordinateSystemException> {
-            geometriatService.saveGeometriat(geometriat, null)
+            geometriatService.saveGeometriat(geometriat, null, USERNAME)
         }
     }
 
@@ -145,7 +145,7 @@ internal class GeometriatServiceITest : IntegrationTest() {
         fun `sets metadata correctly`() {
             val geometriat = GeometriaFactory.createNew()
 
-            val result = geometriatService.createGeometriat(geometriat)
+            val result = geometriatService.createGeometriat(geometriat, USERNAME)
 
             val savedGeometriat = geometriatService.getGeometriat(result.id!!)
             assertThat(savedGeometriat).isNotNull().all {
@@ -165,7 +165,7 @@ internal class GeometriatServiceITest : IntegrationTest() {
         fun `saves geometries correctly`() {
             val geometriat: Geometriat = GeometriaFactory.create()
 
-            val result = geometriatService.createGeometriat(geometriat)
+            val result = geometriatService.createGeometriat(geometriat, USERNAME)
 
             val savedGeometriat = geometriatService.getGeometriat(result.id!!)
             assertThat(savedGeometriat).isNotNull().all {

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankeService.kt
@@ -114,7 +114,7 @@ class HankeService(
 
         val loggingEntryHolder = prepareLogging(entity)
         // Transfer field values from request object to entity object
-        updateEntityFieldsFromRequest(hanke, entity)
+        updateEntityFieldsFromRequest(hanke, entity, userId)
         copyYhteystietosToEntity(hanke, entity, userId, loggingEntryHolder, existingYTs)
 
         // Set relevant audit fields:
@@ -323,7 +323,11 @@ class HankeService(
     private fun createHankeDomainObjectFromEntity(hankeEntity: HankeEntity): Hanke =
         HankeMapper.domainFrom(hankeEntity, hankealueService.geometryMapFrom(hankeEntity.alueet))
 
-    private fun updateEntityFieldsFromRequest(hanke: ModifyHankeRequest, entity: HankeEntity) {
+    private fun updateEntityFieldsFromRequest(
+        hanke: ModifyHankeRequest,
+        entity: HankeEntity,
+        currentUserId: String,
+    ) {
         entity.onYKTHanke = hanke.onYKTHanke
         entity.nimi = hanke.nimi
         entity.kuvaus = hanke.kuvaus
@@ -334,7 +338,7 @@ class HankeService(
         entity.tyomaaTyyppi.removeAll(removedTyyppi)
         entity.tyomaaTyyppi.addAll(newTyyppi)
 
-        hankealueService.mergeAlueetToHanke(hanke.alueet, entity)
+        hankealueService.mergeAlueetToHanke(hanke.alueet, entity, currentUserId)
     }
 
     /**

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Utils.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Utils.kt
@@ -70,6 +70,10 @@ fun LocalDateTime.zonedDateTime(): ZonedDateTime = ZonedDateTime.of(this, TZ_UTC
  */
 fun getCurrentTimeUTCAsLocalTime(): LocalDateTime = getCurrentTimeUTC().toLocalDateTime()
 
+/**
+ * Don't call this outside controllers. If the code is called from scheduled methods, this will
+ * throw a NullPointerException.
+ */
 fun currentUserId(): String = SecurityContextHolder.getContext().userId()
 
 fun SecurityContext.userId(): String = authentication.name

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/muutosilmoitus/MuutosilmoitusService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/muutosilmoitus/MuutosilmoitusService.kt
@@ -117,7 +117,7 @@ class MuutosilmoitusService(
 
         val hakemusEntity = hakemusRepository.getReferenceById(entity.hakemusId)
         hakemusService.assertYhteystiedotValidity(hakemusEntity.hanke, entity.yhteystiedot, request)
-        hakemusService.assertOrUpdateHankealueet(hakemusEntity.hanke, request)
+        hakemusService.assertOrUpdateHankealueet(hakemusEntity.hanke, request, currentUserId)
 
         val originalContactUserIds = entity.allContactUsers().map { it.id }.toSet()
         val updatedMuutosilmoitusEntity = saveWithUpdate(entity, request, hakemusEntity.hanke.id)
@@ -147,6 +147,7 @@ class MuutosilmoitusService(
         hakemusService.resetAreasIfHankeGenerated(
             muutosilmoitusEntity.hakemusId,
             muutosilmoitusEntity,
+            currentUserId,
         )
 
         attachmentService.deleteAllAttachments(muutosilmoitusEntity)

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/geometria/GeometriatServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/geometria/GeometriatServiceTest.kt
@@ -43,7 +43,7 @@ internal class GeometriatServiceTest {
         every { geometriatDao.retrieveGeometriat(geometriaId) } returns oldGeometriat
         every { geometriatDao.updateGeometriat(any()) } just runs
 
-        val savedHankeGeometria = service.saveGeometriat(geometriat, geometriaId)
+        val savedHankeGeometria = service.saveGeometriat(geometriat, geometriaId, USERNAME)
 
         verifySequence {
             geometriatDao.retrieveGeometriat(geometriaId)
@@ -67,7 +67,7 @@ internal class GeometriatServiceTest {
                 firstArg<Geometriat>().apply { id = 42 }
             }
 
-        val savedHankeGeometria = service.saveGeometriat(geometriat, null)
+        val savedHankeGeometria = service.saveGeometriat(geometriat, null, USERNAME)
 
         verifySequence { geometriatDao.createGeometriat(any()) }
         assertThat(savedHankeGeometria).isNotNull().all {
@@ -94,7 +94,7 @@ internal class GeometriatServiceTest {
         every { geometriatDao.retrieveGeometriat(geometriatId) } returns oldGeometriat
         every { geometriatDao.deleteGeometriat(any()) } just runs
 
-        val savedHankeGeometria = service.saveGeometriat(geometriat, geometriatId)
+        val savedHankeGeometria = service.saveGeometriat(geometriat, geometriatId, USERNAME)
 
         verifySequence {
             geometriatDao.retrieveGeometriat(geometriatId)
@@ -116,7 +116,7 @@ internal class GeometriatServiceTest {
         every { geometriatDao.retrieveGeometriat(geometriatId) } returns oldGeometriat
         every { geometriatDao.updateGeometriat(any()) } just runs
 
-        val savedHankeGeometria = service.saveGeometriat(geometriat, geometriatId)
+        val savedHankeGeometria = service.saveGeometriat(geometriat, geometriatId, USERNAME)
 
         verify { geometriatDao.retrieveGeometriat(geometriatId) }
         verify { geometriatDao.updateGeometriat(any()) }
@@ -145,7 +145,7 @@ internal class GeometriatServiceTest {
                     firstArg<Geometriat>().apply { id = 42 }
                 }
 
-            val savedHankeGeometria = service.createGeometriat(geometriat)
+            val savedHankeGeometria = service.createGeometriat(geometriat, USERNAME)
 
             assertThat(savedHankeGeometria).isNotNull().all {
                 prop(Geometriat::version).isEqualTo(0)
@@ -165,7 +165,7 @@ internal class GeometriatServiceTest {
                     firstArg<Geometriat>().apply { id = 42 }
                 }
 
-            val savedHankeGeometria = service.createGeometriat(geometriat)
+            val savedHankeGeometria = service.createGeometriat(geometriat, USERNAME)
 
             assertThat(savedHankeGeometria).isNotNull().all {
                 isNotSameInstanceAs(geometriat)


### PR DESCRIPTION
# Description

When GeometryService code is run through a scheduled method, namely the Allu update method, `currentUserId()` throws a NullPointerException. Replace the implicit user id with an explicit parameter.

In Allu updates, use 'Allu' as a placeholder user id.

## Type of change

- [X] Bug fix 
- [ ] New feature 
- [ ] Other