### PR TITLE
HAI-3579: Fix using months in calculating the hanke deletion date

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/HankeServiceITests.kt
@@ -79,6 +79,7 @@ import fi.hel.haitaton.hanke.test.AuditLogEntryEntityAsserts.isSuccess
 import fi.hel.haitaton.hanke.test.AuditLogEntryEntityAsserts.withTarget
 import fi.hel.haitaton.hanke.test.AuthenticationMocks
 import fi.hel.haitaton.hanke.test.TestUtils
+import fi.hel.haitaton.hanke.test.TestUtils.FIXED_CLOCK
 import fi.hel.haitaton.hanke.test.TestUtils.nextYear
 import fi.hel.haitaton.hanke.test.USERNAME
 import io.mockk.checkUnnecessaryStub
@@ -178,7 +179,7 @@ class HankeServiceITests(
         fun `returns hanke deletion date for a completed hanke`() {
             val hanke =
                 hankeFactory.builder(USERNAME).saveEntity(HankeStatus.COMPLETED) {
-                    it.completedAt = OffsetDateTime.parse("2025-04-09T01:41:13+03:00")
+                    it.completedAt = OffsetDateTime.now(FIXED_CLOCK)
                 }
 
             val response = hankeService.loadHankeById(hanke.id)
@@ -186,7 +187,9 @@ class HankeServiceITests(
             assertThat(response)
                 .isNotNull()
                 .prop(Hanke::deletionDate)
-                .isEqualTo(LocalDate.parse("2025-10-09"))
+                .isEqualTo(
+                    LocalDate.now(FIXED_CLOCK).plusMonthsPreserveEndOfMonth(MONTHS_BEFORE_DELETION)
+                )
         }
 
         @Test
@@ -641,7 +644,7 @@ class HankeServiceITests(
             assertEquals("1", event.appVersion)
             assertEquals("testUser", event.actor.userId)
             assertEquals(UserRole.USER, event.actor.role)
-            assertEquals(TestUtils.mockedIp, event.actor.ipAddress)
+            assertEquals(TestUtils.MOCKED_IP, event.actor.ipAddress)
             assertEquals(hanke.id.toString(), event.target.id)
             assertEquals(ObjectType.HANKE, event.target.type)
             assertNull(event.target.objectAfter)
@@ -683,7 +686,7 @@ class HankeServiceITests(
                 event.transform { it.appVersion }.isEqualTo("1")
                 event.transform { it.actor.userId }.isEqualTo("testUser")
                 event.transform { it.actor.role }.isEqualTo(UserRole.USER)
-                event.transform { it.actor.ipAddress }.isEqualTo(TestUtils.mockedIp)
+                event.transform { it.actor.ipAddress }.isEqualTo(TestUtils.MOCKED_IP)
             }
             val omistajaId = hanke.omistajat[0].id!!
             val omistajaEvent = deleteLogs.findByTargetId(omistajaId).message.auditEvent

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/UpdateHankeITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/UpdateHankeITests.kt
@@ -846,7 +846,7 @@ class UpdateHankeITests(
             )
         val hankeLogs = auditLogRepository.findByType(ObjectType.HANKE)
         assertThat(hankeLogs).single().isSuccess(Operation.UPDATE) {
-            hasUserActor("test7358", TestUtils.mockedIp)
+            hasUserActor("test7358", TestUtils.MOCKED_IP)
             withTarget {
                 hasId(hanke.id)
                 hasTargetType(ObjectType.HANKE)
@@ -888,7 +888,7 @@ class UpdateHankeITests(
             )
         val hankeLogs = auditLogRepository.findByType(ObjectType.HANKE)
         assertThat(hankeLogs).single().isSuccess(Operation.UPDATE) {
-            hasUserActor("test7358", TestUtils.mockedIp)
+            hasUserActor("test7358", TestUtils.MOCKED_IP)
             withTarget {
                 hasId(hanke.id)
                 hasTargetType(ObjectType.HANKE)
@@ -932,7 +932,7 @@ class UpdateHankeITests(
             )
         val hankeLogs = auditLogRepository.findByType(ObjectType.HANKE)
         assertThat(hankeLogs).single().isSuccess(Operation.UPDATE) {
-            hasUserActor("test7358", TestUtils.mockedIp)
+            hasUserActor("test7358", TestUtils.MOCKED_IP)
             withTarget {
                 hasId(hanke.id)
                 hasTargetType(ObjectType.HANKE)

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusServiceITest.kt
@@ -2082,7 +2082,7 @@ class HakemusServiceITest(
             hakemusService.cancelAndDelete(hakemus, USERNAME)
 
             assertThat(auditLogRepository.findAll()).single().isSuccess(Operation.DELETE) {
-                hasUserActor(USERNAME, TestUtils.mockedIp)
+                hasUserActor(USERNAME, TestUtils.MOCKED_IP)
                 withTarget {
                     prop(AuditLogTarget::id).isEqualTo(hakemus.id.toString())
                     prop(AuditLogTarget::type).isEqualTo(ObjectType.HAKEMUS)

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/muutosilmoitus/MuutosilmoitusServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/muutosilmoitus/MuutosilmoitusServiceITest.kt
@@ -326,7 +326,7 @@ class MuutosilmoitusServiceITest(
             muutosilmoitusService.delete(muutosilmoitus.id, USERNAME)
 
             assertThat(auditLogRepository.findAll()).single().isSuccess(Operation.DELETE) {
-                hasUserActor(USERNAME, TestUtils.mockedIp)
+                hasUserActor(USERNAME, TestUtils.MOCKED_IP)
                 withTarget {
                     prop(AuditLogTarget::id).isEqualTo(muutosilmoitus.id.toString())
                     prop(AuditLogTarget::type).isEqualTo(ObjectType.MUUTOSILMOITUS)

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennysServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennysServiceITest.kt
@@ -1308,7 +1308,7 @@ class TaydennysServiceITest(
             taydennysService.delete(taydennys.id, USERNAME)
 
             assertThat(auditLogRepository.findAll()).single().isSuccess(Operation.DELETE) {
-                hasUserActor(USERNAME, TestUtils.mockedIp)
+                hasUserActor(USERNAME, TestUtils.MOCKED_IP)
                 withTarget {
                     prop(AuditLogTarget::id).isEqualTo(taydennys.id.toString())
                     prop(AuditLogTarget::type).isEqualTo(ObjectType.TAYDENNYS)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Constants.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Constants.kt
@@ -31,3 +31,5 @@ const val HANKETUNNUS_PREFIX = "HAI"
 const val ALLOWED_ATTACHMENT_COUNT = 20
 
 const val HANKEALUE_DEFAULT_NAME = "Hankealue"
+
+const val MONTHS_BEFORE_DELETION: Long = 6

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Extensions.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Extensions.kt
@@ -4,6 +4,10 @@ import com.fasterxml.jackson.databind.JsonNode
 import jakarta.validation.ConstraintViolationException
 import java.math.BigDecimal
 import java.math.RoundingMode
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import java.time.OffsetTime
+import java.time.temporal.TemporalAdjusters
 
 fun Any?.toJsonString(): String = OBJECT_MAPPER.writeValueAsString(this)
 
@@ -45,5 +49,29 @@ internal fun ConstraintViolationException.toHankeError(default: HankeError): Han
         HankeError.valueOf(violation)
     } else {
         default
+    }
+}
+
+fun OffsetDateTime.plusMonthsPreserveEndOfMonth(months: Long): OffsetDateTime =
+    this.toLocalDate().plusMonthsPreserveEndOfMonth(months).atTime(OffsetTime.now(TZ_UTC))
+
+fun OffsetDateTime.minusMonthsPreserveEndOfMonth(months: Long): OffsetDateTime =
+    this.toLocalDate().minusMonthsPreserveEndOfMonth(months).atTime(OffsetTime.now(TZ_UTC))
+
+fun LocalDate.plusMonthsPreserveEndOfMonth(months: Long): LocalDate {
+    val newDate = this.plusMonths(months)
+    return if (this.dayOfMonth == this.lengthOfMonth()) {
+        newDate.with(TemporalAdjusters.lastDayOfMonth())
+    } else {
+        newDate
+    }
+}
+
+fun LocalDate.minusMonthsPreserveEndOfMonth(months: Long): LocalDate {
+    val newDate = this.minusMonths(months)
+    return if (this.dayOfMonth == this.lengthOfMonth()) {
+        newDate.with(TemporalAdjusters.lastDayOfMonth())
+    } else {
+        newDate
     }
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Persistence.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/Persistence.kt
@@ -25,7 +25,6 @@ import jakarta.persistence.Table
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.OffsetDateTime
-import java.time.ZoneId
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
@@ -107,7 +106,10 @@ class HankeEntity(
     fun endDate(): LocalDate? = alueet.endDate()
 
     fun deletionDate(): LocalDate? =
-        completedAt?.plusMonths(6)?.atZoneSameInstant(ZoneId.of("Europe/Helsinki"))?.toLocalDate()
+        completedAt
+            ?.plusMonthsPreserveEndOfMonth(MONTHS_BEFORE_DELETION)
+            ?.atZoneSameInstant(TZ_UTC)
+            ?.toLocalDate()
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/test/AuditLogEntryEntityAsserts.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/test/AuditLogEntryEntityAsserts.kt
@@ -49,7 +49,7 @@ object AuditLogEntryEntityAsserts {
             prop(AuditLogActor::userId).isEqualTo(userId)
         }
 
-    fun Assert<AuditLogEvent>.hasMockedIp(ipAddress: String = TestUtils.mockedIp) =
+    fun Assert<AuditLogEvent>.hasMockedIp(ipAddress: String = TestUtils.MOCKED_IP) =
         prop(AuditLogEvent::actor).prop(AuditLogActor::ipAddress).isEqualTo(ipAddress)
 
     fun Assert<AuditLogEvent>.withTarget(body: Assert<AuditLogTarget>.() -> Unit) =

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/test/TestUtils.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/test/TestUtils.kt
@@ -1,14 +1,19 @@
 package fi.hel.haitaton.hanke.test
 
+import fi.hel.haitaton.hanke.TZ_UTC
 import fi.hel.haitaton.hanke.getCurrentTimeUTC
+import java.time.Clock
+import java.time.Instant
 import org.springframework.mock.web.MockHttpServletRequest
 import org.springframework.web.context.request.RequestContextHolder
 import org.springframework.web.context.request.ServletRequestAttributes
 
 object TestUtils {
-    const val mockedIp = "127.0.0.1"
+    val FIXED_CLOCK: Clock = Clock.fixed(Instant.parse("2025-04-09T01:41:13+03:00"), TZ_UTC)
 
-    fun addMockedRequestIp(ip: String = mockedIp) {
+    const val MOCKED_IP = "127.0.0.1"
+
+    fun addMockedRequestIp(ip: String = MOCKED_IP) {
         val request = MockHttpServletRequest()
         request.remoteAddr = ip
         RequestContextHolder.setRequestAttributes(ServletRequestAttributes(request))


### PR DESCRIPTION
# Description

When testing hanke deletion using month increase/decrease has caused errors when the current date is close to month's end. This PR fixes this by using a fixed date in tests instead of current date. Also, in deletion date calculation, PR uses the logic of persisting the end of the month: if a completion date is e.g. 30.4. (end of the month), then adding 6 months into it does not produce 30.10. but 31.10. (end of the month). Same goes when decreasing months from a date.

Also, change constant mockedIp to follow naming practices (all uppercase)

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-3579

## Type of change

- [x] Bug fix 
- [ ] New feature 
- [ ] Other

# Instructions for testing
This fix is only for tests so it should not affect any real functionality.

# Checklist:

- [ ] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 

# Other relevant info
Please describe here if there is e.g. some requirements for this change or
 other info that the tester/user needs to know.