### PR TITLE
HAI-3541 Implement back-channel logout for Helsinki SSO logout

### DIFF
--- a/scripts/nginx/nginx.conf
+++ b/scripts/nginx/nginx.conf
@@ -17,6 +17,14 @@ server {
   client_max_body_size 101M;
   large_client_header_buffers 4 64k;
 
+  location /api/backchannel-logout {
+    proxy_pass http://docker-backend/backchannel-logout;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+  }
+
   location /api/ {
     proxy_pass  http://docker-backend/;
     proxy_redirect  http://docker-backend/ /api/;

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/IntegrationTestConfiguration.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/IntegrationTestConfiguration.kt
@@ -142,12 +142,7 @@ class IntegrationTestConfiguration {
 
     @Bean fun tormaystarkasteluLaskentaService(): TormaystarkasteluLaskentaService = mockk()
 
-    @Bean
-    fun userSessionCache(): UserSessionCache {
-        val mock = mockk<UserSessionCache>(relaxUnitFun = true)
-        every { mock.isSessionKnown(any()) } returns true
-        return mock
-    }
+    @Bean fun userSessionCache(): UserSessionCache = mockk(relaxed = true)
 
     @Bean fun userSessionRepository(): UserSessionRepository = mockk()
 

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/IntegrationTestConfiguration.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/IntegrationTestConfiguration.kt
@@ -30,6 +30,10 @@ import fi.hel.haitaton.hanke.permissions.PermissionService
 import fi.hel.haitaton.hanke.profiili.ProfiiliClient
 import fi.hel.haitaton.hanke.profiili.ProfiiliService
 import fi.hel.haitaton.hanke.security.AccessRules
+import fi.hel.haitaton.hanke.security.LogoutService
+import fi.hel.haitaton.hanke.security.UserSessionCache
+import fi.hel.haitaton.hanke.security.UserSessionRepository
+import fi.hel.haitaton.hanke.security.UserSessionService
 import fi.hel.haitaton.hanke.taydennys.TaydennysAuthorizer
 import fi.hel.haitaton.hanke.taydennys.TaydennysService
 import fi.hel.haitaton.hanke.testdata.TestDataService
@@ -108,6 +112,8 @@ class IntegrationTestConfiguration {
 
     @Bean fun jdbcOperations(): JdbcOperations = mockk()
 
+    @Bean fun logoutService(): LogoutService = mockk()
+
     @Bean fun muutosilmoitusAttachmentService(): MuutosilmoitusAttachmentService = mockk()
 
     @Bean fun muutosilmoitusAuthorizer(): MuutosilmoitusAuthorizer = mockk()
@@ -135,6 +141,17 @@ class IntegrationTestConfiguration {
     @Bean fun tormaysService(): TormaystarkasteluTormaysService = mockk()
 
     @Bean fun tormaystarkasteluLaskentaService(): TormaystarkasteluLaskentaService = mockk()
+
+    @Bean
+    fun userSessionCache(): UserSessionCache {
+        val mock = mockk<UserSessionCache>(relaxUnitFun = true)
+        every { mock.isSessionKnown(any()) } returns true
+        return mock
+    }
+
+    @Bean fun userSessionRepository(): UserSessionRepository = mockk()
+
+    @Bean fun userSessionService(): UserSessionService = mockk()
 
     @EventListener
     fun onApplicationEvent(event: ContextRefreshedEvent) {

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/gdpr/GdprControllerITests.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/gdpr/GdprControllerITests.kt
@@ -5,7 +5,7 @@ import fi.hel.haitaton.hanke.logging.DisclosureLogService
 import fi.hel.haitaton.hanke.test.USERNAME
 import io.mockk.Called
 import io.mockk.checkUnnecessaryStub
-import io.mockk.clearAllMocks
+import io.mockk.clearMocks
 import io.mockk.confirmVerified
 import io.mockk.every
 import io.mockk.verify
@@ -46,7 +46,7 @@ class GdprControllerITests(@Autowired var mockMvc: MockMvc) {
 
     @BeforeEach
     fun cleanup() {
-        clearAllMocks()
+        clearMocks(gdprService, disclosureLogService)
     }
 
     @AfterEach
@@ -307,7 +307,8 @@ class GdprControllerITests(@Autowired var mockMvc: MockMvc) {
         return mockMvc.perform(
             MockMvcRequestBuilders.get("/gdpr-api/$USERNAME")
                 .accept(MediaType.APPLICATION_JSON)
-                .with(jwt().jwt(jwtBuilder.build())))
+                .with(jwt().jwt(jwtBuilder.build()))
+        )
     }
 
     private fun delete(
@@ -320,7 +321,8 @@ class GdprControllerITests(@Autowired var mockMvc: MockMvc) {
         return mockMvc.perform(
             MockMvcRequestBuilders.delete(url)
                 .accept(MediaType.APPLICATION_JSON)
-                .with(jwt().jwt(jwtBuilder.build())))
+                .with(jwt().jwt(jwtBuilder.build()))
+        )
     }
 
     private fun Jwt.Builder.scopes(vararg scopes: String): Jwt.Builder =

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/ApplicationEventServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/ApplicationEventServiceITest.kt
@@ -588,7 +588,7 @@ class ApplicationEventServiceITest(
         assertThat(output).contains("ERROR")
         assertThat(output)
             .contains(
-                "A hakemus moved to handling and it had a täydennyspyyntö, " +
+                "A hakemus moved to handling, and it had a täydennyspyyntö, " +
                     "but the previous state was not 'WAITING_INFORMATION'. status=DECISION"
             )
     }

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/security/BackChannelLogoutControllerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/security/BackChannelLogoutControllerITest.kt
@@ -1,0 +1,98 @@
+package fi.hel.haitaton.hanke.security
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import fi.hel.haitaton.hanke.ControllerTest
+import fi.hel.haitaton.hanke.IntegrationTestConfiguration
+import fi.hel.haitaton.hanke.andReturnBody
+import fi.hel.haitaton.hanke.test.USERNAME
+import io.mockk.Runs
+import io.mockk.checkUnnecessaryStub
+import io.mockk.clearAllMocks
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.just
+import io.mockk.verify
+import io.mockk.verifySequence
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.context.annotation.Import
+import org.springframework.security.oauth2.jwt.JwtException
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+private const val TOKEN = "logout-token"
+
+@WebMvcTest(controllers = [BackChannelLogoutController::class])
+@Import(IntegrationTestConfiguration::class)
+@ActiveProfiles("test")
+@WithMockUser(USERNAME)
+class BackChannelLogoutControllerITest(@Autowired override val mockMvc: MockMvc) : ControllerTest {
+
+    @Autowired lateinit var logoutService: LogoutService
+
+    @BeforeEach
+    fun clearMocks() {
+        clearAllMocks()
+    }
+
+    @AfterEach
+    fun checkMocks() {
+        checkUnnecessaryStub()
+        confirmVerified(logoutService)
+    }
+
+    @Test
+    fun `returns 200 when logout succeeds`() {
+        every { logoutService.logout(TOKEN) } just Runs
+
+        postForm("/backchannel-logout", "logout_token=$TOKEN").andExpect(status().isOk)
+
+        verifySequence { logoutService.logout(TOKEN) }
+    }
+
+    @Test
+    fun `returns 400 if token is missing`() {
+        val (error, _) =
+            postForm("/backchannel-logout", null)
+                .andExpect(status().isBadRequest)
+                .andReturnBody<BackChannelLogoutError>()
+
+        assertThat(error).isEqualTo("InvalidRequest")
+
+        verify(exactly = 0) { logoutService.logout(any()) }
+    }
+
+    @Test
+    fun `returns 400 if token is invalid`() {
+        every { logoutService.logout("invalid-token") } throws JwtException("Invalid token")
+
+        val (error, _) =
+            postForm("/backchannel-logout", "logout_token=invalid-token")
+                .andExpect(status().isBadRequest)
+                .andReturnBody<BackChannelLogoutError>()
+
+        assertThat(error).isEqualTo("InvalidToken")
+
+        verifySequence { logoutService.logout("invalid-token") }
+    }
+
+    @Test
+    fun `returns 500 if handling fails`() {
+        every { logoutService.logout(TOKEN) } throws RuntimeException()
+
+        val (error, _) =
+            postForm("/backchannel-logout", "logout_token=$TOKEN")
+                .andExpect(status().isInternalServerError)
+                .andReturnBody<BackChannelLogoutError>()
+
+        assertThat(error).isEqualTo("InternalServerError")
+
+        verifySequence { logoutService.logout(TOKEN) }
+    }
+}

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/security/BackChannelLogoutControllerITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/security/BackChannelLogoutControllerITest.kt
@@ -26,7 +26,9 @@ import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
-private const val TOKEN = "logout-token"
+private const val PATH = "/backchannel-logout"
+private const val TOKEN_NAME = "logout_token"
+private const val TOKEN_VALUE = "logout-token"
 
 @WebMvcTest(controllers = [BackChannelLogoutController::class])
 @Import(IntegrationTestConfiguration::class)
@@ -49,17 +51,17 @@ class BackChannelLogoutControllerITest(@Autowired override val mockMvc: MockMvc)
 
     @Test
     fun `returns 200 when logout succeeds`() {
-        every { logoutService.logout(TOKEN) } just Runs
+        every { logoutService.logout(TOKEN_VALUE) } just Runs
 
-        postForm("/backchannel-logout", "logout_token=$TOKEN").andExpect(status().isOk)
+        postForm(PATH, "$TOKEN_NAME=$TOKEN_VALUE").andExpect(status().isOk)
 
-        verifySequence { logoutService.logout(TOKEN) }
+        verifySequence { logoutService.logout(TOKEN_VALUE) }
     }
 
     @Test
     fun `returns 400 if token is missing`() {
         val (error, _) =
-            postForm("/backchannel-logout", null)
+            postForm(PATH, null)
                 .andExpect(status().isBadRequest)
                 .andReturnBody<BackChannelLogoutError>()
 
@@ -73,7 +75,7 @@ class BackChannelLogoutControllerITest(@Autowired override val mockMvc: MockMvc)
         every { logoutService.logout("invalid-token") } throws JwtException("Invalid token")
 
         val (error, _) =
-            postForm("/backchannel-logout", "logout_token=invalid-token")
+            postForm(PATH, "$TOKEN_NAME=invalid-token")
                 .andExpect(status().isBadRequest)
                 .andReturnBody<BackChannelLogoutError>()
 
@@ -84,15 +86,15 @@ class BackChannelLogoutControllerITest(@Autowired override val mockMvc: MockMvc)
 
     @Test
     fun `returns 500 if handling fails`() {
-        every { logoutService.logout(TOKEN) } throws RuntimeException()
+        every { logoutService.logout(TOKEN_VALUE) } throws RuntimeException()
 
         val (error, _) =
-            postForm("/backchannel-logout", "logout_token=$TOKEN")
+            postForm(PATH, "$TOKEN_NAME=$TOKEN_VALUE")
                 .andExpect(status().isInternalServerError)
                 .andReturnBody<BackChannelLogoutError>()
 
         assertThat(error).isEqualTo("InternalServerError")
 
-        verifySequence { logoutService.logout(TOKEN) }
+        verifySequence { logoutService.logout(TOKEN_VALUE) }
     }
 }

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/security/LogoutServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/security/LogoutServiceITest.kt
@@ -29,6 +29,8 @@ import org.springframework.security.oauth2.jwt.JwtValidationException
 import org.springframework.security.oauth2.jwt.JwtValidators
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder
 
+private const val ISSUER = "https://haitaton.hel.fi"
+
 @SpringBootTest(properties = ["spring.main.allow-bean-definition-overriding=true"])
 class LogoutServiceITest(
     @Autowired private val logoutService: LogoutService,
@@ -107,7 +109,7 @@ class LogoutServiceITest(
     }
 
     fun createLogoutToken(
-        issuer: String? = "https://haitaton.hel.fi",
+        issuer: String? = ISSUER,
         sid: String? = UUID.randomUUID().toString(),
     ): String {
         val claims = stubJwtClaimsSet(issuer, sid = sid)
@@ -120,7 +122,7 @@ class LogoutServiceITest(
     }
 
     private fun stubJwtClaimsSet(
-        iss: String? = "https://haitaton.hel.fi",
+        iss: String? = ISSUER,
         sub: String? = "subject",
         aud: List<String>? = listOf("haitaton-api-dev"),
         iat: Instant? = Instant.now(),
@@ -151,7 +153,7 @@ class LogoutServiceITest(
         @Primary
         fun logoutJwtDecoderForTest(tokenValidator: LogoutTokenValidator): JwtDecoder {
             val decoder = NimbusJwtDecoder.withPublicKey(KEY_PAIR.second).build()
-            val issuerValidator = JwtValidators.createDefaultWithIssuer("https://haitaton.hel.fi")
+            val issuerValidator = JwtValidators.createDefaultWithIssuer(ISSUER)
             val validator = DelegatingOAuth2TokenValidator(issuerValidator, tokenValidator)
             decoder.setJwtValidator(validator)
             return decoder

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/security/LogoutServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/security/LogoutServiceITest.kt
@@ -1,0 +1,160 @@
+package fi.hel.haitaton.hanke.security
+
+import assertk.assertThat
+import assertk.assertions.isEmpty
+import assertk.assertions.isEqualTo
+import com.nimbusds.jose.JWSAlgorithm
+import com.nimbusds.jose.JWSHeader
+import com.nimbusds.jose.crypto.RSASSASigner
+import com.nimbusds.jwt.JWTClaimsSet
+import com.nimbusds.jwt.SignedJWT
+import fi.hel.haitaton.hanke.IntegrationTest
+import fi.hel.haitaton.hanke.security.LogoutTokenValidator.Companion.BACKCHANNEL_LOGOUT_EVENT
+import java.security.KeyPairGenerator
+import java.security.interfaces.RSAPrivateKey
+import java.security.interfaces.RSAPublicKey
+import java.time.Instant
+import java.util.Date
+import java.util.UUID
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Primary
+import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator
+import org.springframework.security.oauth2.jwt.BadJwtException
+import org.springframework.security.oauth2.jwt.JwtDecoder
+import org.springframework.security.oauth2.jwt.JwtValidationException
+import org.springframework.security.oauth2.jwt.JwtValidators
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder
+
+@SpringBootTest(properties = ["spring.main.allow-bean-definition-overriding=true"])
+class LogoutServiceITest(
+    @Autowired private val logoutService: LogoutService,
+    @Autowired private val userSessionRepository: UserSessionRepository,
+) : IntegrationTest() {
+
+    companion object {
+        private const val SUB = "haitaton"
+        private val SID = UUID.randomUUID().toString()
+        private val KEY_PAIR: Pair<RSAPrivateKey, RSAPublicKey> by lazy {
+            val keyPair =
+                KeyPairGenerator.getInstance("RSA").apply { initialize(2048) }.genKeyPair()
+
+            val privateKey = keyPair.private as RSAPrivateKey
+            val publicKey = keyPair.public as RSAPublicKey
+
+            Pair(privateKey, publicKey)
+        }
+    }
+
+    @Test
+    fun `deletes matching user session`() {
+        userSessionRepository.save(
+            UserSessionEntity(subject = SUB, sessionId = SID, createdAt = Instant.now())
+        )
+        assertThat(userSessionRepository.findAll().single().subject).isEqualTo(SUB)
+        val logoutToken = createLogoutToken(sid = SID)
+
+        logoutService.logout(logoutToken)
+
+        assertThat(userSessionRepository.findAll()).isEmpty()
+    }
+
+    @Test
+    fun `does not throw exception if user session is not found`() {
+        userSessionRepository.save(
+            UserSessionEntity(subject = SUB, sessionId = SID, createdAt = Instant.now())
+        )
+        assertThat(userSessionRepository.findAll().single().subject).isEqualTo(SUB)
+        val logoutToken = createLogoutToken(sid = UUID.randomUUID().toString())
+
+        logoutService.logout(logoutToken)
+
+        assertThat(userSessionRepository.findAll().single().subject).isEqualTo(SUB)
+    }
+
+    @Test
+    fun `throws exception if token is not a JWT`() {
+        userSessionRepository.save(
+            UserSessionEntity(subject = SUB, sessionId = SID, createdAt = Instant.now())
+        )
+        assertThat(userSessionRepository.findAll().single().subject).isEqualTo(SUB)
+
+        val exception = runCatching { logoutService.logout("invalid-token") }.exceptionOrNull()
+
+        assertThat(exception?.javaClass).isEqualTo(BadJwtException::class.java)
+        assertThat(exception?.message)
+            .isEqualTo("An error occurred while attempting to decode the Jwt: Malformed token")
+    }
+
+    @Test
+    fun `throws exception if token is missing a mandatory claim`() {
+        userSessionRepository.save(
+            UserSessionEntity(subject = SUB, sessionId = SID, createdAt = Instant.now())
+        )
+        assertThat(userSessionRepository.findAll().single().subject).isEqualTo(SUB)
+        val logoutToken = createLogoutToken(issuer = null)
+
+        val exception = runCatching { logoutService.logout(logoutToken) }.exceptionOrNull()
+
+        assertThat(exception?.javaClass).isEqualTo(JwtValidationException::class.java)
+        assertThat(exception?.message)
+            .isEqualTo(
+                "An error occurred while attempting to decode the Jwt: The iss claim is not valid"
+            )
+    }
+
+    fun createLogoutToken(
+        issuer: String? = "https://haitaton.hel.fi",
+        sid: String? = UUID.randomUUID().toString(),
+    ): String {
+        val claims = stubJwtClaimsSet(issuer, sid = sid)
+
+        val signedJWT =
+            SignedJWT(JWSHeader.Builder(JWSAlgorithm.RS256).keyID("test-key").build(), claims)
+
+        signedJWT.sign(RSASSASigner(KEY_PAIR.first))
+        return signedJWT.serialize()
+    }
+
+    private fun stubJwtClaimsSet(
+        iss: String? = "https://haitaton.hel.fi",
+        sub: String? = "subject",
+        aud: List<String>? = listOf("haitaton-api-dev"),
+        iat: Instant? = Instant.now(),
+        exp: Instant? = Instant.now().plusSeconds(60),
+        jti: String? = "id",
+        events: Map<String, Any>? = mapOf(BACKCHANNEL_LOGOUT_EVENT to "{}"),
+        sid: String? = "session-id",
+        nonce: String? = null,
+    ): JWTClaimsSet =
+        JWTClaimsSet.Builder()
+            .apply {
+                iss?.let { issuer(it) }
+                sub?.let { subject(it) }
+                aud?.let { audience(it) }
+                iat?.let { issueTime(Date.from(it)) }
+                exp?.let { expirationTime(Date.from(it)) }
+                jti?.let { jwtID(it) }
+                events?.let { claim("events", it) }
+                sid?.let { claim("sid", it) }
+                nonce?.let { claim("nonce", it) }
+            }
+            .build()
+
+    @TestConfiguration
+    class TestConfig {
+
+        @Bean("logoutJwtDecoder")
+        @Primary
+        fun logoutJwtDecoderForTest(tokenValidator: LogoutTokenValidator): JwtDecoder {
+            val decoder = NimbusJwtDecoder.withPublicKey(KEY_PAIR.second).build()
+            val issuerValidator = JwtValidators.createDefaultWithIssuer("https://haitaton.hel.fi")
+            val validator = DelegatingOAuth2TokenValidator(issuerValidator, tokenValidator)
+            decoder.setJwtValidator(validator)
+            return decoder
+        }
+    }
+}

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/security/UserSessionServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/security/UserSessionServiceITest.kt
@@ -1,0 +1,89 @@
+package fi.hel.haitaton.hanke.security
+
+import assertk.assertThat
+import assertk.assertions.isEmpty
+import assertk.assertions.isEqualTo
+import fi.hel.haitaton.hanke.IntegrationTest
+import java.time.Instant
+import java.util.UUID
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+
+class UserSessionServiceITest(
+    @Autowired private val service: UserSessionService,
+    @Autowired private val repository: UserSessionRepository,
+) : IntegrationTest() {
+
+    @Nested
+    inner class CleanupExpiredSessions {
+
+        @Test
+        fun `deletes expired sessions`() {
+            repository.save(
+                UserSessionEntity(
+                    subject = "subject",
+                    sessionId = UUID.randomUUID().toString(),
+                    createdAt = Instant.now().minusSeconds(10),
+                )
+            )
+            assertThat(repository.findAll().single().subject).isEqualTo("subject")
+
+            service.cleanupExpiredSessions(5)
+
+            assertThat(repository.findAll()).isEmpty()
+        }
+
+        @Test
+        fun `does not delete non-expired sessions`() {
+            repository.save(
+                UserSessionEntity(
+                    subject = "subject",
+                    sessionId = UUID.randomUUID().toString(),
+                    createdAt = Instant.now().plusSeconds(60),
+                )
+            )
+            assertThat(repository.findAll().single().subject).isEqualTo("subject")
+
+            service.cleanupExpiredSessions(5)
+
+            assertThat(repository.findAll().single().subject).isEqualTo("subject")
+        }
+    }
+
+    @Nested
+    inner class SaveSessionIfNotExists {
+
+        @Test
+        fun `saves non-existing session`() {
+            service.saveSessionIfNotExists(
+                subject = "subject",
+                sessionId = UUID.randomUUID().toString(),
+                createdAt = Instant.now(),
+            )
+
+            assertThat(repository.findAll().single().subject).isEqualTo("subject")
+        }
+
+        @Test
+        fun `does not save existing session`() {
+            val sessionId = UUID.randomUUID().toString()
+            repository.save(
+                UserSessionEntity(
+                    subject = "subject",
+                    sessionId = sessionId,
+                    createdAt = Instant.now(),
+                )
+            )
+            assertThat(repository.findAll().single().subject).isEqualTo("subject")
+
+            service.saveSessionIfNotExists(
+                subject = "subject",
+                sessionId = sessionId,
+                createdAt = Instant.now(),
+            )
+
+            assertThat(repository.findAll().single().subject).isEqualTo("subject")
+        }
+    }
+}

--- a/services/hanke-service/src/integrationTest/resources/clear-db.sql
+++ b/services/hanke-service/src/integrationTest/resources/clear-db.sql
@@ -31,5 +31,6 @@ TRUNCATE TABLE
     taydennysyhteystieto,
     tormaystarkastelutulos,
     ui_notification_banner,
+    user_sessions,
     valmistumisilmoitus;
 UPDATE allu_status SET history_last_updated = '2017-01-01T00:00:00Z';

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/AlluStatus.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/AlluStatus.kt
@@ -4,7 +4,7 @@ import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.Id
 import jakarta.persistence.Table
-import java.time.OffsetDateTime
+import java.time.ZonedDateTime
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
@@ -13,10 +13,10 @@ import org.springframework.stereotype.Repository
 @Table(name = "allu_status")
 class AlluStatus(
     @Id val id: Long,
-    @Column(name = "history_last_updated") var historyLastUpdated: OffsetDateTime,
+    @Column(name = "history_last_updated") var historyLastUpdated: ZonedDateTime,
 )
 
 @Repository
 interface AlluStatusRepository : JpaRepository<AlluStatus, Long> {
-    @Query("select historyLastUpdated from AlluStatus") fun getLastUpdateTime(): OffsetDateTime
+    @Query("select historyLastUpdated from AlluStatus") fun getLastUpdateTime(): ZonedDateTime
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/configuration/Configuration.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/configuration/Configuration.kt
@@ -8,6 +8,7 @@ import fi.hel.haitaton.hanke.email.EmailProperties
 import fi.hel.haitaton.hanke.gdpr.GdprProperties
 import fi.hel.haitaton.hanke.profiili.ProfiiliProperties
 import fi.hel.haitaton.hanke.security.AdFilterProperties
+import fi.hel.haitaton.hanke.security.UserSessionCleanupProperties
 import io.netty.handler.ssl.SslContextBuilder
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory
 import kotlinx.coroutines.CoroutineDispatcher
@@ -32,6 +33,7 @@ import reactor.netty.http.client.HttpClient
     AdFilterProperties::class,
     Containers::class,
     HankeMapGridProperties::class,
+    UserSessionCleanupProperties::class,
 )
 class Configuration {
     @Value("\${haitaton.allu.insecure}") var alluTrustInsecure: Boolean = false

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/AlluUpdateService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/AlluUpdateService.kt
@@ -3,7 +3,6 @@ package fi.hel.haitaton.hanke.hakemus
 import fi.hel.haitaton.hanke.TZ_UTC
 import fi.hel.haitaton.hanke.allu.AlluClient
 import fi.hel.haitaton.hanke.allu.ApplicationHistory
-import java.time.OffsetDateTime
 import java.time.ZonedDateTime
 import mu.KotlinLogging
 import org.springframework.stereotype.Service
@@ -26,18 +25,18 @@ class AlluUpdateService(
         val lastUpdate = historyService.getLastUpdateTime()
         val currentTime = ZonedDateTime.now(TZ_UTC)
         val applicationHistories = fetchApplicationHistories(ids, lastUpdate)
-        historyService.setLastUpdateTime(currentTime.toOffsetDateTime())
+        historyService.setLastUpdateTime(currentTime)
         historyService.processApplicationHistories(applicationHistories)
     }
 
     private fun fetchApplicationHistories(
         ids: List<Int>,
-        lastUpdate: OffsetDateTime,
+        lastUpdate: ZonedDateTime,
     ): List<ApplicationHistory> {
         logger.info {
             "Preparing to fetch application histories for ${ids.size} applications from Allu since $lastUpdate"
         }
-        val histories = alluClient.getApplicationStatusHistories(ids, lastUpdate.toZonedDateTime())
+        val histories = alluClient.getApplicationStatusHistories(ids, lastUpdate)
         logger.info {
             "Received ${histories.size} application histories from Allu since $lastUpdate"
         }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusHistoryService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusHistoryService.kt
@@ -9,6 +9,7 @@ import fi.hel.haitaton.hanke.allu.ApplicationHistory
 import fi.hel.haitaton.hanke.allu.findPendingAndFailedEventsGrouped
 import java.time.Instant
 import java.time.OffsetDateTime
+import java.time.ZonedDateTime
 import mu.KotlinLogging
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -28,7 +29,7 @@ class HakemusHistoryService(
     fun getLastUpdateTime() = alluStatusRepository.getLastUpdateTime()
 
     @Transactional
-    fun setLastUpdateTime(time: OffsetDateTime) {
+    fun setLastUpdateTime(time: ZonedDateTime) {
         val status = alluStatusRepository.getReferenceById(1)
         status.historyLastUpdated = time
     }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/security/AccessRules.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/security/AccessRules.kt
@@ -36,6 +36,7 @@ object AccessRules {
                         "/testdata/unlink-applications",
                         "/testdata/create-public-hanke/*",
                         "/public-hankkeet/grid",
+                        "/backchannel-logout",
                     )
                     .permitAll()
             }
@@ -44,6 +45,7 @@ object AccessRules {
                     "/testdata/unlink-applications",
                     "/testdata/create-public-hanke/*",
                     "/public-hankkeet/grid",
+                    "/backchannel-logout",
                 )
             }
             .authorizeHttpRequests { it.anyRequest().authenticated() }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/security/BackChannelLogoutController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/security/BackChannelLogoutController.kt
@@ -7,6 +7,8 @@ import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
+import org.springframework.http.CacheControl
+import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
@@ -82,7 +84,7 @@ class BackChannelLogoutController(private val logoutService: LogoutService) {
         e: IllegalArgumentException
     ): ResponseEntity<BackChannelLogoutError> =
         ResponseEntity.badRequest()
-            .header("Cache-Control", "no-store")
+            .header(HttpHeaders.CACHE_CONTROL, CacheControl.noStore().headerValue)
             .body(BackChannelLogoutError(BackChannelLogoutError.ERROR_INVALID_REQUEST, e.message))
 
     @ResponseStatus(HttpStatus.BAD_REQUEST)
@@ -90,7 +92,7 @@ class BackChannelLogoutController(private val logoutService: LogoutService) {
     @Hidden
     fun handleJwtException(e: JwtException): ResponseEntity<BackChannelLogoutError> =
         ResponseEntity.badRequest()
-            .header("Cache-Control", "no-store")
+            .header(HttpHeaders.CACHE_CONTROL, CacheControl.noStore().headerValue)
             .body(BackChannelLogoutError(BackChannelLogoutError.ERROR_INVALID_TOKEN, e.message))
 
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
@@ -98,7 +100,7 @@ class BackChannelLogoutController(private val logoutService: LogoutService) {
     @Hidden
     fun handleException(e: Exception): ResponseEntity<BackChannelLogoutError> =
         ResponseEntity.internalServerError()
-            .header("Cache-Control", "no-store")
+            .header(HttpHeaders.CACHE_CONTROL, CacheControl.noStore().headerValue)
             .body(
                 BackChannelLogoutError(
                     BackChannelLogoutError.ERROR_INTERNAL_SERVER_ERROR,

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/security/BackChannelLogoutController.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/security/BackChannelLogoutController.kt
@@ -1,0 +1,119 @@
+package fi.hel.haitaton.hanke.security
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.swagger.v3.oas.annotations.Hidden
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+import org.springframework.security.oauth2.jwt.JwtException
+import org.springframework.util.MultiValueMap
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+
+private val logger = mu.KotlinLogging.logger {}
+
+/**
+ * Controller for handling backchannel logout requests. By calling this endpoint, Helsinki Profiili
+ * will log out the user from all applications.
+ *
+ * See https://openid.net/specs/openid-connect-backchannel-1_0.html
+ */
+@RestController
+@RequestMapping("/backchannel-logout")
+class BackChannelLogoutController(private val logoutService: LogoutService) {
+
+    @PostMapping(
+        consumes = [MediaType.APPLICATION_FORM_URLENCODED_VALUE],
+        produces = [MediaType.APPLICATION_JSON_VALUE],
+    )
+    @Operation(
+        summary = "Backhannel logout",
+        description =
+            "Logs out the user from all Helsinki applications. Called by Helsinki Profiili.",
+    )
+    @ApiResponses(
+        value =
+            [
+                ApiResponse(
+                    description = "Success",
+                    responseCode = "200",
+                    content =
+                        [Content(schema = Schema(implementation = BackChannelLogoutError::class))],
+                ),
+                ApiResponse(
+                    description = "Invalid request",
+                    responseCode = "400",
+                    content =
+                        [Content(schema = Schema(implementation = BackChannelLogoutError::class))],
+                ),
+                ApiResponse(
+                    description = "Internal server error",
+                    responseCode = "500",
+                    content =
+                        [Content(schema = Schema(implementation = BackChannelLogoutError::class))],
+                ),
+            ]
+    )
+    fun logout(@RequestBody form: MultiValueMap<String, String?>): ResponseEntity<out Any?> {
+        logger.info { "Received backchannel logout request" }
+        val logoutToken = form.getFirst("logout_token")
+        if (logoutToken == null) {
+            logger.error { "Logout token is null" }
+            throw IllegalArgumentException("Logout token is null")
+        }
+        logoutService.logout(logoutToken)
+        logger.info { "Succesfully handled backchannel logout request" }
+        return ResponseEntity.ok().build()
+    }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(IllegalArgumentException::class)
+    @Hidden
+    fun handleIllegalArgumentException(
+        e: IllegalArgumentException
+    ): ResponseEntity<BackChannelLogoutError> =
+        ResponseEntity.badRequest()
+            .header("Cache-Control", "no-store")
+            .body(BackChannelLogoutError(BackChannelLogoutError.ERROR_INVALID_REQUEST, e.message))
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(JwtException::class)
+    @Hidden
+    fun handleJwtException(e: JwtException): ResponseEntity<BackChannelLogoutError> =
+        ResponseEntity.badRequest()
+            .header("Cache-Control", "no-store")
+            .body(BackChannelLogoutError(BackChannelLogoutError.ERROR_INVALID_TOKEN, e.message))
+
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    @ExceptionHandler(Exception::class)
+    @Hidden
+    fun handleException(e: Exception): ResponseEntity<BackChannelLogoutError> =
+        ResponseEntity.internalServerError()
+            .header("Cache-Control", "no-store")
+            .body(
+                BackChannelLogoutError(
+                    BackChannelLogoutError.ERROR_INTERNAL_SERVER_ERROR,
+                    e.message,
+                )
+            )
+}
+
+data class BackChannelLogoutError(
+    val error: String,
+    @JsonProperty("error_description") val errorDescription: String?,
+) {
+    companion object {
+        const val ERROR_INVALID_REQUEST = "InvalidRequest"
+        const val ERROR_INVALID_TOKEN = "InvalidToken"
+        const val ERROR_INTERNAL_SERVER_ERROR = "InternalServerError"
+    }
+}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/security/CustomUserSessionRepositoryImpl.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/security/CustomUserSessionRepositoryImpl.kt
@@ -1,0 +1,37 @@
+package fi.hel.haitaton.hanke.security
+
+import jakarta.persistence.EntityManager
+import jakarta.persistence.PersistenceContext
+import org.springframework.stereotype.Repository
+
+/**
+ * Custom repository interface for UserSessionEntity that handles the case where the session is
+ * either new or already exists in the database. This is used to avoid the need for a separate check
+ * before saving.
+ */
+interface CustomUserSessionRepository {
+    fun saveIfNotExists(session: UserSessionEntity)
+}
+
+@Repository
+class CustomUserSessionRepositoryImpl(
+    @PersistenceContext private val entityManager: EntityManager
+) : CustomUserSessionRepository {
+
+    override fun saveIfNotExists(session: UserSessionEntity) {
+        val sql =
+            """
+            INSERT INTO user_sessions (id, subject, session_id, created_at)
+            VALUES (:id, :subject, :session_id, :created_at)
+            ON CONFLICT ON CONSTRAINT uq_user_sessions_subject_sid DO NOTHING
+        """
+                .trimIndent()
+
+        val query = entityManager.createNativeQuery(sql)
+        query.setParameter("id", session.id)
+        query.setParameter("subject", session.subject)
+        query.setParameter("session_id", session.sessionId)
+        query.setParameter("created_at", session.createdAt)
+        query.executeUpdate()
+    }
+}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/security/CustomUserSessionRepositoryImpl.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/security/CustomUserSessionRepositoryImpl.kt
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Repository
  * either new or already exists in the database. This is used to avoid the need for a separate check
  * before saving.
  */
-interface CustomUserSessionRepository {
+fun interface CustomUserSessionRepository {
     fun saveIfNotExists(session: UserSessionEntity)
 }
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/security/LogoutService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/security/LogoutService.kt
@@ -1,0 +1,45 @@
+package fi.hel.haitaton.hanke.security
+
+import mu.KotlinLogging
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.security.oauth2.jwt.JwtDecoder
+import org.springframework.security.oauth2.jwt.JwtException
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+private val logger = KotlinLogging.logger {}
+
+@Service
+class LogoutService(
+    @Qualifier("logoutJwtDecoder") private val jwtDecoder: JwtDecoder,
+    private val userSessionRepository: UserSessionRepository,
+) {
+    @Transactional
+    fun logout(token: String) {
+        val jwt = jwtDecoder.decode(token)
+
+        val (sid, sub) = parseSidAndSub(jwt)
+
+        val deleted =
+            if (sid != null) {
+                userSessionRepository.deleteBySessionId(sid) > 0
+            } else if (sub != null) {
+                userSessionRepository.deleteBySubject(sub) > 0
+            } else {
+                throw JwtException("Logout token must contain 'sid' or 'sub' claim")
+            }
+
+        if (deleted) {
+            logger.info { "Deleted user session" }
+        } else {
+            logger.info { "No user session found for logout token" }
+        }
+    }
+
+    private fun parseSidAndSub(jwt: Jwt): Pair<String?, String?> {
+        val sid = jwt.claims["sid"]?.toString()
+        val sub = jwt.claims["sub"]?.toString()
+        return Pair(sid, sub)
+    }
+}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/security/LogoutTokenValidator.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/security/LogoutTokenValidator.kt
@@ -1,0 +1,73 @@
+package fi.hel.haitaton.hanke.security
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.security.oauth2.core.OAuth2Error
+import org.springframework.security.oauth2.core.OAuth2TokenValidator
+import org.springframework.security.oauth2.core.OAuth2TokenValidatorResult
+import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.security.oauth2.jwt.JwtException
+import org.springframework.stereotype.Component
+
+@Component
+class LogoutTokenValidator(
+    @Value("\${spring.security.oauth2.resourceserver.jwt.audiences}") private val audience: String
+) : OAuth2TokenValidator<Jwt> {
+
+    companion object {
+        const val BACKCHANNEL_LOGOUT_EVENT = "http://schemas.openid.net/event/backchannel-logout"
+    }
+
+    /**
+     * Validates the logout token. It checks if the token is valid and contains the required claims.
+     * See https://openid.net/specs/openid-connect-backchannel-1_0.html#LogoutToken
+     *
+     * @return Pair of session id (sid) and subject id (sub)
+     * @throws JwtException if the token is invalid or missing required claims
+     */
+    override fun validate(token: Jwt): OAuth2TokenValidatorResult {
+        // iss - REQUIRED
+        token.issuer?.toString() ?: return failure("Missing issuer claim in logout token")
+        // sub - OPTIONAL
+        val sub: String? = token.subject
+        // aud - REQUIRED
+        token.audience?.toString() ?: return failure("Missing audience claim in logout token")
+        if (!token.audience.contains(audience)) {
+            return failure("The required audience '$audience' is missing in logout token")
+        }
+        // iat - REQUIRED
+        token.issuedAt ?: return failure("Missing issued at claim in logout token")
+        // exp - REQUIRED
+        token.expiresAt ?: return failure("Missing expires at claim in logout token")
+        // jti - REQUIRED
+        token.id ?: return failure("Missing id claim in logout token")
+        // events - REQUIRED
+        val events =
+            token.getClaim<Map<String, Any>>("events")
+                ?: return failure("Missing events claim in logout token")
+        if (!events.containsKey(BACKCHANNEL_LOGOUT_EVENT)) {
+            return failure("Missing backchannel logout event in events claim")
+        }
+        // "The corresponding member value MUST be a JSON object and SHOULD be the empty JSON object
+        // {}"
+        if (events[BACKCHANNEL_LOGOUT_EVENT] != "{}") {
+            return failure(
+                "Invalid backchannel logout event in events claim: ${events[BACKCHANNEL_LOGOUT_EVENT]}"
+            )
+        }
+        // sid - OPTIONAL
+        val sid: String? = token.getClaim<String?>("sid")
+        // "A Logout Token MUST contain either a sub or a sid Claim, and MAY contain both"
+        if (sid == null && sub == null) {
+            return failure("Logout token must contain 'sid' or 'sub' claim")
+        }
+        // nonce - PROHIBITED
+        if (token.getClaim<String?>("nonce") != null) {
+            return failure("Logout token must not contain 'nonce' claim")
+        }
+
+        return OAuth2TokenValidatorResult.success()
+    }
+
+    private fun failure(message: String) =
+        OAuth2TokenValidatorResult.failure(OAuth2Error("invalid_token", message, null))
+}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/security/OAuth2ResourceServerSecurityConfiguration.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/security/OAuth2ResourceServerSecurityConfiguration.kt
@@ -40,7 +40,7 @@ class OAuth2ResourceServerSecurityConfiguration(
     @Bean
     fun filterChain(http: HttpSecurity): SecurityFilterChain {
         AccessRules.configureHttpAccessRules(http)
-        http.oauth2ResourceServer { jwt -> defaultJwtDecoder() }
+        http.oauth2ResourceServer { _ -> defaultJwtDecoder() }
 
         http.securityMatcher("/backchannel-logout").oauth2ResourceServer {
             it.jwt { jwt -> jwt.decoder(logoutJwtDecoder()) }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/security/UserSessionCache.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/security/UserSessionCache.kt
@@ -1,0 +1,41 @@
+package fi.hel.haitaton.hanke.security
+
+import java.time.Instant
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ConcurrentMap
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+
+/**
+ * Cache for user sessions to track their expiration. Using a cache to avoid frequent database
+ * lookups.
+ */
+@Component
+class UserSessionCache {
+
+    private val cache: ConcurrentMap<String, Instant> = ConcurrentHashMap()
+    private val ttlSeconds = 3600L // 1 hour
+
+    fun isSessionKnown(key: String): Boolean {
+        val now = Instant.now()
+        val expiration = cache[key]
+
+        return if (expiration != null && expiration.isAfter(now)) {
+            true
+        } else {
+            cache.remove(key)
+            false
+        }
+    }
+
+    fun markSessionAsSeen(key: String) {
+        val expiresAt = Instant.now().plusSeconds(ttlSeconds)
+        cache[key] = expiresAt
+    }
+
+    @Scheduled(fixedDelay = 10 * 60 * 1000) // 10 minutes
+    fun cleanupExpired() {
+        val now = Instant.now()
+        cache.entries.removeIf { it.value.isBefore(now) }
+    }
+}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/security/UserSessionCleanupProperties.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/security/UserSessionCleanupProperties.kt
@@ -1,0 +1,7 @@
+package fi.hel.haitaton.hanke.security
+
+import java.time.Duration
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "haitaton.security.user-session.cleanup")
+data class UserSessionCleanupProperties(val interval: Duration)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/security/UserSessionCleanupSchedulingConfigurer.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/security/UserSessionCleanupSchedulingConfigurer.kt
@@ -1,0 +1,21 @@
+package fi.hel.haitaton.hanke.security
+
+import org.springframework.context.annotation.Profile
+import org.springframework.scheduling.annotation.SchedulingConfigurer
+import org.springframework.scheduling.config.ScheduledTaskRegistrar
+import org.springframework.stereotype.Component
+
+@Component
+@Profile("!test")
+class UserSessionCleanupSchedulingConfigurer(
+    private val userSessionService: UserSessionService,
+    private val properties: UserSessionCleanupProperties,
+) : SchedulingConfigurer {
+
+    override fun configureTasks(taskRegistrar: ScheduledTaskRegistrar) {
+        taskRegistrar.addFixedDelayTask(
+            { userSessionService.cleanupExpiredSessions(properties.interval.seconds) },
+            properties.interval,
+        )
+    }
+}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/security/UserSessionEntity.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/security/UserSessionEntity.kt
@@ -1,0 +1,17 @@
+package fi.hel.haitaton.hanke.security
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.time.Instant
+import java.util.UUID
+
+@Entity
+@Table(name = "user_sessions")
+class UserSessionEntity(
+    @Id var id: UUID = UUID.randomUUID(),
+    var subject: String,
+    @Column(name = "session_id") var sessionId: String? = null,
+    @Column(name = "created_at") var createdAt: Instant = Instant.now(),
+)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/security/UserSessionFilter.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/security/UserSessionFilter.kt
@@ -5,7 +5,6 @@ import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken
-import org.springframework.stereotype.Component
 import org.springframework.web.filter.OncePerRequestFilter
 
 private val log = mu.KotlinLogging.logger {}
@@ -14,7 +13,6 @@ private val log = mu.KotlinLogging.logger {}
  * Filter that checks if the user session is already known. If not, it saves the session to the
  * database.
  */
-@Component
 class UserSessionFilter(
     private val userSessionService: UserSessionService,
     private val cache: UserSessionCache,

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/security/UserSessionFilter.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/security/UserSessionFilter.kt
@@ -1,0 +1,44 @@
+package fi.hel.haitaton.hanke.security
+
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken
+import org.springframework.stereotype.Component
+import org.springframework.web.filter.OncePerRequestFilter
+
+private val log = mu.KotlinLogging.logger {}
+
+/**
+ * Filter that checks if the user session is already known. If not, it saves the session to the
+ * database.
+ */
+@Component
+class UserSessionFilter(
+    private val userSessionService: UserSessionService,
+    private val cache: UserSessionCache,
+) : OncePerRequestFilter() {
+    public override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain,
+    ) {
+        val authentication = SecurityContextHolder.getContext().authentication
+
+        if (authentication is JwtAuthenticationToken) {
+            val jwt = authentication.token
+            val sub = jwt.subject
+            val sid = jwt.getClaim<String>("sid")
+            val key = "$sub|$sid"
+
+            if (!cache.isSessionKnown(key)) {
+                cache.markSessionAsSeen(key)
+                userSessionService.saveSessionIfNotExists(sub, sid, jwt.issuedAt)
+                log.info { "New user session saved" }
+            }
+        }
+
+        filterChain.doFilter(request, response)
+    }
+}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/security/UserSessionRepository.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/security/UserSessionRepository.kt
@@ -1,0 +1,19 @@
+package fi.hel.haitaton.hanke.security
+
+import java.time.Instant
+import java.util.UUID
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+
+interface UserSessionRepository :
+    JpaRepository<UserSessionEntity, UUID>, CustomUserSessionRepository {
+    fun deleteBySessionId(sessionId: String): Int
+
+    fun deleteBySubject(subject: String): Int
+
+    @Modifying
+    @Query("DELETE FROM UserSessionEntity us WHERE us.createdAt < :expirationDateTime")
+    fun deleteAllByExpiration(@Param("expirationDateTime") expirationDateTime: Instant): Int
+}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/security/UserSessionService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/security/UserSessionService.kt
@@ -1,0 +1,31 @@
+package fi.hel.haitaton.hanke.security
+
+import java.time.Instant
+import mu.KotlinLogging
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+private val logger = KotlinLogging.logger {}
+
+@Service
+class UserSessionService(private val repository: UserSessionRepository) {
+
+    @Transactional
+    fun cleanupExpiredSessions(seconds: Long) {
+        val now = Instant.now()
+        val expiration = now.minusSeconds(seconds)
+        val count = repository.deleteAllByExpiration(expiration)
+        logger.info { "Deleted $count expired user sessions older than $expiration" }
+    }
+
+    @Transactional
+    fun saveSessionIfNotExists(subject: String, sessionId: String, createdAt: Instant?) {
+        val session =
+            UserSessionEntity(
+                subject = subject,
+                sessionId = sessionId,
+                createdAt = createdAt ?: Instant.now(),
+            )
+        repository.saveIfNotExists(session)
+    }
+}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennysService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/taydennys/TaydennysService.kt
@@ -175,7 +175,7 @@ class TaydennysService(
 
             if (application.alluStatus != ApplicationStatus.WAITING_INFORMATION) {
                 logger.error {
-                    "A hakemus moved to handling and it had a täydennyspyyntö, " +
+                    "A hakemus moved to handling, and it had a täydennyspyyntö, " +
                         "but the previous state was not 'WAITING_INFORMATION'. " +
                         "status=${application.alluStatus} ${application.logString()}"
                 }

--- a/services/hanke-service/src/main/resources/application.yml
+++ b/services/hanke-service/src/main/resources/application.yml
@@ -83,6 +83,11 @@ haitaton:
   profiili-api:
     graph-ql-url: ${PROFIILI_GRAPHQL_URL:https://profile-api.test.hel.ninja/graphql/}
     audience: ${PROFIILI_AUDIENCE:profile-api-test}
+  security:
+    user-session:
+      cleanup:
+        # By default, run every five minutes.
+        interval: ${HAITATON_USER_SESSION_CLEANUP_INTERVAL:300000}
   testdata:
     enabled: ${HAITATON_TESTDATA_ENABLED:false}  # For dev and test environments, enable the testdata controller for resetting data
 

--- a/services/hanke-service/src/main/resources/db/changelog/changesets/111-add-user-sessions-table.sql
+++ b/services/hanke-service/src/main/resources/db/changelog/changesets/111-add-user-sessions-table.sql
@@ -12,6 +12,7 @@ CREATE TABLE user_sessions
 
 CREATE INDEX idx_user_sessions_subject ON user_sessions (subject);
 CREATE INDEX idx_user_sessions_session_id ON user_sessions (session_id);
+CREATE INDEX idx_user_sessions_created_at ON user_sessions (created_at);
 
 -- Add unique constraint for subject + session_id (used for conflict resolution)
 ALTER TABLE user_sessions

--- a/services/hanke-service/src/main/resources/db/changelog/changesets/111-add-user-sessions-table.sql
+++ b/services/hanke-service/src/main/resources/db/changelog/changesets/111-add-user-sessions-table.sql
@@ -1,0 +1,18 @@
+--liquibase formatted sql
+--changeset Teemu Hiltunen:110-add-user-sessions-table
+--comment: Add user_sessions table for implementing back-channel logout
+
+CREATE TABLE user_sessions
+(
+    id         UUID                     NOT NULL PRIMARY KEY,
+    subject    VARCHAR(255)             NOT NULL,
+    session_id VARCHAR(255),
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_user_sessions_subject ON user_sessions (subject);
+CREATE INDEX idx_user_sessions_session_id ON user_sessions (session_id);
+
+-- Add unique constraint for subject + session_id (used for conflict resolution)
+ALTER TABLE user_sessions
+    ADD CONSTRAINT uq_user_sessions_subject_sid UNIQUE (subject, session_id);

--- a/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -249,3 +249,5 @@ databaseChangeLog:
       file: db/changelog/changesets/109-create-table-for-allu-event-errors.sql
   - include:
       file: db/changelog/changesets/110-create-table-for-allu-events.sql
+  - include:
+      file: db/changelog/changesets/111-add-user-sessions-table.sql

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/ControllerTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/ControllerTest.kt
@@ -16,10 +16,7 @@ interface ControllerTest {
     val mockMvc: MockMvc
 
     /** Send a GET request to the given URL. */
-    fun get(
-        url: String,
-        resultType: MediaType? = MediaType.APPLICATION_JSON,
-    ): ResultActions {
+    fun get(url: String, resultType: MediaType? = MediaType.APPLICATION_JSON): ResultActions {
         val actions =
             mockMvc.perform(MockMvcRequestBuilders.get(url).accept(MediaType.APPLICATION_JSON))
         return if (resultType != null) {
@@ -44,6 +41,15 @@ interface ControllerTest {
     /** Send a POST request with the content object in the request body as JSON. */
     fun post(url: String, content: Any): ResultActions =
         mockMvc.perform(postRequest(url).body(content))
+
+    /** Send a POST request with form content object. */
+    fun postForm(url: String, content: Any?): ResultActions =
+        mockMvc.perform(
+            postRequest(url)
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .characterEncoding("UTF-8")
+                .content(content.toString())
+        )
 
     /**
      * Send a PUT request with the given string as the request body as-is.

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/HankeAuthorizerTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/HankeAuthorizerTest.kt
@@ -36,6 +36,7 @@ class HankeAuthorizerTest {
     @BeforeEach
     fun clearMocks() {
         clearAllMocks()
+        SecurityContextHolder.clearContext()
         mockAuthentication()
     }
 
@@ -43,6 +44,7 @@ class HankeAuthorizerTest {
     fun checkMocks() {
         checkUnnecessaryStub()
         confirmVerified(permissionService, hankeRepository)
+        SecurityContextHolder.clearContext()
     }
 
     private fun mockAuthentication() {

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/AlluUpdateServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/AlluUpdateServiceTest.kt
@@ -14,7 +14,7 @@ import io.mockk.every
 import io.mockk.justRun
 import io.mockk.mockk
 import io.mockk.verifySequence
-import java.time.OffsetDateTime
+import java.time.ZonedDateTime
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -57,7 +57,7 @@ class AlluUpdateServiceTest {
     @Test
     fun `handles updates when no histories`() {
         every { historyService.getAllAlluIds() } returns listOf(23)
-        every { historyService.getLastUpdateTime() } returns OffsetDateTime.now()
+        every { historyService.getLastUpdateTime() } returns ZonedDateTime.now()
         every { alluClient.getApplicationStatusHistories(any(), any()) } returns emptyList()
         justRun { historyService.setLastUpdateTime(any()) }
         justRun { historyService.processApplicationHistories(emptyList()) }
@@ -80,7 +80,7 @@ class AlluUpdateServiceTest {
                 .withDefaultEvents()
                 .asList()
         every { historyService.getAllAlluIds() } returns listOf(23)
-        every { historyService.getLastUpdateTime() } returns OffsetDateTime.now()
+        every { historyService.getLastUpdateTime() } returns ZonedDateTime.now()
         every { alluClient.getApplicationStatusHistories(any(), any()) } returns histories
         justRun { historyService.setLastUpdateTime(any()) }
         justRun { historyService.processApplicationHistories(histories) }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/logging/DisclosureLoggingAspectTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/logging/DisclosureLoggingAspectTest.kt
@@ -32,12 +32,14 @@ class DisclosureLoggingAspectTest {
     @BeforeEach
     fun cleanup() {
         clearAllMocks()
+        SecurityContextHolder.clearContext()
     }
 
     @AfterEach
     fun checkMocks() {
         checkUnnecessaryStub()
         confirmVerified(disclosureLogService)
+        SecurityContextHolder.clearContext()
     }
 
     @Nested
@@ -110,7 +112,8 @@ class DisclosureLoggingAspectTest {
                 messageContains("Mixed types inside a list")
                 messageContains("Expected type: fi.hel.haitaton.hanke.domain.Hanke")
                 messageContains(
-                    "Actual types: fi.hel.haitaton.hanke.domain.Hanke, kotlin.String, kotlin.Int")
+                    "Actual types: fi.hel.haitaton.hanke.domain.Hanke, kotlin.String, kotlin.Int"
+                )
             }
         }
 
@@ -139,7 +142,8 @@ class DisclosureLoggingAspectTest {
             mockAuthentication()
 
             disclosureLoggingAspect.logResponse(
-                ResponseEntity.ofNullable(ProfiiliFactory.DEFAULT_NAMES))
+                ResponseEntity.ofNullable(ProfiiliFactory.DEFAULT_NAMES)
+            )
 
             verifySequence {
                 disclosureLogService.saveForProfiiliNimi(ProfiiliFactory.DEFAULT_NAMES, USERNAME)
@@ -178,7 +182,8 @@ class DisclosureLoggingAspectTest {
                 messageContains("Mixed types inside a list")
                 messageContains("Expected type: fi.hel.haitaton.hanke.domain.Hanke")
                 messageContains(
-                    "Actual types: fi.hel.haitaton.hanke.domain.Hanke, kotlin.String, kotlin.Int")
+                    "Actual types: fi.hel.haitaton.hanke.domain.Hanke, kotlin.String, kotlin.Int"
+                )
             }
         }
 

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/security/LogoutTokenValidatorTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/security/LogoutTokenValidatorTest.kt
@@ -1,0 +1,181 @@
+package fi.hel.haitaton.hanke.security
+
+import assertk.Assert
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import fi.hel.haitaton.hanke.security.LogoutTokenValidator.Companion.BACKCHANNEL_LOGOUT_EVENT
+import java.time.Instant
+import org.junit.jupiter.api.Test
+import org.springframework.security.oauth2.core.OAuth2TokenValidatorResult
+import org.springframework.security.oauth2.jwt.Jwt
+
+class LogoutTokenValidatorTest {
+
+    private val validator = LogoutTokenValidator("haitaton")
+
+    @Test
+    fun `returns success when token is valid`() {
+        val jwt = stubJwt()
+
+        val result = validator.validate(jwt)
+
+        assertThat(result).isEqualTo(OAuth2TokenValidatorResult.success())
+    }
+
+    @Test
+    fun `returns error if iss claim is missing`() {
+        val jwt = stubJwt(iss = null)
+
+        val result = validator.validate(jwt)
+
+        assertThat(result)
+            .hasErrorWithCodeAndDescription("invalid_token", "Missing issuer claim in logout token")
+    }
+
+    @Test
+    fun `returns error if aud claim is missing`() {
+        val jwt = stubJwt(aud = null)
+
+        val result = validator.validate(jwt)
+
+        assertThat(result)
+            .hasErrorWithCodeAndDescription(
+                "invalid_token",
+                "Missing audience claim in logout token",
+            )
+    }
+
+    @Test
+    fun `returns error if iat claim is missing`() {
+        val jwt = stubJwt(iat = null)
+
+        val result = validator.validate(jwt)
+
+        assertThat(result)
+            .hasErrorWithCodeAndDescription(
+                "invalid_token",
+                "Missing issued at claim in logout token",
+            )
+    }
+
+    @Test
+    fun `returns error if exp claim is missing`() {
+        val jwt = stubJwt(exp = null)
+
+        val result = validator.validate(jwt)
+
+        assertThat(result)
+            .hasErrorWithCodeAndDescription(
+                "invalid_token",
+                "Missing expires at claim in logout token",
+            )
+    }
+
+    @Test
+    fun `returns error if jti claim is missing`() {
+        val jwt = stubJwt(jti = null)
+
+        val result = validator.validate(jwt)
+
+        assertThat(result)
+            .hasErrorWithCodeAndDescription("invalid_token", "Missing id claim in logout token")
+    }
+
+    @Test
+    fun `throws exception if events claim is missing`() {
+        val jwt = stubJwt(events = null)
+
+        val result = validator.validate(jwt)
+
+        assertThat(result)
+            .hasErrorWithCodeAndDescription("invalid_token", "Missing events claim in logout token")
+    }
+
+    @Test
+    fun `returns error if events claim does not have correct key`() {
+        val jwt = stubJwt(events = mapOf("wrong-key" to "{}"))
+
+        val result = validator.validate(jwt)
+
+        assertThat(result)
+            .hasErrorWithCodeAndDescription(
+                "invalid_token",
+                "Missing backchannel logout event in events claim",
+            )
+    }
+
+    @Test
+    fun `returns error if events claim does not have correct value`() {
+        val jwt = stubJwt(events = mapOf(BACKCHANNEL_LOGOUT_EVENT to "invalid-value"))
+
+        val result = validator.validate(jwt)
+
+        assertThat(result)
+            .hasErrorWithCodeAndDescription(
+                "invalid_token",
+                "Invalid backchannel logout event in events claim: invalid-value",
+            )
+    }
+
+    @Test
+    fun `throws exception if both sub and sid claims are missing`() {
+        val jwt = stubJwt(sub = null, sid = null)
+
+        val result = validator.validate(jwt)
+
+        assertThat(result)
+            .hasErrorWithCodeAndDescription(
+                "invalid_token",
+                "Logout token must contain 'sid' or 'sub' claim",
+            )
+    }
+
+    @Test
+    fun `throws exception if nonce claim is present`() {
+        val jwt = stubJwt(nonce = "nonce")
+
+        val result = validator.validate(jwt)
+
+        assertThat(result)
+            .hasErrorWithCodeAndDescription(
+                "invalid_token",
+                "Logout token must not contain 'nonce' claim",
+            )
+    }
+
+    private fun stubJwt(
+        iss: String? = "https://server.example.com",
+        sub: String? = "subject",
+        aud: List<String>? = listOf("haitaton"),
+        iat: Instant? = Instant.now(),
+        exp: Instant? = Instant.now().plusSeconds(60),
+        jti: String? = "id",
+        events: Map<String, Any>? = mapOf(BACKCHANNEL_LOGOUT_EVENT to "{}"),
+        sid: String? = "session-id",
+        nonce: String? = null,
+    ): Jwt =
+        Jwt.withTokenValue("token")
+            .header("alg", "RS256")
+            .apply {
+                iss?.let { claim("iss", it) }
+                sub?.let { claim("sub", it) }
+                aud?.let { claim("aud", it) }
+                iat?.let { claim("iat", it) }
+                exp?.let { claim("exp", it) }
+                jti?.let { claim("jti", it) }
+                events?.let { claim("events", it) }
+                sid?.let { claim("sid", it) }
+                nonce?.let { claim("nonce", it) }
+            }
+            .build()
+
+    private fun Assert<OAuth2TokenValidatorResult>.hasErrorWithCodeAndDescription(
+        code: String,
+        description: String,
+    ) = given { actual ->
+        assertThat(actual.hasErrors()).isEqualTo(true)
+        val error = actual.errors.single()
+        assertThat(error.errorCode).isEqualTo(code)
+        assertThat(error.description).isEqualTo(description)
+    }
+}

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/security/UserSessionFilterTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/security/UserSessionFilterTest.kt
@@ -1,0 +1,83 @@
+package fi.hel.haitaton.hanke.security
+
+import io.mockk.clearAllMocks
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import io.mockk.verifySequence
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import java.time.Instant
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken
+
+class UserSessionFilterTest {
+
+    private val userSessionService = mockk<UserSessionService>(relaxed = true)
+    private val sessionCache = mockk<UserSessionCache>(relaxed = true)
+    private val filter = UserSessionFilter(userSessionService, sessionCache)
+
+    private val chain = mockk<FilterChain>(relaxed = true)
+    private val request: HttpServletRequest = mockk()
+    private val response: HttpServletResponse = mockk()
+
+    companion object {
+        private const val SUB = "user-abc"
+        private const val SID = "session-123"
+        private val ISSUED_AT = Instant.now()
+    }
+
+    @BeforeEach
+    fun setup() {
+        clearAllMocks()
+        SecurityContextHolder.clearContext()
+        val jwt =
+            mockk<Jwt> {
+                every { subject } returns SUB
+                every { getClaim<String>("sid") } returns SID
+                every { issuedAt } returns ISSUED_AT
+            }
+        val auth = JwtAuthenticationToken(jwt)
+        SecurityContextHolder.getContext().authentication = auth
+    }
+
+    @AfterEach
+    fun tearDown() {
+        confirmVerified(userSessionService, sessionCache, chain)
+        SecurityContextHolder.clearContext()
+    }
+
+    @Test
+    fun `saves new user session`() {
+        every { sessionCache.isSessionKnown("$SUB|$SID") } returns false
+
+        filter.doFilterInternal(request, response, chain)
+
+        verifySequence {
+            sessionCache.isSessionKnown("$SUB|$SID")
+            sessionCache.markSessionAsSeen("$SUB|$SID")
+            userSessionService.saveSessionIfNotExists(SUB, SID, ISSUED_AT)
+            chain.doFilter(request, response)
+        }
+    }
+
+    @Test
+    fun `does not save cached user session`() {
+        every { sessionCache.isSessionKnown("$SUB|$SID") } returns true
+
+        filter.doFilterInternal(request, response, chain)
+
+        verifySequence {
+            sessionCache.isSessionKnown("$SUB|$SID")
+            chain.doFilter(request, response)
+        }
+        verify(exactly = 0) { sessionCache.markSessionAsSeen(any()) }
+        verify(exactly = 0) { userSessionService.saveSessionIfNotExists(any(), any(), any()) }
+    }
+}

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/test/Asserts.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/test/Asserts.kt
@@ -54,6 +54,12 @@ object Asserts {
         isNotNull().isBetween(now.minus(offset), now)
     }
 
+    @JvmName("isRecentZoned")
+    fun Assert<ZonedDateTime?>.isRecent(offset: TemporalAmount = Duration.ofMinutes(1)) {
+        val now = ZonedDateTime.now()
+        isNotNull().isBetween(now.minus(offset), now)
+    }
+
     fun Assert<Instant?>.isRecentInstant(offset: TemporalAmount = Duration.ofMinutes(1)) {
         val now = Instant.now()
         isNotNull().isBetween(now.minus(offset), now)


### PR DESCRIPTION
# Description

Implement back-channel logout for Helsinki SSO. This includes an endpoint (/api/backchannel-logout) that is called by Helsinki Profiili Keycloak when a user logs out of any of the web services that use Helsinki Profiili.

Testing this new feature cannot be easily done locally but it has to be tested in real environment (dev/test). When this PR is merged into dev and deployed into dev and test environments, we must inform Helsinki Profiili so that they can add the endpoint in Keycloak. After that, we can test the feature by logging in into some other Helsinki service and then using Haitaton before logging out in the other service. After the logout, user should be logged out of Haitaton as well. To get the feature to work, it might need more work and bug fixes.


### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-3541

## Type of change

- [ ] Bug fix 
- [x] New feature 
- [ ] Other

# Instructions for testing
Please describe tests how this change or new feature can be tested.

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 

# Other relevant info
Please describe here if there is e.g. some requirements for this change or
 other info that the tester/user needs to know.