### PR TITLE
HAI-3569 Use only regular classes as JPA Entity - not data classes

### DIFF
--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankealueService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/HankealueService.kt
@@ -114,21 +114,45 @@ class HankealueService(
     }
 
     fun updateTormaystarkastelu(alue: HankealueEntity) {
-        alue.tormaystarkasteluTulos =
-            tormaystarkasteluService.calculateTormaystarkastelu(alue)?.let {
-                TormaystarkasteluTulosEntity(
-                    autoliikenne = it.autoliikenne.indeksi,
-                    haitanKesto = it.autoliikenne.haitanKesto,
-                    katuluokka = it.autoliikenne.katuluokka,
-                    autoliikennemaara = it.autoliikenne.liikennemaara,
-                    kaistahaitta = it.autoliikenne.kaistahaitta,
-                    kaistapituushaitta = it.autoliikenne.kaistapituushaitta,
-                    pyoraliikenne = it.pyoraliikenneindeksi,
-                    linjaautoliikenne = it.linjaautoliikenneindeksi,
-                    raitioliikenne = it.raitioliikenneindeksi,
-                    hankealue = alue,
-                )
+        val tormaystarkasteluTulos = tormaystarkasteluService.calculateTormaystarkastelu(alue)
+        if (tormaystarkasteluTulos != null) {
+            if (alue.tormaystarkasteluTulos == null) {
+                alue.tormaystarkasteluTulos =
+                    TormaystarkasteluTulosEntity(
+                        autoliikenne = tormaystarkasteluTulos.autoliikenne.indeksi,
+                        haitanKesto = tormaystarkasteluTulos.autoliikenne.haitanKesto,
+                        katuluokka = tormaystarkasteluTulos.autoliikenne.katuluokka,
+                        autoliikennemaara = tormaystarkasteluTulos.autoliikenne.liikennemaara,
+                        kaistahaitta = tormaystarkasteluTulos.autoliikenne.kaistahaitta,
+                        kaistapituushaitta = tormaystarkasteluTulos.autoliikenne.kaistapituushaitta,
+                        pyoraliikenne = tormaystarkasteluTulos.pyoraliikenneindeksi,
+                        linjaautoliikenne = tormaystarkasteluTulos.linjaautoliikenneindeksi,
+                        raitioliikenne = tormaystarkasteluTulos.raitioliikenneindeksi,
+                        hankealue = alue,
+                    )
+            } else {
+                alue.tormaystarkasteluTulos!!.autoliikenne =
+                    tormaystarkasteluTulos.autoliikenne.indeksi
+                alue.tormaystarkasteluTulos!!.haitanKesto =
+                    tormaystarkasteluTulos.autoliikenne.haitanKesto
+                alue.tormaystarkasteluTulos!!.katuluokka =
+                    tormaystarkasteluTulos.autoliikenne.katuluokka
+                alue.tormaystarkasteluTulos!!.autoliikennemaara =
+                    tormaystarkasteluTulos.autoliikenne.liikennemaara
+                alue.tormaystarkasteluTulos!!.kaistahaitta =
+                    tormaystarkasteluTulos.autoliikenne.kaistahaitta
+                alue.tormaystarkasteluTulos!!.kaistapituushaitta =
+                    tormaystarkasteluTulos.autoliikenne.kaistapituushaitta
+                alue.tormaystarkasteluTulos!!.pyoraliikenne =
+                    tormaystarkasteluTulos.pyoraliikenneindeksi
+                alue.tormaystarkasteluTulos!!.linjaautoliikenne =
+                    tormaystarkasteluTulos.linjaautoliikenneindeksi
+                alue.tormaystarkasteluTulos!!.raitioliikenne =
+                    tormaystarkasteluTulos.raitioliikenneindeksi
             }
+        } else {
+            alue.tormaystarkasteluTulos = null
+        }
     }
 
     companion object {

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusEntity.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusEntity.kt
@@ -24,7 +24,7 @@ import org.hibernate.annotations.Type
 
 @Entity
 @Table(name = "applications")
-data class HakemusEntity(
+class HakemusEntity(
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY) override val id: Long,
     override var alluid: Int?,
     @Enumerated(EnumType.STRING) override var alluStatus: ApplicationStatus?,

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusService.kt
@@ -1021,7 +1021,7 @@ class HakemusService(
         } else {
             if (hakemusEntity.yhteystiedot[rooli] != null) {
                 // customer was updated
-                val existingYhteystieto = hakemusEntity.yhteystiedot[rooli]!!
+                val existingYhteystieto = hakemusEntity.yhteystiedot.getValue(rooli)
                 val newHenkilot =
                     customerWithContactsRequest.toExistingYhteystietoEntity(existingYhteystieto)
                 newHenkilot.map { hankekayttajaId ->

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluTulos.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/tormaystarkastelu/TormaystarkasteluTulos.kt
@@ -42,7 +42,7 @@ data class TormaystarkasteluTulos(
                 autoliikenne.indeksi,
                 pyoraliikenneindeksi,
                 linjaautoliikenneindeksi,
-                raitioliikenneindeksi
+                raitioliikenneindeksi,
             )
         val type =
             when (max) {
@@ -77,7 +77,7 @@ data class Autoliikenneluokittelu(
             katuluokka,
             liikennemaara,
             kaistahaitta,
-            kaistapituushaitta
+            kaistapituushaitta,
         ),
         haitanKesto,
         katuluokka,
@@ -90,7 +90,7 @@ data class Autoliikenneluokittelu(
 @Schema(description = "Traffic nuisance index type")
 data class LiikennehaittaindeksiType(
     @JsonView(ChangeLogView::class) val indeksi: Float,
-    @JsonView(ChangeLogView::class) val tyyppi: IndeksiType
+    @JsonView(ChangeLogView::class) val tyyppi: IndeksiType,
 )
 
 enum class IndeksiType {
@@ -104,15 +104,15 @@ enum class IndeksiType {
 @Table(name = "tormaystarkastelutulos")
 class TormaystarkasteluTulosEntity(
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY) val id: Int = 0,
-    val autoliikenne: Float,
-    @Column(name = "haitan_kesto") val haitanKesto: Int,
-    val katuluokka: Int,
-    val autoliikennemaara: Int,
-    val kaistahaitta: Int,
-    val kaistapituushaitta: Int,
-    val pyoraliikenne: Float,
-    val linjaautoliikenne: Float,
-    val raitioliikenne: Float,
+    var autoliikenne: Float,
+    @Column(name = "haitan_kesto") var haitanKesto: Int,
+    var katuluokka: Int,
+    var autoliikennemaara: Int,
+    var kaistahaitta: Int,
+    var kaistapituushaitta: Int,
+    var pyoraliikenne: Float,
+    var linjaautoliikenne: Float,
+    var raitioliikenne: Float,
     @OneToOne(optional = false, fetch = FetchType.LAZY)
     @JoinColumn(name = "hankealue_id")
     val hankealue: HankealueEntity,


### PR DESCRIPTION
# Description

Use only regular classes as JPA Entity - not Kotlin data classes (except AuditLogEntryEntity which is an immutable entity and does not use copy to create new entities). Using data classes can cause database errors especially when used in entity collections or creating new entities by copyin existing ones.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-3569

## Type of change

- [x] Bug fix 
- [ ] New feature 
- [ ] Other

# Instructions for testing
* Check that "everything" works in the application: creating a hanke, adding johtoselvitys to it, changing areas (törmäystarkastelu changes), sending applications to Allu, making täydennyspyyntö for them in Allu, making muutosilmoitus after päätös

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 

# Other relevant info
Please describe here if there is e.g. some requirements for this change or
 other info that the tester/user needs to know.