### PR TITLE
HAI-3585 Fix blocking Allu updates

### DIFF
--- a/services/hanke-service/build.gradle.kts
+++ b/services/hanke-service/build.gradle.kts
@@ -166,6 +166,7 @@ tasks {
             showStackTraces = true
             exceptionFormat = TestExceptionFormat.FULL
         }
+        exclude("**/*ManualTest*")
     }
 
     create("copyEmailTemplates", Copy::class) {

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/allu/AlluClientManualTest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/allu/AlluClientManualTest.kt
@@ -1,0 +1,29 @@
+package fi.hel.haitaton.hanke.allu
+
+import org.junit.jupiter.api.Test
+import org.springframework.web.reactive.function.client.WebClient
+
+class AlluClientManualTest {
+
+    @Test
+    fun `load decision`() {
+        val webCliebt =
+            WebClient.builder()
+                .codecs { codecs -> codecs.defaultCodecs().maxInMemorySize(100 * 1024 * 1024) }
+                .build()
+        val alluClient =
+            AlluClient(
+                webCliebt,
+                AlluProperties(
+                    System.getenv("ALLU_BASE_URL"),
+                    System.getenv("ALLU_USERNAME"),
+                    System.getenv("ALLU_PASSWORD"),
+                    1,
+                ),
+            )
+
+        val decisionPdf = alluClient.getDecisionPdf(129117)
+
+        println("Decision PDF size: ${decisionPdf.size}")
+    }
+}

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/configuration/MockAlluUpdateScheduler.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/configuration/MockAlluUpdateScheduler.kt
@@ -1,11 +1,11 @@
 package fi.hel.haitaton.hanke.configuration
 
-import fi.hel.haitaton.hanke.hakemus.AlluUpdateService
+import fi.hel.haitaton.hanke.hakemus.AlluUpdateScheduler
 import io.mockk.mockk
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
 @Configuration
-class MockAlluUpdateService {
-    @Bean fun alluUpdateService(): AlluUpdateService = mockk()
+class MockAlluUpdateScheduler {
+    @Bean fun alluUpdateScheduler(): AlluUpdateScheduler = mockk()
 }

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/AlluUpdateServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/AlluUpdateServiceITest.kt
@@ -1,0 +1,1079 @@
+package fi.hel.haitaton.hanke.hakemus
+
+import assertk.all
+import assertk.assertThat
+import assertk.assertions.contains
+import assertk.assertions.containsExactlyInAnyOrder
+import assertk.assertions.containsOnly
+import assertk.assertions.doesNotContain
+import assertk.assertions.each
+import assertk.assertions.extracting
+import assertk.assertions.hasSize
+import assertk.assertions.isEmpty
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotNull
+import assertk.assertions.prop
+import assertk.assertions.single
+import assertk.assertions.startsWith
+import com.icegreen.greenmail.configuration.GreenMailConfiguration
+import com.icegreen.greenmail.junit5.GreenMailExtension
+import com.icegreen.greenmail.util.ServerSetupTest
+import fi.hel.haitaton.hanke.IntegrationTest
+import fi.hel.haitaton.hanke.allu.AlluClient
+import fi.hel.haitaton.hanke.allu.AlluEventErrorEntity
+import fi.hel.haitaton.hanke.allu.AlluEventErrorRepository
+import fi.hel.haitaton.hanke.allu.AlluStatusRepository
+import fi.hel.haitaton.hanke.allu.ApplicationStatus
+import fi.hel.haitaton.hanke.allu.InformationRequestFieldKey
+import fi.hel.haitaton.hanke.asUtc
+import fi.hel.haitaton.hanke.attachment.PDF_BYTES
+import fi.hel.haitaton.hanke.attachment.azure.Container
+import fi.hel.haitaton.hanke.attachment.common.MockFileClient
+import fi.hel.haitaton.hanke.attachment.common.TestFile
+import fi.hel.haitaton.hanke.factory.AlluFactory
+import fi.hel.haitaton.hanke.factory.ApplicationHistoryFactory
+import fi.hel.haitaton.hanke.factory.ApplicationHistoryFactory.DEFAULT_APPLICATION_IDENTIFIER
+import fi.hel.haitaton.hanke.factory.ApplicationHistoryFactory.asList
+import fi.hel.haitaton.hanke.factory.ApplicationHistoryFactory.withDefaultEvents
+import fi.hel.haitaton.hanke.factory.ApplicationHistoryFactory.withEvent
+import fi.hel.haitaton.hanke.factory.ApplicationHistoryFactory.withEvents
+import fi.hel.haitaton.hanke.factory.DateFactory
+import fi.hel.haitaton.hanke.factory.HakemusFactory
+import fi.hel.haitaton.hanke.factory.HankeFactory
+import fi.hel.haitaton.hanke.factory.HankeKayttajaFactory
+import fi.hel.haitaton.hanke.factory.MuutosilmoitusFactory
+import fi.hel.haitaton.hanke.factory.TaydennysFactory
+import fi.hel.haitaton.hanke.firstReceivedMessage
+import fi.hel.haitaton.hanke.muutosilmoitus.MuutosilmoitusRepository
+import fi.hel.haitaton.hanke.permissions.Kayttooikeustaso
+import fi.hel.haitaton.hanke.taydennys.TaydennysRepository
+import fi.hel.haitaton.hanke.taydennys.TaydennyspyyntoEntity
+import fi.hel.haitaton.hanke.taydennys.TaydennyspyyntoRepository
+import fi.hel.haitaton.hanke.test.Asserts.isRecent
+import fi.hel.haitaton.hanke.test.USERNAME
+import io.mockk.checkUnnecessaryStub
+import io.mockk.clearAllMocks
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.verifySequence
+import jakarta.mail.internet.MimeMessage
+import java.time.OffsetDateTime
+import java.time.ZonedDateTime
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.RegisterExtension
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.system.CapturedOutput
+import org.springframework.boot.test.system.OutputCaptureExtension
+
+@ExtendWith(OutputCaptureExtension::class)
+class AlluUpdateServiceITest(
+    @Autowired private val updateService: AlluUpdateService,
+    @Autowired private val hakemusHistoryService: HakemusHistoryService,
+    @Autowired private val hakemusRepository: HakemusRepository,
+    @Autowired private val alluStatusRepository: AlluStatusRepository,
+    @Autowired private val alluEventErrorRepository: AlluEventErrorRepository,
+    @Autowired private val muutosilmoitusRepository: MuutosilmoitusRepository,
+    @Autowired private val taydennyspyyntoRepository: TaydennyspyyntoRepository,
+    @Autowired private val taydennysRepository: TaydennysRepository,
+    @Autowired private val hakemusFactory: HakemusFactory,
+    @Autowired private val taydennysFactory: TaydennysFactory,
+    @Autowired private val hankeFactory: HankeFactory,
+    @Autowired private val hankeKayttajaFactory: HankeKayttajaFactory,
+    @Autowired private val muutosilmoitusFactory: MuutosilmoitusFactory,
+    @Autowired private val alluClient: AlluClient,
+    @Autowired private val fileClient: MockFileClient,
+) : IntegrationTest() {
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val greenMail: GreenMailExtension =
+            GreenMailExtension(ServerSetupTest.SMTP)
+                .withConfiguration(GreenMailConfiguration.aConfig().withDisabledAuthentication())
+    }
+
+    private val alluId = 42
+    private val identifier = DEFAULT_APPLICATION_IDENTIFIER
+    /** The timestamp used in the initial DB migration. */
+    private val placeholderUpdateTime = OffsetDateTime.parse("2017-01-01T00:00:00Z")
+
+    @BeforeEach
+    fun clearMocks() {
+        clearAllMocks()
+    }
+
+    @AfterEach
+    fun checkMocks() {
+        checkUnnecessaryStub()
+        confirmVerified(alluClient)
+    }
+
+    @Nested
+    inner class HandleNewUpdates {
+
+        @Test
+        fun `updates the last updated time with empty histories`() {
+            assertThat(alluEventErrorRepository.findAll()).isEmpty()
+            assertThat(hakemusRepository.findAll()).isEmpty()
+            assertThat(alluStatusRepository.getLastUpdateTime().asUtc())
+                .isEqualTo(placeholderUpdateTime)
+
+            updateService.handleUpdates()
+
+            assertThat(alluStatusRepository.getLastUpdateTime().asUtc()).isRecent()
+        }
+
+        @Test
+        fun `updates the hakemus statuses in the correct order`() {
+            hakemusFactory.builder(USERNAME).withStatus(alluId = alluId).save()
+            val firstEventTime = ZonedDateTime.parse("2022-09-05T14:15:16Z")
+            val history =
+                ApplicationHistoryFactory.create(alluId)
+                    .withEvent(firstEventTime.plusDays(5), ApplicationStatus.PENDING)
+                    .withEvent(firstEventTime.plusDays(10), ApplicationStatus.HANDLING)
+                    .withEvent(firstEventTime, ApplicationStatus.PENDING)
+                    .asList()
+            every {
+                alluClient.getApplicationStatusHistories(
+                    listOf(alluId),
+                    placeholderUpdateTime.toZonedDateTime(),
+                )
+            } returns history
+
+            updateService.handleUpdates()
+
+            assertThat(alluStatusRepository.getLastUpdateTime().asUtc()).isRecent()
+            val application = hakemusRepository.getOneByAlluid(alluId)
+            assertThat(application)
+                .isNotNull()
+                .prop("alluStatus", HakemusEntity::alluStatus)
+                .isEqualTo(ApplicationStatus.HANDLING)
+            assertThat(application!!.applicationIdentifier).isEqualTo(identifier)
+            assertThat(alluEventErrorRepository.findAll()).isEmpty()
+            verifySequence {
+                alluClient.getApplicationStatusHistories(
+                    listOf(alluId),
+                    placeholderUpdateTime.toZonedDateTime(),
+                )
+            }
+        }
+
+        @Test
+        fun `doesn't update status or identifier when the update status is REPLACED`() {
+            val originalTunnus = "JS2400001-12"
+            hakemusFactory
+                .builder(USERNAME)
+                .withStatus(
+                    alluId = alluId,
+                    status = ApplicationStatus.DECISION,
+                    identifier = originalTunnus,
+                )
+                .save()
+            val history =
+                ApplicationHistoryFactory.create(alluId)
+                    .withEvent(
+                        applicationIdentifier = "JS2400001-13",
+                        newStatus = ApplicationStatus.REPLACED,
+                    )
+                    .asList()
+            every {
+                alluClient.getApplicationStatusHistories(
+                    listOf(alluId),
+                    placeholderUpdateTime.toZonedDateTime(),
+                )
+            } returns history
+
+            updateService.handleUpdates()
+
+            assertThat(hakemusRepository.findAll()).single().all {
+                prop(HakemusEntity::alluStatus).isEqualTo(ApplicationStatus.DECISION)
+                prop(HakemusEntity::applicationIdentifier).isEqualTo(originalTunnus)
+            }
+            assertThat(alluEventErrorRepository.findAll()).isEmpty()
+            verifySequence {
+                alluClient.getApplicationStatusHistories(
+                    listOf(alluId),
+                    placeholderUpdateTime.toZonedDateTime(),
+                )
+            }
+        }
+
+        @Test
+        fun `ignores missing hakemus`() {
+            assertThat(hakemusRepository.findAll()).isEmpty()
+            assertThat(alluStatusRepository.getLastUpdateTime().asUtc())
+                .isEqualTo(placeholderUpdateTime)
+            val hanke = hankeFactory.saveMinimal()
+            hakemusFactory.builder(USERNAME, hanke).withStatus(alluId = alluId).save()
+            hakemusFactory.builder(USERNAME, hanke).withStatus(alluId = alluId + 2).save()
+            val history =
+                listOf(
+                    ApplicationHistoryFactory.create(alluId).withDefaultEvents("JS2300082"),
+                    ApplicationHistoryFactory.create(alluId + 1).withDefaultEvents("JS2300083"),
+                    ApplicationHistoryFactory.create(alluId + 2).withDefaultEvents("JS2300084"),
+                )
+            every {
+                alluClient.getApplicationStatusHistories(
+                    listOf(alluId, alluId + 2),
+                    placeholderUpdateTime.toZonedDateTime(),
+                )
+            } returns history
+
+            updateService.handleUpdates()
+
+            assertThat(alluStatusRepository.getLastUpdateTime().asUtc()).isRecent()
+            val applications = hakemusRepository.findAll()
+            assertThat(applications).hasSize(2)
+            assertThat(applications.map { it.alluid }).containsExactlyInAnyOrder(alluId, alluId + 2)
+            assertThat(applications.map { it.alluStatus })
+                .containsExactlyInAnyOrder(
+                    ApplicationStatus.PENDING_CLIENT,
+                    ApplicationStatus.PENDING_CLIENT,
+                )
+            assertThat(applications.map { it.applicationIdentifier })
+                .containsExactlyInAnyOrder("JS2300082", "JS2300084")
+            assertThat(alluEventErrorRepository.findAll()).isEmpty()
+            verifySequence {
+                alluClient.getApplicationStatusHistories(
+                    listOf(alluId, alluId + 2),
+                    placeholderUpdateTime.toZonedDateTime(),
+                )
+            }
+        }
+
+        @Test
+        fun `sends email to the contacts when a johtoselvityshakemus gets a decision`() {
+            val hanke = hankeFactory.saveMinimal()
+            val hakija = hankeKayttajaFactory.saveUser(hankeId = hanke.id)
+            hakemusFactory
+                .builder(USERNAME, hanke)
+                .withStatus(ApplicationStatus.HANDLING, alluId, identifier)
+                .hakija(hakija)
+                .saveEntity()
+            val history =
+                ApplicationHistoryFactory.create(alluId)
+                    .withEvent(
+                        applicationIdentifier = identifier,
+                        newStatus = ApplicationStatus.DECISION,
+                    )
+                    .asList()
+            every {
+                alluClient.getApplicationStatusHistories(
+                    listOf(alluId),
+                    placeholderUpdateTime.toZonedDateTime(),
+                )
+            } returns history
+
+            updateService.handleUpdates()
+
+            val email = greenMail.firstReceivedMessage()
+            assertThat(email.allRecipients).hasSize(1)
+            assertThat(email.allRecipients[0].toString()).isEqualTo(hakija.sahkoposti)
+            assertThat(email.subject)
+                .isEqualTo(
+                    "Haitaton: Johtoselvitys $identifier / Ledningsutredning $identifier / Cable report $identifier"
+                )
+            verifySequence {
+                alluClient.getApplicationStatusHistories(
+                    listOf(alluId),
+                    placeholderUpdateTime.toZonedDateTime(),
+                )
+            }
+        }
+
+        @ParameterizedTest
+        @EnumSource(
+            ApplicationStatus::class,
+            names = ["DECISION", "OPERATIONAL_CONDITION", "FINISHED"],
+        )
+        fun `sends email to the contacts when a kaivuilmoitus gets a decision`(
+            applicationStatus: ApplicationStatus
+        ) {
+            val identifier = "KP2300001"
+            val hanke = hankeFactory.saveMinimal()
+            val hakija = hankeKayttajaFactory.saveUser(hankeId = hanke.id)
+            hakemusFactory
+                .builder(USERNAME, hanke, ApplicationType.EXCAVATION_NOTIFICATION)
+                .withStatus(ApplicationStatus.HANDLING, alluId, identifier)
+                .hakija(hakija)
+                .saveEntity()
+            val history =
+                ApplicationHistoryFactory.create(alluId)
+                    .withEvent(applicationIdentifier = identifier, newStatus = applicationStatus)
+                    .asList()
+            every {
+                alluClient.getApplicationStatusHistories(
+                    listOf(alluId),
+                    placeholderUpdateTime.toZonedDateTime(),
+                )
+            } returns history
+            every { getPdfMethod(applicationStatus)(alluId) } returns PDF_BYTES
+            every { alluClient.getApplicationInformation(alluId) } returns
+                AlluFactory.createAlluApplicationResponse(id = alluId, applicationId = identifier)
+
+            updateService.handleUpdates()
+
+            val email = greenMail.firstReceivedMessage()
+            assertThat(email.allRecipients).hasSize(1)
+            assertThat(email.allRecipients[0].toString()).isEqualTo(hakija.sahkoposti)
+            assertThat(email.subject)
+                .isEqualTo(
+                    "Haitaton: Kaivuilmoitukseen KP2300001 liittyvä päätös on ladattavissa / Beslut om grävningsanmälan KP2300001 kan laddas ner / The decision concerning an excavation notification KP2300001 can be downloaded"
+                )
+            verifySequence {
+                alluClient.getApplicationStatusHistories(
+                    listOf(alluId),
+                    placeholderUpdateTime.toZonedDateTime(),
+                )
+                getPdfMethod(applicationStatus)(alluId)
+                alluClient.getApplicationInformation(alluId)
+            }
+        }
+
+        @ParameterizedTest
+        @EnumSource(
+            ApplicationStatus::class,
+            names = ["DECISION", "OPERATIONAL_CONDITION", "FINISHED"],
+        )
+        fun `downloads the document when a kaivuilmoitus gets a decision`(
+            status: ApplicationStatus
+        ) {
+            val hakemus =
+                hakemusFactory
+                    .builder(ApplicationType.EXCAVATION_NOTIFICATION)
+                    .withStatus(ApplicationStatus.HANDLING, alluId, identifier)
+                    .save()
+            val history =
+                ApplicationHistoryFactory.create(alluId)
+                    .withEvent(applicationIdentifier = identifier, newStatus = status)
+                    .asList()
+            every {
+                alluClient.getApplicationStatusHistories(
+                    listOf(alluId),
+                    placeholderUpdateTime.toZonedDateTime(),
+                )
+            } returns history
+            every { getPdfMethod(status)(alluId) } returns PDF_BYTES
+            every { alluClient.getApplicationInformation(alluId) } returns
+                AlluFactory.createAlluApplicationResponse()
+
+            updateService.handleUpdates()
+
+            assertThat(fileClient.listBlobs(Container.PAATOKSET))
+                .single()
+                .prop(TestFile::path)
+                .startsWith("${hakemus.id}/")
+            verifySequence {
+                alluClient.getApplicationStatusHistories(
+                    listOf(alluId),
+                    placeholderUpdateTime.toZonedDateTime(),
+                )
+                getPdfMethod(status)(alluId)
+                alluClient.getApplicationInformation(alluId)
+            }
+        }
+
+        @ParameterizedTest
+        @EnumSource(ApplicationType::class)
+        fun `merges changes from muutosilmoitus to the hakemus when a hakemus gets a decision`(
+            applicationType: ApplicationType
+        ) {
+            val muutosilmoitus =
+                muutosilmoitusFactory
+                    .builder(applicationType, alluId = alluId)
+                    .withEndTime(DateFactory.getEndDatetime().plusDays(1))
+                    .withSent()
+                    .save()
+            val history =
+                ApplicationHistoryFactory.create(alluId)
+                    .withEvent(
+                        applicationIdentifier = identifier,
+                        newStatus = ApplicationStatus.DECISION,
+                    )
+                    .asList()
+            every {
+                alluClient.getApplicationStatusHistories(
+                    listOf(alluId),
+                    placeholderUpdateTime.toZonedDateTime(),
+                )
+            } returns history
+            if (applicationType == ApplicationType.EXCAVATION_NOTIFICATION) {
+                every { getPdfMethod(ApplicationStatus.DECISION)(alluId) } returns PDF_BYTES
+                every { alluClient.getApplicationInformation(alluId) } returns
+                    AlluFactory.createAlluApplicationResponse()
+            }
+
+            updateService.handleUpdates()
+
+            val hakemus =
+                hakemusRepository.findOneById(muutosilmoitus.hakemusId)!!.hakemusEntityData
+            assertThat(hakemus.endTime).isEqualTo(muutosilmoitus.hakemusData.endTime)
+            assertThat(muutosilmoitusRepository.findAll()).isEmpty()
+            if (applicationType == ApplicationType.EXCAVATION_NOTIFICATION) {
+                verifySequence {
+                    alluClient.getApplicationStatusHistories(
+                        listOf(alluId),
+                        placeholderUpdateTime.toZonedDateTime(),
+                    )
+                    getPdfMethod(ApplicationStatus.DECISION)(alluId)
+                    alluClient.getApplicationInformation(alluId)
+                }
+            } else {
+                verifySequence {
+                    alluClient.getApplicationStatusHistories(
+                        listOf(alluId),
+                        placeholderUpdateTime.toZonedDateTime(),
+                    )
+                }
+            }
+        }
+
+        @ParameterizedTest
+        @EnumSource(ApplicationType::class)
+        fun `merges changes from muutosilmoitus to the hakemus when a hakemus gets a taydennyspyynto`(
+            applicationType: ApplicationType
+        ) {
+            val newName = "Updated for muutosilmoitus"
+            val muutosilmoitus =
+                muutosilmoitusFactory
+                    .builder(type = applicationType, alluId = alluId)
+                    .withName(newName)
+                    .withSent()
+                    .save()
+            val history =
+                ApplicationHistoryFactory.create(alluId)
+                    .withEvent(newStatus = ApplicationStatus.WAITING_INFORMATION)
+                    .asList()
+            every {
+                alluClient.getApplicationStatusHistories(
+                    listOf(alluId),
+                    placeholderUpdateTime.toZonedDateTime(),
+                )
+            } returns history
+            every { alluClient.getInformationRequest(alluId) } returns
+                AlluFactory.createInformationRequest(applicationAlluId = alluId)
+
+            updateService.handleUpdates()
+
+            val hakemus =
+                hakemusRepository.findOneById(muutosilmoitus.hakemusId)!!.hakemusEntityData
+            assertThat(hakemus.name).isEqualTo(newName)
+            assertThat(muutosilmoitusRepository.findAll()).isEmpty()
+            verifySequence {
+                alluClient.getApplicationStatusHistories(
+                    listOf(alluId),
+                    placeholderUpdateTime.toZonedDateTime(),
+                )
+                alluClient.getInformationRequest(alluId)
+            }
+        }
+
+        @Test
+        fun `sends one email for every user with edit applications permission when the new status is WAITING_INFORMATION`() {
+            val hanke = hankeFactory.saveMinimal()
+            val hakija =
+                hankeKayttajaFactory.saveIdentifiedUser(
+                    hankeId = hanke.id,
+                    sahkoposti = "hakija@yritys.test",
+                    kayttooikeustaso = Kayttooikeustaso.KAIKKI_OIKEUDET,
+                )
+            val suorittaja =
+                hankeKayttajaFactory.saveIdentifiedUser(
+                    hankeId = hanke.id,
+                    sahkoposti = "suorittaja@yritys.test",
+                    kayttooikeustaso = Kayttooikeustaso.HAKEMUSASIOINTI,
+                )
+            val rakennuttaja =
+                hankeKayttajaFactory.saveIdentifiedUser(
+                    hankeId = hanke.id,
+                    sahkoposti = "rakennuttaja@yritys.test",
+                    kayttooikeustaso = Kayttooikeustaso.HANKEMUOKKAUS,
+                )
+            val asianhoitaja =
+                hankeKayttajaFactory.saveIdentifiedUser(
+                    hankeId = hanke.id,
+                    sahkoposti = "asianhoitaja@yritys.test",
+                    kayttooikeustaso = Kayttooikeustaso.KATSELUOIKEUS,
+                )
+            hakemusFactory
+                .builder(hanke)
+                .withStatus(ApplicationStatus.HANDLING, alluId, identifier)
+                .hakija(hakija)
+                .tyonSuorittaja(suorittaja, hakija)
+                .rakennuttaja(rakennuttaja, suorittaja, asianhoitaja)
+                .asianhoitaja(asianhoitaja, rakennuttaja, suorittaja, hakija)
+                .save()
+            val history =
+                ApplicationHistoryFactory.create(alluId)
+                    .withEvent(
+                        applicationIdentifier = identifier,
+                        newStatus = ApplicationStatus.WAITING_INFORMATION,
+                    )
+                    .asList()
+            every {
+                alluClient.getApplicationStatusHistories(
+                    listOf(alluId),
+                    placeholderUpdateTime.toZonedDateTime(),
+                )
+            } returns history
+            every { alluClient.getInformationRequest(alluId) } returns
+                AlluFactory.createInformationRequest()
+
+            updateService.handleUpdates()
+
+            val emails = greenMail.receivedMessages
+            val recipients = emails.map { it.allRecipients.toList() }.flatten()
+            assertThat(recipients)
+                .extracting { it.toString() }
+                .containsExactlyInAnyOrder(hakija.sahkoposti, suorittaja.sahkoposti)
+            assertThat(emails).each {
+                it.prop(MimeMessage::getSubject)
+                    .isEqualTo(
+                        "Haitaton: Hakemuksellesi on tullut täydennyspyyntö / Din ansökan har fått en begäran om komplettering / There is a request for supplementary information for your application"
+                    )
+            }
+            verifySequence {
+                alluClient.getApplicationStatusHistories(
+                    listOf(alluId),
+                    placeholderUpdateTime.toZonedDateTime(),
+                )
+                alluClient.getInformationRequest(alluId)
+            }
+        }
+
+        @Test
+        fun `gets the information request from Allu and saves it when the new status is WAITING_INFORMATION`() {
+            val hanke = hankeFactory.saveMinimal()
+            val hakemus =
+                hakemusFactory
+                    .builder(hanke)
+                    .withStatus(ApplicationStatus.HANDLING, alluId, identifier)
+                    .save()
+            val history =
+                ApplicationHistoryFactory.create(alluId)
+                    .withEvent(
+                        applicationIdentifier = identifier,
+                        newStatus = ApplicationStatus.WAITING_INFORMATION,
+                    )
+                    .asList()
+            every {
+                alluClient.getApplicationStatusHistories(
+                    listOf(alluId),
+                    placeholderUpdateTime.toZonedDateTime(),
+                )
+            } returns history
+            every { alluClient.getInformationRequest(alluId) } returns
+                AlluFactory.createInformationRequest(applicationAlluId = alluId)
+
+            updateService.handleUpdates()
+
+            assertThat(taydennyspyyntoRepository.findAll()).single().all {
+                prop(TaydennyspyyntoEntity::alluId)
+                    .isEqualTo(AlluFactory.DEFAULT_INFORMATION_REQUEST_ID)
+                prop(TaydennyspyyntoEntity::applicationId).isEqualTo(hakemus.id)
+                prop(TaydennyspyyntoEntity::kentat)
+                    .containsOnly(
+                        InformationRequestFieldKey.OTHER to
+                            AlluFactory.DEFAULT_INFORMATION_REQUEST_DESCRIPTION
+                    )
+            }
+            verifySequence {
+                alluClient.getApplicationStatusHistories(
+                    listOf(alluId),
+                    placeholderUpdateTime.toZonedDateTime(),
+                )
+                alluClient.getInformationRequest(alluId)
+            }
+        }
+
+        @Test
+        fun `doesn't send email or save the taydennyspyynto when the new status is WAITING_INFORMATION but Allu doesn't have the taydennyspyynto`() {
+            hakemusFactory
+                .builder()
+                .withStatus(ApplicationStatus.HANDLING, alluId, identifier)
+                .save()
+            val history =
+                ApplicationHistoryFactory.create(alluId)
+                    .withEvent(
+                        applicationIdentifier = identifier,
+                        newStatus = ApplicationStatus.WAITING_INFORMATION,
+                    )
+                    .asList()
+            every {
+                alluClient.getApplicationStatusHistories(
+                    listOf(alluId),
+                    placeholderUpdateTime.toZonedDateTime(),
+                )
+            } returns history
+            every { alluClient.getInformationRequest(alluId) } returns null
+
+            updateService.handleUpdates()
+
+            val emails = greenMail.receivedMessages
+            assertThat(emails).isEmpty()
+            assertThat(taydennyspyyntoRepository.findAll()).isEmpty()
+            verifySequence {
+                alluClient.getApplicationStatusHistories(
+                    listOf(alluId),
+                    placeholderUpdateTime.toZonedDateTime(),
+                )
+                alluClient.getInformationRequest(alluId)
+            }
+        }
+
+        @Test
+        fun `removes any taydennyspyynto and taydennys when the new status is HANDLING`(
+            output: CapturedOutput
+        ) {
+            val hakemus =
+                hakemusFactory
+                    .builder()
+                    .withStatus(ApplicationStatus.WAITING_INFORMATION, alluId)
+                    .save()
+            taydennysFactory.save(applicationId = hakemus.id)
+            val history =
+                ApplicationHistoryFactory.create(alluId)
+                    .withEvent(
+                        applicationIdentifier = identifier,
+                        newStatus = ApplicationStatus.HANDLING,
+                    )
+                    .asList()
+            every {
+                alluClient.getApplicationStatusHistories(
+                    listOf(alluId),
+                    placeholderUpdateTime.toZonedDateTime(),
+                )
+            } returns history
+
+            updateService.handleUpdates()
+
+            assertThat(taydennyspyyntoRepository.findAll()).isEmpty()
+            assertThat(taydennysRepository.findAll()).isEmpty()
+            val updatedHakemus = hakemusRepository.getOneByAlluid(alluId)
+            assertThat(updatedHakemus)
+                .isNotNull()
+                .prop(HakemusEntity::alluStatus)
+                .isEqualTo(ApplicationStatus.HANDLING)
+            assertThat(output).doesNotContain("ERROR")
+            verifySequence {
+                alluClient.getApplicationStatusHistories(
+                    listOf(alluId),
+                    placeholderUpdateTime.toZonedDateTime(),
+                )
+            }
+        }
+
+        @Test
+        fun `sends emails when removing the taydennyspyynto`() {
+            val hakemus =
+                hakemusFactory
+                    .builder()
+                    .withStatus(ApplicationStatus.WAITING_INFORMATION, alluId, identifier)
+                    .hakija(Kayttooikeustaso.KAIKKI_OIKEUDET)
+                    .tyonSuorittaja(Kayttooikeustaso.HAKEMUSASIOINTI)
+                    .rakennuttaja(Kayttooikeustaso.HANKEMUOKKAUS)
+                    .asianhoitaja(Kayttooikeustaso.KATSELUOIKEUS)
+                    .save()
+            taydennysFactory.save(applicationId = hakemus.id)
+            val history =
+                ApplicationHistoryFactory.create(alluId)
+                    .withEvent(
+                        applicationIdentifier = identifier,
+                        newStatus = ApplicationStatus.HANDLING,
+                    )
+                    .asList()
+            every {
+                alluClient.getApplicationStatusHistories(
+                    listOf(alluId),
+                    placeholderUpdateTime.toZonedDateTime(),
+                )
+            } returns history
+
+            updateService.handleUpdates()
+
+            val emails = greenMail.receivedMessages
+            val recipients = emails.map { it.allRecipients.toList() }.flatten()
+            assertThat(recipients)
+                .extracting { it.toString() }
+                .containsExactlyInAnyOrder(
+                    HankeKayttajaFactory.KAYTTAJA_INPUT_HAKIJA.email,
+                    HankeKayttajaFactory.KAYTTAJA_INPUT_SUORITTAJA.email,
+                )
+            assertThat(emails).each {
+                it.prop(MimeMessage::getSubject)
+                    .isEqualTo(
+                        "Haitaton: Hakemustasi koskeva täydennyspyyntö on peruttu / Begäran om komplettering som gäller din ansökan har återtagits / The request for supplementary information concerning your application has been cancelled"
+                    )
+            }
+            verifySequence {
+                alluClient.getApplicationStatusHistories(
+                    listOf(alluId),
+                    placeholderUpdateTime.toZonedDateTime(),
+                )
+            }
+        }
+
+        @Test
+        fun `updates the status when the new status is HANDLING and there is no taydennyspyynto`(
+            output: CapturedOutput
+        ) {
+            hakemusFactory.builder().withStatus(ApplicationStatus.WAITING_INFORMATION, 42).save()
+            val history =
+                ApplicationHistoryFactory.create(alluId)
+                    .withEvent(
+                        applicationIdentifier = identifier,
+                        newStatus = ApplicationStatus.HANDLING,
+                    )
+                    .asList()
+            every {
+                alluClient.getApplicationStatusHistories(
+                    listOf(alluId),
+                    placeholderUpdateTime.toZonedDateTime(),
+                )
+            } returns history
+
+            updateService.handleUpdates()
+
+            val updatedHakemus = hakemusRepository.getOneByAlluid(alluId)
+            assertThat(updatedHakemus)
+                .isNotNull()
+                .prop(HakemusEntity::alluStatus)
+                .isEqualTo(ApplicationStatus.HANDLING)
+            assertThat(output).doesNotContain("ERROR")
+            verifySequence {
+                alluClient.getApplicationStatusHistories(
+                    listOf(alluId),
+                    placeholderUpdateTime.toZonedDateTime(),
+                )
+            }
+        }
+
+        @Test
+        fun `logs an error when the new status is HANDLING, the previous status is not WAITING_INFORMATION and the hakemus has a taydennyspyynto`(
+            output: CapturedOutput
+        ) {
+            val hakemus = hakemusFactory.builder().withStatus(ApplicationStatus.DECISION, 42).save()
+            taydennysFactory.save(applicationId = hakemus.id)
+            val history =
+                ApplicationHistoryFactory.create(alluId)
+                    .withEvent(
+                        applicationIdentifier = identifier,
+                        newStatus = ApplicationStatus.HANDLING,
+                    )
+                    .asList()
+            every {
+                alluClient.getApplicationStatusHistories(
+                    listOf(alluId),
+                    placeholderUpdateTime.toZonedDateTime(),
+                )
+            } returns history
+
+            updateService.handleUpdates()
+
+            assertThat(taydennyspyyntoRepository.findAll()).isEmpty()
+            assertThat(taydennysRepository.findAll()).isEmpty()
+            val updatedHakemus = hakemusRepository.getOneByAlluid(alluId)
+            assertThat(updatedHakemus)
+                .isNotNull()
+                .prop(HakemusEntity::alluStatus)
+                .isEqualTo(ApplicationStatus.HANDLING)
+            assertThat(output).contains("ERROR")
+            assertThat(output)
+                .contains(
+                    "A hakemus moved to handling and it had a täydennyspyyntö, " +
+                        "but the previous state was not 'WAITING_INFORMATION'. status=DECISION"
+                )
+            verifySequence {
+                alluClient.getApplicationStatusHistories(
+                    listOf(alluId),
+                    placeholderUpdateTime.toZonedDateTime(),
+                )
+            }
+        }
+
+        @Test
+        fun `handles updates for other applications when one fails`() {
+            assertThat(hakemusRepository.findAll()).isEmpty()
+            assertThat(alluStatusRepository.getLastUpdateTime().asUtc())
+                .isEqualTo(placeholderUpdateTime)
+            val hanke = hankeFactory.saveMinimal()
+            hakemusFactory.builder(USERNAME, hanke).withStatus(alluId = alluId).save()
+            hakemusFactory
+                .builder(USERNAME, hanke)
+                .withStatus(status = ApplicationStatus.HANDLING, alluId = alluId + 1)
+                .save()
+            hakemusFactory.builder(USERNAME, hanke).withStatus(alluId = alluId + 2).save()
+            val history =
+                listOf(
+                    ApplicationHistoryFactory.create(alluId).withDefaultEvents("JS2300082"),
+                    ApplicationHistoryFactory.create(alluId + 1)
+                        .withEvent(
+                            applicationIdentifier = "JS2300083",
+                            newStatus = ApplicationStatus.WAITING_INFORMATION,
+                            eventTime = ZonedDateTime.parse("2022-09-05T14:15:16Z"),
+                        ),
+                    ApplicationHistoryFactory.create(alluId + 2).withDefaultEvents("JS2300084"),
+                )
+            val exception = RuntimeException("Test exception")
+            every {
+                alluClient.getApplicationStatusHistories(
+                    listOf(alluId, alluId + 1, alluId + 2),
+                    placeholderUpdateTime.toZonedDateTime(),
+                )
+            } returns history
+            every { alluClient.getInformationRequest(alluId + 1) } throws exception
+
+            updateService.handleUpdates()
+
+            assertThat(alluStatusRepository.getLastUpdateTime().asUtc()).isRecent()
+            val applications = hakemusRepository.findAll()
+            assertThat(applications.map { it.alluStatus })
+                .containsExactlyInAnyOrder(
+                    ApplicationStatus.PENDING_CLIENT,
+                    ApplicationStatus.HANDLING,
+                    ApplicationStatus.PENDING_CLIENT,
+                )
+            assertThat(alluEventErrorRepository.findAll()).single().all {
+                prop(AlluEventErrorEntity::alluId).isEqualTo(alluId + 1)
+                prop(AlluEventErrorEntity::newStatus)
+                    .isEqualTo(ApplicationStatus.WAITING_INFORMATION)
+                prop(AlluEventErrorEntity::applicationIdentifier).isEqualTo("JS2300083")
+                prop(AlluEventErrorEntity::eventTime)
+                    .isEqualTo(ZonedDateTime.parse("2022-09-05T14:15:16Z"))
+                prop(AlluEventErrorEntity::stackTrace).isEqualTo(exception.stackTraceToString())
+            }
+
+            verifySequence {
+                alluClient.getApplicationStatusHistories(
+                    listOf(alluId, alluId + 1, alluId + 2),
+                    placeholderUpdateTime.toZonedDateTime(),
+                )
+                alluClient.getInformationRequest(alluId + 1)
+            }
+        }
+
+        @Test
+        fun `does not handle following updates for an application when one fails`() {
+            assertThat(hakemusRepository.findAll()).isEmpty()
+            assertThat(alluStatusRepository.getLastUpdateTime().asUtc())
+                .isEqualTo(placeholderUpdateTime)
+            assertThat(alluEventErrorRepository.findAll()).isEmpty()
+            val hanke = hankeFactory.saveMinimal()
+            hakemusFactory.builder(USERNAME, hanke).withStatus(alluId = alluId).save()
+            val history =
+                ApplicationHistoryFactory.create(alluId)
+                    .withEvents(
+                        ApplicationHistoryFactory.createEvent(
+                            newStatus = ApplicationStatus.PENDING,
+                            eventTime = ZonedDateTime.parse("2022-09-05T14:15:16Z"),
+                        ),
+                        ApplicationHistoryFactory.createEvent(
+                            newStatus = ApplicationStatus.HANDLING,
+                            eventTime = ZonedDateTime.parse("2022-09-05T14:16:16Z"),
+                        ),
+                        ApplicationHistoryFactory.createEvent(
+                            newStatus = ApplicationStatus.WAITING_INFORMATION,
+                            eventTime = ZonedDateTime.parse("2022-09-05T14:17:16Z"),
+                        ),
+                        ApplicationHistoryFactory.createEvent(
+                            newStatus = ApplicationStatus.HANDLING,
+                            eventTime = ZonedDateTime.parse("2022-09-05T14:18:16Z"),
+                        ),
+                        ApplicationHistoryFactory.createEvent(
+                            newStatus = ApplicationStatus.PENDING_CLIENT,
+                            eventTime = ZonedDateTime.parse("2022-09-05T14:19:16Z"),
+                        ),
+                    )
+                    .asList()
+            val exception = RuntimeException("Test exception")
+            every {
+                alluClient.getApplicationStatusHistories(
+                    listOf(alluId),
+                    placeholderUpdateTime.toZonedDateTime(),
+                )
+            } returns history
+            every { alluClient.getInformationRequest(alluId) } throws exception
+
+            updateService.handleUpdates()
+
+            assertThat(alluStatusRepository.getLastUpdateTime().asUtc()).isRecent()
+            val application = hakemusRepository.findAll().single()
+            assertThat(application.alluStatus).isEqualTo(ApplicationStatus.HANDLING)
+            assertThat(alluEventErrorRepository.findAll()).single().all {
+                prop(AlluEventErrorEntity::alluId).isEqualTo(alluId)
+                prop(AlluEventErrorEntity::newStatus)
+                    .isEqualTo(ApplicationStatus.WAITING_INFORMATION)
+                prop(AlluEventErrorEntity::applicationIdentifier)
+                    .isEqualTo(DEFAULT_APPLICATION_IDENTIFIER)
+                prop(AlluEventErrorEntity::eventTime)
+                    .isEqualTo(ZonedDateTime.parse("2022-09-05T14:17:16Z"))
+                prop(AlluEventErrorEntity::stackTrace).isEqualTo(exception.stackTraceToString())
+            }
+
+            verifySequence {
+                alluClient.getApplicationStatusHistories(
+                    listOf(alluId),
+                    placeholderUpdateTime.toZonedDateTime(),
+                )
+                alluClient.getInformationRequest(alluId)
+            }
+        }
+
+        private fun getPdfMethod(applicationStatus: ApplicationStatus) =
+            when (applicationStatus) {
+                ApplicationStatus.DECISION -> alluClient::getDecisionPdf
+                ApplicationStatus.OPERATIONAL_CONDITION -> alluClient::getOperationalConditionPdf
+                ApplicationStatus.FINISHED -> alluClient::getWorkFinishedPdf
+                else -> throw IllegalArgumentException()
+            }
+    }
+
+    @Nested
+    inner class HandleFailedUpdates {
+
+        @Test
+        fun `successfully handle previously failed history`(output: CapturedOutput) {
+            val hanke = hankeFactory.saveMinimal()
+            hakemusFactory
+                .builder(USERNAME, hanke)
+                .withStatus(status = ApplicationStatus.HANDLING, alluId = alluId)
+                .save()
+            val eventTime = ZonedDateTime.parse("2022-09-05T14:17:16Z")
+            hakemusHistoryService.saveErrors(
+                listOf(
+                    ApplicationHistoryFactory.createError(
+                        alluId = alluId,
+                        eventTime = eventTime,
+                        newStatus = ApplicationStatus.WAITING_INFORMATION,
+                        stackTrace = "Test error",
+                    )
+                )
+            )
+            val history =
+                ApplicationHistoryFactory.create(alluId)
+                    .withEvents(
+                        ApplicationHistoryFactory.createEvent(
+                            newStatus = ApplicationStatus.WAITING_INFORMATION,
+                            eventTime = eventTime,
+                        ),
+                        ApplicationHistoryFactory.createEvent(
+                            newStatus = ApplicationStatus.HANDLING,
+                            eventTime = eventTime.plusSeconds(10),
+                        ),
+                        ApplicationHistoryFactory.createEvent(
+                            newStatus = ApplicationStatus.PENDING_CLIENT,
+                            eventTime = eventTime.plusSeconds(20),
+                        ),
+                    )
+                    .asList()
+            every {
+                alluClient.getApplicationStatusHistories(
+                    listOf(alluId),
+                    placeholderUpdateTime.toZonedDateTime(),
+                )
+            } returns emptyList()
+            every {
+                alluClient.getApplicationStatusHistories(listOf(alluId), eventTime.minusSeconds(1))
+            } returns history
+            every { alluClient.getInformationRequest(alluId) } returns
+                AlluFactory.createInformationRequest(applicationAlluId = alluId)
+
+            updateService.handleUpdates()
+
+            assertThat(output).doesNotContain("ERROR")
+            assertThat(alluEventErrorRepository.findAll()).isEmpty()
+            assertThat(taydennyspyyntoRepository.findAll()).isEmpty()
+            assertThat(hakemusRepository.findAll()).single().all {
+                prop(HakemusEntity::alluid).isEqualTo(alluId)
+                prop(HakemusEntity::alluStatus).isEqualTo(ApplicationStatus.PENDING_CLIENT)
+            }
+            verifySequence {
+                alluClient.getApplicationStatusHistories(
+                    listOf(alluId),
+                    placeholderUpdateTime.toZonedDateTime(),
+                )
+                alluClient.getApplicationStatusHistories(listOf(alluId), eventTime.minusSeconds(1))
+                alluClient.getInformationRequest(alluId)
+            }
+        }
+
+        @Test
+        fun `gracefully handle again failing history`(output: CapturedOutput) {
+            val hanke = hankeFactory.saveMinimal()
+            hakemusFactory
+                .builder(USERNAME, hanke)
+                .withStatus(status = ApplicationStatus.HANDLING, alluId = alluId)
+                .save()
+            val exception = RuntimeException("Test error")
+            val eventTime = ZonedDateTime.parse("2022-09-05T14:17:16Z")
+            hakemusHistoryService.saveErrors(
+                listOf(
+                    ApplicationHistoryFactory.createError(
+                        alluId = alluId,
+                        eventTime = eventTime,
+                        newStatus = ApplicationStatus.WAITING_INFORMATION,
+                        stackTrace = exception.stackTraceToString(),
+                    )
+                )
+            )
+            val history =
+                ApplicationHistoryFactory.create(alluId)
+                    .withEvents(
+                        ApplicationHistoryFactory.createEvent(
+                            newStatus = ApplicationStatus.WAITING_INFORMATION,
+                            eventTime = eventTime,
+                        ),
+                        ApplicationHistoryFactory.createEvent(
+                            newStatus = ApplicationStatus.HANDLING,
+                            eventTime = eventTime.plusSeconds(10),
+                        ),
+                        ApplicationHistoryFactory.createEvent(
+                            newStatus = ApplicationStatus.PENDING_CLIENT,
+                            eventTime = eventTime.plusSeconds(20),
+                        ),
+                    )
+                    .asList()
+            every {
+                alluClient.getApplicationStatusHistories(
+                    listOf(alluId),
+                    placeholderUpdateTime.toZonedDateTime(),
+                )
+            } returns emptyList()
+            every {
+                alluClient.getApplicationStatusHistories(listOf(alluId), eventTime.minusSeconds(1))
+            } returns history
+            every { alluClient.getInformationRequest(alluId) } throws exception
+
+            updateService.handleUpdates()
+
+            assertThat(output).contains("ERROR")
+            assertThat(alluEventErrorRepository.findAll()).single().all {
+                prop(AlluEventErrorEntity::alluId).isEqualTo(alluId)
+                prop(AlluEventErrorEntity::newStatus)
+                    .isEqualTo(ApplicationStatus.WAITING_INFORMATION)
+                prop(AlluEventErrorEntity::applicationIdentifier)
+                    .isEqualTo(DEFAULT_APPLICATION_IDENTIFIER)
+                prop(AlluEventErrorEntity::eventTime).isEqualTo(eventTime)
+                prop(AlluEventErrorEntity::stackTrace).isEqualTo(exception.stackTraceToString())
+            }
+            assertThat(taydennyspyyntoRepository.findAll()).isEmpty()
+            assertThat(hakemusRepository.findAll()).single().all {
+                prop(HakemusEntity::alluid).isEqualTo(alluId)
+                prop(HakemusEntity::alluStatus).isEqualTo(ApplicationStatus.HANDLING)
+            }
+            verifySequence {
+                alluClient.getApplicationStatusHistories(
+                    listOf(alluId),
+                    placeholderUpdateTime.toZonedDateTime(),
+                )
+                alluClient.getApplicationStatusHistories(listOf(alluId), eventTime.minusSeconds(1))
+                alluClient.getInformationRequest(alluId)
+            }
+        }
+    }
+}

--- a/services/hanke-service/src/integrationTest/resources/clear-db.sql
+++ b/services/hanke-service/src/integrationTest/resources/clear-db.sql
@@ -1,4 +1,5 @@
 TRUNCATE TABLE
+    allu_event_error,
     application_attachment,
     applications,
     audit_logs,

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/AlluEventError.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/allu/AlluEventError.kt
@@ -1,0 +1,49 @@
+package fi.hel.haitaton.hanke.allu
+
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.time.Instant
+import java.time.ZonedDateTime
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+data class AlluEventError(
+    val id: Long,
+    val alluId: Int,
+    val eventTime: ZonedDateTime,
+    val newStatus: ApplicationStatus,
+    val applicationIdentifier: String,
+    val targetStatus: ApplicationStatus? = null,
+    val stackTrace: String? = null,
+)
+
+@Entity
+@Table(name = "allu_event_error")
+class AlluEventErrorEntity(
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY) val id: Long = 0,
+    val alluId: Int?,
+    val eventTime: ZonedDateTime?,
+    @Enumerated(EnumType.STRING) val newStatus: ApplicationStatus?,
+    val applicationIdentifier: String?,
+    @Enumerated(EnumType.STRING) val targetStatus: ApplicationStatus?,
+    val stackTrace: String?,
+    val createdAt: Instant? = Instant.now(),
+) {
+    fun toDomain(): AlluEventError =
+        AlluEventError(
+            id = id,
+            alluId = alluId!!,
+            eventTime = eventTime!!,
+            newStatus = newStatus!!,
+            applicationIdentifier = applicationIdentifier!!,
+            targetStatus = targetStatus,
+            stackTrace = stackTrace,
+        )
+}
+
+@Repository interface AlluEventErrorRepository : JpaRepository<AlluEventErrorEntity, Long>

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/AlluUpdateScheduler.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/AlluUpdateScheduler.kt
@@ -1,0 +1,31 @@
+package fi.hel.haitaton.hanke.hakemus
+
+import fi.hel.haitaton.hanke.configuration.LockService
+import mu.KotlinLogging
+import org.springframework.context.annotation.Profile
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Service
+
+private val logger = KotlinLogging.logger {}
+
+@Service
+@Profile("!test")
+class AlluUpdateScheduler(
+    private val alluUpdateService: AlluUpdateService,
+    private val lockService: LockService,
+) {
+    @Scheduled(
+        fixedDelayString = "\${haitaton.allu.updateIntervalMilliSeconds}",
+        initialDelayString = "\${haitaton.allu.updateInitialDelayMilliSeconds}",
+    )
+    fun checkApplicationHistories() {
+        logger.info(
+            "Trying to obtain lock $LOCK_NAME to start checking Allu application histories."
+        )
+        lockService.doIfUnlocked(LOCK_NAME) { alluUpdateService.handleUpdates() }
+    }
+
+    companion object {
+        internal const val LOCK_NAME = "alluHistoryUpdate"
+    }
+}

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/AlluUpdateService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/AlluUpdateService.kt
@@ -1,51 +1,231 @@
 package fi.hel.haitaton.hanke.hakemus
 
 import fi.hel.haitaton.hanke.allu.AlluClient
-import fi.hel.haitaton.hanke.configuration.LockService
+import fi.hel.haitaton.hanke.allu.AlluEventError
+import fi.hel.haitaton.hanke.allu.ApplicationHistory
+import fi.hel.haitaton.hanke.allu.ApplicationStatusEvent
 import java.time.OffsetDateTime
+import kotlin.collections.forEach
 import mu.KotlinLogging
-import org.springframework.context.annotation.Profile
-import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 
 private val logger = KotlinLogging.logger {}
 
 @Service
-@Profile("!test")
 class AlluUpdateService(
     private val alluClient: AlluClient,
     private val historyService: HakemusHistoryService,
-    private val lockService: LockService,
 ) {
-    @Scheduled(
-        fixedDelayString = "\${haitaton.allu.updateIntervalMilliSeconds}",
-        initialDelayString = "\${haitaton.allu.updateInitialDelayMilliSeconds}")
-    fun checkApplicationStatuses() {
-        logger.info(
-            "Trying to obtain lock $LOCK_NAME to start checking Allu application histories.")
-        lockService.doIfUnlocked(LOCK_NAME) { getApplicationStatuses() }
+    /** Handles updates from Allu - first new updates, then previously failed updates. */
+    @Transactional
+    fun handleUpdates() {
+        val errors = historyService.getAllErrors()
+        logger.info {
+            "There are ${errors.size} past errors before this history update. Allu IDs: ${errors.map { it.alluId }}"
+        }
+        logger.info { "Handling new Allu updates..." }
+        handleNewUpdates(errors)
+        logger.info { "New Allu updates handled." }
+        logger.info { "Handling previously failed Allu updates..." }
+        handleFailedUpdates(errors)
+        logger.info { "Previously failed Allu updates handled." }
     }
 
-    private fun getApplicationStatuses() {
+    /**
+     * Handles new updates from Allu, fetching application histories for all applications with
+     * alluIds.
+     */
+    private fun handleNewUpdates(errors: List<AlluEventError>) {
+        val currentTime = OffsetDateTime.now()
         val ids = historyService.getAllAlluIds()
-        if (ids.isEmpty()) {
-            // Exit if there are no alluids. Allu handles an empty list as "all", which we don't
-            // want.
+        if (ids.isNotEmpty()) {
+            val lastUpdate = historyService.getLastUpdateTime()
+
+            logger.info {
+                "Preparing to update ${ids.size} applications from Allu since $lastUpdate"
+            }
+
+            val applicationHistories =
+                alluClient.getApplicationStatusHistories(ids, lastUpdate.toZonedDateTime())
+            logger.info {
+                "Received ${applicationHistories.size} application histories from Allu since $lastUpdate"
+            }
+
+            if (applicationHistories.isNotEmpty()) {
+                val (succeed, failed, skipped) = handleHakemusUpdates(applicationHistories, errors)
+                logger.info {
+                    "Handled ${applicationHistories.size} application history updates from $lastUpdate, succeeded: $succeed, failed: $failed, skipped: $skipped"
+                }
+            } else {
+                logger.info("No application histories found in Allu for the Haitaton applications.")
+            }
+        } else {
+            // Allu handles an empty list as "all", which we don't want.
+            logger.info("There are no applications to update, skipping Allu history update.")
+        }
+
+        historyService.setLastUpdateTime(currentTime)
+    }
+
+    private fun handleHakemusUpdates(
+        applicationHistories: List<ApplicationHistory>,
+        pastErrors: List<AlluEventError>,
+        skipPastFailures: Boolean = true,
+    ): Triple<Int, Int, Int> {
+        var success = 0
+        var failure = 0
+        var skipped = 0
+        val saveNewErrors = skipPastFailures // If we skip past failures, we save new errors
+        val newErrors = mutableListOf<AlluEventError>()
+        applicationHistories.forEach { applicationHistory ->
+            if (
+                skipPastFailures &&
+                    (pastErrors.any { it.alluId == applicationHistory.applicationId } ||
+                        newErrors.any { it.alluId == applicationHistory.applicationId })
+            ) {
+                logger.warn {
+                    "Skipping application history with ${applicationHistory.events.size} events for application ${applicationHistory.applicationId} due to its errors"
+                }
+                skipped++
+            } else if (
+                !skipPastFailures &&
+                    pastErrors.none { it.alluId == applicationHistory.applicationId }
+            ) {
+                logger.warn {
+                    "Skipping application history with ${applicationHistory.events.size} events for application ${applicationHistory.applicationId} due to it not having past errors"
+                }
+                skipped++
+            } else {
+                logger.info {
+                    "Handling application history with ${applicationHistory.events.size} events for application ${applicationHistory.applicationId}"
+                }
+                val result = handleHakemusUpdate(applicationHistory, pastErrors)
+                if (result.isSuccess) {
+                    logger.info {
+                        "Successfully handled application history with ${applicationHistory.events.size} events for application ${applicationHistory.applicationId}"
+                    }
+                    success++
+                } else {
+                    logger.error {
+                        "Failed to handle application history with ${applicationHistory.events.size} events for application ${applicationHistory.applicationId}"
+                    }
+                    failure++
+                    newErrors.add(
+                        AlluEventError(
+                            id = 0, // ID is auto-generated by the database
+                            alluId = applicationHistory.applicationId,
+                            eventTime = result.event!!.eventTime,
+                            newStatus = result.event.newStatus,
+                            applicationIdentifier = result.event.applicationIdentifier,
+                            targetStatus = result.event.targetStatus,
+                            stackTrace = result.stackTrace!!,
+                        )
+                    )
+                }
+            }
+        }
+
+        if (saveNewErrors && newErrors.isNotEmpty()) {
+            historyService.saveErrors(newErrors)
+            logger.info {
+                "Saved ${newErrors.size} new errors for Allu events that failed to process. Allu IDs: ${newErrors.map { it.alluId }}"
+            }
+        }
+
+        return Triple(success, failure, skipped)
+    }
+
+    /**
+     * Handles the update of a single application history by processing all events in order.
+     *
+     * @return In case of an error, returns a result with the event that caused the error and the
+     *   error message.
+     */
+    private fun handleHakemusUpdate(
+        applicationHistory: ApplicationHistory,
+        errors: List<AlluEventError>,
+    ): ApplicationEventResult {
+        applicationHistory.events
+            .sortedBy { it.eventTime }
+            .forEach { event ->
+                logger.info {
+                    "Handling event of time ${event.eventTime} for application ${applicationHistory.applicationId} (${event.applicationIdentifier}) with new status ${event.newStatus}"
+                }
+                try {
+                    historyService.handleApplicationEvent(applicationHistory.applicationId, event)
+                    logger.info {
+                        "Successfully handled event of time ${event.eventTime} for application ${applicationHistory.applicationId} (${event.applicationIdentifier}) with new status ${event.newStatus}"
+                    }
+                    val pastError =
+                        errors.find {
+                            it.alluId == applicationHistory.applicationId &&
+                                it.eventTime == event.eventTime
+                        }
+                    if (pastError != null) {
+                        logger.info {
+                            "Removing past error of time ${pastError.eventTime} for application ${applicationHistory.applicationId} (${event.applicationIdentifier}) after successful update"
+                        }
+                        historyService.deleteError(pastError)
+                    }
+                } catch (e: Exception) {
+                    logger.error(e) {
+                        "Error while handling event of time ${event.eventTime} for new status ${event.newStatus} for application ${applicationHistory.applicationId} (${event.applicationIdentifier})"
+                    }
+                    return ApplicationEventResult.failure(event, e.stackTraceToString())
+                }
+            }
+
+        return ApplicationEventResult.success(applicationHistory)
+    }
+
+    /** Handles updates for previously failed applications by fetching their histories from Allu. */
+    private fun handleFailedUpdates(errors: List<AlluEventError>) {
+        if (errors.isEmpty()) {
+            logger.info("No past errors found, skipping Allu history update for them.")
             return
         }
-        val lastUpdate = historyService.getLastUpdateTime()
-        val currentUpdate = OffsetDateTime.now()
+
+        val ids = errors.map { it.alluId }.distinct()
+        val updateTime = errors.minOf { it.eventTime }.minusSeconds(1)
 
         logger.info {
-            "Updating application histories with date $lastUpdate and ${ids.size} Allu IDs"
+            "Preparing to update ${ids.size} previously failed applications from Allu since ${updateTime}."
         }
-        val applicationHistories =
-            alluClient.getApplicationStatusHistories(ids, lastUpdate.toZonedDateTime())
+        val applicationHistories = alluClient.getApplicationStatusHistories(ids, updateTime)
+        logger.info {
+            "Received ${applicationHistories.size} application histories from Allu since $updateTime"
+        }
 
-        historyService.handleHakemusUpdates(applicationHistories, currentUpdate)
+        if (applicationHistories.isNotEmpty()) {
+            val (succeed, failed, skipped) =
+                handleHakemusUpdates(applicationHistories, errors, false)
+            logger.info {
+                "Updated ${applicationHistories.size} application histories from $updateTime, succeeded: $succeed, failed: $failed, skipped: $skipped"
+            }
+        } else {
+            logger.error(
+                "No application histories found in Allu for previously failed applications: $ids"
+            )
+            throw IllegalStateException(
+                "No application histories found in Allu for previously failed applications: $ids"
+            )
+        }
     }
 
-    companion object {
-        internal const val LOCK_NAME = "alluHistoryUpdate"
+    data class ApplicationEventResult(
+        val applicationHistory: ApplicationHistory? = null,
+        val event: ApplicationStatusEvent? = null,
+        val stackTrace: String? = null,
+    ) {
+        val isSuccess: Boolean
+            get() = applicationHistory != null
+
+        companion object {
+            fun success(history: ApplicationHistory) = ApplicationEventResult(history)
+
+            fun failure(event: ApplicationStatusEvent, stackTrace: String) =
+                ApplicationEventResult(null, event, stackTrace)
+        }
     }
 }

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/testdata/TestDataService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/testdata/TestDataService.kt
@@ -5,7 +5,7 @@ import fi.hel.haitaton.hanke.attachment.azure.Container
 import fi.hel.haitaton.hanke.attachment.common.FileClient
 import fi.hel.haitaton.hanke.attachment.common.TaydennysAttachmentRepository
 import fi.hel.haitaton.hanke.attachment.muutosilmoitus.MuutosilmoitusAttachmentRepository
-import fi.hel.haitaton.hanke.hakemus.AlluUpdateService
+import fi.hel.haitaton.hanke.hakemus.AlluUpdateScheduler
 import fi.hel.haitaton.hanke.hakemus.HakemusRepository
 import fi.hel.haitaton.hanke.muutosilmoitus.MuutosilmoitusRepository
 import fi.hel.haitaton.hanke.paatos.PaatosEntity
@@ -29,7 +29,7 @@ class TestDataService(
     private val muutosilmoitusAttachmentRepository: MuutosilmoitusAttachmentRepository,
     private val attachmentContentService: ApplicationAttachmentContentService,
     private val fileClient: FileClient,
-    private val alluUpdateService: AlluUpdateService,
+    private val alluUpdateService: AlluUpdateScheduler,
 ) {
     @Transactional
     fun unlinkApplicationsFromAllu() {
@@ -59,7 +59,7 @@ class TestDataService(
 
     fun triggerAlluUpdates() {
         logger.info { "Manually triggered Allu updates..." }
-        alluUpdateService.checkApplicationStatuses()
+        alluUpdateService.checkApplicationHistories()
         logger.info { "Manual Allu updates done." }
     }
 

--- a/services/hanke-service/src/main/resources/db/changelog/changesets/109-create-table-for-allu-event-errors.sql
+++ b/services/hanke-service/src/main/resources/db/changelog/changesets/109-create-table-for-allu-event-errors.sql
@@ -1,0 +1,28 @@
+--liquibase formatted sql
+--changeset Teemu Hiltunen:109-create-table-for-allu-event-errors
+--comment: Create table for Allu events
+
+CREATE TABLE allu_event_error
+(
+    id                      serial                   NOT NULL PRIMARY KEY,
+    alluid                  int                      NOT NULL,
+    eventtime               timestamp                NOT NULL,
+    newstatus               varchar                  NOT NULL,
+    applicationidentifier   varchar                  NOT NULL,
+    targetstatus            varchar,
+    stacktrace              text,
+    createdat               timestamp with time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT uk_allu_event_error_alluid_eventtime UNIQUE (alluid, eventtime)
+);
+
+CREATE INDEX idx_allu_event_error_alluid ON allu_event_error (alluid);
+CREATE INDEX idx_allu_event_error_applicationidentifier ON allu_event_error (applicationidentifier);
+
+COMMENT ON TABLE allu_event_error is 'Allu history events error table.';
+COMMENT ON COLUMN allu_event_error.alluid is 'The unique Allu identifier for the application.';
+COMMENT ON COLUMN allu_event_error.eventtime is 'Allu event time.';
+COMMENT ON COLUMN allu_event_error.newstatus is 'The new status of the application after the event.';
+COMMENT ON COLUMN allu_event_error.applicationidentifier is 'The application identifier.';
+COMMENT ON COLUMN allu_event_error.targetstatus is 'Tells next status (DECISION, OPERATIONAL_CONDITION or FINISHED) if current status is DECISIONMAKING';
+COMMENT ON COLUMN allu_event_error.stacktrace is 'Stack trace of the error that occurred during the event handling.';
+COMMENT ON COLUMN allu_event_error.createdat is 'Timestamp of when this row was initially created.';

--- a/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/services/hanke-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -245,3 +245,5 @@ databaseChangeLog:
       file: db/changelog/changesets/107-add-completion-date-to-hanke.sql
   - include:
       file: db/changelog/changesets/108-add-sent-reminders-to-hanke.sql
+  - include:
+      file: db/changelog/changesets/109-create-table-for-allu-event-errors.sql

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/ApplicationHistoryFactory.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/factory/ApplicationHistoryFactory.kt
@@ -1,5 +1,6 @@
 package fi.hel.haitaton.hanke.factory
 
+import fi.hel.haitaton.hanke.allu.AlluEventError
 import fi.hel.haitaton.hanke.allu.ApplicationHistory
 import fi.hel.haitaton.hanke.allu.ApplicationStatus
 import fi.hel.haitaton.hanke.allu.ApplicationStatusEvent
@@ -44,6 +45,9 @@ object ApplicationHistoryFactory {
             events = events + createEvent(eventTime, newStatus, applicationIdentifier, targetStatus)
         )
 
+    fun ApplicationHistory.withEvents(vararg events: ApplicationStatusEvent) =
+        this.copy(events = this.events + events.toList())
+
     /** Add two events at different times. Supervision events are not included. */
     fun ApplicationHistory.withDefaultEvents(
         applicationIdentifier: String = DEFAULT_APPLICATION_IDENTIFIER
@@ -61,4 +65,20 @@ object ApplicationHistoryFactory {
 
     /** Return a singleton list with this history. */
     fun ApplicationHistory.asList(): List<ApplicationHistory> = listOf(this)
+
+    fun createError(
+        alluId: Int = DEFAULT_APPLICATION_ID,
+        eventTime: ZonedDateTime = DEFAULT_EVENT_TIME,
+        newStatus: ApplicationStatus = DEFAULT_STATUS,
+        stackTrace: String? = null,
+    ): AlluEventError =
+        AlluEventError(
+            0,
+            alluId,
+            eventTime,
+            newStatus,
+            DEFAULT_APPLICATION_IDENTIFIER,
+            null,
+            stackTrace,
+        )
 }

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/AlluUpdateSchedulerTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/AlluUpdateSchedulerTest.kt
@@ -1,0 +1,73 @@
+package fi.hel.haitaton.hanke.hakemus
+
+import fi.hel.haitaton.hanke.allu.AlluClient
+import fi.hel.haitaton.hanke.configuration.LockService
+import io.mockk.Called
+import io.mockk.checkUnnecessaryStub
+import io.mockk.clearAllMocks
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verifyOrder
+import io.mockk.verifySequence
+import java.util.concurrent.locks.Lock
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.integration.jdbc.lock.JdbcLockRegistry
+
+class AlluUpdateSchedulerTest {
+    private val alluUpdateService: AlluUpdateService = mockk()
+    private val alluClient: AlluClient = mockk()
+    private val historyService: HakemusHistoryService = mockk()
+    private val jdbcLockRegistry: JdbcLockRegistry = mockk()
+    private val lockService = LockService(jdbcLockRegistry)
+
+    private val alluUpdateScheduler = AlluUpdateScheduler(alluUpdateService, lockService)
+
+    @BeforeEach
+    fun clearMocks() {
+        clearAllMocks()
+    }
+
+    @AfterEach
+    fun confirmMocks() {
+        checkUnnecessaryStub()
+        confirmVerified(historyService, alluClient, jdbcLockRegistry)
+    }
+
+    @Test
+    fun `does nothing if can't obtain lock`() {
+        mockLocking(false)
+
+        alluUpdateScheduler.checkApplicationHistories()
+
+        verifyOrder {
+            jdbcLockRegistry.obtain(AlluUpdateScheduler.LOCK_NAME)
+            alluClient wasNot Called
+            historyService wasNot Called
+        }
+    }
+
+    @Test
+    fun `releases lock if there's an exception`() {
+        val lock = mockLocking(true)
+        every { alluUpdateService.handleUpdates() } throws Exception()
+
+        alluUpdateScheduler.checkApplicationHistories()
+
+        verifySequence {
+            jdbcLockRegistry.obtain(AlluUpdateScheduler.LOCK_NAME)
+            lock.tryLock()
+            alluUpdateService.handleUpdates()
+            lock.unlock()
+        }
+    }
+
+    private fun mockLocking(canObtainLock: Boolean): Lock {
+        val mockLock = mockk<Lock>(relaxUnitFun = true)
+        every { mockLock.tryLock() } returns canObtainLock
+        every { jdbcLockRegistry.obtain(AlluUpdateScheduler.LOCK_NAME) } returns mockLock
+        return mockLock
+    }
+}

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/AlluUpdateServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/AlluUpdateServiceTest.kt
@@ -1,12 +1,13 @@
 package fi.hel.haitaton.hanke.hakemus
 
-import assertk.assertThat
+import assertk.assertFailure
+import assertk.assertions.hasClass
 import fi.hel.haitaton.hanke.allu.AlluClient
-import fi.hel.haitaton.hanke.configuration.LockService
 import fi.hel.haitaton.hanke.factory.ApplicationHistoryFactory
+import fi.hel.haitaton.hanke.factory.ApplicationHistoryFactory.DEFAULT_EVENT_TIME
 import fi.hel.haitaton.hanke.factory.ApplicationHistoryFactory.asList
 import fi.hel.haitaton.hanke.factory.ApplicationHistoryFactory.withDefaultEvents
-import fi.hel.haitaton.hanke.test.Asserts.isRecent
+import fi.hel.haitaton.hanke.factory.ApplicationHistoryFactory.withEvent
 import io.mockk.Called
 import io.mockk.checkUnnecessaryStub
 import io.mockk.clearAllMocks
@@ -18,21 +19,16 @@ import io.mockk.verifyOrder
 import io.mockk.verifySequence
 import java.time.OffsetDateTime
 import java.time.ZonedDateTime
-import java.util.concurrent.locks.Lock
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.springframework.integration.jdbc.lock.JdbcLockRegistry
-import org.springframework.web.reactive.function.client.WebClientResponseException
 
 class AlluUpdateServiceTest {
     private val alluClient: AlluClient = mockk()
     private val historyService: HakemusHistoryService = mockk()
-    private val jdbcLockRegistry: JdbcLockRegistry = mockk()
-    private val lockService = LockService(jdbcLockRegistry)
 
-    private val alluUpdateService = AlluUpdateService(alluClient, historyService, lockService)
+    private val alluUpdateService = AlluUpdateService(alluClient, historyService)
 
     @BeforeEach
     fun clearMocks() {
@@ -42,135 +38,265 @@ class AlluUpdateServiceTest {
     @AfterEach
     fun confirmMocks() {
         checkUnnecessaryStub()
-        confirmVerified(historyService, alluClient, jdbcLockRegistry)
+        confirmVerified(historyService, alluClient)
+    }
+
+    @Test
+    fun `updates only last update time when no alluIds or errors`() {
+        every { historyService.getAllErrors() } returns listOf()
+        every { historyService.getAllAlluIds() } returns listOf()
+        justRun { historyService.setLastUpdateTime(any()) }
+
+        alluUpdateService.handleUpdates()
+
+        verifySequence {
+            historyService.getAllErrors()
+            historyService.getAllAlluIds()
+            historyService.setLastUpdateTime(any())
+            alluClient wasNot Called
+        }
     }
 
     @Nested
-    inner class CheckApplicationStatuses {
-        private val lastUpdatedString = "2022-10-12T14:14:58.423521Z"
+    inner class HandleNormalUpdates {
+        private val lastUpdatedString = "2022-10-12T15:25:34.981654Z"
         private val lastUpdated = OffsetDateTime.parse(lastUpdatedString)
         private val eventsAfter = ZonedDateTime.parse(lastUpdatedString)
 
         @Test
-        fun `does nothing with no alluids`() {
-            mockLocking(true)
-            every { historyService.getAllAlluIds() } returns listOf()
-
-            alluUpdateService.checkApplicationStatuses()
-
-            verifySequence {
-                jdbcLockRegistry.obtain(AlluUpdateService.LOCK_NAME)
-                historyService.getAllAlluIds()
-                alluClient wasNot Called
-            }
-        }
-
-        @Test
         fun `calls Allu with alluids and last update date`() {
-            mockLocking(true)
             val alluids = listOf(23, 24)
+            every { historyService.getAllErrors() } returns listOf()
             every { historyService.getAllAlluIds() } returns alluids
             every { historyService.getLastUpdateTime() } returns lastUpdated
             every { alluClient.getApplicationStatusHistories(alluids, eventsAfter) } returns
                 listOf()
-            justRun { historyService.handleHakemusUpdates(listOf(), any()) }
+            justRun { historyService.setLastUpdateTime(any()) }
 
-            alluUpdateService.checkApplicationStatuses()
+            alluUpdateService.handleUpdates()
 
             verifyOrder {
-                jdbcLockRegistry.obtain(AlluUpdateService.LOCK_NAME)
+                historyService.getAllErrors()
                 historyService.getAllAlluIds()
                 historyService.getLastUpdateTime()
                 alluClient.getApplicationStatusHistories(alluids, eventsAfter)
-                historyService.handleHakemusUpdates(listOf(), any())
+                historyService.setLastUpdateTime(any())
             }
         }
 
         @Test
-        fun `calls application service with the returned histories`() {
-            mockLocking(true)
+        fun `handles application events for the one with history`() {
             val alluids = listOf(23, 24)
             val histories =
                 ApplicationHistoryFactory.create(applicationId = 24, *emptyArray())
                     .withDefaultEvents()
                     .asList()
+            val event1 = histories.single().events.first()
+            val event2 = histories.single().events.last()
+            every { historyService.getAllErrors() } returns listOf()
             every { historyService.getAllAlluIds() } returns alluids
             every { historyService.getLastUpdateTime() } returns lastUpdated
             every { alluClient.getApplicationStatusHistories(alluids, eventsAfter) } returns
                 histories
-            justRun { historyService.handleHakemusUpdates(histories, any()) }
+            every { historyService.getAllErrors() } returns emptyList()
+            justRun { historyService.handleApplicationEvent(24, event1) }
+            justRun { historyService.handleApplicationEvent(24, event2) }
+            justRun { historyService.setLastUpdateTime(any()) }
 
-            alluUpdateService.checkApplicationStatuses()
+            alluUpdateService.handleUpdates()
 
             verifyOrder {
-                jdbcLockRegistry.obtain(AlluUpdateService.LOCK_NAME)
+                historyService.getAllErrors()
                 historyService.getAllAlluIds()
                 historyService.getLastUpdateTime()
                 alluClient.getApplicationStatusHistories(alluids, eventsAfter)
-                historyService.handleHakemusUpdates(histories, any())
+                historyService.handleApplicationEvent(24, event1)
+                historyService.handleApplicationEvent(24, event2)
+                historyService.setLastUpdateTime(any())
             }
         }
 
         @Test
-        fun `calls application service with the current time`() {
-            mockLocking(true)
+        fun `handles other application history events when one fails`() {
             val alluids = listOf(23, 24)
+            val histories =
+                listOf(
+                    ApplicationHistoryFactory.create(applicationId = 23, *emptyArray())
+                        .withDefaultEvents(),
+                    ApplicationHistoryFactory.create(applicationId = 24, *emptyArray())
+                        .withDefaultEvents(),
+                )
+            val event1 = histories.first().events.first()
+            val event2 = histories.first().events.last()
+            val exception = RuntimeException("Test exception")
+            val error =
+                ApplicationHistoryFactory.createError(
+                    alluId = 23,
+                    eventTime = event2.eventTime,
+                    newStatus = event2.newStatus,
+                    stackTrace = exception.stackTraceToString(),
+                )
+            val event3 = histories.last().events.first()
+            val event4 = histories.last().events.last()
+            every { historyService.getAllErrors() } returns listOf()
             every { historyService.getAllAlluIds() } returns alluids
             every { historyService.getLastUpdateTime() } returns lastUpdated
             every { alluClient.getApplicationStatusHistories(alluids, eventsAfter) } returns
-                listOf()
-            justRun { historyService.handleHakemusUpdates(listOf(), any()) }
+                histories
+            justRun { historyService.handleApplicationEvent(23, event1) }
+            every { historyService.handleApplicationEvent(23, event2) } throws exception
+            justRun { historyService.handleApplicationEvent(24, event3) }
+            justRun { historyService.handleApplicationEvent(24, event4) }
+            justRun { historyService.saveErrors(listOf(error)) }
+            justRun { historyService.setLastUpdateTime(any()) }
 
-            alluUpdateService.checkApplicationStatuses()
+            alluUpdateService.handleUpdates()
 
             verifyOrder {
-                jdbcLockRegistry.obtain(AlluUpdateService.LOCK_NAME)
+                historyService.getAllErrors()
                 historyService.getAllAlluIds()
                 historyService.getLastUpdateTime()
                 alluClient.getApplicationStatusHistories(alluids, eventsAfter)
-                historyService.handleHakemusUpdates(listOf(), withArg { assertThat(it).isRecent() })
-            }
-        }
-
-        @Test
-        fun `does nothing if can't obtain lock`() {
-            mockLocking(false)
-
-            alluUpdateService.checkApplicationStatuses()
-
-            verifyOrder {
-                jdbcLockRegistry.obtain(AlluUpdateService.LOCK_NAME)
-                alluClient wasNot Called
-                historyService wasNot Called
-            }
-        }
-
-        @Test
-        fun `releases lock if there's an exception`() {
-            val lock = mockLocking(true)
-            val alluids = listOf(23, 24)
-            every { historyService.getAllAlluIds() } returns alluids
-            every { historyService.getLastUpdateTime() } returns lastUpdated
-            every { alluClient.getApplicationStatusHistories(alluids, eventsAfter) } throws
-                WebClientResponseException(500, "Internal server error", null, null, null)
-
-            alluUpdateService.checkApplicationStatuses()
-
-            verifySequence {
-                jdbcLockRegistry.obtain(AlluUpdateService.LOCK_NAME)
-                lock.tryLock()
-                historyService.getAllAlluIds()
-                historyService.getLastUpdateTime()
-                alluClient.getApplicationStatusHistories(alluids, eventsAfter)
-                lock.unlock()
+                historyService.handleApplicationEvent(23, event1)
+                historyService.handleApplicationEvent(23, event2)
+                historyService.handleApplicationEvent(24, event3)
+                historyService.handleApplicationEvent(24, event4)
+                historyService.saveErrors(listOf(error))
+                historyService.setLastUpdateTime(any())
             }
         }
     }
 
-    private fun mockLocking(canObtainLock: Boolean): Lock {
-        val mockLock = mockk<Lock>(relaxUnitFun = true)
-        every { mockLock.tryLock() } returns canObtainLock
-        every { jdbcLockRegistry.obtain(AlluUpdateService.LOCK_NAME) } returns mockLock
-        return mockLock
+    @Nested
+    inner class HandleErrors {
+
+        @Test
+        fun `handles errors and deletes them`() {
+            val histories =
+                ApplicationHistoryFactory.create(applicationId = 24, *emptyArray())
+                    .withDefaultEvents()
+                    .asList()
+            val error1 =
+                ApplicationHistoryFactory.createError(
+                    alluId = 24,
+                    eventTime = histories.single().events.first().eventTime,
+                )
+            val error2 =
+                ApplicationHistoryFactory.createError(
+                    alluId = 24,
+                    eventTime = histories.single().events.last().eventTime,
+                )
+            val event1 = histories.single().events.first()
+            val event2 = histories.single().events.last()
+            every { historyService.getAllErrors() } returns listOf(error1, error2)
+            every { historyService.getAllAlluIds() } returns listOf()
+            justRun { historyService.setLastUpdateTime(any()) }
+            every {
+                alluClient.getApplicationStatusHistories(
+                    listOf(24),
+                    error1.eventTime.minusSeconds(1),
+                )
+            } returns histories
+            justRun { historyService.handleApplicationEvent(24, event1) }
+            justRun { historyService.deleteError(error1) }
+            justRun { historyService.handleApplicationEvent(24, event2) }
+            justRun { historyService.deleteError(error2) }
+
+            alluUpdateService.handleUpdates()
+
+            verifyOrder {
+                historyService.getAllErrors()
+                historyService.getAllAlluIds()
+                historyService.setLastUpdateTime(any())
+                alluClient.getApplicationStatusHistories(
+                    listOf(24),
+                    error1.eventTime.minusSeconds(1),
+                )
+                historyService.handleApplicationEvent(24, event1)
+                historyService.deleteError(error1)
+                historyService.handleApplicationEvent(24, event2)
+                historyService.deleteError(error2)
+            }
+        }
+
+        @Test
+        fun `throws exception if Allu has no history for a past error`() {
+            val histories =
+                ApplicationHistoryFactory.create(applicationId = 24, *emptyArray())
+                    .withDefaultEvents()
+                    .asList()
+            val error1 =
+                ApplicationHistoryFactory.createError(
+                    alluId = 24,
+                    eventTime = histories.single().events.first().eventTime,
+                )
+            val error2 =
+                ApplicationHistoryFactory.createError(
+                    alluId = 24,
+                    eventTime = histories.single().events.last().eventTime,
+                )
+            every { historyService.getAllErrors() } returns listOf(error1, error2)
+            every { historyService.getAllAlluIds() } returns listOf()
+            justRun { historyService.setLastUpdateTime(any()) }
+            every {
+                alluClient.getApplicationStatusHistories(
+                    listOf(24),
+                    error1.eventTime.minusSeconds(1),
+                )
+            } returns emptyList()
+
+            val failure = assertFailure { alluUpdateService.handleUpdates() }
+
+            failure.hasClass(IllegalStateException::class)
+            verifyOrder {
+                historyService.getAllErrors()
+                historyService.getAllAlluIds()
+                historyService.setLastUpdateTime(any())
+                alluClient.getApplicationStatusHistories(
+                    listOf(24),
+                    error1.eventTime.minusSeconds(1),
+                )
+            }
+        }
+
+        @Test
+        fun `skips new history when going through errors`() {
+            val eventTime = DEFAULT_EVENT_TIME
+            val histories =
+                listOf(
+                    ApplicationHistoryFactory.create(applicationId = 24)
+                        .withEvent(eventTime = eventTime),
+                    ApplicationHistoryFactory.create(applicationId = 25)
+                        .withEvent(eventTime = eventTime.plusSeconds(1)),
+                    ApplicationHistoryFactory.create(applicationId = 26)
+                        .withEvent(eventTime = eventTime.plusSeconds(2)),
+                )
+            val error = ApplicationHistoryFactory.createError(alluId = 24, eventTime = eventTime)
+            every { historyService.getAllErrors() } returns listOf(error)
+            every { historyService.getAllAlluIds() } returns listOf()
+            justRun { historyService.setLastUpdateTime(any()) }
+            every {
+                alluClient.getApplicationStatusHistories(
+                    listOf(24),
+                    error.eventTime.minusSeconds(1),
+                )
+            } returns histories
+            justRun { historyService.handleApplicationEvent(24, histories[0].events.first()) }
+            justRun { historyService.deleteError(error) }
+
+            alluUpdateService.handleUpdates()
+
+            verifyOrder {
+                historyService.getAllErrors()
+                historyService.getAllAlluIds()
+                historyService.setLastUpdateTime(any())
+                alluClient.getApplicationStatusHistories(
+                    listOf(24),
+                    error.eventTime.minusSeconds(1),
+                )
+                historyService.handleApplicationEvent(24, histories[0].events.first())
+                historyService.deleteError(error)
+            }
+        }
     }
 }


### PR DESCRIPTION
# Description

Handle Allu history updates so that failing updates do not block handling of other updates on other applications. All updates to a previously failed application are still blocked in order to not go out-of-sync with Allu by handling a later update when earlier has failed. Failed updates are handled separately from new updates. If a failing update succeeds then that application is free to be updated with later updates. The errors are stored in database table allu_event_error. There are more logging for making debugging a bit easier in production.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-3585

## Type of change

- [x] Bug fix 
- [ ] New feature 
- [ ] Other

# Instructions for testing
Test different scenarios where Haitaton and Allu communicate: päätös, täydennyspyyntö, muutosilmoitus etc.

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 

# Other relevant info
Please describe here if there is e.g. some requirements for this change or
 other info that the tester/user needs to know.