### PR TITLE
HAI-3587 Fix Allu event handling for päätös

### DIFF
--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusHistoryServiceITest.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusHistoryServiceITest.kt
@@ -109,16 +109,32 @@ class HakemusHistoryServiceITest(
                     ApplicationStatus.DECISION,
                 ),
             )
+            alluEventFactory.saveEventEntity(
+                alluId,
+                ApplicationHistoryFactory.createEvent(
+                    eventTime.plusDays(3),
+                    ApplicationStatus.DECISIONMAKING,
+                ),
+            )
+            alluEventFactory.saveEventEntity(
+                alluId,
+                ApplicationHistoryFactory.createEvent(
+                    eventTime.plusDays(4),
+                    ApplicationStatus.DECISION,
+                ),
+            )
             var entities =
                 alluEventRepository.findPendingAndFailedEventsGrouped().getOrElse(alluId) {
                     fail { "No Allu events in database" }
                 }
-            assertThat(entities).hasSize(5)
+            assertThat(entities).hasSize(7)
             assertThat(entities[0].newStatus).isEqualTo(ApplicationStatus.PENDING)
             assertThat(entities[1].newStatus).isEqualTo(ApplicationStatus.HANDLING)
             assertThat(entities[2].newStatus).isEqualTo(ApplicationStatus.WAITING_INFORMATION)
             assertThat(entities[3].newStatus).isEqualTo(ApplicationStatus.INFORMATION_RECEIVED)
             assertThat(entities[4].newStatus).isEqualTo(ApplicationStatus.DECISION)
+            assertThat(entities[5].newStatus).isEqualTo(ApplicationStatus.DECISIONMAKING)
+            assertThat(entities[6].newStatus).isEqualTo(ApplicationStatus.DECISION)
 
             historyService.processApplicationHistories(emptyList())
 
@@ -126,11 +142,13 @@ class HakemusHistoryServiceITest(
                 alluEventRepository.findByStatusInOrderByAlluIdAscEventTimeAsc(
                     listOf(AlluEventStatus.PROCESSED)
                 )
-            assertThat(entities).hasSize(5)
+            assertThat(entities).hasSize(7)
             assertThat(entities[1].processedAt).isGreaterThan(entities[0].processedAt)
             assertThat(entities[2].processedAt).isGreaterThan(entities[1].processedAt)
             assertThat(entities[3].processedAt).isGreaterThan(entities[2].processedAt)
             assertThat(entities[4].processedAt).isGreaterThan(entities[3].processedAt)
+            assertThat(entities[5].processedAt).isGreaterThan(entities[4].processedAt)
+            assertThat(entities[6].processedAt).isGreaterThan(entities[5].processedAt)
         }
 
         @Test

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/AlluUpdateService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/AlluUpdateService.kt
@@ -23,17 +23,10 @@ class AlluUpdateService(
             logger.info("There are no applications to update, skipping Allu history update.")
             return
         }
-
         val lastUpdate = historyService.getLastUpdateTime()
         val currentTime = ZonedDateTime.now(TZ_UTC)
         val applicationHistories = fetchApplicationHistories(ids, lastUpdate)
         historyService.setLastUpdateTime(currentTime.toOffsetDateTime())
-
-        if (applicationHistories.isEmpty()) {
-            logger.info("There are no applications to update, skipping Allu history update.")
-            return
-        }
-
         historyService.processApplicationHistories(applicationHistories)
     }
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusHistoryService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusHistoryService.kt
@@ -35,11 +35,13 @@ class HakemusHistoryService(
 
     @Transactional
     fun processApplicationHistories(applicationHistories: List<ApplicationHistory>) {
-        logger.info {
-            "Processing ${applicationHistories.size} new application histories from Allu: " +
-                applicationHistories.joinToString(" : ") { it.toLogString() }
+        if (applicationHistories.isNotEmpty()) {
+            logger.info {
+                "Processing ${applicationHistories.size} new application histories from Allu: " +
+                    applicationHistories.joinToString(" : ") { it.toLogString() }
+            }
+            saveEventsAsPending(applicationHistories)
         }
-        saveEventsAsPending(applicationHistories)
         processPendingAndFailedEvents()
     }
 

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/paatos/Enums.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/paatos/Enums.kt
@@ -1,9 +1,24 @@
 package fi.hel.haitaton.hanke.paatos
 
+import fi.hel.haitaton.hanke.allu.ApplicationStatus
+
 enum class PaatosTyyppi {
     PAATOS,
     TOIMINNALLINEN_KUNTO,
-    TYO_VALMIS,
+    TYO_VALMIS;
+
+    companion object {
+        fun valueOfApplicationStatus(applicationStatus: ApplicationStatus): PaatosTyyppi =
+            when (applicationStatus) {
+                ApplicationStatus.DECISION -> PAATOS
+                ApplicationStatus.OPERATIONAL_CONDITION -> TOIMINNALLINEN_KUNTO
+                ApplicationStatus.FINISHED -> TYO_VALMIS
+                else ->
+                    throw IllegalArgumentException(
+                        "Unsupported application status: $applicationStatus"
+                    )
+            }
+    }
 }
 
 enum class PaatosTila {

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/paatos/PaatosRepository.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/paatos/PaatosRepository.kt
@@ -12,6 +12,8 @@ interface PaatosRepository : JpaRepository<PaatosEntity, UUID> {
 
     fun findByHakemusIdIn(hakemusIds: Collection<Long>): List<PaatosEntity>
 
+    fun existsByHakemustunnusAndTyyppi(hakemustunnus: String, tyyppi: PaatosTyyppi): Boolean
+
     @Modifying
     @Query("UPDATE PaatosEntity SET tila = :tila WHERE hakemustunnus = :hakemustunnus")
     fun markReplacedByHakemustunnus(hakemustunnus: String, tila: PaatosTila = PaatosTila.KORVATTU)

--- a/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/paatos/PaatosService.kt
+++ b/services/hanke-service/src/main/kotlin/fi/hel/haitaton/hanke/paatos/PaatosService.kt
@@ -1,6 +1,7 @@
 package fi.hel.haitaton.hanke.paatos
 
 import fi.hel.haitaton.hanke.allu.AlluClient
+import fi.hel.haitaton.hanke.allu.ApplicationStatus
 import fi.hel.haitaton.hanke.allu.ApplicationStatusEvent
 import fi.hel.haitaton.hanke.attachment.application.ApplicationAttachmentContentService
 import fi.hel.haitaton.hanke.attachment.azure.Container
@@ -44,6 +45,16 @@ class PaatosService(
         val filename = "${paatos.hakemustunnus}-$filenameSuffix.pdf"
         return Pair(filename, bytes)
     }
+
+    @Transactional(readOnly = true)
+    fun isRevertedToDecision(
+        hakemus: HakemusIdentifier,
+        applicationStatus: ApplicationStatus,
+    ): Boolean =
+        paatosRepository.existsByHakemustunnusAndTyyppi(
+            hakemus.applicationIdentifier!!,
+            PaatosTyyppi.valueOfApplicationStatus(applicationStatus),
+        )
 
     @Transactional
     fun saveKaivuilmoituksenPaatos(hakemus: HakemusIdentifier, event: ApplicationStatusEvent) {

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/AlluUpdateServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/AlluUpdateServiceTest.kt
@@ -55,26 +55,26 @@ class AlluUpdateServiceTest {
     }
 
     @Test
-    fun `only updates the timestamp when no histories`(output: CapturedOutput) {
+    fun `handles updates when no histories`() {
         every { historyService.getAllAlluIds() } returns listOf(23)
         every { historyService.getLastUpdateTime() } returns OffsetDateTime.now()
         every { alluClient.getApplicationStatusHistories(any(), any()) } returns emptyList()
         justRun { historyService.setLastUpdateTime(any()) }
+        justRun { historyService.processApplicationHistories(emptyList()) }
 
         alluUpdateService.handleUpdates()
 
-        assertThat(output)
-            .contains("There are no applications to update, skipping Allu history update.")
         verifySequence {
             historyService.getAllAlluIds()
             historyService.getLastUpdateTime()
             alluClient.getApplicationStatusHistories(any(), any())
             historyService.setLastUpdateTime(any())
+            historyService.processApplicationHistories(emptyList())
         }
     }
 
     @Test
-    fun `handles updates`() {
+    fun `handles updates when histories`() {
         val histories =
             ApplicationHistoryFactory.create(applicationId = 24, *emptyArray())
                 .withDefaultEvents()

--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusHistoryServiceTest.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/hakemus/HakemusHistoryServiceTest.kt
@@ -60,7 +60,7 @@ class HakemusHistoryServiceTest {
             val event =
                 ApplicationHistoryFactory.createEvent(newStatus = ApplicationStatus.DECISION)
             val history = ApplicationHistoryFactory.create(alluId, event)
-            val entity = AlluEventFactory.createEntity(alluId, event)
+            val entity = AlluEventFactory.createEntity(alluId, event, AlluEventStatus.PENDING)
             justRun { alluEventRepository.batchInsertIgnoreDuplicates(listOf(entity)) }
             every { alluEventRepository.findByStatusInOrderByAlluIdAscEventTimeAsc(any()) } returns
                 emptyList()
@@ -82,7 +82,6 @@ class HakemusHistoryServiceTest {
             val event =
                 ApplicationHistoryFactory.createEvent(newStatus = ApplicationStatus.DECISION)
             val entity = AlluEventFactory.createEntity(alluId, event, AlluEventStatus.FAILED)
-            justRun { alluEventRepository.batchInsertIgnoreDuplicates(emptyList()) }
             every { alluEventRepository.findByStatusInOrderByAlluIdAscEventTimeAsc(any()) } returns
                 listOf(entity)
             justRun { applicationEventService.handleApplicationEvent(alluId, event) }
@@ -90,7 +89,6 @@ class HakemusHistoryServiceTest {
             historyService.processApplicationHistories(emptyList())
 
             verifySequence {
-                alluEventRepository.batchInsertIgnoreDuplicates(emptyList())
                 alluEventRepository.findByStatusInOrderByAlluIdAscEventTimeAsc(any())
                 applicationEventService.handleApplicationEvent(alluId, event)
             }
@@ -102,7 +100,6 @@ class HakemusHistoryServiceTest {
             val event =
                 ApplicationHistoryFactory.createEvent(newStatus = ApplicationStatus.DECISION)
             val entity = AlluEventFactory.createEntity(alluId, event, AlluEventStatus.FAILED)
-            justRun { alluEventRepository.batchInsertIgnoreDuplicates(emptyList()) }
             every { alluEventRepository.findByStatusInOrderByAlluIdAscEventTimeAsc(any()) } returns
                 listOf(entity)
             every { applicationEventService.handleApplicationEvent(alluId, event) } throws
@@ -111,7 +108,6 @@ class HakemusHistoryServiceTest {
             historyService.processApplicationHistories(emptyList())
 
             verifySequence {
-                alluEventRepository.batchInsertIgnoreDuplicates(emptyList())
                 alluEventRepository.findByStatusInOrderByAlluIdAscEventTimeAsc(any())
                 applicationEventService.handleApplicationEvent(alluId, event)
             }
@@ -126,7 +122,6 @@ class HakemusHistoryServiceTest {
                 ApplicationHistoryFactory.createEvent(newStatus = ApplicationStatus.DECISION)
             val entity1 = AlluEventFactory.createEntity(alluId, event1, AlluEventStatus.FAILED)
             val entity2 = AlluEventFactory.createEntity(alluId, event2, AlluEventStatus.PENDING)
-            justRun { alluEventRepository.batchInsertIgnoreDuplicates(emptyList()) }
             every { alluEventRepository.findByStatusInOrderByAlluIdAscEventTimeAsc(any()) } returns
                 listOf(entity1, entity2)
             justRun { applicationEventService.handleApplicationEvent(alluId, event1) }
@@ -135,7 +130,6 @@ class HakemusHistoryServiceTest {
             historyService.processApplicationHistories(emptyList())
 
             verifySequence {
-                alluEventRepository.batchInsertIgnoreDuplicates(emptyList())
                 alluEventRepository.findByStatusInOrderByAlluIdAscEventTimeAsc(any())
                 applicationEventService.handleApplicationEvent(alluId, event1)
                 applicationEventService.handleApplicationEvent(alluId, event2)
@@ -149,7 +143,6 @@ class HakemusHistoryServiceTest {
             val event =
                 ApplicationHistoryFactory.createEvent(newStatus = ApplicationStatus.DECISION)
             val entity = AlluEventFactory.createEntity(alluId, event, AlluEventStatus.PENDING)
-            justRun { alluEventRepository.batchInsertIgnoreDuplicates(emptyList()) }
             every { alluEventRepository.findByStatusInOrderByAlluIdAscEventTimeAsc(any()) } returns
                 listOf(entity)
             justRun { applicationEventService.handleApplicationEvent(alluId, event) }
@@ -157,7 +150,6 @@ class HakemusHistoryServiceTest {
             historyService.processApplicationHistories(emptyList())
 
             verifySequence {
-                alluEventRepository.batchInsertIgnoreDuplicates(emptyList())
                 alluEventRepository.findByStatusInOrderByAlluIdAscEventTimeAsc(any())
                 applicationEventService.handleApplicationEvent(alluId, event)
             }
@@ -169,7 +161,6 @@ class HakemusHistoryServiceTest {
             val event =
                 ApplicationHistoryFactory.createEvent(newStatus = ApplicationStatus.DECISION)
             val entity = AlluEventFactory.createEntity(alluId, event, AlluEventStatus.PENDING)
-            justRun { alluEventRepository.batchInsertIgnoreDuplicates(emptyList()) }
             every { alluEventRepository.findByStatusInOrderByAlluIdAscEventTimeAsc(any()) } returns
                 listOf(entity)
             every { applicationEventService.handleApplicationEvent(alluId, event) } throws
@@ -178,7 +169,6 @@ class HakemusHistoryServiceTest {
             historyService.processApplicationHistories(emptyList())
 
             verifySequence {
-                alluEventRepository.batchInsertIgnoreDuplicates(emptyList())
                 alluEventRepository.findByStatusInOrderByAlluIdAscEventTimeAsc(any())
                 applicationEventService.handleApplicationEvent(alluId, event)
             }


### PR DESCRIPTION
# Description

Fix handling pending Allu events even when there are no new ones. Fix duplicate key error when päätös gets reverted (a new päätös event is received).


### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-3587

## Type of change

- [x] Bug fix 
- [ ] New feature 
- [ ] Other

# Instructions for testing
Please describe tests how this change or new feature can be tested.

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 

# Other relevant info
Please describe here if there is e.g. some requirements for this change or
 other info that the tester/user needs to know.