### PR TITLE
HAI-3571 switch sentry to European instance

### DIFF
--- a/services/hanke-service/src/main/resources/application.yml
+++ b/services/hanke-service/src/main/resources/application.yml
@@ -100,7 +100,7 @@ management:
 
 sentry:
   # DSN is a public detail.
-  dsn: ${HAITATON_SENTRY_DSN:https://47ff7aa8e32fa0f48fe211771c537299.ingest.de.sentry.io/4509236728627280}
+  dsn: ${HAITATON_SENTRY_DSN:https://47ff7aa8e32fa0f48fe211771c537299@o4508126783602688.ingest.de.sentry.io/4509236728627280}
   environment: ${HAITATON_SENTRY_ENVIRONMENT:dev}
   # Only exceptions that have not been handled by exception resolvers with higher order are sent to Sentry.
   exception-resolver-order: 2147483647


### PR DESCRIPTION
# Description

Added to azure build pipeline libraries ‘haitaton-ui-testing’, ‘haitaton-ui-development’, ‘haitaton-ui-staging’ and ‘haitaton-ui-production’
NGINX_SENTRY=https://04b58689c601e9f0658325ec82650248.ingest.de.sentry.io/
REACT_APP_SENTRY_DSN=https://04b58689c601e9f0658325ec82650248.ingest.de.sentry.io/4509236744224848
Added to azure build pipeline libraries ‘development’, ‘staging’, ‘production’ and ‘testing’
HAITATON_SENTRY_DSN=https://47ff7aa8e32fa0f48fe211771c537299.ingest.de.sentry.io/4509236728627280

Modified system to use them as variables where needed

### Jira Issue: 
HAI-3571
## Type of change

- [ ] Bug fix 
- [x] New feature 
- [ ] Other

# Instructions for testing


# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
 or other location: 

# Other relevant info
