### PR TITLE
HAI-3612 Fix flaky isRecent() assertion due to Docker clock skew

### DIFF
--- a/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/test/Asserts.kt
+++ b/services/hanke-service/src/test/kotlin/fi/hel/haitaton/hanke/test/Asserts.kt
@@ -51,12 +51,13 @@ object Asserts {
 
     fun Assert<OffsetDateTime?>.isRecent(offset: TemporalAmount = Duration.ofMinutes(1)) {
         val now = OffsetDateTime.now()
-        isNotNull().isBetween(now.minus(offset), now)
+        isNotNull().isBetween(now.minus(offset), now.plus(Duration.ofSeconds(5)))
     }
+
 
     fun Assert<Instant?>.isRecentInstant(offset: TemporalAmount = Duration.ofMinutes(1)) {
         val now = Instant.now()
-        isNotNull().isBetween(now.minus(offset), now)
+        isNotNull().isBetween(now.minus(offset), now.plus(Duration.ofSeconds(5)))
     }
 
     fun Assert<Instant?>.isGreaterThan(other: Instant?) {
@@ -69,7 +70,7 @@ object Asserts {
 
     fun Assert<ZonedDateTime?>.isRecentZDT(offset: TemporalAmount = Duration.ofMinutes(1)) {
         val now = ZonedDateTime.now()
-        isNotNull().isBetween(now.minus(offset), now)
+        isNotNull().isBetween(now.minus(offset), now.plus(Duration.ofSeconds(5)))
     }
 
     fun Assert<LocalDateTime?>.isRecentUTC(offset: TemporalAmount = Duration.ofMinutes(1)) =


### PR DESCRIPTION
## Description

`isRecent()` in `Asserts.kt` checks that a timestamp falls between `now - 1min` and `now`, where `now` is the JVM clock. Timestamps written by the DB use PostgreSQL's `now()`. When the Docker container clock is slightly ahead of the JVM clock (observed: ~50ms), the DB timestamp ends up just after the JVM's `now`, causing `isBetween` to fail spuriously.

Added a 5-second upper-bound buffer to all `isRecent` variants to tolerate this clock skew:
- `Assert<OffsetDateTime?>.isRecent`
- `Assert<Instant?>.isRecentInstant`
- `Assert<ZonedDateTime?>.isRecentZDT`

## Jira Issue

[HAI-3612](https://helsinkisolutionoffice.atlassian.net/browse/HAI-3612)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Other relevant info

Observed failure in `MuutosilmoitusServiceITest.clears paper decision when it's null` during pre-push hook run.

[HAI-3612]: https://helsinkisolutionoffice.atlassian.net/browse/HAI-3612?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ