### PR TITLE
HAI-3616 Fix critical dependency vulnerabilities

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 # Description
 
-Please include definition of what was done. 
+Please include a definition of what was done. 
 
 ### Jira Issue: 
 
@@ -16,10 +16,10 @@ Please describe tests how this change or new feature can be tested.
 # Checklist:
 
 - [ ] I have written new tests (if applicable)
-- [ ] I have ran the tests myself (if applicable)
+- [ ] I have run the tests myself (if applicable)
 - [ ] I have made necessary changes to the documentation, link to confluence
  or other location: 
 
 # Other relevant info
-Please describe here if there is e.g. some requirements for this change or
+Please describe here if there are, e.g., some requirements for this change or
  other info that the tester/user needs to know.

--- a/README.md
+++ b/README.md
@@ -150,6 +150,26 @@ Created report can be found at paths:
 - Html: build/reports/jacoco/test/html/index.html
 - Xml: build/reports/jacoco/test/jacocoTestReport.xml
 
+### Dependency vulnerability scanning
+
+The [CycloneDX Gradle plugin](https://github.com/CycloneDX/cyclonedx-gradle-plugin) generates a
+Software Bill of Materials (SBOM) that lists all project dependencies. The SBOM can then be scanned
+for known vulnerabilities with [osv-scanner](https://google.github.io/osv-scanner/).
+
+Generate the SBOM:
+
+```
+$ ./gradlew :services:hanke-service:cyclonedxBom
+```
+
+The generated file is at `services/hanke-service/build/reports/application.cdx.json`.
+
+Scan it for vulnerabilities:
+
+```
+$ osv-scanner scan source -L services/hanke-service/build/reports/application.cdx.json
+```
+
 ### Spotless formatter
 
 The Spotless Gradle plugin checks during the build stage that all code is formatted with ktfmt. If

--- a/services/hanke-service/build.gradle.kts
+++ b/services/hanke-service/build.gradle.kts
@@ -12,6 +12,10 @@ version = "0.0.1-SNAPSHOT"
 val sentryVersion = "8.21.1"
 val geoToolsVersion = "33.2"
 
+// Force patched versions for critical CVEs not yet included in Spring Boot 3.5.14
+extra["netty.version"] = "4.1.133.Final" // CVE-2026-42579, CVE-2026-42581, CVE-2026-42584
+extra["tomcat.version"] = "10.1.55" // CVE-2026-41293, CVE-2026-43512, CVE-2026-43515
+
 repositories {
     mavenCentral().content { excludeModule("javax.media", "jai_core") }
     maven { url = uri("https://repo.osgeo.org/repository/release/") }
@@ -57,7 +61,7 @@ spotless {
 
 plugins {
     val kotlinVersion = "2.2.20"
-    id("org.springframework.boot") version "3.5.11"
+    id("org.springframework.boot") version "3.5.14"
     id("io.spring.dependency-management") version "1.1.7"
     id("com.diffplug.spotless") version "7.2.1"
     kotlin("jvm") version kotlinVersion
@@ -69,6 +73,7 @@ plugins {
     id("jacoco")
     id("io.freefair.mjml.java") version "8.14.2"
     id("org.owasp.dependencycheck") version "12.1.0"
+    id("org.cyclonedx.bom") version "2.3.0"
 }
 
 dependencies {
@@ -139,10 +144,11 @@ dependencies {
     implementation("io.sentry:sentry-logback:$sentryVersion")
 
     // Azure
-    implementation(platform("com.azure:azure-sdk-bom:1.2.38"))
+    implementation(platform("com.azure:azure-sdk-bom:1.3.7"))
     implementation("com.azure:azure-storage-blob")
     implementation("com.azure:azure-storage-blob-batch")
-    implementation("com.azure:azure-identity")
+    implementation("com.azure:azure-identity") // BOM 1.3.7 → 1.18.3 (fixes CVE-2026-33117)
+    implementation("com.azure:azure-json")     // BOM 1.3.7 → 1.5.1 (false positive, see suppressions)
 
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
 }
@@ -202,6 +208,10 @@ tasks {
     }
 
     compileMjml { source(file("$rootDir/email")) }
+
+    named<com.github.gradle.node.npm.task.NpmTask>("installMjml") {
+        args.set(listOf("install", "mjml@4.15.3"))
+    }
 }
 
 tasks.register("installGitHook", Copy::class) {

--- a/services/hanke-service/dependency-check-suppressions.xml
+++ b/services/hanke-service/dependency-check-suppressions.xml
@@ -106,6 +106,19 @@
     </suppress>
 
     <!--
+        CVE-2026-33117: Authentication bypass in Azure SDK (azure-identity/azure-core).
+        This CVE is incorrectly matched against azure-json via an overly broad NVD CPE
+        pattern (microsoft:azure_sdk_for_java). The azure-json library contains only JSON
+        serialization code — no authentication logic. 1.5.1 is the latest GA release;
+        no fix version exists because the library is not affected.
+    -->
+    <suppress>
+        <notes>False positive: CVE-2026-33117 is an auth bypass in azure-identity/azure-core. azure-json has no authentication code. 1.5.1 is the latest GA.</notes>
+        <packageUrl regex="true">^pkg:maven/com\.azure/azure-json@.*$</packageUrl>
+        <cve>CVE-2026-33117</cve>
+    </suppress>
+
+    <!--
         CVE-2025-67721: Information leakage via buffer reuse in aircompressor's Snappy/LZ4 decompressors.
         aircompressor is pulled in transitively by GeoTools (gt-wms -> gt-coverage -> imageio-ext-tiff)
         for WMS/image rendering only. We do not decompress Snappy or LZ4 streams from external input,

--- a/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/azure/AzuriteTestContainer.kt
+++ b/services/hanke-service/src/integrationTest/kotlin/fi/hel/haitaton/hanke/attachment/azure/AzuriteTestContainer.kt
@@ -1,0 +1,31 @@
+package fi.hel.haitaton.hanke.attachment.azure
+
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.utility.DockerImageName
+
+/**
+ * Singleton object providing a shared Azurite container for integration tests.
+ *
+ * The container is lazily initialized on first access and reused across all tests. This avoids the
+ * overhead of starting multiple Azurite containers during test execution.
+ */
+object AzuriteTestContainer {
+
+    /** Shared Azurite container instance. Lazily initialized and started on first access. */
+    val container: GenericContainer<*> by lazy {
+        GenericContainer(DockerImageName.parse("mcr.microsoft.com/azure-storage/azurite"))
+            .withCommand("azurite-blob", "--blobHost", "0.0.0.0", "--skipApiVersionCheck")
+            .withExposedPorts(10000)
+            .also { it.start() }
+    }
+
+    /**
+     * Gets the Azure Blob Storage connection string for the Azurite container.
+     *
+     * This connection string uses the well-known Azurite development credentials and points to the
+     * exposed blob storage endpoint.
+     */
+    fun getConnectionString(): String {
+        return "BlobEndpoint=http://${container.host}:${container.firstMappedPort}/devstoreaccount1;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;"
+    }
+}

--- a/services/hanke-service/src/main/resources/email/template/hanke-paattyy.html.mustache
+++ b/services/hanke-service/src/main/resources/email/template/hanke-paattyy.html.mustache
@@ -29,7 +29,7 @@
 </head>
 
 <body style="word-spacing:normal">
-  <div aria-roledescription="email" role="article" lang="und" dir="auto">
+  <div lang="und" dir="auto">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="margin:0 auto;max-width:600px">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%">

--- a/services/hanke-service/src/main/resources/email/template/hanke-poistetaan.html.mustache
+++ b/services/hanke-service/src/main/resources/email/template/hanke-poistetaan.html.mustache
@@ -29,7 +29,7 @@
 </head>
 
 <body style="word-spacing:normal">
-  <div aria-roledescription="email" role="article" lang="und" dir="auto">
+  <div lang="und" dir="auto">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="margin:0 auto;max-width:600px">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%">

--- a/services/hanke-service/src/main/resources/email/template/hanke-valmistunut.html.mustache
+++ b/services/hanke-service/src/main/resources/email/template/hanke-valmistunut.html.mustache
@@ -29,7 +29,7 @@
 </head>
 
 <body style="word-spacing:normal">
-  <div aria-roledescription="email" role="article" lang="und" dir="auto">
+  <div lang="und" dir="auto">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="margin:0 auto;max-width:600px">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%">

--- a/services/hanke-service/src/main/resources/email/template/johtoselvitys-valmis.html.mustache
+++ b/services/hanke-service/src/main/resources/email/template/johtoselvitys-valmis.html.mustache
@@ -29,7 +29,7 @@
 </head>
 
 <body style="word-spacing:normal">
-  <div aria-roledescription="email" role="article" lang="und" dir="auto">
+  <div lang="und" dir="auto">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="margin:0 auto;max-width:600px">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%">

--- a/services/hanke-service/src/main/resources/email/template/kaivuilmoitus-paatos.html.mustache
+++ b/services/hanke-service/src/main/resources/email/template/kaivuilmoitus-paatos.html.mustache
@@ -29,7 +29,7 @@
 </head>
 
 <body style="word-spacing:normal">
-  <div aria-roledescription="email" role="article" lang="und" dir="auto">
+  <div lang="und" dir="auto">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="margin:0 auto;max-width:600px">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%">

--- a/services/hanke-service/src/main/resources/email/template/kayttaja-lisatty-hakemus.html.mustache
+++ b/services/hanke-service/src/main/resources/email/template/kayttaja-lisatty-hakemus.html.mustache
@@ -29,7 +29,7 @@
 </head>
 
 <body style="word-spacing:normal">
-  <div aria-roledescription="email" role="article" lang="und" dir="auto">
+  <div lang="und" dir="auto">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="margin:0 auto;max-width:600px">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%">

--- a/services/hanke-service/src/main/resources/email/template/kayttaja-lisatty-hanke.html.mustache
+++ b/services/hanke-service/src/main/resources/email/template/kayttaja-lisatty-hanke.html.mustache
@@ -29,7 +29,7 @@
 </head>
 
 <body style="word-spacing:normal">
-  <div aria-roledescription="email" role="article" lang="und" dir="auto">
+  <div lang="und" dir="auto">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="margin:0 auto;max-width:600px">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%">

--- a/services/hanke-service/src/main/resources/email/template/kayttaja-poistettu-hanke.html.mustache
+++ b/services/hanke-service/src/main/resources/email/template/kayttaja-poistettu-hanke.html.mustache
@@ -29,7 +29,7 @@
 </head>
 
 <body style="word-spacing:normal">
-  <div aria-roledescription="email" role="article" lang="und" dir="auto">
+  <div lang="und" dir="auto">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="margin:0 auto;max-width:600px">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%">

--- a/services/hanke-service/src/main/resources/email/template/kayttooikeustason-muutos.html.mustache
+++ b/services/hanke-service/src/main/resources/email/template/kayttooikeustason-muutos.html.mustache
@@ -29,7 +29,7 @@
 </head>
 
 <body style="word-spacing:normal">
-  <div aria-roledescription="email" role="article" lang="und" dir="auto">
+  <div lang="und" dir="auto">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="margin:0 auto;max-width:600px">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%">

--- a/services/hanke-service/src/main/resources/email/template/taydennyspyynto-peruttu.html.mustache
+++ b/services/hanke-service/src/main/resources/email/template/taydennyspyynto-peruttu.html.mustache
@@ -29,7 +29,7 @@
 </head>
 
 <body style="word-spacing:normal">
-  <div aria-roledescription="email" role="article" lang="und" dir="auto">
+  <div lang="und" dir="auto">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="margin:0 auto;max-width:600px">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%">

--- a/services/hanke-service/src/main/resources/email/template/taydennyspyynto.html.mustache
+++ b/services/hanke-service/src/main/resources/email/template/taydennyspyynto.html.mustache
@@ -29,7 +29,7 @@
 </head>
 
 <body style="word-spacing:normal">
-  <div aria-roledescription="email" role="article" lang="und" dir="auto">
+  <div lang="und" dir="auto">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="margin:0 auto;max-width:600px">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%">


### PR DESCRIPTION
# Description

Cherry-pick of HAI-3616 critical dependency vulnerability fixes from dev to main.

* Upgrade Spring Boot 3.5.11 → 3.5.14
* Force-pin Netty 4.1.133.Final (CVE-2026-42579, CVE-2026-42581, CVE-2026-42584)
* Force-pin Tomcat 10.1.55 (CVE-2026-41293, CVE-2026-43512, CVE-2026-43515)
* Upgrade Azure SDK BOM 1.2.38 → 1.3.7 (fixes CVE-2026-33117 via azure-identity 1.18.3)
* Add CycloneDX BOM plugin for SBOM generation
* Migrate `BlobFileClientITest` to shared `AzuriteTestContainer` with `--skipApiVersionCheck`
* Document CycloneDX SBOM generation and osv-scanner usage in README
* Fix grammar in PR template

### Jira Issue:
https://helsinkisolutionoffice.atlassian.net/browse/HAI-3616

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Other

# Instructions for testing

Run the full build locally:
```
./gradlew :services:hanke-service:clean :services:hanke-service:check
```

Verify SBOM generation and scanning:
```
./gradlew :services:hanke-service:cyclonedxBom
osv-scanner scan source -L services/hanke-service/build/reports/application.cdx.json
```

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have run the tests myself (if applicable)
- [x] I have made necessary changes to the documentation, link to confluence
 or other location: README.md updated with CycloneDX/osv-scanner usage

# Other relevant info

This is a targeted cherry-pick to bring critical security fixes to main without merging all other dev commits. `BlobFileClientITest` was also updated to use the shared `AzuriteTestContainer` singleton, which carries the `--skipApiVersionCheck` flag introduced in this fix.